### PR TITLE
fix: resolve vocab CLI auth issues (#131, #132)

### DIFF
--- a/api/api/routes/vocabulary.py
+++ b/api/api/routes/vocabulary.py
@@ -1039,7 +1039,7 @@ async def analyze_vocabulary_type(
         category_fit = category_scores.get(target_category, 0.0)
 
         # Get all similarities
-        similarity_response = await get_similar_types(relationship_type, limit=100, reverse=False)
+        similarity_response = await get_similar_types(relationship_type, current_user, limit=100, reverse=False)
         all_similar = similarity_response.similar_types
 
         # Split by category

--- a/cli/src/cli/vocabulary.ts
+++ b/cli/src/cli/vocabulary.ts
@@ -806,11 +806,11 @@ export const vocabularyCommand = setCommandHelp(
           try {
             const client = createClientFromEnv();
 
-            // Get logged-in user from auth token
+            // Get logged-in user from OAuth credentials
             const { getConfig } = require('../lib/config');
             const configManager = getConfig();
-            const authToken = configManager.getAuthToken();
-            const username = authToken?.username || 'cli-user';
+            const credentials = configManager.getOAuthCredentials();
+            const username = credentials?.username || 'cli-user';
 
             const updates: any = {
               updated_by: username


### PR DESCRIPTION
## Summary
- **#131**: Fixed `kg vocab config` - changed `getAuthToken()` to `getOAuthCredentials()` in vocabulary.ts
- **#132**: Fixed `kg vocab analyze` - added missing `current_user` parameter to `get_similar_types()` call

## Test plan
- [x] Verified `kg vocab config vocab_max 90` works
- [x] Verified `kg vocab analyze SUPPORTS` works

Closes #131, #132