### PR TITLE
fix(mcp): add markdown formatter for job list action

### DIFF
--- a/cli/src/mcp-server.ts
+++ b/cli/src/mcp-server.ts
@@ -25,6 +25,7 @@ import {
   formatConnectionPaths,
   formatRelatedConcepts,
   formatJobStatus,
+  formatJobList,
   formatInspectFileResult,
   formatIngestFileResult,
   formatIngestDirectoryResult,
@@ -1034,8 +1035,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               undefined,
               toolArgs.limit as number || 50
             );
+            const formattedText = formatJobList(result);
             return {
-              content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+              content: [{ type: 'text', text: formattedText }],
             };
           }
 


### PR DESCRIPTION
## Summary
- Added `formatJobList` function to format job list results as readable markdown
- Previously returned raw JSON which was verbose and hard to scan

## Changes
- Status summary with counts (processing, completed, failed, etc.)
- Per-job details: filename, status, ontology  
- Progress info for processing jobs (percentage, chunks)
- Cost estimates for awaiting_approval jobs
- Results summary for completed jobs (concepts, relationships, cost)
- Error snippets for failed jobs

## Test plan
- [x] Build succeeds
- [x] Tested `job` tool with action "list" - shows formatted markdown