### PR TITLE
fix: filter infrastructure nodes from connect path traversal

### DIFF
--- a/api/app/lib/graph_facade.py
+++ b/api/app/lib/graph_facade.py
@@ -1024,6 +1024,11 @@ class GraphFacade:
         if semantic_types:
             edge_types_csv = ','.join(semantic_types)
             cur.execute(f"SET graph_accel.edge_types = %s", (edge_types_csv,))
+        else:
+            logger.warning(
+                "graph_accel: no semantic edge types found — "
+                "edge_types GUC not set (defaults to *)"
+            )
         logger.info(
             f"graph_accel: GUCs set — node_labels=Concept, "
             f"edge_types={len(semantic_types)} semantic / "


### PR DESCRIPTION
## Summary

- graph_accel loaded all node/edge types by default, causing 80% of edges to be provenance plumbing (APPEARS, EVIDENCED_BY, FROM_SOURCE, etc.)
- Yen's k-shortest paths traversed Source/Instance/Ontology nodes, producing ghost paths with blank IDs and "Grounding: Unexplored"
- 4 of 5 returned paths were co-occurrence noise; only 1 carried semantic signal

## Fix

Three-layer defense in `graph_facade.py`:

1. **GUC filtering at load time** — `_set_accel_gucs()` sets `node_labels=Concept` and dynamically builds an `edge_types` include list excluding 6 infrastructure types. Loaded edges drop from 19,206 → 3,904.
2. **Post-filter** — paths containing nodes without `app_id` are skipped (defense-in-depth for stale graphs)
3. **GUC timing** — SET calls moved after `graph_accel_status()` (which loads the shared library and registers GUCs) but before `graph_accel_load()` (which reads them)

## Before / After

| | Before | After |
|---|---|---|
| Loaded edges | 19,206 | 3,904 |
| Ghost paths (trust → complexity) | 4 of 5 | 0 of 5 |
| Semantic paths returned | 1 | 5 |
| Path quality | co-occurrence noise | CONTAINS, SUPPORTS, REQUIRES, APPLIES_TO chains |

## Test plan

- [x] Reproduced defect with MCP `concept connect` (trust→complexity, conway→adaptation, cognitive load→platform team)
- [x] Verified fix: all 3 test cases return clean semantic paths, zero ghost nodes
- [x] Unit tests pass (63/63 graph_facade + path tests)
- [x] Confirmed load stats: 1367 nodes / 3904 edges (367 semantic / 373 total edge types)