### PR TITLE
fix: parse JSONB columns to dicts in job queue queries

### DIFF
--- a/src/api/services/job_queue.py
+++ b/src/api/services/job_queue.py
@@ -259,6 +259,15 @@ class PostgreSQLJobQueue(JobQueue):
                     if job.get(field):
                         job[field] = job[field].isoformat()
 
+                # Parse JSONB columns from strings to dicts (psycopg2 returns JSONB as strings)
+                for json_field in ['progress', 'result', 'analysis', 'job_data']:
+                    if job.get(json_field) and isinstance(job[json_field], str):
+                        try:
+                            job[json_field] = json.loads(job[json_field])
+                        except json.JSONDecodeError:
+                            # If parsing fails, leave as None
+                            job[json_field] = None
+
                 # Rename error to error for consistency
                 job['error'] = job.pop('error', None)
 
@@ -379,6 +388,16 @@ class PostgreSQLJobQueue(JobQueue):
                         if job.get(field):
                             job[field] = job[field].isoformat()
 
+                    # Parse JSONB columns from strings to dicts (psycopg2 returns JSONB as strings)
+                    import json
+                    for json_field in ['progress', 'result', 'analysis', 'job_data']:
+                        if job.get(json_field) and isinstance(job[json_field], str):
+                            try:
+                                job[json_field] = json.loads(job[json_field])
+                            except json.JSONDecodeError:
+                                # If parsing fails, leave as None
+                                job[json_field] = None
+
                     # Rename error to error
                     job['error'] = job.pop('error', None)
 
@@ -443,6 +462,15 @@ class PostgreSQLJobQueue(JobQueue):
                 for field in ['created_at', 'started_at', 'completed_at', 'approved_at', 'expires_at']:
                     if job.get(field):
                         job[field] = job[field].isoformat()
+
+                # Parse JSONB columns from strings to dicts (psycopg2 returns JSONB as strings)
+                for json_field in ['progress', 'result', 'analysis', 'job_data']:
+                    if job.get(json_field) and isinstance(job[json_field], str):
+                        try:
+                            job[json_field] = json.loads(job[json_field])
+                        except json.JSONDecodeError:
+                            # If parsing fails, leave as None
+                            job[json_field] = None
 
                 # Rename error to error for consistency
                 job['error'] = job.pop('error', None)


### PR DESCRIPTION
# Fix: JSONB Deserialization in Job Queue

Fixes `kg jobs list` returning 500 Internal Server Error after the migration to unified `kg_api.jobs` table in ADR-050.

## Issue

After merging #85 (Scheduled Jobs System), the `kg jobs list` command returned 500 errors with Pydantic validation failures:

```
ValidationError: 3 validation errors for JobStatus
progress
  Input should be a valid dictionary or instance of JobProgress [type=model_type, input_value='{"stage": "processing"...', input_type=str]
result
  Input should be a valid dictionary or instance of JobResult [type=model_type, input_value='{"cost": {"total": "$0.1...', input_type=str]
analysis
  Input should be a valid dictionary [type=dict_type, input_value='{"config": {"max_words":...', input_type=str]
```

**Root Cause:** psycopg2's `RealDictCursor` returns PostgreSQL JSONB columns as strings, not parsed Python dictionaries.

## Solution

Added JSON parsing for JSONB columns (`progress`, `result`, `analysis`, `job_data`) in three methods:

### 1. `list_jobs()` (routes/jobs.py endpoint)
```python
# Parse JSONB columns from strings to dicts (psycopg2 returns JSONB as strings)
for json_field in ['progress', 'result', 'analysis', 'job_data']:
    if job.get(json_field) and isinstance(job[json_field], str):
        try:
            job[json_field] = json.loads(job[json_field])
        except json.JSONDecodeError:
            # If parsing fails, leave as None
            job[json_field] = None
```

### 2. `get_job()` (routes/jobs.py endpoint)
Same parsing logic for single job retrieval.

### 3. `check_duplicate()` (ingestion deduplication)
Same parsing logic for duplicate detection.

## Testing

✅ **Verified Fix:**
```bash
$ kg jobs list
# Returns 72 jobs in formatted table (no errors)

$ kg jobs get <job-id>
# Returns job details with properly parsed progress/result/analysis
```

## Impact

- **Non-breaking:** Only affects internal data deserialization
- **Backward compatible:** Graceful fallback to `None` on parse errors
- **Complete coverage:** Fixes all three job query methods

## Files Changed

- `src/api/services/job_queue.py` (+28 lines)
  - Added JSON parsing to `list_jobs()`
  - Added JSON parsing to `get_job()`
  - Added JSON parsing to `check_duplicate()`

## Related

- Fixes regression introduced in #85 (Scheduled Jobs System)
- Caused by migration from `ingestion_jobs` to unified `jobs` table