### PR TITLE
Fix embedding provider reporting, remove SigLIP seed

### DIFF
--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -414,6 +414,13 @@ class OpenAIProvider(AIProvider):
             return self.embedding_provider.get_embedding_model()
         return self.embedding_model
 
+    @property
+    def model_name(self) -> str:
+        """Embedding model name, delegating to embedding_provider if set."""
+        if self.embedding_provider and hasattr(self.embedding_provider, 'model_name'):
+            return self.embedding_provider.model_name
+        return self.embedding_model
+
     def validate_api_key(self) -> bool:
         """Validate OpenAI API key by making a simple API call"""
         try:
@@ -793,6 +800,13 @@ class AnthropicProvider(AIProvider):
 
     def get_embedding_model(self) -> str:
         return self.embedding_provider.get_embedding_model()
+
+    @property
+    def model_name(self) -> str:
+        """Embedding model name, delegating to embedding_provider."""
+        if self.embedding_provider and hasattr(self.embedding_provider, 'model_name'):
+            return self.embedding_provider.model_name
+        return self.extraction_model
 
     def validate_api_key(self) -> bool:
         """Validate Anthropic API key by making a simple API call"""
@@ -1188,6 +1202,13 @@ class OllamaProvider(AIProvider):
 
     def get_embedding_model(self) -> str:
         return self.embedding_provider.get_embedding_model()
+
+    @property
+    def model_name(self) -> str:
+        """Embedding model name, delegating to embedding_provider."""
+        if self.embedding_provider and hasattr(self.embedding_provider, 'model_name'):
+            return self.embedding_provider.model_name
+        return self.extraction_model
 
     def validate_api_key(self) -> bool:
         """


### PR DESCRIPTION
## Summary
- EmbeddingWorker reported `openai/unknown` for concept/vocabulary regeneration because it derived provider name from the extraction wrapper, not the actual embedding provider. Now correctly resolves through the delegation chain.
- Adds `model_name` property to OpenAI, Anthropic, and Ollama providers
- Removes SigLIP 2 Base seed from migration 055 (64-token text context is unusable for document embedding)

## Test plan
- [x] `kg admin embedding regenerate --type concept` → reports `localembedding/nomic-ai/nomic-embed-text-v1.5`
- [x] `kg admin embedding regenerate --type vocabulary` → same
- [x] `kg admin embedding regenerate --type source` → `local/nomic-ai/nomic-embed-text-v1.5`
- [x] 223/223 embeddings regenerated successfully