### PR TITLE
refactor: cross-explorer shared query system (Phase 1+2)

### DIFF
--- a/web/src/components/shared/SavedQueriesPanel.tsx
+++ b/web/src/components/shared/SavedQueriesPanel.tsx
@@ -11,10 +11,11 @@
 import React, { useEffect } from 'react';
 import { FolderOpen, Save, Code, Trash2 } from 'lucide-react';
 import { useQueryDefinitionStore } from '../../store/queryDefinitionStore';
+import type { ReplayableDefinition } from '../../hooks/useQueryReplay';
 
 interface SavedQueriesPanelProps {
   /** Called when user clicks a saved query to load it */
-  onLoadQuery: (query: { id: number; name: string; definition_type: string; definition: Record<string, unknown> }) => void;
+  onLoadQuery: (query: ReplayableDefinition) => void;
   /** Called when user clicks Save — omit to hide the save button */
   onSaveExploration?: () => void;
   /** Called when user clicks Export to Editor — omit to hide the button */

--- a/web/src/hooks/useQueryReplay.ts
+++ b/web/src/hooks/useQueryReplay.ts
@@ -13,7 +13,9 @@ import { useGraphStore } from '../store/graphStore';
 import { apiClient } from '../api/client';
 import { mapCypherResultToRawGraph } from '../utils/cypherResultMapper';
 
-interface ReplayableDefinition {
+export interface ReplayableDefinition {
+  id?: number;
+  name?: string;
   definition_type: string;
   definition: Record<string, unknown>;
 }
@@ -74,7 +76,7 @@ export function useQueryReplay() {
     // Legacy: searchParams-based queries
     if (definition?.searchParams) {
       setSearchParams(definition.searchParams);
-      if (definition.similarityThreshold) {
+      if (typeof definition.similarityThreshold === 'number') {
         setSimilarityThreshold(definition.similarityThreshold);
       }
     }

--- a/web/src/views/ExplorerView.tsx
+++ b/web/src/views/ExplorerView.tsx
@@ -56,7 +56,7 @@ export const ExplorerView: React.FC<ExplorerViewProps> = ({ explorerType }) => {
   const {
     createDefinition: createSavedQuery,
   } = useQueryDefinitionStore();
-  const { replayQuery } = useQueryReplay();
+  const { replayQuery, isReplaying } = useQueryReplay();
 
   // UI state for IconRailPanel
   const [activeTab, setActiveTab] = useState('history');
@@ -454,11 +454,13 @@ export const ExplorerView: React.FC<ExplorerViewProps> = ({ explorerType }) => {
           className={`flex-1 relative ${!graphData && !isLoading ? 'pointer-events-none' : ''}`}
           style={{ zIndex: getZIndexValue('content') }}
         >
-          {isLoading && (
+          {(isLoading || isReplaying) && (
             <div className="absolute inset-0 flex items-center justify-center bg-background/50 z-10">
               <div className="text-center">
                 <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-                <p className="text-muted-foreground">Loading graph data...</p>
+                <p className="text-muted-foreground">
+                  {isReplaying ? 'Replaying exploration steps...' : 'Loading graph data...'}
+                </p>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

- Extract `useQueryReplay` hook and `SavedQueriesPanel` component from ExplorerView into shared modules
- Refactor ExplorerView to use shared components (zero behavior change)
- Add IconRailPanel with saved queries sidebar to VocabularyChord workspace
- VocabularyChord can now load saved explorations, becoming a Level 1 (lens) consumer of shared graph data

## Context

Part of the cross-explorer graph data sharing plan. This establishes the shared contract (`useQueryReplay` + `SavedQueriesPanel`) that subsequent phases will reuse to connect Polarity, DocumentExplorer, and Block Editor.

## New files

- `web/src/hooks/useQueryReplay.ts` — replays `{ op, cypher }[]` statements into graphStore
- `web/src/components/shared/SavedQueriesPanel.tsx` — reusable saved queries list for IconRailPanel tabs

## Test plan

- [ ] Build a graph in 2D explorer, save it, switch to Vocabulary Analysis — verify chord diagram renders
- [ ] Open Vocabulary Analysis with no graph — verify empty state with sidebar shows correctly
- [ ] Load a saved query from Vocabulary Analysis sidebar — verify graph populates and chord renders
- [ ] Verify ExplorerView save/load/delete behavior is unchanged (regression check)
- [ ] `npx tsc --noEmit` passes, `npx vite build` succeeds