### PR TITLE
fix(api): strip embedding vectors from cypher endpoint response

### DIFF
--- a/api/app/routes/queries.py
+++ b/api/app/routes/queries.py
@@ -1623,6 +1623,7 @@ async def execute_cypher_query(
                         if node_id not in nodes_map:
                             # Prefer properties.label (actual name) over AGE label (node type like "Concept")
                             props = value.get('properties', {})
+                            props.pop('embedding', None)
                             node_label = props.get('label') or value.get('label', node_id)
                             nodes_map[node_id] = CypherNode(
                                 id=node_id,
@@ -1650,6 +1651,7 @@ async def execute_cypher_query(
                                 if node_id not in nodes_map:
                                     # Prefer properties.label (actual name) over AGE label (node type)
                                     props = item.get('properties', {})
+                                    props.pop('embedding', None)
                                     node_label = props.get('label') or item.get('label', node_id)
                                     nodes_map[node_id] = CypherNode(
                                         id=node_id,


### PR DESCRIPTION
## Summary

- Strip `embedding` property from node objects in `/query/cypher` responses
- Two-line fix in both node extraction paths (direct nodes and path-extracted nodes)

## Context

The cypher endpoint dumped all node properties into the JSON response, including 384-float embedding arrays (~3KB each). The web client never does vector math — all similarity operations happen server-side. On neighborhood queries this caused multi-hundred-megabyte responses that crashed Chrome.

Closes #260

## Test plan

- [x] Web workstation: search for a concept, run neighborhood depth 2 — should no longer crash
- [x] Verify `embedding` field is absent from response nodes
- [ ] Verify "Follow Concept" (searchByEmbedding) still works — it sends embeddings *to* the API, doesn't rely on them in cypher responses