### PR TITLE
feat(fuse): Obsidian wikilinks and aliases in concept files

### DIFF
--- a/fuse/kg_fuse/formatters.py
+++ b/fuse/kg_fuse/formatters.py
@@ -160,7 +160,7 @@ def format_concept(data: dict, tags_config: TagsConfig = None) -> str:
             target_label = rel.get("to_label", rel.get("to_id", "unknown"))
             target_id = rel.get("to_id", "unknown")
             lines.append(f"  - type: {rel_type}")
-            lines.append(f'    target: "[[{target_label}]]"')
+            lines.append(f'    target: "[[{target_label}.concept]]"')
             lines.append(f"    target_id: {target_id}")
 
     # Tags for tool integration (Obsidian, Logseq, etc.)
@@ -223,7 +223,7 @@ def format_concept(data: dict, tags_config: TagsConfig = None) -> str:
         for rel in relationships:
             rel_type = rel.get("rel_type", "RELATED_TO")
             target = rel.get("to_label", rel.get("to_id", "unknown"))
-            lines.append(f"- **{rel_type}** → [[{target}]]")
+            lines.append(f"- **{rel_type}** → [[{target}.concept]]")
         lines.append("")
 
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Relationships now render as `[[wikilinks]]` in both YAML frontmatter and body
- Aliases populated from API `search_terms` for Obsidian alternative name indexing
- Enables Obsidian graph view and backlink navigation between concepts

## Test plan
- [ ] Mount FUSE and verify `[[target]]` syntax in concept files
- [ ] Open vault in Obsidian, check graph view shows connections
- [ ] Verify aliases field appears with search terms