### PR TITLE
docs(api): Enhance API endpoint and model documentation

### DIFF
--- a/src/api/models/queries.py
+++ b/src/api/models/queries.py
@@ -6,26 +6,34 @@ from typing import List, Optional, Dict, Any
 
 # Search Models
 class SearchRequest(BaseModel):
-    """Request to search for concepts"""
-    query: str = Field(..., description="Search query text", min_length=1)
-    limit: int = Field(10, description="Maximum number of results", ge=1, le=100)
-    min_similarity: float = Field(0.7, description="Minimum similarity score", ge=0.0, le=1.0)
+    """Request to search for concepts using semantic similarity.
+
+    Uses vector embeddings to find concepts matching the query text.
+    Returns concepts ranked by cosine similarity score.
+    """
+    query: str = Field(..., description="Search query text (2-3 word phrases work best)", min_length=1)
+    limit: int = Field(10, description="Maximum number of results to return", ge=1, le=100)
+    min_similarity: float = Field(0.7, description="Minimum similarity score (0.0-1.0, default 70%)", ge=0.0, le=1.0)
 
 
 class ConceptSearchResult(BaseModel):
-    """Single concept search result"""
-    concept_id: str
-    label: str
-    score: float
-    documents: List[str]
-    evidence_count: int
+    """Single concept search result with similarity score and evidence"""
+    concept_id: str = Field(..., description="Unique concept identifier")
+    label: str = Field(..., description="Human-readable concept label")
+    score: float = Field(..., description="Similarity score (0.0-1.0)")
+    documents: List[str] = Field(..., description="Documents where concept appears")
+    evidence_count: int = Field(..., description="Number of evidence instances")
 
 
 class SearchResponse(BaseModel):
-    """Search results response"""
-    query: str
-    count: int
-    results: List[ConceptSearchResult]
+    """Search results with smart threshold hints.
+
+    If few results found at current threshold, suggests lowering threshold
+    to reveal near-miss concepts.
+    """
+    query: str = Field(..., description="Original search query")
+    count: int = Field(..., description="Number of results returned")
+    results: List[ConceptSearchResult] = Field(..., description="Ranked search results")
     below_threshold_count: Optional[int] = Field(None, description="Number of additional concepts below threshold")
     suggested_threshold: Optional[float] = Field(None, description="Suggested threshold to reveal below-threshold results")
     threshold_used: Optional[float] = Field(None, description="Similarity threshold used for filtering")
@@ -33,106 +41,141 @@ class SearchResponse(BaseModel):
 
 # Concept Details Models
 class ConceptInstance(BaseModel):
-    """Evidence instance for a concept"""
-    quote: str
-    document: str
-    paragraph: int
-    source_id: str
+    """Evidence instance showing where concept appears in source text.
+
+    Each instance is a quoted text snippet from a specific document and paragraph.
+    """
+    quote: str = Field(..., description="Quoted text from source")
+    document: str = Field(..., description="Source document name")
+    paragraph: int = Field(..., description="Paragraph number in document")
+    source_id: str = Field(..., description="Unique source identifier")
 
 
 class ConceptRelationship(BaseModel):
-    """Relationship to another concept"""
-    to_id: str
-    to_label: str
-    rel_type: str
-    confidence: Optional[float] = None
+    """Semantic relationship connecting two concepts.
+
+    Relationship types include: IMPLIES, SUPPORTS, CONTRADICTS, RESULTS_FROM, ENABLES, etc.
+    """
+    to_id: str = Field(..., description="Target concept ID")
+    to_label: str = Field(..., description="Target concept label")
+    rel_type: str = Field(..., description="Relationship type (e.g., IMPLIES, SUPPORTS)")
+    confidence: Optional[float] = Field(None, description="Confidence score (0.0-1.0) if available")
 
 
 class ConceptDetailsResponse(BaseModel):
-    """Detailed concept information"""
-    concept_id: str
-    label: str
-    search_terms: List[str]
-    documents: List[str]
-    instances: List[ConceptInstance]
-    relationships: List[ConceptRelationship]
+    """Complete concept information with evidence and relationships.
+
+    Includes all text instances where concept appears and all semantic relationships
+    connecting it to other concepts in the graph.
+    """
+    concept_id: str = Field(..., description="Unique concept identifier")
+    label: str = Field(..., description="Human-readable concept label")
+    search_terms: List[str] = Field(..., description="Alternative search terms for this concept")
+    documents: List[str] = Field(..., description="Documents where concept appears")
+    instances: List[ConceptInstance] = Field(..., description="Evidence instances (quotes from text)")
+    relationships: List[ConceptRelationship] = Field(..., description="Outgoing relationships to other concepts")
 
 
 # Related Concepts Models
 class RelatedConceptsRequest(BaseModel):
