### PR TITLE
feat(web): add Reports workspace for tabular graph/polarity data

### DIFF
--- a/docs/TODO-reports-feature.md
+++ b/docs/TODO-reports-feature.md
@@ -1,0 +1,133 @@
+# Reports Feature Implementation
+
+Send graph/polarity data from explorers to a tabular Reports view.
+
+## Architecture
+
+```
+Explorers (2D, 3D, Polarity)
+    ↓ "Send to Reports" button
+Report Store (Zustand + localStorage)
+    ↓
+Report Workspace (IconRailPanel + Table Views)
+    ↓
+Copy/Export (JSON, CSV, Markdown)
+```
+
+## Implementation Checklist
+
+### Phase 1: Core Infrastructure
+
+- [x] Create `reportStore.ts` with Zustand + persist
+  - Report types: `graph` | `polarity`
+  - CRUD operations: add, delete, rename, select
+  - localStorage persistence
+  - Delta tracking with previousValues for recalculation
+
+- [x] Update `ReportWorkspace.tsx`
+  - IconRailPanel with tabs: Reports (list), Settings
+  - Center: Table view of selected report
+  - Empty state when no reports
+
+### Phase 2: Table Views
+
+- [x] Graph Report Table View
+  - Concepts table (label, description, ontology, grounding, diversity)
+  - Relationships table (source, type, target, category, confidence)
+  - Sortable columns (all columns clickable to sort)
+  - Query info display (mode, center concept, depth)
+
+- [x] Polarity Report Table View
+  - Axis info (poles, magnitude)
+  - Concepts table (label, position, similarities, grounding)
+  - Direction distribution summary
+  - Sortable columns
+
+### Phase 3: Send to Reports Buttons
+
+- [x] 2D Explorer: Add "Send to Reports" button
+  - Capture current graph state from `useGraphStore`
+  - Navigate to `/report` after sending
+
+- [x] 3D Explorer: Add "Send to Reports" button
+  - Same as 2D
+
+- [x] Polarity Explorer: Add "Send to Reports" button
+  - Capture polarity analysis result
+  - Include axis definition and projections
+
+### Phase 4: Copy/Export
+
+- [x] Copy as JSON button
+- [x] Copy as CSV button
+- [x] Copy as Markdown button
+- [x] Download as file option
+
+### Phase 5: Polish
+
+- [x] Report naming/renaming (double-click to edit)
+- [x] Delete confirmation
+- [x] Recalculate button with progress indicator
+- [x] Delta indicators (↑ green, ↓ red, – flat)
+- [x] "Computed at" timestamp display
+- [ ] Keyboard shortcuts (Ctrl+C for copy)
+- [ ] Empty state illustrations
+
+## Files Created/Modified
+
+| File | Action | Description |
+|------|--------|-------------|
+| `web/src/store/reportStore.ts` | Created | Zustand store with delta tracking |
+| `web/src/components/report/ReportWorkspace.tsx` | Modified | Full workspace with tables, sorting, recalculate |
+| `web/src/views/ExplorerView.tsx` | Modified | Added Send to Reports button |
+| `web/src/components/polarity/PolarityExplorerWorkspace.tsx` | Modified | Added Send to Reports button |
+
+## Data Flow
+
+### Graph Report
+```typescript
+// From graphStore
+const { rawGraphData, searchParams } = useGraphStore();
+
+// Transform to report
+const report: GraphReportData = {
+  type: 'graph',
+  nodes: rawGraphData.nodes.map(n => ({
+    id: n.id,
+    label: n.label,
+    description: n.description,
+    ontology: n.ontology,
+    grounding_strength: n.grounding_strength,
+    diversity_score: n.diversity_score,
+  })),
+  links: rawGraphData.links,
+  searchParams: { ... }
+};
+```
+
+### Polarity Report
+```typescript
+// From polarityState.analysisHistory[selected]
+const analysis = polarityState.analysisHistory.find(a => a.id === selectedAnalysisId);
+
+// Transform to report
+const report: PolarityReportData = {
+  type: 'polarity',
+  positivePole: { ... },
+  negativePole: { ... },
+  axisMagnitude: analysis.result.axis_quality.magnitude,
+  concepts: analysis.result.projections,
+  directionDistribution: analysis.result.direction_distribution,
+};
+```
+
+### Recalculate Flow
+```typescript
+// Fetch full concept details for all nodes
+const details = await apiClient.getConceptDetails(node.id);
+
+// Enrich nodes with grounding, diversity, description
+// Enrich links with confidence, category from relationships
+// Store previous values for delta comparison
+updateReportData(id, newData);
+```

--- a/web/src/components/report/ReportWorkspace.tsx
+++ b/web/src/components/report/ReportWorkspace.tsx
@@ -1,42 +1,914 @@
 /**
  * Report Workspace
  *
- * Tabular and export views for query results.
+ * Tabular views of graph/polarity data sent from explorers.
+ * Uses IconRailPanel for saved reports list navigation.
  */
 
