### PR TITLE
feat: track authenticated users in jobs

### DIFF
--- a/client/src/cli/jobs.ts
+++ b/client/src/cli/jobs.ts
@@ -90,11 +90,11 @@ async function displayJobsList(status?: string, clientId?: string, limit: number
         minWidth: fullId ? 38 : 20
       },
       {
-        header: 'Client',
-        field: 'client_id',
+        header: 'User',
+        field: 'username',
         type: 'user',
         width: 12,
-        customFormat: (id) => id || 'anonymous',
+        customFormat: (username) => username || 'unknown',
         truncate: true
       },
       {
@@ -148,9 +148,9 @@ async function displayJobsList(status?: string, clientId?: string, limit: number
 
 // List command with subcommands
 const listCommand = new Command('list')
-  .description('List recent jobs with optional filtering by status or client - includes subcommands for common filters')
+  .description('List recent jobs with optional filtering by status or user - includes subcommands for common filters')
   .option('-s, --status <status>', 'Filter by status (pending|awaiting_approval|approved|queued|processing|completed|failed|cancelled)')
-  .option('-c, --client <client-id>', 'Filter by client ID (view specific user\'s jobs in multi-tenant setups)')
+  .option('-c, --client <user-id>', 'Filter by user ID (view specific user\'s jobs)')
   .option('-l, --limit <n>', 'Maximum jobs to return (max: 500, default: 100)', '100')
   .option('-o, --offset <n>', 'Number of jobs to skip for pagination (default: 0)', '0')
   .option('--full-id', 'Show full job IDs without truncation', false)
@@ -171,7 +171,7 @@ const listCommand = new Command('list')
 listCommand
   .command('pending')
   .description('List jobs awaiting approval')
-  .option('-c, --client <client-id>', 'Filter by client ID')
+  .option('-c, --client <user-id>', 'Filter by user ID')
   .option('-l, --limit <n>', 'Maximum jobs to return', '20')
   .option('--full-id', 'Show full job IDs (no truncation)', false)
   .action(async (options) => {
@@ -188,7 +188,7 @@ listCommand
 listCommand
   .command('approved')
   .description('List approved jobs (queued or processing)')
-  .option('-c, --client <client-id>', 'Filter by client ID')
+  .option('-c, --client <user-id>', 'Filter by user ID')
   .option('-l, --limit <n>', 'Maximum jobs to return', '20')
   .option('--full-id', 'Show full job IDs (no truncation)', false)
   .action(async (options) => {
@@ -205,7 +205,7 @@ listCommand
 listCommand
   .command('done')
   .description('List completed jobs')
-  .option('-c, --client <client-id>', 'Filter by client ID')
+  .option('-c, --client <user-id>', 'Filter by user ID')
   .option('-l, --limit <n>', 'Maximum jobs to return', '20')
   .option('--full-id', 'Show full job IDs (no truncation)', false)
   .action(async (options) => {
@@ -222,7 +222,7 @@ listCommand
 listCommand
   .command('failed')
   .description('List failed jobs')
-  .option('-c, --client <client-id>', 'Filter by client ID')
+  .option('-c, --client <user-id>', 'Filter by user ID')
   .option('-l, --limit <n>', 'Maximum jobs to return', '20')
   .option('--full-id', 'Show full job IDs (no truncation)', false)
   .action(async (options) => {
@@ -239,7 +239,7 @@ listCommand
 listCommand
   .command('cancelled')
   .description('List cancelled jobs')
-  .option('-c, --client <client-id>', 'Filter by client ID')
+  .option('-c, --client <user-id>', 'Filter by user ID')
   .option('-l, --limit <n>', 'Maximum jobs to return', '20')
   .option('--full-id', 'Show full job IDs (no truncation)', false)
   .action(async (options) => {
@@ -285,7 +285,7 @@ approveCommand
 approveCommand
   .command('pending')
   .description('Approve all jobs awaiting approval (batch operation with confirmation)')
-  .option('-c, --client <client-id>', 'Filter by client ID for multi-tenant environments')
+  .option('-c, --client <user-id>', 'Filter by user ID')
   .option('-l, --limit <n>', 'Maximum jobs to approve (default: 100)', '100')
   .action(async (options) => {
     try {
@@ -328,7 +328,7 @@ approveCommand
 approveCommand
   .command('filter <status>')
   .description('Approve all jobs matching status filter')
-  .option('-c, --client <client-id>', 'Filter by client ID')
+  .option('-c, --client <user-id>', 'Filter by user ID')
   .action(async (statusFilter: string, options) => {
       try {
         const client = createClientFromEnv();
@@ -378,7 +378,7 @@ jobsCommand
   .command('cancel <job-id-or-filter>')
   .description('Cancel a specific job by ID or batch cancel using filters (all, pending, running, queued, approved)')
   .showHelpAfterError()
-  .option('-c, --client <client-id>', 'Filter by client ID for batch operations in multi-tenant setups')
+  .option('-c, --client <user-id>', 'Filter by user ID for batch operations')
   .option('-l, --limit <n>', 'Maximum jobs to cancel for safety (default: 100)', '100')
   .action(async (jobIdOrFilter: string, options) => {
     try {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -62,6 +62,8 @@ export interface JobStatus {
   job_id: string;
   job_type: string;
   status: 'pending' | 'awaiting_approval' | 'approved' | 'queued' | 'processing' | 'completed' | 'failed' | 'cancelled';
+  user_id?: number;  // User ID who submitted the job (from kg_auth.users)
+  username?: string;  // Username who submitted the job
   progress?: JobProgress;
   result?: JobResult;
   error?: string;
@@ -70,7 +72,7 @@ export interface JobStatus {
   completed_at?: string;
   content_hash?: string;
   ontology?: string;
-  client_id?: string;
+  client_id?: string;  // DEPRECATED: kept for backwards compatibility, use user_id instead
   processing_mode?: string;  // Serial or parallel processing
   analysis?: any;  // Pre-ingestion analysis (ADR-014)
   approved_at?: string;

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -397,7 +397,7 @@ kg job [options]
 **Subcommands:**
 
 - `status` - Get detailed status information for a job (progress, costs, errors) - use --watch to poll until completion
-- `list` - List recent jobs with optional filtering by status or client - includes subcommands for common filters
+- `list` - List recent jobs with optional filtering by status or user - includes subcommands for common filters
 - `approve` - Approve jobs for processing (ADR-014 approval workflow) - single job, batch pending, or filter by status
 - `cancel` - Cancel a specific job by ID or batch cancel using filters (all, pending, running, queued, approved)
 - `clear` - Clear ALL jobs from database - DESTRUCTIVE operation requiring --confirm flag (use for dev/testing cleanup)
@@ -425,7 +425,7 @@ kg status <job-id>
 
 ### list
 
-List recent jobs with optional filtering by status or client - includes subcommands for common filters
+List recent jobs with optional filtering by status or user - includes subcommands for common filters
 
 **Usage:**
 ```bash
@@ -437,7 +437,7 @@ kg list [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-s, --status <status>` | Filter by status (pending|awaiting_approval|approved|queued|processing|completed|failed|cancelled) | - |
-| `-c, --client <client-id>` | Filter by client ID (view specific user's jobs in multi-tenant setups) | - |
+| `-c, --client <user-id>` | Filter by user ID (view specific user's jobs) | - |
 | `-l, --limit <n>` | Maximum jobs to return (max: 500, default: 100) | `"100"` |
 | `-o, --offset <n>` | Number of jobs to skip for pagination (default: 0) | `"0"` |
 | `--full-id` | Show full job IDs without truncation | `false` |
@@ -465,7 +465,7 @@ kg pending [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -482,7 +482,7 @@ kg approved [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -499,7 +499,7 @@ kg done [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -516,7 +516,7 @@ kg failed [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -533,7 +533,7 @@ kg cancelled [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -580,7 +580,7 @@ kg pending [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID for multi-tenant environments | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to approve (default: 100) | `"100"` |
 
 #### filter
@@ -600,7 +600,7 @@ kg filter <status>
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 
 ### cancel
 
@@ -619,7 +619,7 @@ kg cancel <job-id-or-filter>
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID for batch operations in multi-tenant setups | - |
+| `-c, --client <user-id>` | Filter by user ID for batch operations | - |
 | `-l, --limit <n>` | Maximum jobs to cancel for safety (default: 100) | `"100"` |
 
 ### clear

--- a/docs/reference/cli/commands/job.md
+++ b/docs/reference/cli/commands/job.md
@@ -14,7 +14,7 @@ kg job [options]
 **Subcommands:**
 
 - `status` - Get detailed status information for a job (progress, costs, errors) - use --watch to poll until completion
-- `list` - List recent jobs with optional filtering by status or client - includes subcommands for common filters
+- `list` - List recent jobs with optional filtering by status or user - includes subcommands for common filters
 - `approve` - Approve jobs for processing (ADR-014 approval workflow) - single job, batch pending, or filter by status
 - `cancel` - Cancel a specific job by ID or batch cancel using filters (all, pending, running, queued, approved)
 - `clear` - Clear ALL jobs from database - DESTRUCTIVE operation requiring --confirm flag (use for dev/testing cleanup)
@@ -42,7 +42,7 @@ kg status <job-id>
 
 ### list
 
-List recent jobs with optional filtering by status or client - includes subcommands for common filters
+List recent jobs with optional filtering by status or user - includes subcommands for common filters
 
 **Usage:**
 ```bash
@@ -54,7 +54,7 @@ kg list [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-s, --status <status>` | Filter by status (pending|awaiting_approval|approved|queued|processing|completed|failed|cancelled) | - |
-| `-c, --client <client-id>` | Filter by client ID (view specific user's jobs in multi-tenant setups) | - |
+| `-c, --client <user-id>` | Filter by user ID (view specific user's jobs) | - |
 | `-l, --limit <n>` | Maximum jobs to return (max: 500, default: 100) | `"100"` |
 | `-o, --offset <n>` | Number of jobs to skip for pagination (default: 0) | `"0"` |
 | `--full-id` | Show full job IDs without truncation | `false` |
@@ -82,7 +82,7 @@ kg pending [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -99,7 +99,7 @@ kg approved [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -116,7 +116,7 @@ kg done [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -133,7 +133,7 @@ kg failed [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -150,7 +150,7 @@ kg cancelled [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to return | `"20"` |
 | `--full-id` | Show full job IDs (no truncation) | `false` |
 
@@ -197,7 +197,7 @@ kg pending [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID for multi-tenant environments | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 | `-l, --limit <n>` | Maximum jobs to approve (default: 100) | `"100"` |
 
 #### filter
@@ -217,7 +217,7 @@ kg filter <status>
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID | - |
+| `-c, --client <user-id>` | Filter by user ID | - |
 
 ### cancel
 
@@ -236,7 +236,7 @@ kg cancel <job-id-or-filter>
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-c, --client <client-id>` | Filter by client ID for batch operations in multi-tenant setups | - |
+| `-c, --client <user-id>` | Filter by user ID for batch operations | - |
 | `-l, --limit <n>` | Maximum jobs to cancel for safety (default: 100) | `"100"` |
 
 ### clear

--- a/schema/migrations/020_track_authenticated_users_in_jobs.sql
+++ b/schema/migrations/020_track_authenticated_users_in_jobs.sql
@@ -1,0 +1,60 @@
+-- Migration 020: Track Authenticated Users in Jobs
+-- Convert jobs.client_id from TEXT to INTEGER and link to kg_auth.users
+--
+-- Context:
+-- - Previously jobs used client_id TEXT with placeholder value "anonymous"
+-- - Now jobs should track the authenticated user from JWT tokens
+-- - Leverages existing kg_auth.users table (id SERIAL PRIMARY KEY)
+-- - Admin user is id=1 for simplicity (no UUIDs needed)
+--
+-- Changes:
+-- 1. Ensure admin user exists with id=1
+-- 2. Convert client_id TEXT → INTEGER (map "anonymous" → 1)
+-- 3. Add foreign key to kg_auth.users
+-- 4. Rename client_id → user_id for clarity
+--
+-- Related: Authentication system (ADR-027, ADR-028)
+
+BEGIN;
+
+-- Step 1: Ensure admin user exists with predictable id=1
+-- (Safe with ON CONFLICT - won't override if already exists)
+INSERT INTO kg_auth.users (id, username, password_hash, primary_role, created_at)
+VALUES (
+    1,
+    'admin',
+    '$2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewY5oCDxDO1b5tZK',  -- password: 'admin' (CHANGE IN PRODUCTION!)
+    'admin',
+    NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Reset sequence to ensure next user gets id > 1
+SELECT setval('kg_auth.users_id_seq', (SELECT COALESCE(MAX(id), 1) FROM kg_auth.users));
+
+-- Step 2: Add temporary column for integer user IDs
+ALTER TABLE kg_api.jobs
+    ADD COLUMN user_id INTEGER;
+
+-- Step 3: Migrate existing data
+-- Map all "anonymous" entries to admin user (id=1)
+-- Any other values also map to admin (cleanup weird data)
+UPDATE kg_api.jobs
+SET user_id = 1;
+
+-- Step 4: Make user_id NOT NULL and add foreign key
+ALTER TABLE kg_api.jobs
+    ALTER COLUMN user_id SET NOT NULL,
+    ADD CONSTRAINT fk_jobs_user FOREIGN KEY (user_id) REFERENCES kg_auth.users(id);
+
+-- Step 5: Drop old client_id column
+ALTER TABLE kg_api.jobs
+    DROP COLUMN client_id;
+
+-- Step 6: Add index for performance (user's jobs lookup)
+CREATE INDEX idx_jobs_user_id ON kg_api.jobs(user_id);
+
+-- Add comment for documentation
+COMMENT ON COLUMN kg_api.jobs.user_id IS 'User who submitted the job (FK to kg_auth.users.id)';
+
+COMMIT;

--- a/src/api/models/job.py
+++ b/src/api/models/job.py
@@ -53,6 +53,8 @@ class JobStatus(BaseModel):
     job_id: str = Field(..., description="Unique job identifier")
     job_type: str = Field(..., description="Type of job")
     status: str = Field(..., description="Job status: pending|awaiting_approval|approved|queued|processing|completed|failed|cancelled")
+    user_id: Optional[int] = Field(None, description="User ID who submitted the job (from kg_auth.users)")
+    username: Optional[str] = Field(None, description="Username who submitted the job")
     progress: Optional[JobProgress] = Field(None, description="Progress information")
     result: Optional[JobResult] = Field(None, description="Result data (if completed)")
     error: Optional[str] = Field(None, description="Error message (if failed)")

--- a/src/api/routes/ingest.py
+++ b/src/api/routes/ingest.py
@@ -17,7 +17,8 @@ from ..services.content_hasher import ContentHasher
 from ..services.job_analysis import JobAnalyzer
 from ..models.ingest import IngestionOptions
 from ..models.job import JobSubmitResponse, DuplicateJobResponse
-from ..middleware.auth import get_current_user
+from ..dependencies.auth import get_current_active_user
+from ..models.auth import UserInDB
 
 router = APIRouter(prefix="/ingest", tags=["ingestion"])
 
@@ -124,7 +125,7 @@ async def ingest_document(
     min_words: Optional[int] = Form(None, description="Minimum words per chunk"),
     max_words: Optional[int] = Form(None, description="Maximum words per chunk"),
     overlap_words: int = Form(200, description="Overlap between chunks"),
-    current_user: dict = Depends(get_current_user)  # Auth placeholder
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Submit a document for async ingestion into the knowledge graph with approval workflow.
@@ -243,7 +244,7 @@ async def ingest_document(
         "content_hash": content_hash,
         "ontology": ontology,
         "filename": use_filename,
-        "client_id": current_user["client_id"],  # Track job owner
+        "user_id": current_user.id,  # Track job owner (user ID from kg_auth.users)
         "processing_mode": processing_mode,
         "options": {
             "target_words": options.target_words,
@@ -285,7 +286,7 @@ async def ingest_text(
     processing_mode: str = Form("serial", description="Processing mode: serial or parallel (default: serial for clean concept matching)"),
     target_words: int = Form(1000, description="Target words per chunk"),
     overlap_words: int = Form(200, description="Overlap between chunks"),
-    current_user: dict = Depends(get_current_user)  # Auth placeholder
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Submit raw text content for async ingestion into the knowledge graph.
@@ -354,7 +355,7 @@ async def ingest_text(
         "content_hash": content_hash,
         "ontology": ontology,
         "filename": use_filename,
-        "client_id": current_user["client_id"],  # Track job owner
+        "user_id": current_user.id,  # Track job owner (user ID from kg_auth.users)
         "processing_mode": processing_mode,
         "options": {
             "target_words": target_words,

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -64,7 +64,7 @@ async def list_jobs(
         None,
         description="Filter by status (pending|awaiting_approval|approved|queued|processing|completed|failed|cancelled)"
     ),
-    client_id: Optional[str] = Query(
+    user_id: Optional[str] = Query(
         None,
         description="Filter by client ID (ADR-014: view specific user's jobs)"
     ),
@@ -73,24 +73,24 @@ async def list_jobs(
     current_user: dict = Depends(get_current_user)  # Auth placeholder
 ):
     """
-    List recent jobs, optionally filtered by status and/or client_id.
+    List recent jobs, optionally filtered by status and/or user_id.
 
     Useful for:
     - Viewing jobs awaiting approval: `?status=awaiting_approval`
-    - Viewing your own jobs: `?client_id=your-client-id`
-    - Viewing another user's jobs: `?client_id=other-user`
+    - Viewing your own jobs: `?user_id=your-client-id`
+    - Viewing another user's jobs: `?user_id=other-user`
     - Monitoring queue backlog
     - Debugging failed jobs
 
     Examples:
     - `GET /jobs?status=awaiting_approval` - Jobs needing approval
-    - `GET /jobs?client_id=alice&status=awaiting_approval` - Alice's pending jobs
+    - `GET /jobs?user_id=alice&status=awaiting_approval` - Alice's pending jobs
     - `GET /jobs?status=completed&limit=100` - Last 100 completed jobs
     """
     queue = get_job_queue()
-    jobs = queue.list_jobs(status=status, client_id=client_id, limit=limit, offset=offset)
+    jobs = queue.list_jobs(status=status, user_id=user_id, limit=limit, offset=offset)
 
-    # Phase 2: Enforce ownership filtering based on current_user.client_id
+    # Phase 2: Enforce ownership filtering based on current_user.user_id
     # For now, allow viewing all jobs (no filtering enforcement)
 
     return [JobStatus(**job) for job in jobs]


### PR DESCRIPTION
## Summary

Replace placeholder "anonymous" client_id with authenticated user tracking throughout the job system.

## Changes

**Database Migration (020)**
- Convert `jobs.client_id` TEXT → `user_id` INTEGER FK
- Links to existing `kg_auth.users.id` table (INTEGER primary key)
- Admin user ensured at id=1 for emergency access
- All existing jobs migrated to admin user (id=1)
- Added index on `user_id` for query performance

**API Changes**
- Switch ingestion endpoints to use real JWT auth (`dependencies/auth.py`)
- `JobStatus` model adds `user_id` and `username` fields
- Job queue queries LEFT JOIN with `kg_auth.users` to return username
- All job endpoints return username for convenience

**CLI Changes**
- Jobs list displays "User" column with username (was "Client")
- TypeScript types updated to include `user_id` and `username` fields
- Option descriptions updated to use "user" terminology

## Test Plan

✅ Migration 020 applied successfully
✅ Database schema verified (user_id column, FK constraint, index)
✅ Existing jobs show "admin" username
✅ New jobs via CLI capture authenticated user ("aaron")
✅ New jobs via MCP server capture authenticated user ("aaron")
✅ Jobs list displays username correctly
✅ Jobs status detail works correctly

## Related

- Uses existing auth infrastructure from ADR-027 (User Management) and ADR-028 (Dynamic RBAC)
- Follows migration pattern from previous database changes
- MCP server remains auth-unaware but correctly passes through JWT tokens