-    """Request to find related concepts"""
+    """Request to find concepts related through graph traversal.
+
+    Performs breadth-first search from a starting concept to find all connected concepts
+    within max_depth hops. Optionally filters by specific relationship types.
+    """
     concept_id: str = Field(..., description="Starting concept ID")
-    relationship_types: Optional[List[str]] = Field(None, description="Filter by relationship types")
-    max_depth: int = Field(2, description="Maximum traversal depth", ge=1, le=5)
+    relationship_types: Optional[List[str]] = Field(None, description="Filter by relationship types (e.g., ['IMPLIES', 'SUPPORTS'])")
+    max_depth: int = Field(2, description="Maximum traversal depth (1-5 hops)", ge=1, le=5)
 
 
 class RelatedConcept(BaseModel):
-    """Related concept result"""
-    concept_id: str
-    label: str
-    distance: int
-    path_types: List[str]
+    """Concept found through graph traversal with distance information"""
+    concept_id: str = Field(..., description="Related concept ID")
+    label: str = Field(..., description="Related concept label")
+    distance: int = Field(..., description="Number of hops from starting concept")
+    path_types: List[str] = Field(..., description="Relationship types traversed to reach this concept")
 
 
 class RelatedConceptsResponse(BaseModel):
-    """Related concepts response"""
-    concept_id: str
-    max_depth: int
-    count: int
-    results: List[RelatedConcept]
+    """Related concepts grouped by distance from starting concept.
+
+    Results ordered by distance (closer concepts first).
+    """
+    concept_id: str = Field(..., description="Starting concept ID")
+    max_depth: int = Field(..., description="Maximum depth searched")
+    count: int = Field(..., description="Number of related concepts found")
+    results: List[RelatedConcept] = Field(..., description="Related concepts ordered by distance")
 
 
 # Find Connection Models
 class FindConnectionRequest(BaseModel):
-    """Request to find path between concepts"""
-    from_id: str = Field(..., description="Starting concept ID")
-    to_id: str = Field(..., description="Target concept ID")
-    max_hops: int = Field(5, description="Maximum path length", ge=1, le=10)
+    """Request to find shortest paths between two concepts using exact IDs.
+
+    Uses graph traversal to find up to 5 shortest paths connecting the concepts.
+    For phrase-based search, use /query/connect-by-search instead.
+    """
+    from_id: str = Field(..., description="Starting concept ID (exact match required)")
+    to_id: str = Field(..., description="Target concept ID (exact match required)")
+    max_hops: int = Field(5, description="Maximum path length to search (1-10 hops)", ge=1, le=10)
 
 
 class PathNode(BaseModel):
-    """Node in a path"""
-    id: str
-    label: str
+    """Node in a connection path"""
+    id: str = Field(..., description="Concept ID")
+    label: str = Field(..., description="Concept label")
 
 
 class ConnectionPath(BaseModel):
-    """Single path between concepts"""
-    nodes: List[PathNode]
-    relationships: List[str]
-    hops: int
+    """Single path connecting two concepts through relationships.
+
+    Shows the sequence of nodes and relationship types traversed.
+    """
+    nodes: List[PathNode] = Field(..., description="Ordered list of concepts in path")
+    relationships: List[str] = Field(..., description="Ordered list of relationship types (e.g., IMPLIES, ENABLES)")
+    hops: int = Field(..., description="Path length (number of relationships)")
 
 
 class FindConnectionResponse(BaseModel):
-    """Connection paths response"""
-    from_id: str
-    to_id: str
-    max_hops: int
-    count: int
-    paths: List[ConnectionPath]
+    """Connection paths between two concepts.
+
+    Returns up to 5 shortest paths found within max_hops limit.
+    """
+    from_id: str = Field(..., description="Starting concept ID")
+    to_id: str = Field(..., description="Target concept ID")
+    max_hops: int = Field(..., description="Maximum path length searched")
+    count: int = Field(..., description="Number of paths found")
+    paths: List[ConnectionPath] = Field(..., description="Discovered paths (up to 5)")
 
 
 # Find Connection by Search Models
 class FindConnectionBySearchRequest(BaseModel):
