### PR TITLE
fix(api): store dict parameters as JSON strings in Cypher queries

### DIFF
--- a/api/app/lib/age_client.py
+++ b/api/app/lib/age_client.py
@@ -124,10 +124,15 @@ class AGEClient:
                         # Then escape single quotes
                         value_str = value_str.replace("'", "\\'")
                         query = query.replace(f"${key}", f"'{value_str}'")
-                    elif isinstance(value, (list, dict)):
-                        # Convert lists/dicts to JSON strings
+                    elif isinstance(value, list):
+                        # Lists: JSON array syntax is Cypher-compatible
                         value_str = json.dumps(value).replace("\\", "\\\\").replace("'", "\\'")
                         query = query.replace(f"${key}", value_str)
+                    elif isinstance(value, dict):
+                        # Dicts: Store as JSON string (Cypher maps require unquoted keys,
+                        # but JSON uses quoted keys - see GitHub issue for future improvement)
+                        value_str = json.dumps(value).replace("\\", "\\\\").replace("'", "\\'")
+                        query = query.replace(f"${key}", f"'{value_str}'")
                     elif isinstance(value, (int, float)):
                         query = query.replace(f"${key}", str(value))
                     elif value is None:


### PR DESCRIPTION
## Summary

Fixes dict parameter serialization in AGE client that was causing epistemic status storage to fail silently.

## Problem

When storing Python dicts as Cypher properties, `json.dumps()` produces `{"key": val}` (quoted keys), but openCypher map literals require `{key: val}` (unquoted keys). This caused syntax errors:

```
Error: syntax error at or near ""total_edges""
```

All 97 vocab types would measure correctly but fail to persist.

## Solution

Wrap dict values in quotes so they're stored as JSON strings rather than attempting to parse as Cypher maps. Lists continue to work as-is since JSON array syntax is Cypher-compatible.

```python
# Before (broken for dicts)
elif isinstance(value, (list, dict)):
    value_str = json.dumps(value)
    query = query.replace(f"${key}", value_str)

# After (dicts stored as JSON strings)
elif isinstance(value, list):
    value_str = json.dumps(value)
    query = query.replace(f"${key}", value_str)
elif isinstance(value, dict):
    value_str = json.dumps(value)
    query = query.replace(f"${key}", f"'{value_str}'")  # Wrap in quotes
```

## Testing

```bash
kg vocab epistemic-status measure
# Now stores all 97 types successfully

kg vocab epistemic-status list
# Shows persisted data
```

## Related

- GitHub issue #220: Consider native Cypher map syntax (future improvement)
- GitHub issue #221: Separate issue discovered - scheduled job launchers don't trigger execution