### PR TITLE
feat: display docs ingested and graph epoch in web UI

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -691,11 +691,20 @@ class APIClient {
   }
 
   /**
-   * API root info including graph epoch
+   * API root info including document ingestion epoch
    */
   async getApiInfo(): Promise<{ epoch: number; status: string }> {
     const response = await this.client.get<{ epoch: number; status: string }>('/');
     return response.data;
+  }
+
+  /**
+   * Graph change epoch (cache invalidation counter).
+   * Increments on any graph mutation (concept/edge/source create/delete).
+   */
+  async getDatabaseEpoch(): Promise<number> {
+    const response = await this.client.get<{ epoch: number }>('/database/epoch');
+    return response.data.epoch ?? 0;
   }
 
   // ============================================================

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -43,6 +43,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const [dbStats, setDbStats] = useState<any>(null);
   const [dbCounters, setDbCounters] = useState<any>(null);
   const [schedulerStatus, setSchedulerStatus] = useState<SchedulerStatus | null>(null);
+  const [docsIngested, setDocsIngested] = useState<number>(0);
   const [graphEpoch, setGraphEpoch] = useState<number>(0);
   const [embeddingConfigs, setEmbeddingConfigs] = useState<EmbeddingConfig[]>([]);
   const [extractionConfig, setExtractionConfig] = useState<ExtractionConfig | null>(null);
@@ -68,7 +69,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const loadData = async () => {
     setLoading(true);
     try {
-      const [status, stats, counters, scheduler, embeddings, extraction, keys, apiInfo] = await Promise.all([
+      const [status, stats, counters, scheduler, embeddings, extraction, keys, apiInfo, dbEpoch] = await Promise.all([
         apiClient.getSystemStatus().catch(() => null),
         apiClient.getDatabaseStats().catch(() => null),
         apiClient.getDatabaseCounters().catch(() => null),
@@ -77,12 +78,14 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
         apiClient.getExtractionConfig().catch(() => null),
         apiClient.listApiKeys().catch(() => []),
         apiClient.getApiInfo().catch(() => ({ epoch: 0, status: 'error' })),
+        apiClient.getDatabaseEpoch().catch(() => 0),
       ]);
       setSystemStatus(status);
       setDbStats(stats);
       setDbCounters(counters);
       setSchedulerStatus(scheduler);
-      setGraphEpoch(apiInfo.epoch || 0);
+      setDocsIngested(apiInfo.epoch || 0);
+      setGraphEpoch(dbEpoch);
       setEmbeddingConfigs(embeddings);
       setExtractionConfig(extraction);
       setApiKeys(keys);
@@ -415,7 +418,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
         icon={<Activity className="w-5 h-5" />}
       >
         {schedulerStatus?.jobs_by_status ? (
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
             <div className="p-4 bg-status-warning/10 rounded-lg">
               <div className="text-2xl font-bold text-status-warning">
                 {(schedulerStatus.jobs_by_status.pending ?? 0) + (schedulerStatus.jobs_by_status.awaiting_approval ?? 0)}
@@ -439,6 +442,12 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                 {schedulerStatus.jobs_by_status.failed ?? 0}
               </div>
               <div className="text-sm text-destructive">Failed</div>
+            </div>
+            <div className="p-4 bg-muted/50 rounded-lg">
+              <div className="text-2xl font-bold text-foreground">
+                {docsIngested.toLocaleString()}
+              </div>
+              <div className="text-sm text-muted-foreground">Docs Ingested</div>
             </div>
             <div className="p-4 bg-muted/50 rounded-lg">
               <div className="text-2xl font-bold text-foreground">

--- a/web/src/components/home/HomeWorkspace.tsx
+++ b/web/src/components/home/HomeWorkspace.tsx
@@ -277,7 +277,7 @@ export const HomeWorkspace: React.FC = () => {
                 </div>
                 <div className="p-4 rounded-lg bg-card border border-border dark:border-gray-800">
                   <div className="text-sm font-medium text-muted-foreground dark:text-gray-400 mb-2">
-                    Epoch
+                    Docs Ingested
                   </div>
                   <div className="text-2xl font-bold text-card-foreground dark:text-gray-200">
                     {status.epoch?.toLocaleString() || 0}


### PR DESCRIPTION
## Summary
- Show document ingestion count ("Docs Ingested") on home dashboard and admin system tab
- Show graph change counter ("Graph Epoch") on admin system tab
- Add `getDatabaseEpoch()` API client method for `/database/epoch` endpoint
- Correctly distinguish the two metrics: `document_ingestion_counter` (147 docs) vs `graph_change_counter` (all mutations)

## Test plan
- [ ] Verify home dashboard shows 6-column grid with "Docs Ingested" card
- [ ] Verify admin System tab Job Queue section shows 6 cards including both "Docs Ingested" and "Graph Epoch"
- [ ] Verify values load without errors (check browser console)