### PR TITLE
feat(admin): add user and role management UI (ADR-074)

### DIFF
--- a/api/api/models/auth.py
+++ b/api/api/models/auth.py
@@ -304,6 +304,38 @@ class ValidationError(BaseModel):
 
 
 # =============================================================================
+# Password Reset Models
+# =============================================================================
+
+class AdminPasswordReset(BaseModel):
+    """Admin password reset request - sets a new password for a user"""
+    new_password: str = Field(..., min_length=8, description="New password for the user")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "new_password": "NewSecurePass456!"
+            }]
+        }
+    }
+
+
+class PasswordResetResponse(BaseModel):
+    """Password reset response"""
+    success: bool = Field(..., description="Whether the reset was successful")
+    message: str = Field(..., description="Result message")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "message": "Password reset successfully"
+            }]
+        }
+    }
+
+
+# =============================================================================
 # Pagination Models (for admin user list)
 # =============================================================================
 

--- a/schema/migrations/028_platform_admin_resources.sql
+++ b/schema/migrations/028_platform_admin_resources.sql
@@ -169,4 +169,9 @@ VALUES
     ('platform_admin', 'graph', 'execute', 'global', TRUE)
 ON CONFLICT DO NOTHING;
 
+-- Record migration (idempotent)
+INSERT INTO public.schema_migrations (version, name)
+VALUES (28, 'platform_admin_resources')
+ON CONFLICT (version) DO NOTHING;
+
 COMMIT;

--- a/schema/migrations/029_fix_role_hierarchy.sql
+++ b/schema/migrations/029_fix_role_hierarchy.sql
@@ -28,4 +28,9 @@ SET parent_role = 'admin'
 WHERE role_name = 'platform_admin'
   AND (parent_role IS NULL OR parent_role != 'admin');
 
+-- Record migration (idempotent)
+INSERT INTO public.schema_migrations (version, name)
+VALUES (29, 'fix_role_hierarchy')
+ON CONFLICT (version) DO NOTHING;
+
 COMMIT;

--- a/schema/migrations/030_users_create_permission.sql
+++ b/schema/migrations/030_users_create_permission.sql
@@ -1,0 +1,31 @@
+-- Migration 030: Add 'create' action to users resource type
+-- Supports POST /users endpoint for admin user creation (ADR-074 enhancement)
+--
+-- Idempotent: Safe to run multiple times
+
+BEGIN;
+
+-- Update users resource to include 'create' action (idempotent - just sets the value)
+UPDATE kg_auth.resources
+SET available_actions = ARRAY['read', 'write', 'delete', 'create']
+WHERE resource_type = 'users';
+
+-- Grant users:create to admin role (inherits to platform_admin)
+-- Idempotent: only insert if not exists
+INSERT INTO kg_auth.role_permissions (role_name, resource_type, action, scope_type, granted)
+SELECT 'admin', 'users', 'create', 'global', TRUE
+WHERE NOT EXISTS (
+    SELECT 1 FROM kg_auth.role_permissions
+    WHERE role_name = 'admin'
+      AND resource_type = 'users'
+      AND action = 'create'
+      AND scope_type = 'global'
+      AND scope_id IS NULL
+);
+
+-- Record migration (idempotent)
+INSERT INTO public.schema_migrations (version, name)
+VALUES (30, 'users_create_permission')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **User Management**: Add complete user CRUD operations in the Admin Dashboard
  - Create users with username, email, password, and role assignment
  - Edit user details (username, email, role)
  - Delete users with confirmation modal
  - Reset passwords via admin action

- **Role Management**: Add new Roles tab between Users and System in Admin Dashboard
  - View all roles with inheritance hierarchy display
  - Create custom roles with optional parent role (inherits permissions)
  - Expand roles to view/manage individual permissions
  - Grant permissions by selecting resource → action
  - Revoke permissions with confirmation
  - Delete custom roles (built-in roles protected)
  - Resources reference panel showing all available resources and actions

- **API Endpoints**: Add POST /users and POST /users/{id}/reset-password
- **Database**: Add migration 030 for users:create permission

## Design Notes (per ADR-074)

- Platform admin has full RBAC control without guardrails
- Admins can accidentally lock themselves out (intentional)
- Role inheritance: child roles inherit all parent permissions
- Built-in roles (admin, contributor, curator, platform_admin, read_only) cannot be deleted

## Test plan

- [ ] Login as platform_admin
- [ ] Navigate to Admin → Users tab
- [ ] Create a new user with a role
- [ ] Edit the user's details
- [ ] Reset the user's password
- [ ] Delete the test user
- [ ] Navigate to Admin → Roles tab
- [ ] View role hierarchy and permissions
- [ ] Create a custom role with parent inheritance
- [ ] Expand role and grant a new permission
- [ ] Revoke a permission
- [ ] Delete the custom role
- [ ] Toggle Resources panel to view available resources/actions