### PR TITLE
fix: bind $W_IDS in program Cypher, readable link labels, tool hints

### DIFF
--- a/api/app/services/program_executor.py
+++ b/api/app/services/program_executor.py
@@ -153,7 +153,7 @@ async def _execute_one(
 
     # --- CypherOp / ApiOp ---
     if isinstance(op, CypherOp):
-        r = await asyncio.to_thread(dispatch_cypher, ctx, op)
+        r = await asyncio.to_thread(dispatch_cypher, ctx, op, w)
         operation_type = 'cypher'
     elif isinstance(op, ApiOp):
         r = await asyncio.to_thread(dispatch_api, ctx, op)

--- a/cli/src/cli/program.ts
+++ b/cli/src/cli/program.ts
@@ -248,10 +248,16 @@ export const programCommand = setCommandHelp(
           }
 
           if (!options.logOnly && result.result.links.length > 0) {
+            const nodeLabels = new Map<string, string>();
+            for (const node of result.result.nodes) {
+              nodeLabels.set(node.concept_id, node.label);
+            }
             console.log('\n' + colors.stats.section('Links'));
             for (const link of result.result.links.slice(0, 30)) {
+              const from = nodeLabels.get(link.from_id) || link.from_id;
+              const to = nodeLabels.get(link.to_id) || link.to_id;
               console.log(
-                `  ${colors.status.dim(link.from_id)} → ${colors.ui.key(link.relationship_type)} → ${colors.status.dim(link.to_id)}`
+                `  ${colors.status.dim(from)} → ${colors.ui.key(link.relationship_type)} → ${colors.status.dim(to)}`
               );
             }
             if (result.result.links.length > 30) {

--- a/docs/reference/mcp/README.md
+++ b/docs/reference/mcp/README.md
@@ -3,7 +3,7 @@
 > **Auto-Generated Documentation**
 > 
 > Generated from MCP server tool schemas.
-> Last updated: 2026-02-11
+> Last updated: 2026-02-12
 
 ---
 
@@ -61,6 +61,8 @@ For multi-step exploration, compose searches into a GraphProgram (program tool) 
 
 ESCALATION: If you find yourself making multiple search/connect calls without converging on an answer, switch to the program tool — one composed query replaces many individual calls.
 
+To verify a result, use source to retrieve the original text behind any evidence, or concept (action: "details") to see all evidence and relationships for a concept.
+
 Use 2-3 word phrases (e.g., "linear thinking patterns").
 
 **Parameters:**
@@ -87,7 +89,7 @@ For "connect" action, defaults (threshold=0.5, max_hops=5) match the CLI and wor
 
 If connect returns no paths or you need to combine multiple lookups, escalate to the program tool — one composed query replaces many individual calls. Do not repeat connect hoping for different results.
 
-For multi-step workflows (search → connect → expand → filter), compose these into a GraphProgram instead of making individual calls. See the program tool and program/syntax resource.
+For multi-step workflows (search → connect → expand → filter), compose these into a GraphProgram instead of making individual calls. For example, seed from a search then expand via Cypher using $W_IDS to reference accumulated concept IDs. See the program tool and program/syntax resource for this and other composition patterns.
 
 **Parameters:**
 
@@ -223,6 +225,8 @@ Use when you need to:
 - Retrieve images for visual analysis
 - Check character offsets for highlighting
 
+Source IDs appear in search results and concept details evidence. Use concept (action: "details") to see all evidence for a concept, or search (type: "sources") to find passages directly.
+
 **Parameters:**
 
 - `source_id` (`string`) **(required)** - Source ID from evidence or search results
@@ -247,6 +251,8 @@ EPISTEMIC STATUS CLASSIFICATIONS:
 - UNCLASSIFIED: Doesn't fit known patterns
 
 Use for filtering relationships by epistemic reliability, identifying contested knowledge areas, and curating high-confidence vs exploratory subgraphs.
+
+Concept (action: "related") and connect accept include_epistemic_status/exclude_epistemic_status filters to narrow traversals by reliability. Use search to find concepts in contested areas, then epistemic_status to understand why.
 
 **Parameters:**
 
@@ -281,6 +287,8 @@ Use Cases:
 - Identify position-grounding correlation patterns
 - Discover concepts balanced between opposing ideas
 - Map semantic dimensions in the knowledge graph
+
+Requires concept IDs for poles — use search to find opposing concepts first. Use concept (action: "details") to inspect pole concepts before analysis.
 
 **Parameters:**
 
@@ -336,7 +344,7 @@ Three actions available:
 - "concepts": Get all concepts extracted from a document
 
 Documents are aggregated from source chunks and stored in Garage (S3-compatible storage).
-Use search tool with type="documents" to find documents semantically.
+Use search tool with type="documents" to find documents semantically. Use document (action: "concepts") to see what was extracted, then concept (action: "details") or source to drill into specifics.
 
 **Parameters:**
 

--- a/docs/reference/mcp/tools/analyze_polarity_axis.md
+++ b/docs/reference/mcp/tools/analyze_polarity_axis.md
@@ -21,6 +21,8 @@ Use Cases:
 - Discover concepts balanced between opposing ideas
 - Map semantic dimensions in the knowledge graph
 
+Requires concept IDs for poles — use search to find opposing concepts first. Use concept (action: "details") to inspect pole concepts before analysis.
+
 **Parameters:**
 
 - `positive_pole_id` (`string`) **(required)** - Concept ID for positive pole (e.g., ID for "Modern")

--- a/docs/reference/mcp/tools/concept.md
+++ b/docs/reference/mcp/tools/concept.md
@@ -10,7 +10,7 @@ For "connect" action, defaults (threshold=0.5, max_hops=5) match the CLI and wor
 
 If connect returns no paths or you need to combine multiple lookups, escalate to the program tool — one composed query replaces many individual calls. Do not repeat connect hoping for different results.
 
-For multi-step workflows (search → connect → expand → filter), compose these into a GraphProgram instead of making individual calls. See the program tool and program/syntax resource.
+For multi-step workflows (search → connect → expand → filter), compose these into a GraphProgram instead of making individual calls. For example, seed from a search then expand via Cypher using $W_IDS to reference accumulated concept IDs. See the program tool and program/syntax resource for this and other composition patterns.
 
 **Parameters:**
 

--- a/docs/reference/mcp/tools/document.md
+++ b/docs/reference/mcp/tools/document.md
@@ -12,7 +12,7 @@ Three actions available:
 - "concepts": Get all concepts extracted from a document
 
 Documents are aggregated from source chunks and stored in Garage (S3-compatible storage).
-Use search tool with type="documents" to find documents semantically.
+Use search tool with type="documents" to find documents semantically. Use document (action: "concepts") to see what was extracted, then concept (action: "details") or source to drill into specifics.
 
 **Parameters:**
 

--- a/docs/reference/mcp/tools/epistemic_status.md
+++ b/docs/reference/mcp/tools/epistemic_status.md
@@ -21,6 +21,8 @@ EPISTEMIC STATUS CLASSIFICATIONS:
 
 Use for filtering relationships by epistemic reliability, identifying contested knowledge areas, and curating high-confidence vs exploratory subgraphs.
 
+Concept (action: "related") and connect accept include_epistemic_status/exclude_epistemic_status filters to narrow traversals by reliability. Use search to find concepts in contested areas, then epistemic_status to understand why.
+
 **Parameters:**
 
 - `action` (`string`) **(required)** - Operation: "list" (all types), "show" (specific type), "measure" (run measurement)

--- a/docs/reference/mcp/tools/search.md
+++ b/docs/reference/mcp/tools/search.md
@@ -32,6 +32,8 @@ For multi-step exploration, compose searches into a GraphProgram (program tool) 
 
 ESCALATION: If you find yourself making multiple search/connect calls without converging on an answer, switch to the program tool — one composed query replaces many individual calls.
 
+To verify a result, use source to retrieve the original text behind any evidence, or concept (action: "details") to see all evidence and relationships for a concept.
+
 Use 2-3 word phrases (e.g., "linear thinking patterns").
 
 **Parameters:**

--- a/docs/reference/mcp/tools/source.md
+++ b/docs/reference/mcp/tools/source.md
@@ -15,6 +15,8 @@ Use when you need to:
 - Retrieve images for visual analysis
 - Check character offsets for highlighting
 
+Source IDs appear in search results and concept details evidence. Use concept (action: "details") to see all evidence for a concept, or search (type: "sources") to find passages directly.
+
 **Parameters:**
 
 - `source_id` (`string`) **(required)** - Source ID from evidence or search results


### PR DESCRIPTION
## Summary
- **$W_IDS binding**: `dispatch_cypher` now receives the working graph and passes accumulated concept IDs as a Cypher parameter. The seed-then-expand pattern (API search → Cypher expansion via `$W_IDS`) was documented but never actually worked — now it does.
- **Link labels**: Program execute and chain output resolves link endpoints to concept labels instead of raw content-hash IDs (e.g. `Infrastructure Sovereignty → INFLUENCES → Geopolitical Computational Resources` instead of `sha256:26f76_chunk1_dc5194d6 → INFLUENCES → sha256:26f76_chunk1_1b374980`).
- **Cross-tool hints**: Added terse hints to tool descriptions so calling LLMs discover related tools naturally — search→connect→program escalation, source/details for verification, epistemic status filters, polarity axis prerequisites. Sharpened the program escalation threshold from vague "if you're stuck" to concrete "more than 2 concepts or analytical questions."

## Test plan
- [x] Verified $W_IDS binding: seed-then-expand program executed successfully (2 seed nodes → 4 nodes + 2 links after expansion)
- [x] Verified link labels render as concept names in MCP output
- [ ] Run `cd cli && npm test` for CLI unit tests
- [ ] Run `docker exec kg-api-dev pytest tests/ -x -q` for API tests