### PR TITLE
fix: Use UTC timezone-aware datetimes consistently

### DIFF
--- a/src/api/services/job_analysis.py
+++ b/src/api/services/job_analysis.py
@@ -280,7 +280,7 @@ class JobAnalyzer:
                 "analyzed_at": "ISO timestamp"
             }
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         # Extract parameters
         file_path = job_data.get("file_path")
@@ -384,7 +384,7 @@ class JobAnalyzer:
                 "checkpoint_interval": job_data.get("checkpoint_interval", 5)
             },
             "warnings": warnings,
-            "analyzed_at": datetime.now().isoformat()
+            "analyzed_at": datetime.now(timezone.utc).isoformat()
         }
 
         return analysis

--- a/src/api/services/job_queue.py
+++ b/src/api/services/job_queue.py
@@ -7,7 +7,7 @@ changing route handlers.
 
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, List, Callable
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 import json
 import sqlite3
@@ -253,7 +253,7 @@ class InMemoryJobQueue(JobQueue):
                 "progress": None,
                 "result": None,
                 "error": None,
-                "created_at": datetime.now().isoformat(),
+                "created_at": datetime.now(timezone.utc).isoformat(),
                 "started_at": None,
                 "completed_at": None,
                 "job_data": job_data,
@@ -297,10 +297,10 @@ class InMemoryJobQueue(JobQueue):
 
             # Update timestamps
             if updates.get("status") == "processing" and not self.jobs[job_id].get("started_at"):
-                self.jobs[job_id]["started_at"] = datetime.now().isoformat()
+                self.jobs[job_id]["started_at"] = datetime.now(timezone.utc).isoformat()
 
             if updates.get("status") in ["completed", "failed"]:
-                self.jobs[job_id]["completed_at"] = datetime.now().isoformat()
+                self.jobs[job_id]["completed_at"] = datetime.now(timezone.utc).isoformat()
 
             # Persist to DB
             self._save_to_db(self.jobs[job_id])
@@ -320,7 +320,7 @@ class InMemoryJobQueue(JobQueue):
                 return False  # Can't cancel running jobs in Phase 1
 
             job["status"] = "cancelled"
-            job["completed_at"] = datetime.now().isoformat()
+            job["completed_at"] = datetime.now(timezone.utc).isoformat()
             self._save_to_db(job)
 
             return True

--- a/src/api/services/job_scheduler.py
+++ b/src/api/services/job_scheduler.py
@@ -10,7 +10,7 @@ Based on ADR-014: Job Approval Workflow
 """
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict
 import logging
 import os
@@ -96,7 +96,7 @@ class JobScheduler:
         from .job_queue import get_job_queue
 
         queue = get_job_queue()
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         # Task 1: Cancel expired unapproved jobs
         expired_count = 0
@@ -158,7 +158,7 @@ class JobScheduler:
         from .job_queue import get_job_queue
 
         queue = get_job_queue()
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         stats = {
             "expired_cancelled": 0,


### PR DESCRIPTION
## Summary
Fix `TypeError: can't subtract offset-naive and offset-aware datetimes` in job scheduler cleanup.

## Problem
The job scheduler was using timezone-naive `datetime.now()` to compare against PostgreSQL timestamps which are timezone-aware (UTC). This caused the scheduler cleanup task to fail every hour with:

```
Error in job cleanup: can't subtract offset-naive and offset-aware datetimes
Traceback (most recent call last):
  File ".../job_scheduler.py", line 123, in cleanup_jobs
    age = now - completed
          ~~~~^~~~~~~~~~~
TypeError: can't subtract offset-naive and offset-aware datetimes
```

## Solution
Consistently use UTC timezone-aware datetimes throughout the job lifecycle system:
- Import `timezone` from `datetime` module
- Replace all `datetime.now()` with `datetime.now(timezone.utc)`
- Ensures compatibility with PostgreSQL's `NOW()` function behavior

## Files Changed
- `src/api/services/job_scheduler.py` - cleanup_jobs() and manual_cleanup()
- `src/api/services/job_queue.py` - InMemoryJobQueue timestamp creation
- `src/api/services/job_analysis.py` - analyzed_at timestamp

## Testing
- [x] API server hot-reloaded successfully
- [x] No more "Error in job cleanup" messages in logs
- [x] API health check passes
- [x] User confirmed error resolved

## Notes
- This was a recurring timezone issue mentioned by the user
- PostgreSQL job queue uses `NOW()` which returns timezone-aware timestamps
- Consistent UTC usage prevents future comparison errors