### PR TITLE
feat: worker lane visibility + embedding config fix

### DIFF
--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -1276,6 +1276,51 @@ export class KnowledgeGraphClient {
   }
 
   /**
+   * Get worker status overview (ADR-100)
+   * Returns slot utilization, running jobs, queue depth, and lane summary.
+   */
+  async getWorkerStatus(): Promise<{
+    running_jobs: Array<{
+      job_id: string;
+      job_type: string;
+      claimed_by: string | null;
+      claimed_at: string | null;
+      started_at: string | null;
+      priority: number;
+    }>;
+    running_count: number;
+    queued_by_type: Array<{ job_type: string; count: number; oldest: string | null }>;
+    total_queued: number;
+    lanes: Array<{ name: string; max_slots: number; enabled: boolean }>;
+    total_slots: number;
+    slots_in_use: number;
+  }> {
+    const response = await this.client.get('/admin/workers/status');
+    return response.data;
+  }
+
+  /**
+   * Get worker lane configuration with slot utilization (ADR-100)
+   * Returns lane configs enriched with running/queued job counts.
+   */
+  async getWorkerLanes(): Promise<{
+    lanes: Array<{
+      name: string;
+      job_types: string[];
+      max_slots: number;
+      poll_interval_ms: number;
+      stale_timeout_minutes: number;
+      enabled: boolean;
+      running_jobs: number;
+      queued_jobs: number;
+      slots_available: number;
+    }>;
+  }> {
+    const response = await this.client.get('/admin/workers/lanes');
+    return response.data;
+  }
+
+  /**
    * Regenerate embeddings for concept nodes in the graph
    */
   async regenerateConceptEmbeddings(params: {

--- a/cli/src/cli/admin/index.ts
+++ b/cli/src/cli/admin/index.ts
@@ -14,6 +14,7 @@ import { createEmbeddingCommand, createExtractionCommand, createKeysCommand } fr
 import { createStatusCommand } from './status';
 import { createBackupCommand, createListBackupsCommand, createRestoreCommand } from './backup';
 import { createSchedulerCommand } from './scheduler';
+import { createWorkersCommand } from './workers';
 
 // Create command instances
 const statusCommand = createStatusCommand();
@@ -21,6 +22,7 @@ const backupCommand = createBackupCommand();
 const listBackupsCommand = createListBackupsCommand();
 const restoreCommand = createRestoreCommand();
 const schedulerCommand = createSchedulerCommand();
+const workersCommand = createWorkersCommand();
 
 // Main admin command
 export const adminCommand = setCommandHelp(
@@ -34,7 +36,8 @@ export const adminCommand = setCommandHelp(
   .addCommand(backupCommand)
   .addCommand(listBackupsCommand)
   .addCommand(restoreCommand)
-  .addCommand(schedulerCommand);
+  .addCommand(schedulerCommand)
+  .addCommand(workersCommand);
 
 // ADR-027: Register user management commands
 registerAuthAdminCommand(adminCommand);
@@ -59,4 +62,4 @@ adminCommand.addCommand(extractionCommand);
 adminCommand.addCommand(keysCommand);
 
 // Configure colored help for all admin commands
-[statusCommand, backupCommand, listBackupsCommand, restoreCommand, schedulerCommand].forEach(configureColoredHelp);
+[statusCommand, backupCommand, listBackupsCommand, restoreCommand, schedulerCommand, workersCommand].forEach(configureColoredHelp);

--- a/cli/src/cli/admin/workers.ts
+++ b/cli/src/cli/admin/workers.ts
@@ -1,0 +1,109 @@
+/**
+ * Admin Workers Commands (ADR-100)
+ * Worker lane management - monitor slot utilization, queue depth, active jobs
+ */
+
+import { Command } from 'commander';
+import { createClientFromEnv } from '../../api/client';
+import * as colors from '../colors';
+import { separator, coloredCount } from '../colors';
+
+function formatDuration(startedAt: string | null): string {
+  if (!startedAt) return 'unknown';
+  const seconds = Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+export function createWorkersCommand(): Command {
+  const workersCommand = new Command('workers')
+    .description('Worker lane management (ADR-100) - monitor slot utilization, queue depth, active jobs')
+    .action(async () => {
+      try {
+        const client = createClientFromEnv();
+
+        console.log('\n' + separator());
+        console.log(colors.ui.title('⚙️  Worker Status'));
+        console.log(separator());
+
+        const status = await client.getWorkerStatus();
+
+        // Slot summary
+        console.log('\n' + colors.ui.header('Slot Utilization'));
+        console.log(`  ${colors.ui.key('Slots In Use:')} ${coloredCount(status.slots_in_use)}/${colors.ui.value(String(status.total_slots))}`);
+        console.log(`  ${colors.ui.key('Running Jobs:')} ${coloredCount(status.running_count)}`);
+        console.log(`  ${colors.ui.key('Queued Jobs:')}  ${coloredCount(status.total_queued)}`);
+
+        // Lane summary
+        console.log('\n' + colors.ui.header('Lanes'));
+        for (const lane of status.lanes) {
+          const icon = lane.enabled ? colors.status.success('✓') : colors.status.error('✗');
+          const label = lane.enabled
+            ? colors.ui.value(`${lane.max_slots} slots`)
+            : colors.status.dim('disabled');
+          console.log(`  ${icon} ${colors.ui.key(lane.name + ':')} ${label}`);
+        }
+
+        // Running jobs
+        if (status.running_jobs.length > 0) {
+          console.log('\n' + colors.ui.header('Active Jobs'));
+          for (const job of status.running_jobs) {
+            const shortId = job.job_id.substring(0, 8);
+            const duration = formatDuration(job.started_at);
+            console.log(`  ${colors.ui.key(shortId + '...')} ${colors.ui.value(job.job_type)} ${colors.status.dim(`(${duration})`)}`);
+          }
+        }
+
+        // Queue depth
+        if (status.queued_by_type.length > 0) {
+          console.log('\n' + colors.ui.header('Queue Depth'));
+          for (const q of status.queued_by_type) {
+            console.log(`  ${colors.ui.key(q.job_type + ':')} ${coloredCount(q.count)}`);
+          }
+        }
+
+        console.log('\n' + separator() + '\n');
+
+      } catch (error: any) {
+        console.error(colors.status.error('✗ Failed to get worker status'));
+        console.error(colors.status.error(error.response?.data?.detail || error.message));
+        process.exit(1);
+      }
+    });
+
+  // workers lanes subcommand
+  workersCommand.addCommand(
+    new Command('lanes')
+      .description('Show worker lane configuration and utilization')
+      .action(async () => {
+        try {
+          const client = createClientFromEnv();
+
+          console.log('\n' + separator());
+          console.log(colors.ui.title('⚙️  Worker Lanes'));
+          console.log(separator());
+
+          const result = await client.getWorkerLanes();
+
+          for (const lane of result.lanes) {
+            const icon = lane.enabled ? colors.status.success('✓') : colors.status.error('✗');
+            console.log(`\n  ${icon} ${colors.ui.header(lane.name)}`);
+            console.log(`    ${colors.ui.key('Job Types:')}     ${colors.ui.value(lane.job_types.join(', '))}`);
+            console.log(`    ${colors.ui.key('Slots:')}         ${coloredCount(lane.running_jobs)}/${colors.ui.value(String(lane.max_slots))} (${lane.slots_available} available, ${lane.queued_jobs} queued)`);
+            console.log(`    ${colors.ui.key('Poll Interval:')} ${colors.ui.value(`${(lane.poll_interval_ms / 1000).toFixed(1)}s`)}`);
+            console.log(`    ${colors.ui.key('Stale Timeout:')} ${colors.ui.value(`${lane.stale_timeout_minutes}m`)}`);
+          }
+
+          console.log('\n' + separator() + '\n');
+
+        } catch (error: any) {
+          console.error(colors.status.error('✗ Failed to get worker lanes'));
+          console.error(colors.status.error(error.response?.data?.detail || error.message));
+          process.exit(1);
+        }
+      })
+  );
+
+  return workersCommand;
+}

--- a/cli/src/mcp-server.ts
+++ b/cli/src/mcp-server.ts
@@ -35,6 +35,7 @@ import {
   formatDatabaseHealth,
   formatSystemStatus,
   formatApiHealth,
+  formatWorkerStatus,
   formatMcpAllowedPaths,
   formatEpistemicStatusList,
   formatEpistemicStatusDetails,
@@ -1358,6 +1359,12 @@ server.setRequestHandler(ListResourcesRequestSchema, async () => {
         mimeType: 'application/json'
       },
       {
+        uri: 'workers/status',
+        name: 'Worker Status',
+        description: 'Lane slot utilization, active jobs, queue depth (ADR-100)',
+        mimeType: 'application/json'
+      },
+      {
         uri: 'api/health',
         name: 'API Health',
         description: 'API server health and timestamp',
@@ -1425,6 +1432,20 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
             uri,
             mimeType: 'text/plain',
             text: formatSystemStatus(result)
+          }]
+        };
+      }
+
+      case 'workers/status': {
+        const [workerStatusResult, workerLanesResult] = await Promise.all([
+          client.getWorkerStatus(),
+          client.getWorkerLanes(),
+        ]);
+        return {
+          contents: [{
+            uri,
+            mimeType: 'text/plain',
+            text: formatWorkerStatus(workerStatusResult, workerLanesResult)
           }]
         };
       }

--- a/cli/src/mcp/formatters/index.ts
+++ b/cli/src/mcp/formatters/index.ts
@@ -35,6 +35,7 @@ export {
   formatDatabaseHealth,
   formatSystemStatus,
   formatApiHealth,
+  formatWorkerStatus,
   formatMcpAllowedPaths,
 } from './system.js';
 

--- a/cli/src/mcp/formatters/system.ts
+++ b/cli/src/mcp/formatters/system.ts
@@ -119,6 +119,48 @@ export function formatApiHealth(result: any): string {
   return output;
 }
 
+export function formatWorkerStatus(status: any, lanes: any): string {
+  let output = `# Worker Status (ADR-100)\n\n`;
+
+  output += `## Slot Utilization\n\n`;
+  output += `Slots In Use: ${status.slots_in_use}/${status.total_slots}\n`;
+  output += `Running Jobs: ${status.running_count}\n`;
+  output += `Queued Jobs: ${status.total_queued}\n\n`;
+
+  if (lanes?.lanes && lanes.lanes.length > 0) {
+    output += `## Lane Configuration\n\n`;
+    for (const lane of lanes.lanes) {
+      output += `### ${lane.name} (${lane.enabled ? 'enabled' : 'disabled'})\n`;
+      output += `Job Types: ${lane.job_types.join(', ')}\n`;
+      output += `Slots: ${lane.running_jobs}/${lane.max_slots} (${lane.slots_available} available, ${lane.queued_jobs} queued)\n`;
+      output += `Poll Interval: ${(lane.poll_interval_ms / 1000).toFixed(1)}s\n`;
+      output += `Stale Timeout: ${lane.stale_timeout_minutes}m\n\n`;
+    }
+  }
+
+  if (status.running_jobs && status.running_jobs.length > 0) {
+    output += `## Active Jobs\n\n`;
+    for (const job of status.running_jobs) {
+      const startedAt = job.started_at ? new Date(job.started_at) : null;
+      const seconds = startedAt ? Math.floor((Date.now() - startedAt.getTime()) / 1000) : null;
+      const duration = seconds !== null
+        ? seconds < 60 ? `${seconds}s` : seconds < 3600 ? `${Math.floor(seconds / 60)}m` : `${Math.floor(seconds / 3600)}h`
+        : 'unknown';
+      output += `- ${job.job_id.substring(0, 8)}... ${job.job_type} (${duration})\n`;
+    }
+    output += `\n`;
+  }
+
+  if (status.queued_by_type && status.queued_by_type.length > 0) {
+    output += `## Queue Depth by Type\n\n`;
+    for (const q of status.queued_by_type) {
+      output += `${q.job_type}: ${q.count}\n`;
+    }
+  }
+
+  return output;
+}
+
 export function formatMcpAllowedPaths(result: any): string {
   if (!result.configured) {
     let output = `# MCP File Access Allowlist\n\n`;

--- a/docs/guides/ASYNC-ARCHITECTURE.md
+++ b/docs/guides/ASYNC-ARCHITECTURE.md
@@ -1,0 +1,157 @@
+# Async Architecture and Worker Lanes
+
+## Overview
+
+The knowledge graph platform processes documents through a multi-stage pipeline: chunking, LLM extraction, concept matching, and graph upsert. Each stage involves CPU-bound or I/O-bound work that must run concurrently without starving the API server or exhausting database connections.
+
+ADR-100 replaced the original in-memory thread dispatch model with **database-driven worker lanes** — typed job queues coordinated entirely through PostgreSQL, with no in-memory dispatch state.
+
+## Process Model
+
+The API runs as a **FastAPI application under Uvicorn with 2 OS-level worker processes** (`--workers 2` in the Dockerfile). Each process is a full Python interpreter with its own event loop and thread pools.
+
+Only one process becomes the **dispatch leader**. On startup, each process attempts a PostgreSQL session-level advisory lock (`pg_try_advisory_lock(100_000_001)` in `api/app/main.py`). The winner starts:
+
+- **LaneManager** — poll loops that claim and execute jobs
+- **JobScheduler** — lifecycle cleanup (stale recovery, expired job cancellation)
+- **ScheduledJobsManager** — cron-like maintenance job creation
+
+The non-leader process handles HTTP requests only. If the leader process dies, the next restart races for the lock again.
+
+## Worker Lanes
+
+A **lane** is a named polling loop with its own concurrency limit and job type affinity. Lane configuration lives in the `kg_api.worker_lanes` PostgreSQL table and is re-read on every poll cycle — changes take effect without a container restart.
+
+### Default Lane Configuration
+
+| Lane | Job Types | Slots | Poll Interval | Stale Timeout |
+|------|-----------|-------|---------------|---------------|
+| `interactive` | ingestion, ingest_image, polarity | 2 | 2s | 30m |
+| `maintenance` | projection, vocab_refresh, epistemic_remeasurement, ontology_annealing, proposal_execution | 1 | 15s | 60m |
+| `system` | restore, vocab_consolidate, artifact_cleanup, source_embedding | 1 | 30s | 120m |
+
+Lane separation guarantees that a long-running t-SNE projection in the maintenance lane cannot prevent an ingestion job from claiming an interactive slot.
+
+### Poll-and-Claim
+
+Each lane runs an async polling loop in `api/app/services/lane_manager.py`. On each cycle:
+
+1. Check if slots are available (`active_jobs < max_slots`)
+2. Attempt an atomic claim query against the jobs table
+3. If a job is claimed, submit it to the `ThreadPoolExecutor` for execution
+4. If no job available, sleep for the lane's `poll_interval_ms`
+
+The claim query uses `FOR UPDATE SKIP LOCKED` so multiple lanes can poll concurrently without blocking:
+
+```sql
+UPDATE kg_api.jobs
+SET status = 'running', claimed_by = :worker_id, claimed_at = NOW()
+WHERE job_id = (
+    SELECT job_id FROM kg_api.jobs
+    WHERE status = 'approved' AND job_type = ANY(:claimable_types)
+    ORDER BY priority DESC, created_at ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING *;
+```
+
+## Thread Pool Inventory
+
+| Pool | Location | Workers | Purpose |
+|------|----------|---------|---------|
+| Lane executor | `lane_manager.py` | 4 (`MAX_CONCURRENT_JOBS`) | Runs claimed jobs in threads |
+| Legacy job executor | `job_queue.py` | 4 (`MAX_CONCURRENT_JOBS`) | Fallback if lane manager unavailable |
+| Local embedding | `embedding_worker.py` | 1 (fixed) | Serializes GPU/CPU model access |
+| Graph parallelizer | `graph_parallelizer.py` | 8 (per-request) | Multi-hop Cypher fan-out |
+
+All heavy work (database queries, LLM calls, embeddings) runs in synchronous threads. The async event loop orchestrates via `loop.run_in_executor()`.
+
+## Connection Pools
+
+The platform uses **psycopg2's `ThreadedConnectionPool`** (synchronous). There is no async database driver.
+
+| Pool | Location | Min/Max | Purpose |
+|------|----------|---------|---------|
+| Job queue | `job_queue.py` | 1/10 | Job lifecycle and claim operations |
+| AGEClient | `age_client/base.py` | 1/20 | Cypher graph queries |
+| Auth | `dependencies/auth.py` | 1/5 | RBAC permission checks |
+
+Each `AGEClient()` instantiation creates its own pool. With default lane config (4 total slots), worst case is ~80 connections from workers plus the job queue and auth pools. The lane model bounds this indirectly by limiting concurrent workers.
+
+## Concurrency Controls
+
+| Control | Mechanism | Default | Location |
+|---------|-----------|---------|----------|
+| AI provider rate limiting | `threading.Semaphore` per provider | ollama=1, anthropic=4, openai=8 | `rate_limiter.py` |
+| Global graph workers | `threading.Semaphore` singleton | 8 | `graph_parallelizer.py` |
+| Lane slot enforcement | In-memory set + `call_soon_threadsafe` | Per lane config | `lane_manager.py` |
+| Job claim atomicity | `FOR UPDATE SKIP LOCKED` | — | `lane_manager.py` |
+| API backoff | Exponential retry with jitter | 60s cap | `rate_limiter.py` |
+| Cancellation | Poll `cancelled` column at chunk boundaries | — | `job_queue.py` |
+| Global thread cap | `MAX_CONCURRENT_THREADS` env var | 32 | `rate_limiter.py` |
+
+## Tuning
+
+### When to increase slots
+
+If ingestion jobs are queuing behind each other and the system has CPU/memory headroom, increase the interactive lane's `max_slots`:
+
+```bash
+# Via API (takes effect on next poll cycle)
+curl -X PATCH http://localhost:8000/admin/workers/lanes/interactive \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"max_slots": 3}'
+```
+
+### When to reduce poll interval
+
+If the 2-second interactive poll delay is noticeable for user-triggered ingestion, reduce `poll_interval_ms`. Lower values increase database polling load slightly.
+
+### When to drain a lane
+
+For maintenance operations (database migrations, schema changes), drain a lane to stop claiming new jobs while letting running jobs finish:
+
+```bash
+curl -X PATCH http://localhost:8000/admin/workers/lanes/maintenance \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"enabled": false}'
+```
+
+Re-enable with `{"enabled": true}` when done.
+
+## Admin Endpoints
+
+All endpoints require authentication and `workers:view` or `workers:manage` RBAC permissions.
+
+| Method | Path | Permission | Purpose |
+|--------|------|------------|---------|
+| GET | `/admin/workers/status` | `workers:view` | Slot utilization, running jobs, queue depth |
+| GET | `/admin/workers/lanes` | `workers:view` | Per-lane config with utilization |
+| PATCH | `/admin/workers/lanes/{name}` | `workers:manage` | Update lane config at runtime |
+| POST | `/admin/workers/jobs/{id}/cancel` | `workers:manage` | Cancel a running job (sets cancelled flag) |
+| PATCH | `/admin/workers/jobs/{id}/priority` | `workers:manage` | Reprioritize a queued job |
+
+## CLI Reference
+
+```bash
+kg admin workers          # Slot overview, lane summary, active jobs
+kg admin workers lanes    # Per-lane config detail with utilization
+```
+
+## MCP Resource
+
+The `workers/status` MCP resource combines both status and lane data:
+
+```
+Resource URI: workers/status
+```
+
+## RBAC
+
+| Permission | Scope | Grants |
+|------------|-------|--------|
+| `workers:view` | Platform | Read lane config, slot utilization, queue depth |
+| `workers:manage` | Platform | Cancel jobs, reprioritize, modify lane config, drain/resume lanes |
+
+Both permissions are granted to the `platform_admin` role by the ADR-100 migration. Custom roles can be granted either permission independently via the RBAC system.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -971,6 +971,30 @@ class APIClient {
   }
 
   /**
+   * Get worker status overview (ADR-100)
+   * Returns slot utilization, running jobs, queue depth, and lane summary.
+   */
+  async getWorkerStatus(): Promise<{
+    running_jobs: Array<{
+      job_id: string;
+      job_type: string;
+      claimed_by: string | null;
+      claimed_at: string | null;
+      started_at: string | null;
+      priority: number;
+    }>;
+    running_count: number;
+    queued_by_type: Array<{ job_type: string; count: number; oldest: string | null }>;
+    total_queued: number;
+    lanes: Array<{ name: string; max_slots: number; enabled: boolean }>;
+    total_slots: number;
+    slots_in_use: number;
+  }> {
+    const response = await this.client.get('/admin/workers/status');
+    return response.data;
+  }
+
+  /**
    * Get database statistics
    * Response format: { nodes: { concepts, sources, instances }, relationships: { total, by_type } }
    */
@@ -1027,11 +1051,20 @@ class APIClient {
    */
   async listEmbeddingConfigs(): Promise<Array<{
     id: number;
-    provider: string;
-    model_name: string;
-    embedding_dimensions: number;
-    precision: string;
+    name: string;
+    vector_space: string;
+    multimodal: boolean;
+    text_provider: string;
+    text_model_name: string;
+    text_loader: string;
+    text_dimensions: number;
+    text_precision: string;
+    image_provider: string | null;
+    image_model_name: string | null;
+    image_dimensions: number | null;
     device: string | null;
+    batch_size: number;
+    max_seq_length: number;
     active: boolean;
     delete_protected: boolean;
     change_protected: boolean;

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -21,6 +21,7 @@ import {
   CheckCircle,
   AlertCircle,
   BarChart3,
+  Layers,
   Play,
   Save,
   Trash2,
@@ -31,7 +32,7 @@ import {
 } from 'lucide-react';
 import { apiClient, API_BASE_URL } from '../../api/client';
 import { Section, StatusBadge } from './components';
-import type { SystemStatus, EmbeddingConfig, ExtractionConfig, ApiKeyInfo, SchedulerStatus } from './types';
+import type { SystemStatus, EmbeddingConfig, ExtractionConfig, ApiKeyInfo, SchedulerStatus, WorkerStatus } from './types';
 
 interface SystemTabProps {
   onError: (error: string) => void;
@@ -43,6 +44,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const [dbStats, setDbStats] = useState<any>(null);
   const [dbCounters, setDbCounters] = useState<any>(null);
   const [schedulerStatus, setSchedulerStatus] = useState<SchedulerStatus | null>(null);
+  const [workerStatus, setWorkerStatus] = useState<WorkerStatus | null>(null);
   const [docsIngested, setDocsIngested] = useState<number>(0);
   const [graphEpoch, setGraphEpoch] = useState<number>(0);
   const [embeddingConfigs, setEmbeddingConfigs] = useState<EmbeddingConfig[]>([]);
@@ -69,11 +71,12 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const loadData = async () => {
     setLoading(true);
     try {
-      const [status, stats, counters, scheduler, embeddings, extraction, keys, apiInfo, dbEpoch] = await Promise.all([
+      const [status, stats, counters, scheduler, workers, embeddings, extraction, keys, apiInfo, dbEpoch] = await Promise.all([
         apiClient.getSystemStatus().catch(() => null),
         apiClient.getDatabaseStats().catch(() => null),
         apiClient.getDatabaseCounters().catch(() => null),
         apiClient.getSchedulerStatus().catch(() => null),
+        apiClient.getWorkerStatus().catch(() => null),
         apiClient.listEmbeddingConfigs().catch(() => []),
         apiClient.getExtractionConfig().catch(() => null),
         apiClient.listApiKeys().catch(() => []),
@@ -84,6 +87,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       setDbStats(stats);
       setDbCounters(counters);
       setSchedulerStatus(scheduler);
+      setWorkerStatus(workers);
       setDocsIngested(apiInfo.epoch || 0);
       setGraphEpoch(dbEpoch);
       setEmbeddingConfigs(embeddings);
@@ -464,6 +468,90 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       </Section>
 
       <Section
+        title="Workers"
+        icon={<Layers className="w-5 h-5" />}
+      >
+        {workerStatus ? (
+          <>
+            <div className="grid grid-cols-3 gap-4 mb-4">
+              <div className="p-4 bg-status-info/20 rounded-lg">
+                <div className="text-2xl font-bold text-status-info">
+                  {workerStatus.slots_in_use}/{workerStatus.total_slots}
+                </div>
+                <div className="text-sm text-status-info">Slots In Use</div>
+              </div>
+              <div className="p-4 bg-muted/50 rounded-lg">
+                <div className="text-2xl font-bold text-foreground">
+                  {workerStatus.running_count}
+                </div>
+                <div className="text-sm text-muted-foreground">Running Jobs</div>
+              </div>
+              <div className="p-4 bg-status-warning/10 rounded-lg">
+                <div className="text-2xl font-bold text-status-warning">
+                  {workerStatus.total_queued}
+                </div>
+                <div className="text-sm text-status-warning">Queued</div>
+              </div>
+            </div>
+
+            <div className="space-y-2 mb-4">
+              <div className="text-sm font-medium text-foreground">Lanes</div>
+              {workerStatus.lanes.map((lane) => (
+                <div
+                  key={lane.name}
+                  className={`flex items-center justify-between p-2 rounded-lg border ${
+                    lane.enabled
+                      ? 'bg-status-active/10 border-status-active/30'
+                      : 'bg-muted/50 border-border opacity-60'
+                  }`}
+                >
+                  <span className="text-sm font-medium text-foreground">{lane.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {lane.enabled ? `${lane.max_slots} slots` : 'disabled'}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {workerStatus.running_jobs.length > 0 && (
+              <div className="space-y-1 mb-4">
+                <div className="text-sm font-medium text-foreground">Active Jobs</div>
+                {workerStatus.running_jobs.map((job) => {
+                  const startedAt = job.started_at ? new Date(job.started_at) : null;
+                  const durationSeconds = startedAt
+                    ? Math.floor((Date.now() - startedAt.getTime()) / 1000)
+                    : null;
+                  const durationLabel = durationSeconds !== null
+                    ? durationSeconds < 60 ? `${durationSeconds}s`
+                      : durationSeconds < 3600 ? `${Math.floor(durationSeconds / 60)}m ${durationSeconds % 60}s`
+                        : `${Math.floor(durationSeconds / 3600)}h ${Math.floor((durationSeconds % 3600) / 60)}m`
+                    : null;
+                  return (
+                    <div key={job.job_id} className="flex items-center justify-between p-2 bg-muted/30 rounded text-sm">
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {job.job_id.substring(0, 8)}...
+                      </span>
+                      <span className="text-foreground">{job.job_type}</span>
+                      {durationLabel && (
+                        <span className="text-xs text-muted-foreground">{durationLabel}</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        ) : (
+          <p className="text-muted-foreground text-center py-8">
+            Unable to load worker status.
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground mt-3">
+          Use <code className="bg-muted px-1 rounded">kg admin workers</code> for CLI view
+        </p>
+      </Section>
+
+      <Section
         title="API Documentation"
         icon={<FileText className="w-5 h-5" />}
       >
@@ -528,7 +616,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                       </span>
                     )}
                     <span className="font-medium text-foreground">
-                      Config {config.id}
+                      {config.name || `Config ${config.id}`}
                     </span>
                     {config.delete_protected && (
                       <span title="Delete protected">
@@ -581,15 +669,15 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                 <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2 text-sm">
                   <div>
                     <span className="text-muted-foreground">Provider:</span>
-                    <span className="ml-1 text-foreground">{config.provider}</span>
+                    <span className="ml-1 text-foreground">{config.text_provider}</span>
                   </div>
                   <div>
                     <span className="text-muted-foreground">Model:</span>
-                    <span className="ml-1 text-foreground font-mono text-xs">{config.model_name}</span>
+                    <span className="ml-1 text-foreground font-mono text-xs">{config.text_model_name}</span>
                   </div>
                   <div>
                     <span className="text-muted-foreground">Dims:</span>
-                    <span className="ml-1 text-foreground">{config.embedding_dimensions}</span>
+                    <span className="ml-1 text-foreground">{config.text_dimensions}</span>
                   </div>
                   <div>
                     <span className="text-muted-foreground">Device:</span>

--- a/web/src/components/admin/types.ts
+++ b/web/src/components/admin/types.ts
@@ -103,11 +103,20 @@ export interface PermissionInfo {
 
 export interface EmbeddingConfig {
   id: number;
-  provider: string;
-  model_name: string;
-  embedding_dimensions: number;
-  precision: string;
+  name: string;
+  vector_space: string;
+  multimodal: boolean;
+  text_provider: string;
+  text_model_name: string;
+  text_loader: string;
+  text_dimensions: number;
+  text_precision: string;
+  image_provider: string | null;
+  image_model_name: string | null;
+  image_dimensions: number | null;
   device: string | null;
+  batch_size: number;
+  max_seq_length: number;
   active: boolean;
   delete_protected: boolean;
   change_protected: boolean;
@@ -139,6 +148,23 @@ export interface SchedulerStatus {
   jobs_by_status: Record<string, number>;
   last_cleanup: string | null;
   next_cleanup: string | null;
+}
+
+export interface WorkerStatus {
+  running_jobs: Array<{
+    job_id: string;
+    job_type: string;
+    claimed_by: string | null;
+    claimed_at: string | null;
+    started_at: string | null;
+    priority: number;
+  }>;
+  running_count: number;
+  queued_by_type: Array<{ job_type: string; count: number; oldest: string | null }>;
+  total_queued: number;
+  lanes: Array<{ name: string; max_slots: number; enabled: boolean }>;
+  total_slots: number;
+  slots_in_use: number;
 }
 
 export type TabType = 'account' | 'users' | 'roles' | 'system';


### PR DESCRIPTION
## Summary
- Wire ADR-100 worker lane API to CLI (`kg admin workers`), web UI (Workers section in SystemTab), and MCP (`workers/status` resource)
- Fix embedding config display — update types to match migration 055 multi-provider schema (was showing blank fields)
- Add async architecture guide (`docs/guides/ASYNC-ARCHITECTURE.md`)

## Test plan
- `cd cli && npm run build` — TypeScript compiles clean
- `kg admin workers` — shows slot utilization, lane summary, active jobs
- `kg admin workers lanes` — shows per-lane config with poll intervals and stale timeouts
- Web Admin > System tab — Workers section renders between Job Queue and API Documentation
- Web Embedding Profiles — shows "Nomic v1.5" / "OpenAI Small" with provider, model, dims