### PR TITLE
fix: store content_type and storage_key on DocumentMeta nodes

### DIFF
--- a/api/app/lib/age_client.py
+++ b/api/app/lib/age_client.py
@@ -2421,7 +2421,9 @@ class AGEClient:
         ingested_at: Optional[str] = None,
         source_ids: Optional[List[str]] = None,
         # ADR-081: Source document lifecycle
-        garage_key: Optional[str] = None
+        garage_key: Optional[str] = None,
+        content_type: str = "document",
+        storage_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Create a DocumentMeta node and link it to Source nodes (ADR-051, ADR-081).
@@ -2443,6 +2445,8 @@ class AGEClient:
             ingested_at: ISO timestamp (optional, defaults to now())
             source_ids: List of source_ids to link via HAS_SOURCE relationship (optional)
             garage_key: Garage object key for source document (ADR-081)
+            content_type: "document" or "image" (default: "document")
+            storage_key: Garage object key for image binary (ADR-057, images only)
 
         Returns:
             Created DocumentMeta node properties
@@ -2478,6 +2482,10 @@ class AGEClient:
             "job_id": job_id
         }
 
+        # Content type (document or image)
+        if content_type != "document":
+            properties["content_type"] = content_type
+
         # Add optional provenance metadata (best-effort)
         if filename:
             properties["filename"] = filename
@@ -2490,6 +2498,9 @@ class AGEClient:
         # ADR-081: Link to source document in Garage
         if garage_key:
             properties["garage_key"] = garage_key
+        # ADR-057: Image binary location in Garage
+        if storage_key:
+            properties["storage_key"] = storage_key
 
         # Add timestamp (default to now if not provided)
         if ingested_at:

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -395,7 +395,10 @@ def run_ingestion_worker(
                 hostname=job_data.get("source_hostname"),      # Hostname where ingested
                 source_ids=source_ids,
                 # ADR-081: Link to source document in Garage
-                garage_key=job_data.get("source_garage_key")
+                garage_key=job_data.get("source_garage_key"),
+                content_type=job_data.get("content_type", "document"),
+                # ADR-057: Image binary location in Garage
+                storage_key=job_data.get("storage_key"),
             )
             logger.info(f"✓ Created DocumentMeta node: {job_data['content_hash'][:16]}... ({stats.sources_created} sources)")
         except Exception as e:

--- a/schema/migrations/043_backfill_document_meta_content_type.sql
+++ b/schema/migrations/043_backfill_document_meta_content_type.sql
@@ -1,0 +1,107 @@
+-- ===========================================================================
+-- Migration 043: Backfill content_type and storage_key on DocumentMeta Nodes
+-- ===========================================================================
+-- Date: 2026-01-29
+-- Related: FUSE image support - content_type and storage_key were stored on
+--          Source nodes but never on DocumentMeta nodes, causing GET /documents
+--          to always return content_type="document" even for images, and
+--          GET /documents/{id}/content to fail to find image binaries.
+--
+-- Copies content_type and storage_key from Source nodes to their parent
+-- DocumentMeta nodes where the properties are missing.
+--
+-- This migration is idempotent - safe to run multiple times.
+-- ===========================================================================
+
+-- Set search path
+LOAD 'age';
+SET search_path = ag_catalog, kg_api, public;
+
+-- ---------------------------------------------------------------------------
+-- STEP 1: Backfill content_type from Source nodes to DocumentMeta nodes
+-- ---------------------------------------------------------------------------
+
+DO $migration$
+DECLARE
+    docs_updated INTEGER := 0;
+BEGIN
+    RAISE NOTICE 'Backfilling content_type on DocumentMeta nodes from Source nodes...';
+
+    -- Find DocumentMeta nodes linked to image Source nodes that are missing
+    -- content_type, and set it to 'image'
+    EXECUTE format(
+        'SELECT * FROM cypher(''knowledge_graph'', $cypher$
+            MATCH (d:DocumentMeta)-[:HAS_SOURCE]->(s:Source)
+            WHERE s.content_type = ''image'' AND d.content_type IS NULL
+            SET d.content_type = ''image''
+            RETURN count(DISTINCT d) as updated
+        $cypher$) as (updated agtype)'
+    ) INTO docs_updated;
+
+    RAISE NOTICE 'Backfilled content_type=image on % DocumentMeta node(s)', docs_updated;
+END $migration$;
+
+-- ---------------------------------------------------------------------------
+-- STEP 2: Backfill storage_key from Source nodes to DocumentMeta nodes
+-- ---------------------------------------------------------------------------
+
+DO $migration$
+DECLARE
+    docs_updated INTEGER := 0;
+BEGIN
+    RAISE NOTICE 'Backfilling storage_key on DocumentMeta nodes from Source nodes...';
+
+    -- Copy storage_key from image Source nodes to their parent DocumentMeta
+    -- Use the first Source node's storage_key (images have one source per doc)
+    EXECUTE format(
+        'SELECT * FROM cypher(''knowledge_graph'', $cypher$
+            MATCH (d:DocumentMeta)-[:HAS_SOURCE]->(s:Source)
+            WHERE s.content_type = ''image'' AND s.storage_key IS NOT NULL AND d.storage_key IS NULL
+            SET d.storage_key = s.storage_key
+            RETURN count(DISTINCT d) as updated
+        $cypher$) as (updated agtype)'
+    ) INTO docs_updated;
+
+    RAISE NOTICE 'Backfilled storage_key on % DocumentMeta node(s)', docs_updated;
+END $migration$;
+
+-- ---------------------------------------------------------------------------
+-- Verification
+-- ---------------------------------------------------------------------------
+
+DO $migration$
+DECLARE
+    total_with_type INTEGER := 0;
+    total_with_key INTEGER := 0;
+BEGIN
+    EXECUTE format(
+        'SELECT total::int FROM cypher(''knowledge_graph'', $cypher$
+            MATCH (d:DocumentMeta)
+            WHERE d.content_type IS NOT NULL
+            RETURN count(d) as total
+        $cypher$) as (total agtype)'
+    ) INTO total_with_type;
+
+    EXECUTE format(
+        'SELECT total::int FROM cypher(''knowledge_graph'', $cypher$
+            MATCH (d:DocumentMeta)
+            WHERE d.storage_key IS NOT NULL
+            RETURN count(d) as total
+        $cypher$) as (total agtype)'
+    ) INTO total_with_key;
+
+    RAISE NOTICE 'DocumentMeta nodes with content_type set: %', total_with_type;
+    RAISE NOTICE 'DocumentMeta nodes with storage_key set: %', total_with_key;
+END $migration$;
+
+-- ---------------------------------------------------------------------------
+-- Migration Tracking
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (43, 'backfill_document_meta_content_type')
+ON CONFLICT (version) DO NOTHING;
+
+-- ===========================================================================
+-- End of Migration 043
+-- ===========================================================================


### PR DESCRIPTION
## Summary

- `create_document_meta()` never stored `content_type` or `storage_key` on DocumentMeta nodes — only Source nodes had them
- This caused `GET /documents` to always return `content_type: "document"`, breaking FUSE image detection
- `GET /documents/{id}/content` couldn't find image binaries without `storage_key` on DocumentMeta

## Changes

- **`api/app/lib/age_client.py`** — Add `content_type` and `storage_key` parameters to `create_document_meta()`
- **`api/app/workers/ingestion_worker.py`** — Pass both from `job_data` at the call site
- **`schema/migrations/043_backfill_document_meta_content_type.sql`** — Backfill existing DocumentMeta nodes from their Source nodes
- **`fuse/kg_fuse/filesystem.py`** — Set `direct_io=True` on image file handles so kernel reads aren't truncated to `st_size`
- **`fuse/tests/test_fuse_integration.sh`** — Fix byte-count test (`cat|wc`), regex warning (`grep -qF`), extend job cleanup retries

## Test plan

- [x] Integration tests: 28/29 pass (1 flaky timing test for job cleanup)
- [x] `kg search query 'road'` returns "Dirt Road" concept with inline image evidence
- [x] FUSE serves full image bytes (1,008,066 bytes matches fixture)
- [x] Image companion `.md` has correct frontmatter and relative link
- [x] Migration backfills `content_type` and `storage_key` on existing DocumentMeta nodes
<img width="1119" height="853" alt="2026-01-29_00-01" src="https://github.com/user-attachments/assets/42051c89-f786-471f-97c7-69c8703205c1" />