-import React from 'react';
-import { FileText } from 'lucide-react';
-import { WorkspacePlaceholder } from '../shared/WorkspacePlaceholder';
+import React, { useState, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronUp, ChevronDown } from 'lucide-react';
+import {
+  FileText,
+  FolderOpen,
+  Trash2,
+  Clock,
+  Copy,
+  Download,
+  Table2,
+  GitBranch,
+  Compass,
+  Settings2,
+  CheckCircle2,
+  RefreshCw,
+  Loader2,
+} from 'lucide-react';
+import { IconRailPanel } from '../shared/IconRailPanel';
+import { apiClient } from '../../api/client';
+import {
+  useReportStore,
+  type Report,
+  type GraphReportData,
+  type PolarityReportData,
+  type PreviousValues,
+} from '../../store/reportStore';
+
+// Format utilities
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+// Sort types for tables
+type SortField = string;
+type SortDirection = 'asc' | 'desc' | null;
+
+interface SortState {
+  field: SortField | null;
+  direction: SortDirection;
+}
+
+// Sortable column header component
+const SortableHeader: React.FC<{
+  field: string;
+  label: string;
+  sortState: SortState;
+  onSort: (field: string) => void;
+  align?: 'left' | 'right' | 'center';
+}> = ({ field, label, sortState, onSort, align = 'left' }) => {
+  const isActive = sortState.field === field;
+  const alignClass = align === 'right' ? 'justify-end' : align === 'center' ? 'justify-center' : 'justify-start';
+
+  return (
+    <th
+      className={`px-3 py-2 font-medium cursor-pointer hover:bg-muted/70 select-none text-${align}`}
+      onClick={() => onSort(field)}
+    >
+      <div className={`flex items-center gap-1 ${alignClass}`}>
+        <span>{label}</span>
+        <span className="w-3">
+          {isActive && sortState.direction === 'asc' && <ChevronUp className="w-3 h-3" />}
+          {isActive && sortState.direction === 'desc' && <ChevronDown className="w-3 h-3" />}
+        </span>
+      </div>
+    </th>
+  );
+};
+
+// Generic sort function
+const sortData = <T,>(data: T[], field: string, direction: SortDirection): T[] => {
+  if (!direction || !field) return data;
+
+  return [...data].sort((a, b) => {
+    const aVal = (a as any)[field];
+    const bVal = (b as any)[field];
+
+    // Handle undefined/null values - put them at the end
+    if (aVal == null && bVal == null) return 0;
+    if (aVal == null) return 1;
+    if (bVal == null) return -1;
+
+    // String comparison
+    if (typeof aVal === 'string' && typeof bVal === 'string') {
+      const cmp = aVal.localeCompare(bVal);
+      return direction === 'asc' ? cmp : -cmp;
+    }
+
+    // Number comparison
+    const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+    return direction === 'asc' ? cmp : -cmp;
+  });
+};
+
+// Delta indicator component
+const DeltaIndicator: React.FC<{
+  current?: number;
+  previous?: number;
+  precision?: number;
+}> = ({ current, previous, precision = 3 }) => {
+  if (current === undefined) return <span className="text-muted-foreground">-</span>;
+  if (previous === undefined) return <span className="font-mono">{current.toFixed(precision)}</span>;
+
+  const delta = current - previous;
+  const threshold = Math.pow(10, -(precision + 1)); // Small threshold to avoid float comparison issues
+
+  if (Math.abs(delta) < threshold) {
+    return (
+      <span className="font-mono">
+        {current.toFixed(precision)}
+        <span className="ml-1 text-muted-foreground">–</span>
+      </span>
+    );
+  }
+
+  if (delta > 0) {
+    return (
+      <span className="font-mono">
+        {current.toFixed(precision)}
+        <span className="ml-1 text-green-600 dark:text-green-400">↑</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="font-mono">
+      {current.toFixed(precision)}
+      <span className="ml-1 text-red-600 dark:text-red-400">↓</span>
+    </span>
+  );
+};
+
+// Copy to clipboard with feedback
+const copyToClipboard = async (text: string, format: string, setCopied: (f: string | null) => void) => {
+  try {
+    await navigator.clipboard.writeText(text);
+    setCopied(format);
+    setTimeout(() => setCopied(null), 2000);
+  } catch (err) {
+    console.error('Failed to copy:', err);
+  }
+};
+
+// Convert report to JSON string
+const toJSON = (report: Report): string => {
+  return JSON.stringify(report.data, null, 2);
+};
+
+// Convert graph report to CSV
+const graphToCSV = (data: GraphReportData): string => {
+  const lines: string[] = [];
+
+  // Concepts section
+  lines.push('# Concepts');
+  lines.push('ID,Label,Description,Ontology,Grounding,Diversity,Evidence');
+  data.nodes.forEach(n => {
+    lines.push([
+      n.id,
+      `"${(n.label || '').replace(/"/g, '""')}"`,
+      `"${(n.description || '').replace(/"/g, '""')}"`,
+      n.ontology || '',
+      n.grounding_strength?.toFixed(3) || '',
+      n.diversity_score?.toFixed(3) || '',
+      n.evidence_count || '',
+    ].join(','));
+  });
+
+  lines.push('');
+  lines.push('# Relationships');
+  lines.push('Source,Type,Target,Category,Confidence');
+  data.links.forEach(l => {
+    lines.push([
+      l.source,
+      l.type,
+      l.target,
+      (l as any).category || '',
+      l.grounding_strength?.toFixed(3) || '',
+    ].join(','));
+  });
+
+  return lines.join('\n');
+};
+
+// Convert polarity report to CSV
+const polarityToCSV = (data: PolarityReportData): string => {
+  const lines: string[] = [];
+
+  lines.push('# Polarity Axis');
+  lines.push(`Positive Pole,${data.positivePole.label}`);
+  lines.push(`Negative Pole,${data.negativePole.label}`);
+  lines.push(`Axis Magnitude,${data.axisMagnitude.toFixed(3)}`);
+
+  lines.push('');
+  lines.push('# Projected Concepts');
+  lines.push('ID,Label,Position,Positive Similarity,Negative Similarity,Grounding');
+  data.concepts.forEach(c => {
+    lines.push([
+      c.concept_id,
+      `"${(c.label || '').replace(/"/g, '""')}"`,
+      c.position.toFixed(3),
+      c.positive_similarity.toFixed(3),
+      c.negative_similarity.toFixed(3),
+      c.grounding_strength?.toFixed(3) || '',
+    ].join(','));
+  });
+
+  return lines.join('\n');
+};
+
+// Convert to Markdown
+const toMarkdown = (report: Report): string => {
+  const lines: string[] = [];
+  lines.push(`# ${report.name}`);
+  lines.push(`*Generated: ${formatDate(report.createdAt)}*`);
+  lines.push('');
+
+  if (report.type === 'graph') {
+    const data = report.data as GraphReportData;
+
+    lines.push('## Concepts');
+    lines.push('| Label | Description | Ontology | Grounding | Diversity |');
+    lines.push('|-------|-------------|----------|-----------|-----------|');
+    data.nodes.forEach(n => {
+      lines.push(`| ${n.label || ''} | ${(n.description || '').slice(0, 50)}... | ${n.ontology || ''} | ${n.grounding_strength?.toFixed(2) || '-'} | ${n.diversity_score?.toFixed(2) || '-'} |`);
+    });
+
+    lines.push('');
+    lines.push('## Relationships');
+    lines.push('| Source | Type | Target |');
+    lines.push('|--------|------|--------|');
+    data.links.slice(0, 50).forEach(l => {
+      const sourceNode = data.nodes.find(n => n.id === l.source);
+      const targetNode = data.nodes.find(n => n.id === l.target);
+      lines.push(`| ${sourceNode?.label || l.source} | ${l.type} | ${targetNode?.label || l.target} |`);
+    });
+    if (data.links.length > 50) {
+      lines.push(`*... and ${data.links.length - 50} more relationships*`);
+    }
+  } else {
+    const data = report.data as PolarityReportData;
+
+    lines.push('## Polarity Axis');
+    lines.push(`- **Positive Pole:** ${data.positivePole.label}`);
+    lines.push(`- **Negative Pole:** ${data.negativePole.label}`);
+    lines.push(`- **Axis Magnitude:** ${data.axisMagnitude.toFixed(3)}`);
+
+    lines.push('');
+    lines.push('## Direction Distribution');
+    lines.push(`- Positive: ${data.directionDistribution.positive}`);
+    lines.push(`- Neutral: ${data.directionDistribution.neutral}`);
+    lines.push(`- Negative: ${data.directionDistribution.negative}`);
+
+    lines.push('');
+    lines.push('## Projected Concepts');
+    lines.push('| Label | Position | Grounding |');
+    lines.push('|-------|----------|-----------|');
+    data.concepts.forEach(c => {
+      lines.push(`| ${c.label} | ${c.position.toFixed(3)} | ${c.grounding_strength?.toFixed(2) || '-'} |`);
+    });
+  }
+
+  return lines.join('\n');
+};
 
 export const ReportWorkspace: React.FC = () => {
+  const navigate = useNavigate();
+  const {
+    reports,
+    selectedReportId,
+    selectReport,
+    deleteReport,
+    renameReport,
+    getSelectedReport,
+    updateReportData,
+  } = useReportStore();
+
+  const [activeTab, setActiveTab] = useState<string>('reports');
+  const [copiedFormat, setCopiedFormat] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState<string | null>(null);
+  const [editNameValue, setEditNameValue] = useState('');
+  const [isRecalculating, setIsRecalculating] = useState(false);
+  const [recalculateProgress, setRecalculateProgress] = useState<{ current: number; total: number } | null>(null);
+
+  // Sort states for different tables
+  const [conceptSort, setConceptSort] = useState<SortState>({ field: null, direction: null });
+  const [relationshipSort, setRelationshipSort] = useState<SortState>({ field: null, direction: null });
+  const [polaritySort, setPolaritySort] = useState<SortState>({ field: null, direction: null });
+
+  const selectedReport = getSelectedReport();
+
+  // Sort handler - toggles through: null -> asc -> desc -> null
+  const handleSort = (setter: React.Dispatch<React.SetStateAction<SortState>>) => (field: string) => {
+    setter((prev) => {
+      if (prev.field !== field) {
+        return { field, direction: 'asc' };
+      }
+      if (prev.direction === 'asc') {
+        return { field, direction: 'desc' };
+      }
+      return { field: null, direction: null };
+    });
+  };
+
+  // Recalculate data for a graph report (fetch full concept details and relationship grounding)
+  const handleRecalculate = useCallback(async () => {
+    if (!selectedReport || selectedReport.type !== 'graph') return;
+
+    setIsRecalculating(true);
+    const graphData = selectedReport.data as GraphReportData;
+    const totalNodes = graphData.nodes.length;
+    setRecalculateProgress({ current: 0, total: totalNodes });
+
+    try {
+      // Fetch details for all concepts in parallel (batched)
+      const enrichedNodes: GraphReportData['nodes'] = [];
+      const conceptDetailsMap = new Map<string, any>(); // Store full details for relationship lookup
+      const batchSize = 5; // Limit concurrent requests
+
+      for (let i = 0; i < graphData.nodes.length; i += batchSize) {
+        const batch = graphData.nodes.slice(i, i + batchSize);
+        const batchResults = await Promise.all(
+          batch.map(async (node) => {
+            try {
+              const details = await apiClient.getConceptDetails(node.id);
+              conceptDetailsMap.set(node.id, details); // Store for relationship lookup
+              return {
+                id: node.id,
+                label: details.label || node.label,
+                description: details.description,
+                ontology: details.ontology || node.ontology,
+                grounding_strength: details.grounding_strength,
+                diversity_score: details.diversity_score,
+                evidence_count: details.evidence?.length || 0,
+              };
+            } catch (err) {
+              // If fetch fails, keep original data
+              return node;
+            }
+          })
+        );
+        enrichedNodes.push(...batchResults);
+        setRecalculateProgress({ current: enrichedNodes.length, total: totalNodes });
+      }
+
+      // Build enriched links with grounding and category from concept relationships
+      const enrichedLinks = graphData.links.map((link) => {
+        // Look up relationship details from source concept's relationships
+        const sourceDetails = conceptDetailsMap.get(link.source);
+        if (sourceDetails?.relationships) {
+          const rel = sourceDetails.relationships.find(
+            (r: any) => r.to_id === link.target && r.rel_type === link.type
+          );
+          if (rel) {
+            // Use avg_grounding if available, otherwise fall back to confidence
+            const grounding = rel.avg_grounding ?? rel.confidence;
+            return {
+              ...link,
+              grounding_strength: grounding,
+              category: rel.category,
+              epistemic_status: rel.epistemic_status,
+            };
+          }
+        }
+        return link;
+      });
+
+      // Update report with enriched data
+      const newData: GraphReportData = {
+        ...graphData,
+        nodes: enrichedNodes,
+        links: enrichedLinks,
+      };
+      updateReportData(selectedReport.id, newData);
+    } catch (err) {
+      console.error('Failed to recalculate:', err);
+    } finally {
+      setIsRecalculating(false);
+      setRecalculateProgress(null);
+    }
+  }, [selectedReport, updateReportData]);
+
+  const handleDeleteReport = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (confirm('Delete this report?')) {
+      deleteReport(id);
+    }
+  };
+
+  const handleStartRename = (report: Report, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingName(report.id);
+    setEditNameValue(report.name);
+  };
+
+  const handleFinishRename = (id: string) => {
+    if (editNameValue.trim()) {
+      renameReport(id, editNameValue.trim());
+    }
+    setEditingName(null);
+  };
+
+  const getReportIcon = (report: Report) => {
+    if (report.type === 'polarity') return Compass;
+    return GitBranch;
+  };
+
+  // Reports list tab content
+  const reportsContent = (
+    <div className="p-2">
+      <div className="flex items-center justify-between mb-2 px-2">
+        <span className="text-xs font-medium text-muted-foreground">
+          {reports.length} saved
+        </span>
+      </div>
+
+      {reports.length === 0 ? (
+        <div className="text-center py-8 text-sm text-muted-foreground">
+          <FileText className="w-8 h-8 mx-auto mb-2 opacity-50" />
+          <p>No saved reports</p>
+          <p className="text-xs mt-1">Use "Send to Reports" from an explorer</p>
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {reports.map((report) => {
+            const Icon = getReportIcon(report);
+            const isSelected = selectedReportId === report.id;
+            const nodeCount = report.type === 'graph'
+              ? (report.data as GraphReportData).nodes.length
+              : (report.data as PolarityReportData).concepts.length;
+
+            return (
+              <div
+                key={report.id}
+                onClick={() => selectReport(report.id)}
+                className={`
+                  w-full text-left p-2 rounded-lg transition-colors group cursor-pointer
+                  ${isSelected
+                    ? 'bg-primary text-primary-foreground'
+                    : 'hover:bg-accent'
+                  }
+                `}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    {editingName === report.id ? (
+                      <input
+                        type="text"
+                        value={editNameValue}
+                        onChange={(e) => setEditNameValue(e.target.value)}
+                        onBlur={() => handleFinishRename(report.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') handleFinishRename(report.id);
+                          if (e.key === 'Escape') setEditingName(null);
+                        }}
+                        className="w-full px-1 py-0.5 text-sm bg-background text-foreground rounded border"
+                        autoFocus
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    ) : (
+                      <div
+                        className="font-medium text-sm truncate"
+                        onDoubleClick={(e) => handleStartRename(report, e)}
+                      >
+                        <Icon className="w-3 h-3 inline mr-1.5" />
+                        {report.name}
+                      </div>
+                    )}
+                    <div className="flex items-center gap-1.5 text-xs opacity-70 mt-0.5">
+                      <span>{nodeCount} items</span>
+                      <span>·</span>
+                      <Clock className="w-3 h-3" />
+                      <span>{formatDate(report.createdAt)}</span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      onClick={(e) => handleDeleteReport(report.id, e)}
+                      className={`
+                        p-1 rounded
+                        ${isSelected
+                          ? 'hover:bg-primary-foreground/20'
+                          : 'hover:bg-destructive/20 text-destructive'
+                        }
+                      `}
+                      title="Delete report"
+                    >
+                      <Trash2 className="w-3 h-3" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+
+  // Settings tab content (placeholder for future options)
+  const settingsContent = (
+    <div className="p-4 text-sm text-muted-foreground">
+      <Settings2 className="w-8 h-8 mx-auto mb-2 opacity-50" />
+      <p className="text-center">Report settings coming soon</p>
+    </div>
+  );
+
+  const panelTabs = [
+    { id: 'reports', icon: FolderOpen, label: 'Reports', content: reportsContent },
+    { id: 'settings', icon: Settings2, label: 'Settings', content: settingsContent },
+  ];
+
+  // Render table for graph report
+  const renderGraphTable = (data: GraphReportData, report: Report) => {
+    const prevValues = report.previousValues || {};
+
+    // Sort nodes and links
+    const sortedNodes = useMemo(
+      () => sortData(data.nodes, conceptSort.field || '', conceptSort.direction),
+      [data.nodes, conceptSort.field, conceptSort.direction]
+    );
+
+    // For relationships, we need to add source/target labels for sorting
+    const linksWithLabels = useMemo(() => {
+      return data.links.map((link) => {
+        const sourceNode = data.nodes.find((n) => n.id === link.source);
+        const targetNode = data.nodes.find((n) => n.id === link.target);
+        return {
+          ...link,
+          sourceLabel: sourceNode?.label || link.source,
+          targetLabel: targetNode?.label || link.target,
+          category: (link as any).category,
+        };
+      });
+    }, [data.links, data.nodes]);
+
+    const sortedLinks = useMemo(
+      () => sortData(linksWithLabels, relationshipSort.field || '', relationshipSort.direction),
+      [linksWithLabels, relationshipSort.field, relationshipSort.direction]
+    );
+
+    return (
+      <div className="space-y-6">
+        {/* Query Info */}
+        {data.searchParams && (
+          <div className="p-3 bg-muted/30 rounded-lg border text-sm">
+            <div className="flex items-center gap-4 flex-wrap">
+              <span className="text-muted-foreground">Mode:</span>
+              <span className="font-medium capitalize">{data.searchParams.mode}</span>
+              {data.searchParams.conceptId && (
+                <>
+                  <span className="text-muted-foreground">Center:</span>
+                  <span className="font-mono text-xs bg-background px-2 py-0.5 rounded">
+                    {data.searchParams.conceptId}
+                  </span>
+                </>
+              )}
+              {data.searchParams.depth && (
+                <>
+                  <span className="text-muted-foreground">Depth:</span>
+                  <span className="font-medium">{data.searchParams.depth}</span>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Concepts Table */}
+        <div>
+          <h3 className="text-sm font-semibold mb-2 flex items-center gap-2">
+            <Table2 className="w-4 h-4" />
+            Concepts ({data.nodes.length})
+          </h3>
+          <div className="border rounded-lg overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50">
+                  <tr>
+                    <SortableHeader field="label" label="Label" sortState={conceptSort} onSort={handleSort(setConceptSort)} />
+                    <SortableHeader field="description" label="Description" sortState={conceptSort} onSort={handleSort(setConceptSort)} />
+                    <SortableHeader field="ontology" label="Ontology" sortState={conceptSort} onSort={handleSort(setConceptSort)} />
+                    <SortableHeader field="grounding_strength" label="Grounding" sortState={conceptSort} onSort={handleSort(setConceptSort)} align="right" />
+                    <SortableHeader field="diversity_score" label="Diversity" sortState={conceptSort} onSort={handleSort(setConceptSort)} align="right" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {sortedNodes.map((node) => {
+                    const prev = prevValues[node.id];
+                    return (
+                      <tr key={node.id} className="hover:bg-muted/30">
+                        <td className="px-3 py-2 font-medium">{node.label}</td>
+                        <td className="px-3 py-2 text-muted-foreground max-w-xs truncate">
+                          {node.description || '-'}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className="px-1.5 py-0.5 bg-primary/10 text-primary text-xs rounded">
+                            {node.ontology || '-'}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-right text-xs">
+                          <DeltaIndicator
+                            current={node.grounding_strength}
+                            previous={prev?.grounding_strength}
+                          />
+                        </td>
+                        <td className="px-3 py-2 text-right text-xs">
+                          <DeltaIndicator
+                            current={node.diversity_score}
+                            previous={prev?.diversity_score}
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+      {/* Relationships Table */}
+      <div>
+        <h3 className="text-sm font-semibold mb-2 flex items-center gap-2">
+          <GitBranch className="w-4 h-4" />
+          Relationships ({data.links.length})
+        </h3>
+        <div className="border rounded-lg overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 sticky top-0">
+                <tr>
+                  <SortableHeader field="sourceLabel" label="Source" sortState={relationshipSort} onSort={handleSort(setRelationshipSort)} />
+                  <SortableHeader field="type" label="Type" sortState={relationshipSort} onSort={handleSort(setRelationshipSort)} align="center" />
+                  <SortableHeader field="targetLabel" label="Target" sortState={relationshipSort} onSort={handleSort(setRelationshipSort)} />
+                  <SortableHeader field="category" label="Category" sortState={relationshipSort} onSort={handleSort(setRelationshipSort)} />
+                  <SortableHeader field="grounding_strength" label="Confidence" sortState={relationshipSort} onSort={handleSort(setRelationshipSort)} align="right" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {sortedLinks.map((link, i) => (
+                  <tr key={i} className="hover:bg-muted/30">
+                    <td className="px-3 py-2">{link.sourceLabel}</td>
+                    <td className="px-3 py-2 text-center">
+                      <span className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs rounded">
+                        {link.type}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2">{link.targetLabel}</td>
+                    <td className="px-3 py-2">
+                      {link.category ? (
+                        <span className="px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 text-xs rounded capitalize">
+                          {link.category}
+                        </span>
+                      ) : '-'}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-xs">
+                      {link.grounding_strength?.toFixed(3) || '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    );
+  };
+
+  // Render table for polarity report
+  const renderPolarityTable = (data: PolarityReportData) => {
+    // Sort polarity concepts
+    const sortedPolarityConcepts = useMemo(
+      () => sortData(data.concepts, polaritySort.field || '', polaritySort.direction),
+      [data.concepts, polaritySort.field, polaritySort.direction]
+    );
+
+    return (
+      <div className="space-y-6">
+        {/* Axis Info */}
+        <div className="grid grid-cols-3 gap-4">
+          <div className="p-4 border rounded-lg">
+            <div className="text-xs text-muted-foreground mb-1">Positive Pole</div>
+            <div className="font-semibold text-green-600 dark:text-green-400">
+              {data.positivePole.label}
+            </div>
+          </div>
+          <div className="p-4 border rounded-lg text-center">
+            <div className="text-xs text-muted-foreground mb-1">Axis Magnitude</div>
+            <div className="font-semibold font-mono">{data.axisMagnitude.toFixed(3)}</div>
+          </div>
+          <div className="p-4 border rounded-lg text-right">
+            <div className="text-xs text-muted-foreground mb-1">Negative Pole</div>
+            <div className="font-semibold text-red-600 dark:text-red-400">
+              {data.negativePole.label}
+            </div>
+          </div>
+        </div>
+
+        {/* Direction Distribution */}
+        <div className="flex gap-4 justify-center text-sm">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded bg-green-500"></div>
+            <span>Positive: {data.directionDistribution.positive}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded bg-gray-400"></div>
+            <span>Neutral: {data.directionDistribution.neutral}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 rounded bg-red-500"></div>
+            <span>Negative: {data.directionDistribution.negative}</span>
+          </div>
+        </div>
+
+        {/* Concepts Table */}
+        <div>
+          <h3 className="text-sm font-semibold mb-2 flex items-center gap-2">
+            <Table2 className="w-4 h-4" />
+            Projected Concepts ({data.concepts.length})
+          </h3>
+          <div className="border rounded-lg overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50">
+                  <tr>
+                    <SortableHeader field="label" label="Label" sortState={polaritySort} onSort={handleSort(setPolaritySort)} />
+                    <SortableHeader field="position" label="Position" sortState={polaritySort} onSort={handleSort(setPolaritySort)} align="right" />
+                    <SortableHeader field="positive_similarity" label="+ Similarity" sortState={polaritySort} onSort={handleSort(setPolaritySort)} align="right" />
+                    <SortableHeader field="negative_similarity" label="- Similarity" sortState={polaritySort} onSort={handleSort(setPolaritySort)} align="right" />
+                    <SortableHeader field="grounding_strength" label="Grounding" sortState={polaritySort} onSort={handleSort(setPolaritySort)} align="right" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {sortedPolarityConcepts.map((concept) => (
+                    <tr key={concept.concept_id} className="hover:bg-muted/30">
+                      <td className="px-3 py-2 font-medium">{concept.label}</td>
+                      <td className="px-3 py-2 text-right">
+                        <span className={`font-mono text-xs px-1.5 py-0.5 rounded ${
+                          concept.position > 0.1
+                            ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
+                            : concept.position < -0.1
+                            ? 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300'
+                            : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
+                        }`}>
+                          {concept.position > 0 ? '+' : ''}{concept.position.toFixed(3)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-xs">
+                        {concept.positive_similarity.toFixed(3)}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-xs">
+                        {concept.negative_similarity.toFixed(3)}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-xs">
+                        {concept.grounding_strength?.toFixed(3) || '-'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   return (
-    <WorkspacePlaceholder
-      icon={FileText}
-      title="Report"
-      description="View query results in tabular format and export"
-      pattern="Query → view table → export"
-      features={[
-        {
-          label: 'Saved queries list',
-          description: 'Quick access to your saved queries',
-        },
-        {
-          label: 'Tabular result view',
-          description: 'Data grid with column sorting and filtering',
-        },
-        {
-          label: 'Export formats',
-          description: 'Download as JSON, CSV, or Markdown',
-        },
-        {
-          label: 'Column selection',
-          description: 'Choose which fields to display',
-        },
-        {
-          label: 'Pagination',
-          description: 'Handle large result sets efficiently',
-        },
-      ]}
-    />
+    <div className="h-full flex">
+      {/* Left Panel - Icon Rail with Reports list */}
+      <IconRailPanel
+        tabs={panelTabs}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        defaultExpanded={true}
+      />
+
+      {/* Center - Report View */}
+      <div className="flex-1 flex flex-col bg-background">
+        {/* Toolbar */}
+        <div className="h-14 border-b border-border bg-card px-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <FileText className="w-5 h-5 text-muted-foreground" />
+            <div>
+              <div className="font-semibold">
+                {selectedReport?.name || 'No Report Selected'}
+              </div>
+              {selectedReport?.lastCalculatedAt && (
+                <div className="text-xs text-muted-foreground flex items-center gap-1">
+                  <Clock className="w-3 h-3" />
+                  Computed: {formatDate(selectedReport.lastCalculatedAt)}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Actions */}
+          {selectedReport && (
+            <div className="flex items-center gap-2">
+              {/* Recalculate button */}
+              {selectedReport.type === 'graph' && (
+                <button
+                  onClick={handleRecalculate}
+                  disabled={isRecalculating}
+                  className="px-3 py-1.5 text-sm rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 flex items-center gap-2"
+                  title="Recalculate grounding and diversity scores"
+                >
+                  {isRecalculating ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      {recalculateProgress
+                        ? `${recalculateProgress.current}/${recalculateProgress.total}`
+                        : 'Calculating...'}
+                    </>
+                  ) : (
+                    <>
+                      <RefreshCw className="w-4 h-4" />
+                      Recalculate
+                    </>
+                  )}
+                </button>
+              )}
+
+              <div className="w-px h-6 bg-border" />
+
+              {/* Copy/Export buttons */}
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => copyToClipboard(toJSON(selectedReport), 'json', setCopiedFormat)}
+                className="px-2 py-1 text-xs rounded hover:bg-accent flex items-center gap-1"
+                title="Copy as JSON"
+              >
+                {copiedFormat === 'json' ? <CheckCircle2 className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
+                JSON
+              </button>
+              <button
+                onClick={() => {
+                  const csv = selectedReport.type === 'graph'
+                    ? graphToCSV(selectedReport.data as GraphReportData)
+                    : polarityToCSV(selectedReport.data as PolarityReportData);
+                  copyToClipboard(csv, 'csv', setCopiedFormat);
+                }}
+                className="px-2 py-1 text-xs rounded hover:bg-accent flex items-center gap-1"
+                title="Copy as CSV"
+              >
+                {copiedFormat === 'csv' ? <CheckCircle2 className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
+                CSV
+              </button>
+              <button
+                onClick={() => copyToClipboard(toMarkdown(selectedReport), 'md', setCopiedFormat)}
+                className="px-2 py-1 text-xs rounded hover:bg-accent flex items-center gap-1"
+                title="Copy as Markdown"
+              >
+                {copiedFormat === 'md' ? <CheckCircle2 className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
+                MD
+              </button>
+              <div className="w-px h-4 bg-border mx-1" />
+              <button
+                onClick={() => {
+                  const content = toJSON(selectedReport);
+                  const blob = new Blob([content], { type: 'application/json' });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = `${selectedReport.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.json`;
+                  a.click();
+                  URL.revokeObjectURL(url);
+                }}
+                className="px-2 py-1 text-xs rounded hover:bg-accent flex items-center gap-1"
+                title="Download JSON file"
+              >
+                <Download className="w-3 h-3" />
+              </button>
+            </div>
+            </div>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-4">
+          {selectedReport ? (
+            selectedReport.type === 'graph'
+              ? renderGraphTable(selectedReport.data as GraphReportData, selectedReport)
+              : renderPolarityTable(selectedReport.data as PolarityReportData)
+          ) : (
+            <div className="h-full flex items-center justify-center">
+              <div className="text-center text-muted-foreground">
+                <FileText className="w-16 h-16 mx-auto mb-4 opacity-30" />
+                <h3 className="text-lg font-medium mb-2">No Report Selected</h3>
+                <p className="text-sm max-w-sm mx-auto">
+                  Use "Send to Reports" from the 2D, 3D, or Polarity Explorer
+                  to create a tabular view of your graph data.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 };

--- a/web/src/store/reportStore.ts
+++ b/web/src/store/reportStore.ts
@@ -1,0 +1,242 @@
+/**
+ * Report Store - Zustand State Management
+ *
+ * Manages report state for tabular views of graph/polarity data.
+ * Reports are sent from explorers (2D, 3D, Polarity) via "Send to Reports".
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// Report types
+export type ReportType = 'graph' | 'polarity';
+
+// Graph report data (from 2D/3D explorers)
+export interface GraphReportData {
+  type: 'graph';
+  nodes: Array<{
+    id: string;
+    label: string;
+    description?: string;
+    ontology?: string;
+    grounding_strength?: number;
+    diversity_score?: number;
+    evidence_count?: number;
+  }>;
+  links: Array<{
+    source: string;
+    target: string;
+    type: string;
+    grounding_strength?: number;
+    category?: string;
+    epistemic_status?: string;
+  }>;
+  searchParams?: {
+    mode: string;
+    query?: string;
+    conceptId?: string;
+    depth?: number;
+  };
+}
+
+// Polarity report data (from Polarity Explorer)
+export interface PolarityReportData {
+  type: 'polarity';
+  positivePole: { concept_id: string; label: string };
+  negativePole: { concept_id: string; label: string };
+  axisMagnitude: number;
+  concepts: Array<{
+    concept_id: string;
+    label: string;
+    position: number; // -1 to +1
+    positive_similarity: number;
+    negative_similarity: number;
+    grounding_strength?: number;
+  }>;
+  directionDistribution: {
+    positive: number;
+    neutral: number;
+    negative: number;
+  };
+  groundingCorrelation?: number;
+}
+
+export type ReportData = GraphReportData | PolarityReportData;
+
+// Previous values for delta comparison (keyed by concept_id)
+export interface PreviousValues {
+  [conceptId: string]: {
+    grounding_strength?: number;
+    diversity_score?: number;
+    evidence_count?: number;
+    position?: number; // For polarity reports
+  };
+}
+
+export interface Report {
+  id: string;
+  name: string;
+  type: ReportType;
+  data: ReportData;
+  createdAt: string;
+  sourceExplorer: '2d' | '3d' | 'polarity';
+  // Recalculation tracking
+  lastCalculatedAt?: string;
+  previousValues?: PreviousValues;
+}
+
+interface ReportStore {
+  // Reports list
+  reports: Report[];
+
+  // Currently selected report
+  selectedReportId: string | null;
+
+  // Add a new report
+  addReport: (report: Omit<Report, 'id' | 'createdAt'>) => string;
+
+  // Delete a report
+  deleteReport: (id: string) => void;
+
+  // Select a report
+  selectReport: (id: string | null) => void;
+
+  // Rename a report
+  renameReport: (id: string, name: string) => void;
+
+  // Clear all reports
+  clearReports: () => void;
+
+  // Get selected report
+  getSelectedReport: () => Report | null;
+
+  // Update report data after recalculation (preserves previous values for delta)
+  updateReportData: (id: string, newData: ReportData) => void;
+}
+
+// Generate unique ID
+const generateId = () => `report_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+// Generate default name based on report type and data
+const generateDefaultName = (type: ReportType, data: ReportData): string => {
+  const timestamp = new Date().toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  if (type === 'graph') {
+    const graphData = data as GraphReportData;
+    const nodeCount = graphData.nodes.length;
+    const mode = graphData.searchParams?.mode || 'graph';
+    return `${mode} (${nodeCount} nodes) - ${timestamp}`;
+  } else {
+    const polarityData = data as PolarityReportData;
+    return `${polarityData.positivePole.label} ↔ ${polarityData.negativePole.label} - ${timestamp}`;
+  }
+};
+
+export const useReportStore = create<ReportStore>()(
+  persist(
+    (set, get) => ({
+      reports: [],
+      selectedReportId: null,
+
+      addReport: (reportInput) => {
+        const id = generateId();
+        const name = reportInput.name || generateDefaultName(reportInput.type, reportInput.data);
+        const report: Report = {
+          ...reportInput,
+          id,
+          name,
+          createdAt: new Date().toISOString(),
+        };
+
+        set((state) => ({
+          reports: [report, ...state.reports],
+          selectedReportId: id,
+        }));
+
+        return id;
+      },
+
+      deleteReport: (id) => {
+        set((state) => {
+          const newReports = state.reports.filter((r) => r.id !== id);
+          return {
+            reports: newReports,
+            selectedReportId: state.selectedReportId === id
+              ? (newReports[0]?.id || null)
+              : state.selectedReportId,
+          };
+        });
+      },
+
+      selectReport: (id) => {
+        set({ selectedReportId: id });
+      },
+
+      renameReport: (id, name) => {
+        set((state) => ({
+          reports: state.reports.map((r) =>
+            r.id === id ? { ...r, name } : r
+          ),
+        }));
+      },
+
+      clearReports: () => {
+        set({ reports: [], selectedReportId: null });
+      },
+
+      getSelectedReport: () => {
+        const state = get();
+        return state.reports.find((r) => r.id === state.selectedReportId) || null;
+      },
+
+      updateReportData: (id, newData) => {
+        set((state) => ({
+          reports: state.reports.map((report) => {
+            if (report.id !== id) return report;
+
+            // Extract current values to store as previous
+            const previousValues: PreviousValues = {};
+
+            if (report.data.type === 'graph') {
+              const graphData = report.data as GraphReportData;
+              graphData.nodes.forEach((node) => {
+                previousValues[node.id] = {
+                  grounding_strength: node.grounding_strength,
+                  diversity_score: node.diversity_score,
+                  evidence_count: node.evidence_count,
+                };
+              });
+            } else if (report.data.type === 'polarity') {
+              const polarityData = report.data as PolarityReportData;
+              polarityData.concepts.forEach((concept) => {
+                previousValues[concept.concept_id] = {
+                  grounding_strength: concept.grounding_strength,
+                  position: concept.position,
+                };
+              });
+            }
+
+            return {
+              ...report,
+              data: newData,
+              previousValues,
+              lastCalculatedAt: new Date().toISOString(),
+            };
+          }),
+        }));
+      },
+    }),
+    {
+      name: 'kg-reports-storage',
+      partialize: (state) => ({
+        reports: state.reports,
+        selectedReportId: state.selectedReportId,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary

- Adds a Reports workspace that displays graph and polarity exploration data in tabular format
- "Send to Reports" buttons in 2D/3D explorers and Polarity workspace capture current state
- Reports persist to localStorage via Zustand store with delta tracking for recalculation comparisons
- Full export support (JSON, CSV, Markdown) with copy and download options

## Features

### Report Types
- **Graph Reports**: Concepts table (label, description, ontology, grounding, diversity) + Relationships table (source, type, target, category, confidence)
- **Polarity Reports**: Axis info (poles, magnitude) + Projections table (label, position, similarities, grounding)

### Functionality
- Sortable columns for all tables (ascending/descending toggle)
- Recalculate button fetches fresh data from API and shows delta indicators (↑↓–)
- Report naming/renaming with double-click inline edit
- Delete confirmation for reports
- Computed timestamp display

### Data Flow
```
Explorers (2D, 3D, Polarity)
    ↓ "Send to Reports" button
Report Store (Zustand + localStorage)
    ↓
Report Workspace (tables + export)
```

## Files Changed

| File | Description |
|------|-------------|
| `web/src/store/reportStore.ts` | New Zustand store with persistence and delta tracking |
| `web/src/components/report/ReportWorkspace.tsx` | Full workspace implementation with tables, sorting, recalculate |
| `web/src/views/ExplorerView.tsx` | Added "Send to Reports" button to 2D/3D explorers |
| `web/src/components/polarity/PolarityExplorerWorkspace.tsx` | Added "Send to Reports" button to polarity explorer |
| `docs/TODO-reports-feature.md` | Feature documentation and implementation checklist |

## Test plan

- [ ] Navigate to 2D/3D explorer, run a query, click "Send to Reports"
- [ ] Verify report appears in Reports workspace with correct data
- [ ] Test column sorting (click headers for ascending/descending)
- [ ] Test recalculate button - verify delta indicators appear
- [ ] Navigate to Polarity explorer, run analysis, click "Send to Reports"
- [ ] Test export buttons (JSON, CSV, Markdown)
- [ ] Test report renaming (double-click name)
- [ ] Test report deletion
- [ ] Refresh page and verify reports persist in localStorage