### PR TITLE
security: fix shell injection vulnerability in dev entrypoint

### DIFF
--- a/web/docker-entrypoint-dev.sh
+++ b/web/docker-entrypoint-dev.sh
@@ -6,22 +6,36 @@ set -e
 
 echo "Generating runtime configuration from environment variables..."
 
+# Escape function: Escapes single quotes and backslashes for JavaScript strings
+# Usage: escape_js "some'value"
+escape_js() {
+  printf '%s' "$1" | sed "s/\\\\/\\\\\\\\/g; s/'/\\\'/g"
+}
+
+# Set defaults and escape values
+API_URL=$(escape_js "${VITE_API_URL:-http://localhost:8000}")
+OAUTH_CLIENT_ID=$(escape_js "${VITE_OAUTH_CLIENT_ID:-kg-viz}")
+OAUTH_REDIRECT_URI=$(escape_js "${VITE_OAUTH_REDIRECT_URI:-http://localhost:3000/callback}")
+APP_NAME=$(escape_js "${VITE_APP_NAME:-Knowledge Graph Visualizer}")
+APP_VERSION=$(escape_js "${VITE_APP_VERSION:-1.0.0}")
+
 # Create config.js from environment variables in public directory (served by Vite)
+# Using escaped values to prevent injection
 cat > /app/public/config.js <<EOF
 // Runtime Configuration - Generated from Docker environment variables
 // DO NOT EDIT - This file is auto-generated at container startup
 
 window.APP_CONFIG = {
-  apiUrl: '${VITE_API_URL:-http://localhost:8000}',
+  apiUrl: '${API_URL}',
 
   oauth: {
-    clientId: '${VITE_OAUTH_CLIENT_ID:-kg-viz}',
-    redirectUri: '${VITE_OAUTH_REDIRECT_URI:-http://localhost:3000/callback}',
+    clientId: '${OAUTH_CLIENT_ID}',
+    redirectUri: '${OAUTH_REDIRECT_URI}',
   },
 
   app: {
-    name: '${VITE_APP_NAME:-Knowledge Graph Visualizer}',
-    version: '${VITE_APP_VERSION:-1.0.0}',
+    name: '${APP_NAME}',
+    version: '${APP_VERSION}',
   },
 };
 EOF


### PR DESCRIPTION
Fixes shell injection vulnerability in web/docker-entrypoint-dev.sh identified during code review of PR #116.

Added escape_js() function that properly escapes backslashes and single quotes before injecting environment variables into JavaScript config file.

Impact: Low severity (dev-only container, controlled env vars)
Defense-in-depth best practice to prevent potential code injection.

Addresses code review feedback from PR #116