### PR TITLE
feat: Add dark mode theme switcher to web app

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { OAuthCallback } from './components/auth/OAuthCallback';
 import { useGraphStore } from './store/graphStore';
 import { useVocabularyStore } from './store/vocabularyStore';
 import { useAuthStore } from './store/authStore';
+import { useThemeStore } from './store/themeStore';
 import { useSubgraph, useFindConnection } from './hooks/useGraphData';
 import { getExplorer } from './explorers';
 import { apiClient } from './api/client';
@@ -33,6 +34,12 @@ const AppContent: React.FC = () => {
   const { selectedExplorer, searchParams, graphData: storeGraphData, rawGraphData, setGraphData, setRawGraphData, queryMode, blockBuilderExpanded } = useGraphStore();
   const { setTypes, setLoading, setError } = useVocabularyStore();
   const { checkAuth } = useAuthStore();
+  const { theme, setTheme } = useThemeStore();
+
+  // Initialize theme on mount
+  useEffect(() => {
+    setTheme(theme);
+  }, []);
 
   // Check authentication status on mount
   useEffect(() => {

--- a/web/src/components/shared/UserProfile.tsx
+++ b/web/src/components/shared/UserProfile.tsx
@@ -7,12 +7,14 @@
  */
 
 import React, { useState, useRef, useEffect } from 'react';
-import { User, LogIn, LogOut, Shield } from 'lucide-react';
+import { User, LogIn, LogOut, Shield, Moon, Sun } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
+import { useThemeStore } from '../../store/themeStore';
 import { LoginModal } from '../auth/LoginModal';
 
 export const UserProfile: React.FC = () => {
   const { user, isAuthenticated, isLoading, error, logout, clearError } = useAuthStore();
+  const { theme, toggleTheme } = useThemeStore();
   const [isOpen, setIsOpen] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -65,14 +67,23 @@ export const UserProfile: React.FC = () => {
   if (!isAuthenticated) {
     return (
       <>
-        <button
-          onClick={handleLogin}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-          title="Login with OAuth 2.0"
-        >
-          <LogIn className="w-4 h-4" />
-          <span>Login</span>
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={toggleTheme}
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
+            title={theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+          >
+            {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+          </button>
+          <button
+            onClick={handleLogin}
+            className="flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
+            title="Login with OAuth 2.0"
+          >
+            <LogIn className="w-4 h-4" />
+            <span>Login</span>
+          </button>
+        </div>
         <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       </>
     );
@@ -90,9 +101,9 @@ export const UserProfile: React.FC = () => {
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-lg overflow-hidden z-50">
+        <div className="absolute right-0 mt-2 w-64 bg-background border border-border rounded-lg shadow-lg overflow-hidden z-50">
           {/* User Info Header */}
-          <div className="px-4 py-3 border-b border-border bg-accent/50">
+          <div className="px-4 py-3 border-b border-border bg-accent">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center">
                 <User className="w-5 h-5 text-primary" />
@@ -128,6 +139,22 @@ export const UserProfile: React.FC = () => {
 
           {/* Actions */}
           <div className="border-t border-border">
+            <button
+              onClick={toggleTheme}
+              className="w-full flex items-center gap-2 px-4 py-2 hover:bg-accent hover:text-accent-foreground transition-colors text-left"
+            >
+              {theme === 'dark' ? (
+                <>
+                  <Sun className="w-4 h-4" />
+                  <span>Light Mode</span>
+                </>
+              ) : (
+                <>
+                  <Moon className="w-4 h-4" />
+                  <span>Dark Mode</span>
+                </>
+              )}
+            </button>
             <button
               onClick={handleLogout}
               className="w-full flex items-center gap-2 px-4 py-2 hover:bg-accent hover:text-accent-foreground transition-colors text-left"

--- a/web/src/store/themeStore.ts
+++ b/web/src/store/themeStore.ts
@@ -1,0 +1,54 @@
+/**
+ * Theme Store
+ *
+ * Manages theme state (light/dark mode) with localStorage persistence.
+ */
+
+import { create } from 'zustand';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeStore {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+// Get initial theme from localStorage or default to light
+const getInitialTheme = (): Theme => {
+  if (typeof window === 'undefined') return 'light';
+
+  const stored = localStorage.getItem('kg-theme');
+  if (stored === 'dark' || stored === 'light') {
+    return stored;
+  }
+
+  // Check system preference as fallback
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+
+  return 'light';
+};
+
+export const useThemeStore = create<ThemeStore>((set, get) => ({
+  theme: getInitialTheme(),
+
+  setTheme: (theme: Theme) => {
+    localStorage.setItem('kg-theme', theme);
+    set({ theme });
+
+    // Apply theme class to document root
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  },
+
+  toggleTheme: () => {
+    const currentTheme = get().theme;
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    get().setTheme(newTheme);
+  },
+}));

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary

Implements a dark/light mode theme switcher for the web visualization app with localStorage persistence. Users can now toggle between themes using a sun/moon icon in the upper right corner.

**Key features:**
- Theme state management using Zustand store
- Persists theme preference in localStorage
- Accessible for both authenticated and non-authenticated users
- Smooth transitions between light and dark modes
- Utilizes existing CSS variables already defined in index.css

## Changes

- **New file:** `src/store/themeStore.ts` - Zustand store for theme state management
- **Modified:** `src/App.tsx` - Initialize theme on app mount
- **Modified:** `src/components/shared/UserProfile.tsx` - Added theme toggle buttons (sun/moon icons)
- **Modified:** `tailwind.config.js` - Enabled class-based dark mode strategy
- **Fixed:** User menu dropdown backgrounds for better readability in both themes

## Screenshots

The theme toggle appears in the user menu (authenticated users) or next to the login button (non-authenticated users). Clicking toggles between light and dark modes instantly.

## Test plan

- [x] Theme toggles from light to dark mode
- [x] Theme toggles from dark to light mode
- [x] Theme preference persists after page reload
- [x] Theme toggle works for authenticated users (in dropdown menu)
- [x] Theme toggle works for non-authenticated users (icon button)
- [x] Dropdown menu is readable in both light and dark modes
- [x] All UI components properly styled in both themes
- [x] CSS variables correctly applied via Tailwind classes

## Notes

- Uses existing dark mode CSS variables already defined in `index.css`
- No breaking changes - purely additive feature
- Hot reload confirmed working during development