### PR TITLE
fix(age_client): use ThreadedConnectionPool for thread safety

### DIFF
--- a/api/api/lib/age_client.py
+++ b/api/api/lib/age_client.py
@@ -58,8 +58,8 @@ class AGEClient:
 
         try:
             # Create connection pool for better performance
-            # Increased for parallel graph queries (ADR-071)
-            self.pool = psycopg2.pool.SimpleConnectionPool(
+            # ThreadedConnectionPool for thread-safe access (parallel graph queries, ADR-071)
+            self.pool = psycopg2.pool.ThreadedConnectionPool(
                 1,  # minconn
                 20,  # maxconn (supports up to 16 parallel workers + buffer)
                 host=self.host,


### PR DESCRIPTION
## Summary

- Fix race condition in AGEClient connection pool when used with parallel graph queries

## Problem

`AGEClient` uses `psycopg2.pool.SimpleConnectionPool` which is **not thread-safe** per psycopg2 documentation:

> `SimpleConnectionPool` - A connection pool that can't be shared across threads.

However, `GraphParallelizer` (ADR-071) uses `ThreadPoolExecutor` with multiple workers, all calling `_execute_cypher()` on the same shared `AGEClient` instance:

```
GraphParallelizer(age_client)  # Shared client
    └── ThreadPoolExecutor(8 workers)
        ├── worker 1 → client.pool.getconn()  ┐
        ├── worker 2 → client.pool.getconn()  │ RACE CONDITION
        ├── worker 3 → client.pool.getconn()  │
        └── ...                               ┘
```

This can cause unpredictable behavior when multiple threads call `getconn()` / `putconn()` concurrently.

## Solution

One-line fix: `SimpleConnectionPool` → `ThreadedConnectionPool`

`ThreadedConnectionPool` has the identical API but adds internal locking for thread-safe access.

## Test plan

- [ ] Verify API starts without errors
- [ ] Test parallel graph queries (concept details with diversity calculation)
- [ ] Confirm no connection pool errors under concurrent load