### PR TITLE
fix: pin transformers<5.0 for Nomic Vision compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ python-dotenv>=1.0.0
 anthropic>=0.18.0  # Optional: only needed if using AI_PROVIDER=anthropic
 numpy>=1.24.0  # Required for learned knowledge similarity calculations & vector search
 sentence-transformers>=2.3.0  # Local embedding models for ADR-039 (nomic-embed-text, BGE)
-transformers>=4.35.0  # Required for Nomic Vision embeddings (ADR-057)
+transformers>=4.41.0,<5.0  # Pinned: Nomic Vision requires trust_remote_code, broken on transformers 5.x (#313)
 torch>=2.0.0  # Required for visual embeddings (Nomic Vision)
 torchvision>=0.15.0  # Fast image preprocessing for transformers (ADR-057)
 accelerate>=0.20.0  # Required for device_map in transformers model loading


### PR DESCRIPTION
## Summary

- Pin `transformers>=4.41.0,<5.0` in requirements.txt to fix Nomic Vision model loading failure

## Root cause

Nomic Vision v1.5 uses `trust_remote_code=True` to load custom model classes from HuggingFace Hub. These custom classes are not maintained for transformers 5.x:

1. `all_tied_weights_keys` AttributeError — model loading crashes
2. Non-persistent buffers (rotary position embeddings) silently corrupted to NaN
3. No native transformers integration planned (HF issue #30995 still open)

## Verification

- Rebuilt API container with transformers 4.57.6
- Nomic Vision model loads successfully, produces 768-dim embeddings
- Nomic text embedding model loads successfully, produces 768-dim embeddings
- API health check passes

## Next steps

Multi-backend embedding system migration planned in `.claude/todo-embedding-migration.md` — will add SigLIP 2 as primary backend (native transformers, no trust_remote_code), keeping Nomic as pinned fallback.

Closes #313