### PR TITLE
feat(web): add job deletion and cleanup functionality

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -13,6 +13,9 @@ import type {
   JobApproveResponse,
   JobCancelResponse,
   JobsClearResponse,
+  JobDeleteResponse,
+  JobsDeleteFilters,
+  JobsDeleteResponse,
   JobProgressEvent,
   JobCompletedEvent,
   JobFailedEvent,
@@ -516,10 +519,51 @@ class APIClient {
 
   /**
    * Clear all jobs (admin operation)
+   * @deprecated Use deleteJobs() with filters instead
    */
   async clearAllJobs(): Promise<JobsClearResponse> {
     const response = await this.client.delete<JobsClearResponse>('/jobs', {
       params: { confirm: true },
+    });
+    return response.data;
+  }
+
+  /**
+   * Delete a single job permanently
+   */
+  async deleteJob(
+    jobId: string,
+    options: { purge?: boolean; force?: boolean } = {}
+  ): Promise<JobDeleteResponse> {
+    const response = await this.client.delete<JobDeleteResponse>(`/jobs/${jobId}`, {
+      params: {
+        purge: options.purge ?? true,
+        force: options.force ?? false
+      },
+    });
+    return response.data;
+  }
+
+  /**
+   * Delete jobs matching filters (with dry-run support)
+   */
+  async deleteJobs(options: {
+    confirm?: boolean;
+    dryRun?: boolean;
+    status?: string;
+    system?: boolean;
+    olderThan?: string;
+    jobType?: string;
+  }): Promise<JobsDeleteResponse> {
+    const response = await this.client.delete<JobsDeleteResponse>('/jobs', {
+      params: {
+        confirm: options.confirm,
+        dry_run: options.dryRun,
+        status: options.status,
+        system: options.system,
+        older_than: options.olderThan,
+        job_type: options.jobType,
+      },
     });
     return response.data;
   }

--- a/web/src/types/jobs.ts
+++ b/web/src/types/jobs.ts
@@ -141,6 +141,38 @@ export interface JobsClearResponse {
   message: string;
 }
 
+// Delete single job response
+export interface JobDeleteResponse {
+  job_id: string;
+  deleted?: boolean;
+  cancelled?: boolean;
+  message: string;
+}
+
+// Bulk delete with filters
+export interface JobsDeleteFilters {
+  status?: string;
+  system?: boolean;
+  olderThan?: string;  // '1h', '24h', '7d', '30d'
+  jobType?: string;
+}
+
+export interface JobsDeleteResponse {
+  success?: boolean;
+  dry_run?: boolean;
+  jobs_deleted?: number;
+  jobs_to_delete?: number;
+  jobs?: Array<{
+    job_id: string;
+    job_type: string;
+    status: string;
+    ontology: string | null;
+    created_at: string;
+  }>;
+  filters?: Record<string, unknown>;
+  message: string;
+}
+
 // SSE Event types for streaming
 export interface JobProgressEvent {
   stage: string;


### PR DESCRIPTION
## Summary

Adds job deletion and bulk cleanup capabilities to the web frontend, matching the CLI and MCP tool functionality from PR #224.

- Add delete button for terminal jobs (completed/failed/cancelled) in job detail view
- Add cleanup modal with filter-based bulk deletion
- Support dry-run preview before executing deletion
- Filter by status, age (1h/24h/7d/30d), and system jobs

## Changes

- `web/src/types/jobs.ts` - Add deletion response types
- `web/src/api/client.ts` - Add `deleteJob()` and `deleteJobs()` methods
- `web/src/components/jobs/JobsWorkspace.tsx` - Add delete button and cleanup modal UI

## Test plan

- [x] Navigate to Jobs workspace
- [x] Click a completed/failed/cancelled job → verify "Delete Job Record" button appears
- [x] Delete a job → verify it's removed from list
- [x] Click trash icon in header → verify cleanup modal opens
- [x] Set filters and click Preview → verify dry-run shows matching jobs
- [x] Execute deletion → verify jobs are removed