### PR TITLE
fix(extraction): Fix double-formatting bug causing extraction failures

### DIFF
--- a/src/api/lib/ingestion.py
+++ b/src/api/lib/ingestion.py
@@ -218,6 +218,11 @@ def process_chunk(
               f"{len(extraction['relationships'])} relationships")
         sys.stdout.flush()  # Show extraction results immediately
     except Exception as e:
+        # Print full error for debugging
+        print(f"  ✗ Extraction failed: {str(e)}")
+        import traceback
+        traceback.print_exc()
+        sys.stdout.flush()
         raise Exception(f"Failed to extract concepts: {e}")
 
     # Step 3: Process each concept


### PR DESCRIPTION
## Summary

Fixes the concept extraction failure caused by double-formatting of prompt templates. The bug was introduced when both `llm_extractor.py` and the AI providers tried to format the same prompt string, causing a KeyError on the JSON structure example.

## Problem

**Error:** `Concept extraction failed: '\n  "concepts"'`

The extraction pipeline was:
1. `llm_extractor.py:114` - Formats prompt with `{existing_concepts_list}` and `{relationship_types}` ✅
2. `ai_providers.py:97` - Tries to format AGAIN with `{existing_concepts}` ❌

This caused Python's `.format()` to fail on the JSON example in the prompt:
```json
{
  "concepts": [    ← This was being interpreted as a format key!
    ...
  ]
}
```

## Solution

**Removed duplicate formatting in AI providers:**
- OpenAI provider now receives pre-formatted prompt from `llm_extractor.py`
- Anthropic provider now receives pre-formatted prompt from `llm_extractor.py`
- Added `_extract_json()` helper to handle edge cases (markdown code blocks)
- Added better error logging in `ingestion.py` for future debugging

## Testing

✅ Successfully tested with `ingest_source/watts_lecture_1.txt`:
```
✔ Ingestion completed!
  Concepts created: 7
  Sources created: 1  
  Relationships: 5
  Cost: $0.01
```

## Files Changed

- `src/api/lib/ai_providers.py` - Removed duplicate `.format()` in both providers
- `src/api/lib/ingestion.py` - Added detailed error logging with traceback

## Impact

- ✅ Fixes all concept extraction failures
- ✅ Works with both OpenAI and Anthropic providers
- ✅ Better error messages for future debugging
- ✅ No breaking changes

---

**Related Issues:** Fixes extraction errors reported in testing