### PR TITLE
fix(api): register ArtifactCleanupLauncher in scheduled jobs

### DIFF
--- a/api/api/launchers/artifact_cleanup.py
+++ b/api/api/launchers/artifact_cleanup.py
@@ -58,6 +58,10 @@ class ArtifactCleanupLauncher(JobLauncher):
             "description": f"Scheduled artifact cleanup ({datetime.utcnow().isoformat()})"
         }
 
+    def get_job_type(self) -> str:
+        """Return job type for worker registry lookup."""
+        return "artifact_cleanup"
+
     def launch(self) -> Optional[str]:
         """
         Check conditions and enqueue cleanup job if needed.

--- a/api/api/main.py
+++ b/api/api/main.py
@@ -37,7 +37,7 @@ from .workers.source_embedding_worker import run_source_embedding_worker
 from .workers.projection_worker import run_projection_worker
 from .workers.polarity_worker import run_polarity_worker
 from .workers.artifact_cleanup_worker import run_artifact_cleanup_worker
-from .launchers import CategoryRefreshLauncher, VocabConsolidationLauncher, EpistemicRemeasurementLauncher, ProjectionLauncher
+from .launchers import CategoryRefreshLauncher, VocabConsolidationLauncher, EpistemicRemeasurementLauncher, ProjectionLauncher, ArtifactCleanupLauncher
 from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, oauth, sources, projection, artifacts, grants, query_definitions
 from .services.embedding_worker import get_embedding_worker
 from .lib.age_client import AGEClient
@@ -288,7 +288,8 @@ async def startup_event():
         'CategoryRefreshLauncher': CategoryRefreshLauncher,
         'VocabConsolidationLauncher': VocabConsolidationLauncher,
         'EpistemicRemeasurementLauncher': EpistemicRemeasurementLauncher,
-        'ProjectionLauncher': ProjectionLauncher  # ADR-078: Embedding projections
+        'ProjectionLauncher': ProjectionLauncher,  # ADR-078: Embedding projections
+        'ArtifactCleanupLauncher': ArtifactCleanupLauncher  # ADR-083: Artifact cleanup
     }
     scheduled_jobs_manager = ScheduledJobsManager(queue, launcher_registry)
     await scheduled_jobs_manager.start()


### PR DESCRIPTION
## Summary

Fixes the scheduled jobs manager failing to run artifact cleanup jobs due to missing launcher registration.

## Changes

1. **main.py**: Added `ArtifactCleanupLauncher` to the launcher registry
2. **artifact_cleanup.py**: Added missing `get_job_type()` abstract method implementation

## Error Fixed

```
❌ Unknown launcher: ArtifactCleanupLauncher
```

and

```
TypeError: Can't instantiate abstract class ArtifactCleanupLauncher with abstract method get_job_type
```

## Test plan

- [x] API starts without launcher errors
- [x] Scheduled jobs manager starts successfully