### PR TITLE
docs(graph-accel): README and technical design document

### DIFF
--- a/graph-accel/README.md
+++ b/graph-accel/README.md
@@ -10,12 +10,12 @@ Apache AGE stores graphs in PostgreSQL and translates Cypher path matches into n
 
 | Depth | AGE (SQL) | graph_accel | Speedup |
 |-------|-----------|-------------|---------|
-| 1 | 3,644ms | 0.18ms | 20,000x |
-| 2 | 471ms | 0.09ms | 5,200x |
-| 3 | 1,790ms | 0.14ms | 12,800x |
-| 4 | 11,460ms | 0.31ms | 37,000x |
-| 5 | 92,474ms | 0.42ms | **220,000x** |
-| 6 | Hangs | 0.38ms | --- |
+| 1 | 3,644ms | 0.101ms | 36,000x |
+| 2 | 471ms | 0.066ms | 7,100x |
+| 3 | 1,790ms | 0.122ms | 14,700x |
+| 4 | 11,460ms | 0.267ms | 42,900x |
+| 5 | 92,474ms | 0.378ms | **244,600x** |
+| 6 | Hangs | 0.377ms | --- |
 
 AGE hits a hard wall at depth 6. graph_accel handles arbitrary depth in sub-millisecond time.
 
@@ -253,7 +253,7 @@ graph-accel/
     └── benchmark-comparison.sh  # AGE vs graph_accel automated comparison
 ```
 
-**Core engine:** 771 lines, zero dependencies, 23 unit tests.
+**Core engine:** 771 lines, zero dependencies, 28 tests (26 unit + 2 integration).
 **Extension:** 602 lines wrapping core via pgrx.
 **Total:** ~1,400 lines of Rust.
 


### PR DESCRIPTION
## Summary

- Adds `graph-accel/README.md` — project entry point for external audience (pgrx community, AGE users)
- Adds `graph-accel/docs/DESIGN.md` — technical deep dive for contributors and reviewers

### README covers
- Problem statement (AGE depth 6+ hangs)
- Benchmark table (depths 1-5, up to 244,600x speedup)
- SQL reference for all 4 functions with signatures, parameters, return columns
- 7 GUC configuration parameters
- Build instructions (extension + standalone benchmark)
- 3 deployment options (manual copy, volume mount, custom Dockerfile)
- Project structure and roadmap

### DESIGN.md covers
- Dual build architecture (core → ext .so + bench binary)
- Data structures (HashMap adjacency list, u16 rel-type interning, memory accounting)
- BFS algorithm with parent pointers and lazy path reconstruction
- PostgreSQL integration (SPI loading, GUC registration, per-backend state)
- Memory model tradeoffs (per-backend vs shared memory)
- Safety guarantees (read-only, pg_guard, SQL injection prevention)
- Benchmark methodology (6 synthetic topologies + live comparison)
- Known limitations and future work

## Test plan
- [ ] Verify all SQL examples match actual `#[pg_extern]` signatures
- [ ] Verify GUC table matches `register_gucs()` in guc.rs
- [ ] Verify benchmark numbers match `docs/benchmark-findings.md`
- [ ] Verify relative links resolve (README → docs/DESIGN.md, benchmark-findings.md)
- [ ] Verify build commands are accurate