### PR TITLE
Remove dead facades and fix MCP connect grounding (#279, #280)

### DIFF
--- a/cli/src/mcp-server.ts
+++ b/cli/src/mcp-server.ts
@@ -1372,6 +1372,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 from_id: toolArgs.from_id as string,
                 to_id: toolArgs.to_id as string,
                 max_hops: toolArgs.max_hops as number || DEFAULT_MAX_HOPS,
+                include_grounding: true,
+                include_evidence: true,
                 // ADR-065: Epistemic status filtering
                 include_epistemic_status: toolArgs.include_epistemic_status as string[] | undefined,
                 exclude_epistemic_status: toolArgs.exclude_epistemic_status as string[] | undefined,


### PR DESCRIPTION
## Summary

- Delete `pathfinding_facade.py` (654 lines) and `query_service.py` (~350 lines) — zero callers, fully superseded by GraphFacade
- Remove dead imports from `queries.py`
- Fix MCP `connect` exact mode to pass `include_grounding: true` (was missing, inconsistent with `connect-by-search`)

## What's NOT deleted

`query_facade.py` (GraphQueryFacade) — still has ~15 active callers for namespace-safe Cypher. Migration tracked in #279.

## Test plan

- [x] 266 unit tests pass
- [x] API restarts clean
- [x] CLI/MCP builds clean (`npm run build`)

Partially closes #279, partially closes #280