### PR TITLE
Improve 'kg search connect' help text to explain semantic matching

### DIFF
--- a/client/src/cli/search.ts
+++ b/client/src/cli/search.ts
@@ -135,12 +135,24 @@ const relatedCommand = new Command('related')
       });
 
 const connectCommand = new Command('connect')
-      .description('Find shortest path between two concepts (accepts concept IDs or natural language queries)')
+      .description('Find shortest path between two concepts using IDs or semantic phrase matching')
       .showHelpAfterError()
-      .argument('<from>', 'Starting concept (ID or search phrase)')
-      .argument('<to>', 'Target concept (ID or search phrase)')
+      .argument('<from>', 'Starting concept (exact ID or descriptive phrase - e.g., "licensing issues" not "licensing")')
+      .argument('<to>', 'Target concept (exact ID or descriptive phrase - use 2-3 word phrases for best results)')
       .option('--max-hops <number>', 'Maximum path length', '5')
-      .option('--min-similarity <number>', 'Minimum similarity threshold for concept matching (0.0-1.0)', '0.5')
+      .option('--min-similarity <number>', 'Semantic similarity threshold for phrase matching (default 50% - lower for broader matches)', '0.5')
+      .addHelpText('after', `
+Examples:
+  $ kg search connect concept-id-123 concept-id-456
+  $ kg search connect "licensing issues" "AGE benefits"
+  $ kg search connect "Apache AGE" "graph database" --min-similarity 0.3
+
+Notes:
+  - Generic single words ("features", "issues") may not match well
+  - Use specific 2-3 word phrases for better semantic matching
+  - Lower --min-similarity (e.g., 0.3) to find weaker concept matches
+  - Error messages suggest threshold adjustments when near-misses exist
+      `)
       .action(async (from, to, options) => {
         try {
           const client = createClientFromEnv();


### PR DESCRIPTION
## Problem

Users expect `kg search connect "licensing" "features"` to work like exact string matching, but it actually uses semantic vector similarity. Generic single words like "features" often fail to match concepts without clear explanation.

This was discovered while testing ADR-023 (code block preprocessing) when natural language queries revealed UX gaps.

## Solution

Enhanced the `kg search connect --help` output with:

### Updated Description
- Changed "natural language queries" → "semantic phrase matching"
- Sets clearer expectations about how matching works

### Improved Argument Descriptions
- Added concrete examples: `"licensing issues"` not `"licensing"`
- Explains that 2-3 word phrases work best

### Better Option Description
- Clarifies 50% default threshold
- Suggests lowering for broader matches

### New Examples Section
```
$ kg search connect concept-id-123 concept-id-456
$ kg search connect "licensing issues" "AGE benefits"
$ kg search connect "Apache AGE" "graph database" --min-similarity 0.3
```

### New Notes Section
- Warns about generic single words
- Explains best practices for semantic matching
- References error message threshold suggestions

## Testing

Before:
```
$ kg search connect "licensing" "features"
✗ No concepts found matching 'features'
```
(User confused - no guidance on what went wrong)

After (with new help):
```
$ kg search connect --help
Notes:
  - Generic single words ("features", "issues") may not match well
  - Use specific 2-3 word phrases for better semantic matching
  - Lower --min-similarity (e.g., 0.3) to find weaker concept matches
```
(User understands semantic matching behavior)

## Impact

- Better UX for phrase-based path finding
- Sets correct expectations about similarity thresholds
- Reduces confusion when generic words don't match
- Documents the existing intelligent error message system (threshold hints)