### PR TITLE
fix(web): resolve TypeScript errors and use theme tokens

### DIFF
--- a/web/src/components/polarity/PolarityScatterPlot.tsx
+++ b/web/src/components/polarity/PolarityScatterPlot.tsx
@@ -236,9 +236,9 @@ export const PolarityScatterPlot: React.FC<PolarityScatterPlotProps> = ({
     neutral: 'Show concepts balanced between both poles',
   };
 
-  // Generate regression line points
-  const regressionPoints = useMemo(() => {
-    if (!regressionLine) return [];
+  // Generate regression line points as a tuple for ReferenceLineSegment
+  const regressionPoints = useMemo((): [{ x: number; y: number }, { x: number; y: number }] | null => {
+    if (!regressionLine) return null;
     const { slope, intercept } = regressionLine;
     return [
       { x: -1, y: slope * -1 + intercept },
@@ -348,8 +348,8 @@ export const PolarityScatterPlot: React.FC<PolarityScatterPlotProps> = ({
     const maxDensity = Math.max(...grid.flat());
     if (maxDensity === 0) return null;
 
-    // Render cells directly as JSX (cached)
-    const cells: JSX.Element[] = [];
+    // Render cells directly as React elements (cached)
+    const cells: React.ReactElement[] = [];
     for (let y = 0; y < gridSize; y++) {
       for (let x = 0; x < gridSize; x++) {
         const density = grid[y][x];
@@ -369,7 +369,7 @@ export const PolarityScatterPlot: React.FC<PolarityScatterPlotProps> = ({
               fill={getHeatColor(intensity)}
               fillOpacity={1}
               stroke="none"
-              isFront={false}
+              ifOverflow="hidden"
             />
           );
         }
@@ -667,9 +667,9 @@ export const PolarityScatterPlot: React.FC<PolarityScatterPlotProps> = ({
           )}
 
           {/* Regression line (color shows significance via p-value) */}
-          {visualLayers.regressionLine && regressionLine && (
+          {visualLayers.regressionLine && regressionLine && regressionPoints && (
             <ReferenceLine
-              segment={regressionPoints.map(p => ({ x: p.x, y: p.y }))}
+              segment={regressionPoints}
               stroke={regressionLineColor}
               strokeWidth={2}
               strokeDasharray="5 5"

--- a/web/src/components/preferences/IngestTab.tsx
+++ b/web/src/components/preferences/IngestTab.tsx
@@ -11,6 +11,7 @@ import {
   Folder,
   Layers,
   Zap,
+  SplitSquareVertical,
 } from 'lucide-react';
 import { usePreferencesStore } from '../../store/preferencesStore';
 import { apiClient } from '../../api/client';
@@ -62,6 +63,16 @@ export const IngestTab: React.FC = () => {
         label="Default chunk size"
         description="Target words per chunk (200-3000)"
         icon={<Layers className="w-4 h-4" />}
+      />
+      <NumberInput
+        value={ingest.defaultOverlapWords}
+        onChange={(v) => updateIngestDefaults({ defaultOverlapWords: v })}
+        min={0}
+        max={500}
+        step={50}
+        label="Overlap words"
+        description="Words overlapping between chunks (0-500)"
+        icon={<SplitSquareVertical className="w-4 h-4" />}
       />
       <Select
         value={ingest.defaultProcessingMode}

--- a/web/src/components/shared/ConfirmDialog.tsx
+++ b/web/src/components/shared/ConfirmDialog.tsx
@@ -139,7 +139,7 @@ export function useConfirmDialog(): UseConfirmDialogReturn {
     message: '',
     buttons: [],
   });
-  const resolveRef = React.useRef<(value: boolean) => void>();
+  const resolveRef = React.useRef<((value: boolean) => void) | undefined>(undefined);
 
   const show = React.useCallback(
     (newConfig: Omit<ConfirmDialogProps, 'isOpen' | 'onClose'>): Promise<boolean> => {

--- a/web/src/components/shared/SearchResultsDropdown.tsx
+++ b/web/src/components/shared/SearchResultsDropdown.tsx
@@ -4,18 +4,11 @@
 
 import React from 'react';
 import { getZIndexValue } from '../../config/zIndex';
-
-interface SearchResult {
-  concept_id: string;
-  label: string;
-  description?: string;
-  score: number;
-  evidence_count: number;
-}
+import type { ConceptSearchResult } from '../../types/polarity';
 
 interface SearchResultsDropdownProps {
-  results: SearchResult[];
-  onSelect: (result: SearchResult) => void;
+  results: ConceptSearchResult[];
+  onSelect: (result: ConceptSearchResult) => void;
 }
 
 export const SearchResultsDropdown: React.FC<SearchResultsDropdownProps> = ({ results, onSelect }) => {
@@ -24,21 +17,27 @@ export const SearchResultsDropdown: React.FC<SearchResultsDropdownProps> = ({ re
       className="absolute top-full left-0 right-0 mt-2 space-y-2 bg-background/95 backdrop-blur-sm rounded-lg p-2 shadow-lg max-h-80 overflow-y-auto"
       style={{ zIndex: getZIndexValue('searchResults') }}
     >
-      {results.map((result) => (
-        <button
-          key={result.concept_id}
-          onClick={() => onSelect(result)}
-          className="w-full text-left p-3 rounded-lg border border-border bg-muted hover:border-primary/50 transition-colors"
-        >
-          <div className="text-sm font-mono font-medium">{result.label}</div>
-          {result.description && (
-            <div className="text-xs text-muted-foreground mt-1">{result.description}</div>
-          )}
-          <div className="text-xs text-muted-foreground mt-1">
-            Similarity: {(result.score * 100).toFixed(0)}% • {result.evidence_count} instances
-          </div>
-        </button>
-      ))}
+      {results.map((result) => {
+        // Use score or similarity, whichever is available
+        const similarityScore = result.score ?? result.similarity;
+        return (
+          <button
+            key={result.concept_id}
+            onClick={() => onSelect(result)}
+            className="w-full text-left p-3 rounded-lg border border-border bg-muted hover:border-primary/50 transition-colors"
+          >
+            <div className="text-sm font-mono font-medium">{result.label}</div>
+            {result.description && (
+              <div className="text-xs text-muted-foreground mt-1">{result.description}</div>
+            )}
+            <div className="text-xs text-muted-foreground mt-1">
+              {similarityScore !== undefined && `Similarity: ${(similarityScore * 100).toFixed(0)}%`}
+              {similarityScore !== undefined && result.evidence_count !== undefined && ' • '}
+              {result.evidence_count !== undefined && `${result.evidence_count} instances`}
+            </div>
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/web/src/lib/blockCompiler.ts
+++ b/web/src/lib/blockCompiler.ts
@@ -291,7 +291,7 @@ function compileNeighborhoodBlock(
   inputVariable: string,
   _isFirst: boolean,
   counter: number
-): { cypher: string; outputVariable: string } {
+): { cypher: string; outputVariable: string; pathVariable: string } {
   if (_isFirst) {
     throw new Error('Neighborhood block cannot be the first block');
   }

--- a/web/src/store/preferencesStore.ts
+++ b/web/src/store/preferencesStore.ts
@@ -19,6 +19,7 @@ export interface IngestDefaults {
   autoApprove: boolean;
   defaultOntology: string;
   defaultChunkSize: number;
+  defaultOverlapWords: number;
   defaultProcessingMode: 'serial' | 'parallel';
 }
 
@@ -53,6 +54,7 @@ const DEFAULT_INGEST: IngestDefaults = {
   autoApprove: false,
   defaultOntology: '',
   defaultChunkSize: 1000,
+  defaultOverlapWords: 200,
   defaultProcessingMode: 'serial',
 };
 

--- a/web/src/types/blocks.ts
+++ b/web/src/types/blocks.ts
@@ -93,6 +93,12 @@ export interface NodeFilterBlockParams {
   minConfidence?: number; // 0.0 - 1.0
 }
 
+// Combined filter params for the legacy FilterBlock component
+export interface FilterBlockParams {
+  ontologies?: string[];
+  minConfidence?: number; // 0.0 - 1.0
+}
+
 export interface LimitBlockParams {
   count: number;
 }

--- a/web/src/types/polarity.ts
+++ b/web/src/types/polarity.ts
@@ -76,9 +76,15 @@ export interface ConceptSearchResult {
   label: string;
   description?: string;
   similarity?: number;
+  score?: number;          // Alias for similarity in some API responses
+  evidence_count?: number; // Number of evidence instances
 }
 
 export interface ConceptSearchResponse {
   results: ConceptSearchResult[];
   total: number;
+  // Smart search recommendation fields (optional)
+  below_threshold_count?: number;
+  suggested_threshold?: number;
+  top_match?: ConceptSearchResult;
 }

--- a/web/src/views/ExplorerView.tsx
+++ b/web/src/views/ExplorerView.tsx
@@ -17,9 +17,10 @@ import { useSubgraph, useFindConnection } from '../hooks/useGraphData';
 import { getExplorer } from '../explorers';
 import { apiClient } from '../api/client';
 import { getZIndexValue } from '../config/zIndex';
+import type { VisualizationType } from '../types/explorer';
 
 interface ExplorerViewProps {
-  explorerType: string;
+  explorerType: VisualizationType;
 }
 
 export const ExplorerView: React.FC<ExplorerViewProps> = ({ explorerType }) => {
@@ -380,7 +381,7 @@ export const ExplorerView: React.FC<ExplorerViewProps> = ({ explorerType }) => {
       name: '', // Will auto-generate name based on content
       type: 'graph',
       data: reportData,
-      sourceExplorer: explorerType === 'force-graph-3d' ? '3d' : '2d',
+      sourceExplorer: explorerType === 'force-3d' ? '3d' : '2d',
     });
 
     navigate('/report');


### PR DESCRIPTION
## Summary

- Fix TypeScript compilation errors across multiple components
- Replace hardcoded colors with semantic theme tokens in IngestWorkspace
- Add configurable overlap words setting to ingest preferences

## Changes

### TypeScript Fixes
- Add missing `FilterBlockParams` interface to `types/blocks.ts`
- Fix `IngestWorkspace` API types (`chunking` → `options`, handle `job_id` union type)
- Fix `PolarityScatterPlot` JSX types and `regressionPoints` tuple typing
- Fix `ConfirmDialog` useRef initialization
- Extend `ConceptSearchResult`/`ConceptSearchResponse` types for API compatibility
- Fix `blockCompiler` return type to include `pathVariable`
- Fix `ExplorerView` to use proper `VisualizationType`

### Theme Token Conversion (IngestWorkspace)
- `bg-white`/`bg-gray-*` → `bg-card`/`bg-muted`/`bg-input`
- `border-gray-*` → `border-border`
- `text-gray-*` → `text-muted-foreground`/`text-card-foreground`
- `text-red-*` → `text-destructive`
- `bg-amber-*`/`text-amber-*` → `bg-status-warning`/`text-status-warning`
- Removed redundant `dark:` modifiers (semantic tokens handle dark mode)

### New Feature
- Added `defaultOverlapWords` to ingest preferences store
- Added UI control in Settings → Ingest tab (0-500 words)
- IngestWorkspace now uses preference value instead of hardcoded 200

## Test plan
- [ ] Verify build compiles without TypeScript errors
- [ ] Test IngestWorkspace theming in light/dark/twilight modes
- [ ] Verify ingest options inherit from user preferences
- [ ] Test overlap words setting persists across sessions