### PR TITLE
feat(polarity): enhance explorer with NodeInfoBox, labels, and UI improvements

### DIFF
--- a/web/src/store/graphStore.ts
+++ b/web/src/store/graphStore.ts
@@ -132,6 +132,7 @@ interface GraphStore {
     selectedAnalysisId: string | null;
     maxCandidates: number;
     maxHops: number;
+    minSimilarity: number; // Similarity threshold for pole search
     autoDiscover: boolean;
     activeTab: string;
   };
@@ -308,7 +309,8 @@ export const useGraphStore = create<GraphStore>((set) => ({
     analysisHistory: [],
     selectedAnalysisId: null,
     maxCandidates: 20,
-    maxHops: 1,
+    maxHops: 3, // Increased from 1 - BFS optimization (ADR-076) makes higher hops practical
+    minSimilarity: 0.6, // Similarity threshold for pole search
     autoDiscover: true,
     activeTab: 'search',
   },


### PR DESCRIPTION
## Summary

Enhances the Polarity Explorer with improved interactivity, better information display, and refined UI/UX.

### New Features
- **NodeInfoBox on click**: Left-clicking a concept bubble shows the shared `NodeInfoBox` component with full details (description, ontology, grounding, diversity, relationships, evidence, provenance)
- **Labels layer**: New toggle button to show concept names directly on the scatter plot (truncated to 15 chars)
- **Exposed parameters**: `minSimilarity` now configurable in Settings (default 0.6), `maxHops` increased to 3 (enabled by BFS optimization from #168)

### UI/UX Improvements
- Removed hover tooltip in favor of click-to-inspect interaction pattern
- Improved Settings UI with organized cards for "Search Settings" and "Auto-Discovery"
- Added concept descriptions to Polarity Axis section (previously only showed label + grounding)
- Removed max-width constraint so content fills available width
- Collapsed Projected Concepts sections by default
- Changed chart sizing from fixed 500px height to aspect-ratio based (4:3)
- Fixed focus outline causing white rectangle when clicking chart background

### Files Changed
- `web/src/components/polarity/PolarityScatterPlot.tsx` - Main visualization component
- `web/src/components/polarity/PolarityExplorerWorkspace.tsx` - Workspace layout and settings
- `web/src/store/graphStore.ts` - Added `minSimilarity` to polarity state

## Test plan
- [ ] Load existing polarity analysis from history
- [ ] Left-click concept bubble → NodeInfoBox appears with full details
- [ ] Toggle "Labels" layer → concept names appear on chart
- [ ] Click chart background → no white rectangle appears
- [ ] Verify Settings tab shows similarity slider and auto-discovery options
- [ ] Run new analysis with adjusted parameters