-    """Request to find path between concepts using natural language queries"""
-    from_query: str = Field(..., description="Natural language query for starting concept", min_length=1)
-    to_query: str = Field(..., description="Natural language query for target concept", min_length=1)
-    max_hops: int = Field(5, description="Maximum path length", ge=1, le=10)
-    threshold: float = Field(0.5, description="Minimum similarity threshold for concept matching", ge=0.0, le=1.0)
+    """Request to find path between concepts using semantic phrase matching.
+
+    Uses vector embeddings to match query phrases to existing concepts, then finds paths.
+    Generic single words may not match well - use specific 2-3 word phrases for best results.
+    """
+    from_query: str = Field(..., description="Semantic phrase for starting concept (e.g., 'licensing issues' not 'licensing')", min_length=1)
+    to_query: str = Field(..., description="Semantic phrase for target concept (use specific 2-3 word phrases)", min_length=1)
+    max_hops: int = Field(5, description="Maximum path length to search", ge=1, le=10)
+    threshold: float = Field(0.5, description="Minimum similarity threshold (default 50% - lower for broader matches)", ge=0.0, le=1.0)
 
 
 class FindConnectionBySearchResponse(BaseModel):
-    """Connection paths response with search queries"""
-    from_query: str
-    to_query: str
+    """Connection paths response with semantic phrase matching details.
+
+    Shows which concepts matched the search phrases and provides threshold hints
+    if matches were weak or missing. Includes similarity scores to help tune queries.
+    """
+    from_query: str = Field(..., description="Original from query phrase")
+    to_query: str = Field(..., description="Original to query phrase")
     from_concept: Optional[PathNode] = Field(None, description="Top matching concept for from_query")
     to_concept: Optional[PathNode] = Field(None, description="Top matching concept for to_query")
-    from_similarity: Optional[float] = Field(None, description="Similarity score of from match")
-    to_similarity: Optional[float] = Field(None, description="Similarity score of to match")
+    from_similarity: Optional[float] = Field(None, description="Similarity score of from match (0.0-1.0)")
+    to_similarity: Optional[float] = Field(None, description="Similarity score of to match (0.0-1.0)")
     from_suggested_threshold: Optional[float] = Field(None, description="Suggested threshold if from query had no matches")
     to_suggested_threshold: Optional[float] = Field(None, description="Suggested threshold if to query had no matches")
-    from_near_misses: Optional[int] = Field(None, description="Count of near-miss concepts for from query")
-    to_near_misses: Optional[int] = Field(None, description="Count of near-miss concepts for to query")
-    max_hops: int
-    count: int
-    paths: List[ConnectionPath]
+    from_near_misses: Optional[int] = Field(None, description="Count of near-miss concepts for from query below threshold")
+    to_near_misses: Optional[int] = Field(None, description="Count of near-miss concepts for to query below threshold")
+    max_hops: int = Field(..., description="Maximum path length searched")
+    count: int = Field(..., description="Number of paths found")
+    paths: List[ConnectionPath] = Field(..., description="Discovered paths between matched concepts")


### PR DESCRIPTION
## Summary

Comprehensive documentation improvements for REST API endpoints and Pydantic models to enhance discoverability and understanding through the OpenAPI-generated `/docs` and `/redoc` interfaces.

## Changes Made

### Query Endpoints (src/api/routes/queries.py)
- **POST /query/search**: Added "How It Works" and "Best Practices" sections for vector similarity search
- **GET /query/concept/{id}**: Added "Use Cases" and "Response Details" for concept inspection
- **POST /query/related**: Added "How It Works" for BFS traversal, relationship types, and performance notes
- **POST /query/connect**: Clarified exact ID matching and referenced semantic alternative
- **POST /query/connect-by-search**: Enhanced with best practices for phrase matching (already updated in previous PR)

### Ingestion Endpoints (src/api/routes/ingest.py)
- **POST /ingest**: Detailed ADR-014 workflow steps, deduplication, processing modes, and chunking parameters
- **POST /ingest/text**: Added "When to Use" section and parameter details

### Pydantic Models (src/api/models/queries.py)
Enhanced all 13 query models with comprehensive docstrings and Field() descriptions:
- SearchRequest, SearchResponse, ConceptSearchResult
- ConceptDetailsResponse, ConceptInstance, ConceptRelationship
- RelatedConceptsRequest, RelatedConceptsResponse, RelatedConcept
- FindConnectionRequest, FindConnectionResponse
- FindConnectionBySearchRequest, FindConnectionBySearchResponse
- PathNode, ConnectionPath

## Benefits

- **Better Discoverability**: Users can explore API capabilities through /docs and /redoc
- **Consistent Terminology**: "semantic phrase matching" used throughout (replaces "natural language")
- **Practical Guidance**: Best practices, performance notes, and concrete examples
- **Clear Workflows**: Step-by-step explanations of ADR-014 approval workflow
- **Cross-References**: Endpoints reference related endpoints where appropriate

## Testing

- All changes auto-reload via watchfiles mode
- Documentation immediately visible at http://localhost:8000/docs and /redoc
- No functional changes to code, only docstrings and field descriptions

Closes: User request to improve API documentation coverage and accuracy