### PR TITLE
fix: prevent duplicate 'New edge type discovered' log messages

### DIFF
--- a/src/api/lib/ingestion.py
+++ b/src/api/lib/ingestion.py
@@ -405,7 +405,7 @@ def process_chunk(
             # Generate embedding immediately for vocabulary matching on subsequent chunks
             try:
                 provider = get_provider()  # Get current AI provider for embedding generation
-                age_client.add_edge_type(
+                was_added = age_client.add_edge_type(
                     relationship_type=canonical_type,
                     category=category,
                     description=f"LLM-generated relationship type from ingestion",
@@ -414,7 +414,11 @@ def process_chunk(
                     direction_semantics=direction_semantics,  # ADR-049: Store LLM's direction decision
                     ai_provider=provider  # Pass provider for automatic embedding generation
                 )
-                logger.info(f"  🆕 New edge type discovered: '{canonical_type}' (direction: {direction_semantics}, embedding generated)")
+                # Only log if this call actually added the type (not if it already existed)
+                if was_added:
+                    logger.info(f"  🆕 New edge type discovered: '{canonical_type}' (direction: {direction_semantics}, embedding generated)")
+                else:
+                    logger.debug(f"  Edge type '{canonical_type}' already exists (reused)")
             except Exception as e:
                 # If adding fails (e.g., already exists from another worker), continue anyway
                 logger.debug(f"  Note: Edge type '{canonical_type}' may already exist: {e}")


### PR DESCRIPTION
## Problem

When processing a single chunk with multiple relationships using the same new edge type, the log message "🆕 New edge type discovered" was repeated for each occurrence, even though only the first call actually added it to the vocabulary.

**Example (before fix):**
```
12:18:44 | INFO | 🆕 New edge type discovered: 'INCLUDES'
12:18:45 | INFO | 🆕 New edge type discovered: 'INCLUDES'
12:18:46 | INFO | 🆕 New edge type discovered: 'INCLUDES'
```

This made logs noisy and gave the false impression that the same type was being added multiple times.

## Root Cause

In `src/api/lib/ingestion.py:408-417`, the code called `age_client.add_edge_type()` but **ignored its return value**.

The `add_edge_type()` method:
- Uses `ON CONFLICT (relationship_type) DO NOTHING`
- Returns `True` if it successfully added the type
- Returns `False` if the type already existed

Without checking the return value, every relationship using the same new type logged the discovery message, regardless of whether it was actually new in that iteration.

## Solution

**Code change:**
```python
# Before
age_client.add_edge_type(...)
logger.info(f"  🆕 New edge type discovered: '{canonical_type}'...")

# After
was_added = age_client.add_edge_type(...)
if was_added:
    logger.info(f"  🆕 New edge type discovered: '{canonical_type}'...")
else:
    logger.debug(f"  Edge type '{canonical_type}' already exists (reused)")
```

**After this fix:**
```
12:18:44 | INFO  | 🆕 New edge type discovered: 'INCLUDES' (direction: outward, embedding generated)
12:18:45 | DEBUG | Edge type 'INCLUDES' already exists (reused)
12:18:46 | DEBUG | Edge type 'INCLUDES' already exists (reused)
```

## Benefits

1. **Cleaner Logs**: Only logs "New edge type discovered" once per actual discovery
2. **Accurate Monitoring**: Makes it easier to track actual vocabulary growth rate
3. **Better Debugging**: Debug logs show when types are reused within a chunk
4. **No Functional Change**: Ingestion behavior unchanged, only logging improved

## Testing

**Scenario:** Ingest a document where LLM extracts multiple relationships using the same new edge type (e.g., "INCLUDES") within one chunk.

**Expected behavior:**
- First relationship: Logs "🆕 New edge type discovered"
- Subsequent relationships: Log at DEBUG level "already exists (reused)"

## Files Changed

- `src/api/lib/ingestion.py` - 4 lines changed (capture return value, check before logging)

## Impact

- ✅ Low risk: Only affects logging, not functionality
- ✅ Improves log clarity
- ✅ Makes vocabulary growth tracking more accurate
- ✅ No database or API changes