### PR TITLE
feat: add rich metadata to Garage source documents for FUSE support

### DIFF
--- a/api/api/lib/garage/__init__.py
+++ b/api/api/lib/garage/__init__.py
@@ -36,7 +36,7 @@ from typing import Optional
 from .base import GarageBaseClient, sanitize_path_component
 from .image_storage import ImageStorageService
 from .projection_storage import ProjectionStorageService
-from .source_storage import SourceDocumentService, DocumentIdentity, normalize_content_hash
+from .source_storage import SourceDocumentService, DocumentIdentity, SourceMetadata, normalize_content_hash
 from .retention import RetentionPolicyManager, CleanupResult, StorageStats
 
 
@@ -247,6 +247,7 @@ __all__ = [
 
     # Data classes
     'DocumentIdentity',
+    'SourceMetadata',
     'CleanupResult',
     'StorageStats',
 

--- a/api/api/routes/ingest.py
+++ b/api/api/routes/ingest.py
@@ -255,6 +255,7 @@ async def ingest_document(
         "ontology": ontology,
         "filename": use_filename,
         "user_id": current_user.id,  # Track job owner (user ID from kg_auth.users)
+        "username": current_user.username,  # For Garage metadata (FUSE support)
         "processing_mode": processing_mode,
         "options": {
             "target_words": options.target_words,
@@ -380,6 +381,7 @@ async def ingest_text(
         "ontology": ontology,
         "filename": use_filename,
         "user_id": current_user.id,  # Track job owner (user ID from kg_auth.users)
+        "username": current_user.username,  # For Garage metadata (FUSE support)
         "processing_mode": processing_mode,
         "options": {
             "target_words": target_words,


### PR DESCRIPTION
## Summary

Adds rich provenance metadata to Garage S3 object headers, enabling fast FUSE filesystem operations without database queries. When the FUSE filesystem (ADR-069) calls `stat()` or `getattr()`, it can retrieve file attributes directly from S3 HEAD requests instead of querying PostgreSQL.

### Metadata Fields Added

| Field | Description | Example |
|-------|-------------|---------|
| `user-id` | User ID who ingested | `1` |
| `username` | Username for display | `admin` |
| `source-type` | Ingestion type | `file`, `url`, `text` |
| `file-path` | Original path | `/home/user/docs/file.txt` |
| `source-url` | Source URL | `https://example.com/doc.html` |
| `hostname` | Source machine | `workstation-01` |
| `ingested-at` | ISO 8601 timestamp | `2025-12-15T23:09:08Z` |

### Changes

- **source_storage.py**: Add `SourceMetadata` dataclass and update `store()` to accept optional metadata
- **__init__.py**: Export `SourceMetadata` 
- **ingest.py**: Add `username` to job_data alongside existing `user_id`
- **ingestion_worker.py**: Construct `SourceMetadata` from job_data and pass to `store()`

### Design Notes

- All metadata fields are optional - only non-None values are stored
- S3 metadata limit (~2KB) easily accommodates this (~500 bytes typical)
- DocumentMeta nodes remain the authoritative source; Garage metadata is a read-optimized cache
- Backward compatible - existing callers work without changes

## Test Plan

- [x] Ingest test document via MCP
- [x] Verify metadata in Garage S3 headers:
  ```
  user-id: 1
  username: admin
  ingested-at: 2025-12-15T23:09:08.539304Z
  ```
- [x] Verify cascade delete still works
- [x] Verify optional fields (source-type, file-path, etc.) only appear when provided