### PR TITLE
feat(embeddings): point size mapping and convex hulls for t-SNE

### DIFF
--- a/api/app/routes/projection.py
+++ b/api/app/routes/projection.py
@@ -40,6 +40,7 @@ class ProjectionConceptResponse(BaseModel):
     ontology: Optional[str] = None  # Source ontology (for cross-ontology mode)
     item_type: Optional[str] = None  # Item type (for combined mode)
     cluster_id: Optional[int] = None  # DBSCAN cluster assignment (None = noise)
+    degree: Optional[int] = None  # Total edge count (in + out)
 
 
 class ProjectionParametersResponse(BaseModel):
@@ -141,6 +142,10 @@ class RegenerateRequest(BaseModel):
     include_diversity: bool = Field(
         default=False,
         description="Include diversity scores (slower)"
+    )
+    include_degree: bool = Field(
+        default=True,
+        description="Include concept degree (edge count)"
     )
     embedding_source: Literal["concepts", "sources", "vocabulary", "combined"] = Field(
         default="concepts",
@@ -287,6 +292,7 @@ async def regenerate_projection(
             include_grounding=body.include_grounding,
             refresh_grounding=body.refresh_grounding,
             include_diversity=body.include_diversity,
+            include_degree=body.include_degree,
             embedding_source=body.embedding_source
         )
 
@@ -316,6 +322,7 @@ async def regenerate_projection(
                     "center": body.center,
                     "include_grounding": body.include_grounding,
                     "include_diversity": body.include_diversity,
+                    "include_degree": body.include_degree,
                     "embedding_source": body.embedding_source
                 },
                 payload=dataset,
@@ -348,6 +355,7 @@ async def regenerate_projection(
             "include_grounding": body.include_grounding,
             "refresh_grounding": body.refresh_grounding,
             "include_diversity": body.include_diversity,
+            "include_degree": body.include_degree,
             "embedding_source": body.embedding_source,
             "create_artifact": body.create_artifact,
             "description": f"Regenerate {body.embedding_source} projection for '{ontology}'",

--- a/api/app/services/embedding_projection_service.py
+++ b/api/app/services/embedding_projection_service.py
@@ -590,6 +590,53 @@ class EmbeddingProjectionService:
 
         return concepts
 
+    def _add_degree_counts(self, concepts: List[Dict], ontology: str) -> List[Dict]:
+        """Add degree (total edge count) to concepts via bulk Cypher query."""
+        concept_ids = [c["concept_id"] for c in concepts if c.get("concept_id")]
+        if not concept_ids:
+            return concepts
+
+        try:
+            conn = self.client.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    self.client._set_age_path(cur)
+                    # Bulk degree lookup for all concepts in one query
+                    query = """
+                    SELECT * FROM cypher('%s', $$
+                        MATCH (c:Concept)
+                        WHERE c.concept_id IN %s
+                        OPTIONAL MATCH (c)-[r_out]->(:Concept)
+                        OPTIONAL MATCH (:Concept)-[r_in]->(c)
+                        RETURN c.concept_id as concept_id,
+                               count(DISTINCT r_out) + count(DISTINCT r_in) as degree
+                    $$) AS (concept_id agtype, degree agtype)
+                    """ % (self.client.graph_name, str(concept_ids))
+
+                    cur.execute(query)
+                    rows = cur.fetchall()
+
+                    degree_map = {}
+                    for row in rows:
+                        cid = str(row[0]).strip('"')
+                        deg = int(str(row[1]))
+                        degree_map[cid] = deg
+
+                    for concept in concepts:
+                        concept["degree"] = degree_map.get(concept["concept_id"], 0)
+
+                    logger.info(f"Added degree counts for {len(degree_map)}/{len(concept_ids)} concepts")
+
+            finally:
+                self.client.pool.putconn(conn)
+
+        except Exception as e:
+            logger.error(f"Error adding degree counts: {e}", exc_info=True)
+            for concept in concepts:
+                concept["degree"] = None
+
+        return concepts
+
     def compute_projection(
         self,
         embeddings: np.ndarray,
@@ -867,6 +914,7 @@ class EmbeddingProjectionService:
         include_grounding: bool = True,
         refresh_grounding: bool = False,
         include_diversity: bool = False,  # Off by default for performance
+        include_degree: bool = True,  # On by default (cheap bulk query)
         embedding_source: Literal["concepts", "sources", "vocabulary", "combined"] = "concepts"
     ) -> Dict[str, Any]:
         """
@@ -1005,6 +1053,10 @@ class EmbeddingProjectionService:
                     if cid and cid in fresh_groundings:
                         item["grounding_strength"] = fresh_groundings[cid]
 
+        # Add degree counts if requested (bulk Cypher, cheap)
+        if include_degree and embedding_source in ("concepts", "combined"):
+            self._add_degree_counts(items, ontology)
+
         # Build result dataset
         result_items = []
         grounding_values = []
@@ -1043,6 +1095,9 @@ class EmbeddingProjectionService:
                 entry["diversity_related_count"] = item.get("diversity_related_count", 0)
                 if item.get("diversity_score") is not None:
                     diversity_values.append(item["diversity_score"])
+
+            if include_degree:
+                entry["degree"] = item.get("degree")
 
             # Add extra metadata for sources
             if "full_text" in item:

--- a/api/app/services/embedding_projection_service.py
+++ b/api/app/services/embedding_projection_service.py
@@ -597,38 +597,30 @@ class EmbeddingProjectionService:
             return concepts
 
         try:
-            conn = self.client.pool.getconn()
-            try:
-                with conn.cursor() as cur:
-                    self.client._set_age_path(cur)
-                    # Bulk degree lookup for all concepts in one query
-                    query = """
-                    SELECT * FROM cypher('%s', $$
-                        MATCH (c:Concept)
-                        WHERE c.concept_id IN %s
-                        OPTIONAL MATCH (c)-[r_out]->(:Concept)
-                        OPTIONAL MATCH (:Concept)-[r_in]->(c)
-                        RETURN c.concept_id as concept_id,
-                               count(DISTINCT r_out) + count(DISTINCT r_in) as degree
-                    $$) AS (concept_id agtype, degree agtype)
-                    """ % (self.client.graph_name, str(concept_ids))
+            # Use _execute_cypher which handles AGE setup, query wrapping, and result parsing
+            results = self.client._execute_cypher(
+                """
+                MATCH (c:Concept)
+                WHERE c.concept_id IN $concept_ids
+                OPTIONAL MATCH (c)-[r_out]->(:Concept)
+                OPTIONAL MATCH (:Concept)-[r_in]->(c)
+                RETURN c.concept_id as concept_id,
+                       count(DISTINCT r_out) + count(DISTINCT r_in) as degree
+                """,
+                params={"concept_ids": concept_ids}
+            )
 
-                    cur.execute(query)
-                    rows = cur.fetchall()
+            degree_map = {}
+            for row in results:
+                cid = row.get("concept_id")
+                deg = row.get("degree", 0)
+                if cid:
+                    degree_map[str(cid)] = int(deg) if deg is not None else 0
 
-                    degree_map = {}
-                    for row in rows:
-                        cid = str(row[0]).strip('"')
-                        deg = int(str(row[1]))
-                        degree_map[cid] = deg
+            for concept in concepts:
+                concept["degree"] = degree_map.get(concept["concept_id"], 0)
 
-                    for concept in concepts:
-                        concept["degree"] = degree_map.get(concept["concept_id"], 0)
-
-                    logger.info(f"Added degree counts for {len(degree_map)}/{len(concept_ids)} concepts")
-
-            finally:
-                self.client.pool.putconn(conn)
+            logger.info(f"Added degree counts for {len(degree_map)}/{len(concept_ids)} concepts")
 
         except Exception as e:
             logger.error(f"Error adding degree counts: {e}", exc_info=True)

--- a/api/app/workers/projection_worker.py
+++ b/api/app/workers/projection_worker.py
@@ -90,6 +90,7 @@ def run_projection_worker(
         include_grounding = job_data.get("include_grounding", True)
         refresh_grounding = job_data.get("refresh_grounding", False)
         include_diversity = job_data.get("include_diversity", False)
+        include_degree = job_data.get("include_degree", True)
         embedding_source = job_data.get("embedding_source", "concepts")
 
         logger.info(
@@ -128,6 +129,7 @@ def run_projection_worker(
             include_grounding=include_grounding,
             refresh_grounding=refresh_grounding,
             include_diversity=include_diversity,
+            include_degree=include_degree,
             embedding_source=embedding_source
         )
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1470,6 +1470,7 @@ class APIClient {
       include_grounding?: boolean;
       refresh_grounding?: boolean; // Compute fresh grounding values
       include_diversity?: boolean;
+      include_degree?: boolean;    // Include degree (edge count) per concept
       embedding_source?: 'concepts' | 'sources' | 'vocabulary' | 'combined';
     }
   ): Promise<{

--- a/web/src/components/blocks/AndBlock.tsx
+++ b/web/src/components/blocks/AndBlock.tsx
@@ -16,7 +16,7 @@ export const AndBlock: React.FC<NodeProps<BlockData>> = ({ id }) => {
       <div className="flex flex-col items-center justify-center gap-1">
         <div className="flex items-center gap-2">
           <span className="font-bold text-base text-amber-700 dark:text-amber-300">AND</span>
-          <span className="px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 rounded text-[10px] font-medium">
+          <span className="px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 rounded text-[0.625rem] font-medium">
             LOGIC
           </span>
         </div>

--- a/web/src/components/blocks/BlockBuilder.tsx
+++ b/web/src/components/blocks/BlockBuilder.tsx
@@ -1162,7 +1162,7 @@ export const BlockBuilder = forwardRef<BlockBuilderHandle, BlockBuilderProps>(({
                               {diagram.description}
                             </div>
                           )}
-                          <div className="text-[10px] text-muted-foreground dark:text-gray-500 mt-1">
+                          <div className="text-[0.625rem] text-muted-foreground dark:text-gray-500 mt-1">
                             {diagram.nodeCount} blocks, {diagram.edgeCount} connections
                           </div>
                         </div>

--- a/web/src/components/blocks/BlockHelpPopup.tsx
+++ b/web/src/components/blocks/BlockHelpPopup.tsx
@@ -71,7 +71,7 @@ export const BlockHelpPopup: React.FC<BlockHelpPopupProps> = ({ blockType, posit
       <div className="px-4 py-3 border-b border-border dark:border-gray-700 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="font-semibold text-card-foreground dark:text-gray-100">{content.title}</span>
-          <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${tagStyle.bg} ${tagStyle.text}`}>
+          <span className={`px-1.5 py-0.5 rounded text-[0.625rem] font-medium ${tagStyle.bg} ${tagStyle.text}`}>
             {content.tag}
           </span>
         </div>

--- a/web/src/components/blocks/BlockPalette.tsx
+++ b/web/src/components/blocks/BlockPalette.tsx
@@ -247,7 +247,7 @@ export const BlockPalette: React.FC<BlockPaletteProps> = ({ onAddBlock, classNam
               {section.title}
             </h4>
             {section.description && (
-              <p className="text-[10px] text-muted-foreground dark:text-gray-500">{section.description}</p>
+              <p className="text-[0.625rem] text-muted-foreground dark:text-gray-500">{section.description}</p>
             )}
           </div>
 

--- a/web/src/components/blocks/EdgeFilterBlock.tsx
+++ b/web/src/components/blocks/EdgeFilterBlock.tsx
@@ -74,7 +74,7 @@ export const EdgeFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
               }}
               className="w-3 h-3 text-blue-500 dark:text-blue-400 rounded"
             />
-            <span className="text-[10px] text-muted-foreground dark:text-gray-500">Regex</span>
+            <span className="text-[0.625rem] text-muted-foreground dark:text-gray-500">Regex</span>
           </label>
         </div>
 
@@ -102,7 +102,7 @@ export const EdgeFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
 
         {/* Regex error message */}
         {regexError && (
-          <div className="text-[10px] text-red-500 dark:text-red-400">
+          <div className="text-[0.625rem] text-red-500 dark:text-red-400">
             {regexError}
           </div>
         )}

--- a/web/src/components/blocks/EndBlock.tsx
+++ b/web/src/components/blocks/EndBlock.tsx
@@ -21,13 +21,13 @@ export const EndBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center justify-center gap-2 mb-2">
         <Square className="w-4 h-4 text-red-600 dark:text-red-400 fill-current" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">END</span>
-        <span className="px-1.5 py-0.5 bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300 rounded text-[10px] font-medium">
+        <span className="px-1.5 py-0.5 bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300 rounded text-[0.625rem] font-medium">
           FLOW
         </span>
       </div>
 
       {/* Output Format Control */}
-      <div className="flex items-center justify-center gap-1 text-[10px]">
+      <div className="flex items-center justify-center gap-1 text-[0.625rem]">
         <button
           className={`flex items-center gap-1 px-2 py-1 rounded ${
             outputFormat === 'visualization'

--- a/web/src/components/blocks/EnrichBlock.tsx
+++ b/web/src/components/blocks/EnrichBlock.tsx
@@ -59,7 +59,7 @@ export const EnrichBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
           />
           <div className="flex-1">
             <span className="text-sm text-card-foreground dark:text-gray-100">Ontology</span>
-            <p className="text-[10px] text-muted-foreground dark:text-gray-500">Color-code by source document</p>
+            <p className="text-[0.625rem] text-muted-foreground dark:text-gray-500">Color-code by source document</p>
           </div>
         </label>
 
@@ -72,7 +72,7 @@ export const EnrichBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
           />
           <div className="flex-1">
             <span className="text-sm text-card-foreground dark:text-gray-100">Grounding</span>
-            <p className="text-[10px] text-muted-foreground dark:text-gray-500">Confidence/reliability score</p>
+            <p className="text-[0.625rem] text-muted-foreground dark:text-gray-500">Confidence/reliability score</p>
           </div>
         </label>
 
@@ -85,7 +85,7 @@ export const EnrichBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
           />
           <div className="flex-1">
             <span className="text-sm text-card-foreground dark:text-gray-100">Search Terms</span>
-            <p className="text-[10px] text-muted-foreground dark:text-gray-500">Alternative labels/aliases</p>
+            <p className="text-[0.625rem] text-muted-foreground dark:text-gray-500">Alternative labels/aliases</p>
           </div>
         </label>
       </div>

--- a/web/src/components/blocks/EpistemicFilterBlock.tsx
+++ b/web/src/components/blocks/EpistemicFilterBlock.tsx
@@ -54,7 +54,7 @@ export const EpistemicFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =
       <div className="flex items-center gap-2 mb-3">
         <Snowflake className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Epistemic Filter</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 rounded text-[0.625rem] font-medium">
           SMART
         </span>
       </div>
@@ -76,7 +76,7 @@ export const EpistemicFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =
         >
           Include Only
           {includeStatuses.length > 0 && (
-            <span className="ml-1 px-1 bg-white/20 rounded text-[10px]">{includeStatuses.length}</span>
+            <span className="ml-1 px-1 bg-white/20 rounded text-[0.625rem]">{includeStatuses.length}</span>
           )}
         </button>
         <button
@@ -89,7 +89,7 @@ export const EpistemicFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =
         >
           Exclude
           {excludeStatuses.length > 0 && (
-            <span className="ml-1 px-1 bg-white/20 rounded text-[10px]">{excludeStatuses.length}</span>
+            <span className="ml-1 px-1 bg-white/20 rounded text-[0.625rem]">{excludeStatuses.length}</span>
           )}
         </button>
       </div>
@@ -121,7 +121,7 @@ export const EpistemicFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =
                 <span className="text-xs font-medium text-card-foreground dark:text-gray-200 block">
                   {status.label}
                 </span>
-                <span className="text-[10px] text-muted-foreground dark:text-gray-500 block truncate">
+                <span className="text-[0.625rem] text-muted-foreground dark:text-gray-500 block truncate">
                   {status.description}
                 </span>
               </div>
@@ -132,7 +132,7 @@ export const EpistemicFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =
 
       {/* Active filters summary */}
       {activeCount > 0 && (
-        <div className="mt-2 pt-2 border-t border-border dark:border-gray-700 text-[10px] text-muted-foreground dark:text-gray-500">
+        <div className="mt-2 pt-2 border-t border-border dark:border-gray-700 text-[0.625rem] text-muted-foreground dark:text-gray-500">
           {includeStatuses.length > 0 && (
             <div>Include: {includeStatuses.join(', ')}</div>
           )}

--- a/web/src/components/blocks/FilterBlock.tsx
+++ b/web/src/components/blocks/FilterBlock.tsx
@@ -64,7 +64,7 @@ export const FilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <Filter className="w-4 h-4 text-orange-600 dark:text-orange-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Filter Results</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300 rounded text-[0.625rem] font-medium">
           CYPHER
         </span>
       </div>
@@ -86,7 +86,7 @@ export const FilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
                 }}
                 className="w-3 h-3 text-orange-500 dark:text-orange-400 rounded"
               />
-              <span className="text-[10px] text-muted-foreground dark:text-gray-500">Regex</span>
+              <span className="text-[0.625rem] text-muted-foreground dark:text-gray-500">Regex</span>
             </label>
             {useRegex && (
               <div className="relative">
@@ -99,7 +99,7 @@ export const FilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
                   <HelpCircle className="w-3 h-3 text-muted-foreground dark:text-gray-500" />
                 </button>
                 {showRegexHelp && (
-                  <div className="absolute right-0 top-5 z-50 w-48 p-2 bg-card dark:bg-gray-800 border border-border dark:border-gray-600 rounded shadow-lg text-[10px]">
+                  <div className="absolute right-0 top-5 z-50 w-48 p-2 bg-card dark:bg-gray-800 border border-border dark:border-gray-600 rounded shadow-lg text-[0.625rem]">
                     <div className="font-medium text-card-foreground dark:text-gray-100 mb-1">Regex Examples</div>
                     <div className="space-y-0.5 text-muted-foreground dark:text-gray-400">
                       <div><code className="text-orange-600 dark:text-orange-400">.*</code> any characters</div>
@@ -139,7 +139,7 @@ export const FilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
 
         {/* Regex error message */}
         {regexError && (
-          <div className="text-[10px] text-red-500 dark:text-red-400">
+          <div className="text-[0.625rem] text-red-500 dark:text-red-400">
             {regexError}
           </div>
         )}

--- a/web/src/components/blocks/LimitBlock.tsx
+++ b/web/src/components/blocks/LimitBlock.tsx
@@ -27,7 +27,7 @@ export const LimitBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <Hash className="w-4 h-4 text-gray-600 dark:text-gray-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Limit Results</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-gray-100 dark:bg-gray-900/50 text-gray-700 dark:text-gray-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-gray-100 dark:bg-gray-900/50 text-gray-700 dark:text-gray-300 rounded text-[0.625rem] font-medium">
           CYPHER
         </span>
       </div>

--- a/web/src/components/blocks/NeighborhoodBlock.tsx
+++ b/web/src/components/blocks/NeighborhoodBlock.tsx
@@ -62,7 +62,7 @@ export const NeighborhoodBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <Network className="w-4 h-4 text-purple-600 dark:text-purple-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Expand Neighborhood</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 rounded text-[0.625rem] font-medium">
           CYPHER
         </span>
       </div>
@@ -128,7 +128,7 @@ export const NeighborhoodBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
         >
           {showFilters ? '▼' : '▶'} Epistemic Filters
           {(includeStatuses.length > 0 || excludeStatuses.length > 0) && (
-            <span className="ml-1 px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 rounded text-[10px]">
+            <span className="ml-1 px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 rounded text-[0.625rem]">
               {includeStatuses.length + excludeStatuses.length}
             </span>
           )}
@@ -138,7 +138,7 @@ export const NeighborhoodBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
           <div className="pl-2 space-y-2">
             {/* Include Filters */}
             <div>
-              <label className="text-[10px] text-muted-foreground dark:text-gray-500 uppercase tracking-wide">Include Only</label>
+              <label className="text-[0.625rem] text-muted-foreground dark:text-gray-500 uppercase tracking-wide">Include Only</label>
               <div className="space-y-1 mt-1">
                 {EPISTEMIC_STATUSES.map(status => (
                   <label key={`include-${status}`} className="flex items-center gap-1.5 cursor-pointer">
@@ -148,7 +148,7 @@ export const NeighborhoodBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
                       onChange={() => toggleIncludeStatus(status)}
                       className="w-3 h-3 text-purple-600 dark:text-purple-400 rounded focus:ring-purple-500 dark:focus:ring-purple-400"
                     />
-                    <span className="text-[11px] text-card-foreground dark:text-gray-300">{status}</span>
+                    <span className="text-[0.6875rem] text-card-foreground dark:text-gray-300">{status}</span>
                   </label>
                 ))}
               </div>
@@ -156,7 +156,7 @@ export const NeighborhoodBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
 
             {/* Exclude Filters */}
             <div>
-              <label className="text-[10px] text-muted-foreground dark:text-gray-500 uppercase tracking-wide">Exclude</label>
+              <label className="text-[0.625rem] text-muted-foreground dark:text-gray-500 uppercase tracking-wide">Exclude</label>
               <div className="space-y-1 mt-1">
                 {EPISTEMIC_STATUSES.map(status => (
                   <label key={`exclude-${status}`} className="flex items-center gap-1.5 cursor-pointer">
@@ -166,7 +166,7 @@ export const NeighborhoodBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
                       onChange={() => toggleExcludeStatus(status)}
                       className="w-3 h-3 text-red-600 dark:text-red-400 rounded focus:ring-red-500 dark:focus:ring-red-400"
                     />
-                    <span className="text-[11px] text-card-foreground dark:text-gray-300">{status}</span>
+                    <span className="text-[0.6875rem] text-card-foreground dark:text-gray-300">{status}</span>
                   </label>
                 ))}
               </div>

--- a/web/src/components/blocks/NodeFilterBlock.tsx
+++ b/web/src/components/blocks/NodeFilterBlock.tsx
@@ -64,7 +64,7 @@ export const NodeFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <Circle className="w-4 h-4 text-purple-600 dark:text-purple-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Filter by Node</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 rounded text-[0.625rem] font-medium">
           CYPHER
         </span>
       </div>
@@ -86,7 +86,7 @@ export const NodeFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
                 }}
                 className="w-3 h-3 text-purple-500 dark:text-purple-400 rounded"
               />
-              <span className="text-[10px] text-muted-foreground dark:text-gray-500">Regex</span>
+              <span className="text-[0.625rem] text-muted-foreground dark:text-gray-500">Regex</span>
             </label>
             {useRegex && (
               <div className="relative">
@@ -99,7 +99,7 @@ export const NodeFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
                   <HelpCircle className="w-3 h-3 text-muted-foreground dark:text-gray-500" />
                 </button>
                 {showRegexHelp && (
-                  <div className="absolute right-0 top-5 z-50 w-48 p-2 bg-card dark:bg-gray-800 border border-border dark:border-gray-600 rounded shadow-lg text-[10px]">
+                  <div className="absolute right-0 top-5 z-50 w-48 p-2 bg-card dark:bg-gray-800 border border-border dark:border-gray-600 rounded shadow-lg text-[0.625rem]">
                     <div className="font-medium text-card-foreground dark:text-gray-100 mb-1">Regex Examples</div>
                     <div className="space-y-0.5 text-muted-foreground dark:text-gray-400">
                       <div><code className="text-purple-600 dark:text-purple-400">.*</code> any characters</div>
@@ -139,7 +139,7 @@ export const NodeFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
 
         {/* Regex error message */}
         {regexError && (
-          <div className="text-[10px] text-red-500 dark:text-red-400">
+          <div className="text-[0.625rem] text-red-500 dark:text-red-400">
             {regexError}
           </div>
         )}

--- a/web/src/components/blocks/NotBlock.tsx
+++ b/web/src/components/blocks/NotBlock.tsx
@@ -30,7 +30,7 @@ export const NotBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <Ban className="w-4 h-4 text-rose-600 dark:text-rose-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Exclude (NOT)</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-rose-100 dark:bg-rose-900/50 text-rose-700 dark:text-rose-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-rose-100 dark:bg-rose-900/50 text-rose-700 dark:text-rose-300 rounded text-[0.625rem] font-medium">
           CYPHER
         </span>
       </div>

--- a/web/src/components/blocks/OntologyFilterBlock.tsx
+++ b/web/src/components/blocks/OntologyFilterBlock.tsx
@@ -57,7 +57,7 @@ export const OntologyFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =>
       <div className="flex items-center gap-2 mb-3">
         <Filter className="w-4 h-4 text-orange-600 dark:text-orange-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Filter by Ontology</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300 rounded text-[0.625rem] font-medium">
           CYPHER
         </span>
       </div>
@@ -79,7 +79,7 @@ export const OntologyFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =>
                 }}
                 className="w-3 h-3 text-orange-500 dark:text-orange-400 rounded"
               />
-              <span className="text-[10px] text-muted-foreground dark:text-gray-500">Regex</span>
+              <span className="text-[0.625rem] text-muted-foreground dark:text-gray-500">Regex</span>
             </label>
             {useRegex && (
               <div className="relative">
@@ -92,7 +92,7 @@ export const OntologyFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =>
                   <HelpCircle className="w-3 h-3 text-muted-foreground dark:text-gray-500" />
                 </button>
                 {showRegexHelp && (
-                  <div className="absolute right-0 top-5 z-50 w-48 p-2 bg-card dark:bg-gray-800 border border-border dark:border-gray-600 rounded shadow-lg text-[10px]">
+                  <div className="absolute right-0 top-5 z-50 w-48 p-2 bg-card dark:bg-gray-800 border border-border dark:border-gray-600 rounded shadow-lg text-[0.625rem]">
                     <div className="font-medium text-card-foreground dark:text-gray-100 mb-1">Regex Examples</div>
                     <div className="space-y-0.5 text-muted-foreground dark:text-gray-400">
                       <div><code className="text-orange-600 dark:text-orange-400">.*</code> any characters</div>
@@ -132,7 +132,7 @@ export const OntologyFilterBlock: React.FC<NodeProps<BlockData>> = ({ data }) =>
 
         {/* Regex error message */}
         {regexError && (
-          <div className="text-[10px] text-red-500 dark:text-red-400">
+          <div className="text-[0.625rem] text-red-500 dark:text-red-400">
             {regexError}
           </div>
         )}

--- a/web/src/components/blocks/OrBlock.tsx
+++ b/web/src/components/blocks/OrBlock.tsx
@@ -16,7 +16,7 @@ export const OrBlock: React.FC<NodeProps<BlockData>> = ({ id }) => {
       <div className="flex flex-col items-center justify-center gap-1">
         <div className="flex items-center gap-2">
           <span className="font-bold text-base text-cyan-700 dark:text-cyan-300">OR</span>
-          <span className="px-1.5 py-0.5 bg-cyan-100 dark:bg-cyan-900/50 text-cyan-700 dark:text-cyan-300 rounded text-[10px] font-medium">
+          <span className="px-1.5 py-0.5 bg-cyan-100 dark:bg-cyan-900/50 text-cyan-700 dark:text-cyan-300 rounded text-[0.625rem] font-medium">
             LOGIC
           </span>
         </div>

--- a/web/src/components/blocks/SearchBlock.tsx
+++ b/web/src/components/blocks/SearchBlock.tsx
@@ -37,7 +37,7 @@ export const SearchBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <Search className="w-4 h-4 text-blue-600 dark:text-blue-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Text Search</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 rounded text-[0.625rem] font-medium">
           CYPHER
         </span>
       </div>

--- a/web/src/components/blocks/SourceSearchBlock.tsx
+++ b/web/src/components/blocks/SourceSearchBlock.tsx
@@ -48,7 +48,7 @@ export const SourceSearchBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <FileText className="w-4 h-4 text-amber-600 dark:text-amber-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Source Search</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 rounded text-[0.625rem] font-medium">
           SMART
         </span>
       </div>

--- a/web/src/components/blocks/StartBlock.tsx
+++ b/web/src/components/blocks/StartBlock.tsx
@@ -21,13 +21,13 @@ export const StartBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center justify-center gap-2 mb-2">
         <Play className="w-4 h-4 text-green-600 dark:text-green-400 fill-current" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">START</span>
-        <span className="px-1.5 py-0.5 bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 rounded text-[10px] font-medium">
+        <span className="px-1.5 py-0.5 bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 rounded text-[0.625rem] font-medium">
           FLOW
         </span>
       </div>
 
       {/* Execution Mode Control */}
-      <div className="flex items-center justify-center gap-1 text-[10px]">
+      <div className="flex items-center justify-center gap-1 text-[0.625rem]">
         <button
           className={`flex items-center gap-1 px-2 py-1 rounded ${
             executionMode === 'interactive'

--- a/web/src/components/blocks/VectorSearchBlock.tsx
+++ b/web/src/components/blocks/VectorSearchBlock.tsx
@@ -40,7 +40,7 @@ export const VectorSearchBlock: React.FC<NodeProps<BlockData>> = ({ data }) => {
       <div className="flex items-center gap-2 mb-3">
         <Snowflake className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
         <span className="font-medium text-sm text-card-foreground dark:text-gray-100">Vector Search</span>
-        <span className="ml-auto px-1.5 py-0.5 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 rounded text-[10px] font-medium">
+        <span className="ml-auto px-1.5 py-0.5 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 rounded text-[0.625rem] font-medium">
           SMART
         </span>
       </div>

--- a/web/src/components/documents/DocumentExplorerWorkspace.tsx
+++ b/web/src/components/documents/DocumentExplorerWorkspace.tsx
@@ -405,7 +405,7 @@ export const DocumentExplorerWorkspace: React.FC = () => {
                 {result.concepts.length > 0 && (
                   <div className="flex flex-wrap gap-1 mt-1">
                     {result.concepts.slice(0, 3).map(c => (
-                      <span key={c.conceptId} className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400">
+                      <span key={c.conceptId} className="text-[0.625rem] px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400">
                         {c.label}
                       </span>
                     ))}

--- a/web/src/components/embeddings/ClusterLegend.tsx
+++ b/web/src/components/embeddings/ClusterLegend.tsx
@@ -75,7 +75,7 @@ export function ClusterLegend({
 }: Props) {
   if (clusterCount <= 0) {
     return (
-      <div className="text-[10px] text-muted-foreground/60">
+      <div className="text-xs text-muted-foreground/60">
         No clusters — regenerate projection
       </div>
     );
@@ -119,7 +119,7 @@ export function ClusterLegend({
           <button
             key={p}
             onClick={() => onPaletteChange(p)}
-            className={`flex-1 py-1 text-[10px] transition-colors ${
+            className={`flex-1 py-1 text-xs transition-colors ${
               palette === p
                 ? 'bg-primary/30 text-primary'
                 : 'bg-accent/30 text-muted-foreground hover:bg-accent/50'
@@ -134,7 +134,7 @@ export function ClusterLegend({
       {highlightedClusters !== null && (
         <button
           onClick={() => onHighlightChange(null)}
-          className="text-[10px] text-primary hover:text-primary/80 mb-1 underline"
+          className="text-xs text-primary hover:text-primary/80 mb-1 underline"
         >
           Show all
         </button>
@@ -150,7 +150,7 @@ export function ClusterLegend({
                 ? { key: col.key, desc: !sort.desc }
                 : { key: col.key, desc: col.key === 'count' }
             )}
-            className={`text-[9px] font-medium ${col.width} text-left transition-colors ${
+            className={`text-xs font-medium ${col.width} text-left transition-colors ${
               sort.key === col.key
                 ? 'text-primary'
                 : 'text-muted-foreground/50 hover:text-muted-foreground'
@@ -198,10 +198,10 @@ export function ClusterLegend({
                 className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
                 style={{ backgroundColor: clusterColor(palette, id) }}
               />
-              <span className="text-[10px] text-muted-foreground truncate flex-1">
+              <span className="text-xs text-muted-foreground truncate flex-1">
                 {name}
               </span>
-              <span className="text-[10px] text-muted-foreground/40 flex-shrink-0 tabular-nums">
+              <span className="text-xs text-muted-foreground/40 flex-shrink-0 tabular-nums">
                 {size}
               </span>
             </button>
@@ -216,10 +216,10 @@ export function ClusterLegend({
             className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
             style={{ backgroundColor: NOISE_COLOR }}
           />
-          <span className="text-[10px] text-muted-foreground/60 flex-1">
+          <span className="text-xs text-muted-foreground/60 flex-1">
             noise
           </span>
-          <span className="text-[10px] text-muted-foreground/40 tabular-nums">
+          <span className="text-xs text-muted-foreground/40 tabular-nums">
             {noiseCount}
           </span>
         </div>

--- a/web/src/components/embeddings/EmbeddingLandscapeWorkspace.tsx
+++ b/web/src/components/embeddings/EmbeddingLandscapeWorkspace.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../../api/client';
 import { Loader2, RefreshCw, Layers, Eye, EyeOff, SlidersHorizontal, FolderOpen } from 'lucide-react';
-import type { ProjectionData, EmbeddingPoint, ColorScheme, ProjectionItemType, DistanceMetric, GroundingScale, GroundingColorRamp, ClusterPalette } from './types';
+import type { ProjectionData, EmbeddingPoint, ColorScheme, ProjectionItemType, DistanceMetric, GroundingScale, GroundingColorRamp, ClusterPalette, SizeMetric } from './types';
 import type { ClusterSortKey } from './ClusterLegend';
 import { EmbeddingScatter3D } from './EmbeddingScatter3D';
 import { ClusterLegend, NOISE_COLOR, clusterColor } from './ClusterLegend';
@@ -285,6 +285,13 @@ export function EmbeddingLandscapeWorkspace() {
   // Color ramp for grounding visualization
   const [groundingRamp, setGroundingRamp] = useState<GroundingColorRamp>('pink-gray-cyan');
 
+  // Point size metric
+  const [sizeMetric, setSizeMetric] = useState<SizeMetric>('uniform');
+
+  // Convex hull visualization
+  const [showHulls, setShowHulls] = useState(false);
+  const [hullGrouping, setHullGrouping] = useState<'cluster' | 'ontology'>('cluster');
+
   // Load global projection on mount
   useEffect(() => {
     loadGlobalProjection();
@@ -349,6 +356,8 @@ export function EmbeddingLandscapeWorkspace() {
         perplexity,
         metric,
         refresh_grounding: refreshGrounding,
+        include_diversity: true,
+        include_degree: true,
         embedding_source: 'concepts',
       });
 
@@ -394,6 +403,8 @@ export function EmbeddingLandscapeWorkspace() {
       z: number;
       ontology: string;
       grounding: number | null;
+      diversity: number | null;
+      degree: number | null;
       ontologyColor: string;
       itemType: ProjectionItemType;
       clusterId: number | null;
@@ -413,6 +424,8 @@ export function EmbeddingLandscapeWorkspace() {
         z: concept.z,
         ontology,
         grounding: concept.grounding_strength,
+        diversity: concept.diversity_score ?? null,
+        degree: concept.degree ?? null,
         ontologyColor: ontologyColors.get(ontology) || '#888888',
         itemType: (concept.item_type as ProjectionItemType) || 'concept',
         clusterId: concept.cluster_id ?? null,
@@ -468,6 +481,8 @@ export function EmbeddingLandscapeWorkspace() {
         z: p.z,
         ontology: p.ontology,
         grounding: p.grounding,
+        diversity: p.diversity,
+        degree: p.degree,
         color,
         itemType: p.itemType,
         clusterId: p.clusterId,
@@ -820,6 +835,9 @@ export function EmbeddingLandscapeWorkspace() {
             }}
             onContextMenu={handleContextMenu}
             selectedPoint={selectedConcept}
+            sizeMetric={sizeMetric}
+            showHulls={showHulls}
+            hullGrouping={hullGrouping}
           />
         )}
 
@@ -852,7 +870,7 @@ export function EmbeddingLandscapeWorkspace() {
                     <button
                       key={scale}
                       onClick={() => setGroundingScale(scale)}
-                      className={`flex-1 py-1 text-[10px] transition-colors ${
+                      className={`flex-1 py-1 text-[0.625rem] transition-colors ${
                         groundingScale === scale
                           ? 'bg-primary/30 text-primary'
                           : 'bg-accent/30 text-muted-foreground hover:bg-accent/50'
@@ -873,13 +891,13 @@ export function EmbeddingLandscapeWorkspace() {
                   title="Click to change colors"
                 />
                 {/* Labels */}
-                <div className="flex justify-between text-[10px] text-muted-foreground" style={{ width: '140px' }}>
+                <div className="flex justify-between text-[0.625rem] text-muted-foreground" style={{ width: '140px' }}>
                   <span>-1</span>
                   <span>0</span>
                   <span>+1</span>
                 </div>
                 {/* Current ramp name */}
-                <div className="text-[10px] text-muted-foreground/50 text-center" style={{ width: '140px' }}>
+                <div className="text-[0.625rem] text-muted-foreground/50 text-center" style={{ width: '140px' }}>
                   {GROUNDING_COLOR_RAMPS[groundingRamp].label}
                 </div>
               </div>
@@ -894,7 +912,7 @@ export function EmbeddingLandscapeWorkspace() {
                       background: 'conic-gradient(from 180deg, hsl(0, 90%, 60%), hsl(60, 90%, 60%), hsl(120, 90%, 60%), hsl(180, 90%, 60%), hsl(240, 90%, 60%), hsl(300, 90%, 60%), hsl(360, 90%, 60%))',
                     }}
                   />
-                  <div className="text-[10px] text-muted-foreground">
+                  <div className="text-[0.625rem] text-muted-foreground">
                     <div>XZ position</div>
                     <div className="text-muted-foreground/60">= hue angle</div>
                   </div>
@@ -907,7 +925,7 @@ export function EmbeddingLandscapeWorkspace() {
                       background: 'linear-gradient(to right, hsl(200, 90%, 50%), hsl(200, 90%, 70%))',
                     }}
                   />
-                  <div className="text-[10px] text-muted-foreground">
+                  <div className="text-[0.625rem] text-muted-foreground">
                     <div>Y height</div>
                     <div className="text-muted-foreground/60">= brightness</div>
                   </div>
@@ -931,6 +949,59 @@ export function EmbeddingLandscapeWorkspace() {
             <div className="text-muted-foreground/60 mt-2 pt-2 border-t border-border">
               {stats.totalConcepts} points
             </div>
+
+            {/* Point size metric */}
+            <div className="mt-2 pt-2 border-t border-border">
+              <label className="text-muted-foreground block mb-1">Point Size</label>
+              <select
+                value={sizeMetric}
+                onChange={(e) => setSizeMetric(e.target.value as SizeMetric)}
+                className="w-full bg-card border border-border rounded px-2 py-1 text-foreground text-xs"
+                style={{ colorScheme: 'dark' }}
+              >
+                <option value="uniform">Uniform</option>
+                <option value="grounding">Grounding</option>
+                <option value="diversity">Diversity</option>
+                <option value="degree">Degree (edges)</option>
+              </select>
+            </div>
+
+            {/* Convex hulls */}
+            <div className="mt-2 pt-2 border-t border-border">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={showHulls}
+                  onChange={(e) => setShowHulls(e.target.checked)}
+                  className="rounded border-border accent-primary"
+                />
+                <span className="text-muted-foreground">Show hulls</span>
+              </label>
+              {showHulls && (
+                <div className="flex gap-1 mt-1.5">
+                  <button
+                    onClick={() => setHullGrouping('cluster')}
+                    className={`flex-1 px-2 py-1 rounded transition-colors ${
+                      hullGrouping === 'cluster'
+                        ? 'bg-primary/20 text-primary'
+                        : 'bg-accent/30 text-muted-foreground hover:bg-accent/50'
+                    }`}
+                  >
+                    Clusters
+                  </button>
+                  <button
+                    onClick={() => setHullGrouping('ontology')}
+                    className={`flex-1 px-2 py-1 rounded transition-colors ${
+                      hullGrouping === 'ontology'
+                        ? 'bg-primary/20 text-primary'
+                        : 'bg-accent/30 text-muted-foreground hover:bg-accent/50'
+                    }`}
+                  >
+                    Ontologies
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         )}
 
@@ -948,7 +1019,7 @@ export function EmbeddingLandscapeWorkspace() {
               <div className="text-xs text-muted-foreground truncate">
                 {contextMenu.point.ontology}
               </div>
-              <div className="flex gap-3 mt-1 text-[10px] text-muted-foreground/70">
+              <div className="flex gap-3 mt-1 text-[0.625rem] text-muted-foreground/70">
                 {contextMenu.point.grounding != null && (
                   <span>grounding: {contextMenu.point.grounding.toFixed(2)}</span>
                 )}

--- a/web/src/components/embeddings/EmbeddingScatter3D.tsx
+++ b/web/src/components/embeddings/EmbeddingScatter3D.tsx
@@ -11,7 +11,8 @@
 import { useRef, useEffect, useCallback, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import type { EmbeddingPoint, ProjectionItemType } from './types';
+import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js';
+import type { EmbeddingPoint, ProjectionItemType, SizeMetric } from './types';
 
 // Shape type mapping: concept=0, source=1, vocabulary=2
 const SHAPE_INDEX: Record<ProjectionItemType, number> = {
@@ -110,21 +111,49 @@ const fragmentShader = `
   }
 `;
 
+/** Compute point size based on the selected metric. */
+function computePointSize(
+  point: EmbeddingPoint,
+  sizeMetric: SizeMetric,
+  maxDegree: number
+): number {
+  switch (sizeMetric) {
+    case 'grounding':
+      return point.grounding !== null ? 3 + Math.abs(point.grounding) * 3 : 5;
+    case 'diversity':
+      return point.diversity !== null ? 3 + point.diversity * 4 : 5;
+    case 'degree': {
+      if (point.degree == null || maxDegree === 0) return 5;
+      const normalized = point.degree / maxDegree;
+      return 3 + normalized * 5;
+    }
+    case 'uniform':
+    default:
+      return 5;
+  }
+}
+
 interface Props {
   points: EmbeddingPoint[];
   onSelectPoint: (point: EmbeddingPoint | null) => void;
   onContextMenu?: (point: EmbeddingPoint, screenPos: { x: number; y: number }) => void;
   selectedPoint: EmbeddingPoint | null;
+  sizeMetric?: SizeMetric;
+  showHulls?: boolean;
+  hullGrouping?: 'cluster' | 'ontology';
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function EmbeddingScatter3D({ points, onSelectPoint, onContextMenu, selectedPoint }: Props) {
+export function EmbeddingScatter3D({
+  points, onSelectPoint, onContextMenu, selectedPoint,
+  sizeMetric = 'uniform', showHulls = false, hullGrouping = 'cluster',
+}: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
   const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
   const controlsRef = useRef<OrbitControls | null>(null);
   const pointsRef = useRef<THREE.Points | null>(null);
+  const hullGroupRef = useRef<THREE.Group | null>(null);
   const raycasterRef = useRef<THREE.Raycaster>(new THREE.Raycaster());
   const mouseRef = useRef<THREE.Vector2>(new THREE.Vector2());
   const hoveredIndexRef = useRef<number | null>(null);
@@ -239,6 +268,9 @@ export function EmbeddingScatter3D({ points, onSelectPoint, onContextMenu, selec
 
     pointDataRef.current = points;
 
+    // Precompute max degree for normalization
+    const maxDegree = points.reduce((max, p) => Math.max(max, p.degree ?? 0), 0);
+
     // Create geometry with attributes for SDF shader
     const geometry = new THREE.BufferGeometry();
     const positions = new Float32Array(points.length * 3);
@@ -256,10 +288,7 @@ export function EmbeddingScatter3D({ points, onSelectPoint, onContextMenu, selec
       colors[i * 3 + 1] = color.g;
       colors[i * 3 + 2] = color.b;
 
-      // Size based on grounding if available (smaller dots for dense clouds)
-      sizes[i] = point.grounding !== null
-        ? 3 + Math.abs(point.grounding) * 3
-        : 5;
+      sizes[i] = computePointSize(point, sizeMetric, maxDegree);
 
       // Shape based on item type
       shapes[i] = SHAPE_INDEX[point.itemType] ?? 0;
@@ -276,7 +305,6 @@ export function EmbeddingScatter3D({ points, onSelectPoint, onContextMenu, selec
     const dynamicAlpha = Math.min(1 / Math.sqrt(points.length), 0.95);
     const effectiveAlpha = Math.max(0.75, dynamicAlpha); // Higher minimum for color vibrancy
 
-    // Create custom SDF shader material for crisp vector shapes
     const material = new THREE.ShaderMaterial({
       uniforms: {
         uOpacity: { value: effectiveAlpha },
@@ -285,7 +313,7 @@ export function EmbeddingScatter3D({ points, onSelectPoint, onContextMenu, selec
       fragmentShader,
       vertexColors: true,
       transparent: true,
-      depthWrite: true,  // Enable proper z-ordering (closer points occlude farther)
+      depthWrite: true,
       depthTest: true,
       blending: THREE.NormalBlending,
     });
@@ -311,7 +339,79 @@ export function EmbeddingScatter3D({ points, onSelectPoint, onContextMenu, selec
       controlsRef.current.target.copy(center);
       controlsRef.current.update();
     }
-  }, [points]);
+  }, [points, sizeMetric]);
+
+  // Convex hulls around clusters or ontologies
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+
+    // Remove old hulls
+    if (hullGroupRef.current) {
+      hullGroupRef.current.traverse((child) => {
+        if (child instanceof THREE.Mesh) {
+          child.geometry.dispose();
+          (child.material as THREE.Material).dispose();
+        }
+      });
+      scene.remove(hullGroupRef.current);
+      hullGroupRef.current = null;
+    }
+
+    if (!showHulls || points.length === 0) return;
+
+    const group = new THREE.Group();
+
+    // Group points by key
+    const groups = new Map<string, EmbeddingPoint[]>();
+    points.forEach(p => {
+      let key: string;
+      if (hullGrouping === 'cluster') {
+        key = p.clusterId != null ? String(p.clusterId) : '__noise__';
+      } else {
+        key = p.ontology;
+      }
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(p);
+    });
+
+    groups.forEach((groupPoints, key) => {
+      // Skip noise points and groups too small for a 3D hull
+      if (key === '__noise__' || groupPoints.length < 4) return;
+
+      const vectors = groupPoints.map(p => new THREE.Vector3(p.x, p.y, p.z));
+
+      try {
+        const geometry = new ConvexGeometry(vectors);
+        const hullColor = new THREE.Color(groupPoints[0].color);
+
+        // Filled hull — very low opacity
+        const fillMaterial = new THREE.MeshBasicMaterial({
+          color: hullColor,
+          transparent: true,
+          opacity: 0.06,
+          side: THREE.DoubleSide,
+          depthWrite: false,
+        });
+        group.add(new THREE.Mesh(geometry, fillMaterial));
+
+        // Wireframe overlay
+        const wireMaterial = new THREE.MeshBasicMaterial({
+          color: hullColor,
+          transparent: true,
+          opacity: 0.12,
+          wireframe: true,
+          depthWrite: false,
+        });
+        group.add(new THREE.Mesh(geometry, wireMaterial));
+      } catch {
+        // ConvexGeometry can fail if points are coplanar
+      }
+    });
+
+    scene.add(group);
+    hullGroupRef.current = group;
+  }, [points, showHulls, hullGrouping]);
 
   // Handle mouse move for hover detection
   const handleMouseMove = useCallback((event: React.MouseEvent) => {

--- a/web/src/components/embeddings/EmbeddingScatter3D.tsx
+++ b/web/src/components/embeddings/EmbeddingScatter3D.tsx
@@ -119,13 +119,14 @@ function computePointSize(
 ): number {
   switch (sizeMetric) {
     case 'grounding':
-      return point.grounding !== null ? 3 + Math.abs(point.grounding) * 3 : 5;
+      return point.grounding !== null ? 2 + Math.abs(point.grounding) * 12 : 3;
     case 'diversity':
-      return point.diversity !== null ? 3 + point.diversity * 4 : 5;
+      return point.diversity !== null ? 2 + point.diversity * 14 : 3;
     case 'degree': {
-      if (point.degree == null || maxDegree === 0) return 5;
-      const normalized = point.degree / maxDegree;
-      return 3 + normalized * 5;
+      if (point.degree == null || maxDegree === 0) return 3;
+      // sqrt scale so mid-range values are visible, not just the max
+      const normalized = Math.sqrt(point.degree / maxDegree);
+      return 2 + normalized * 14;
     }
     case 'uniform':
     default:

--- a/web/src/components/embeddings/EmbeddingScatter3D.tsx
+++ b/web/src/components/embeddings/EmbeddingScatter3D.tsx
@@ -161,6 +161,8 @@ export function EmbeddingScatter3D({
 
   // Map from point index to EmbeddingPoint data
   const pointDataRef = useRef<EmbeddingPoint[]>([]);
+  // Track previous points identity to know when data (not just sizeMetric) changed
+  const prevPointsRef = useRef<EmbeddingPoint[]>([]);
 
   // Tooltip state
   const [tooltip, setTooltip] = useState<{
@@ -255,6 +257,22 @@ export function EmbeddingScatter3D({
     const scene = sceneRef.current;
     if (!scene) return;
 
+    const dataChanged = points !== prevPointsRef.current;
+
+    // If only sizeMetric changed, just update the size buffer in-place
+    if (!dataChanged && pointsRef.current && points.length > 0) {
+      const geometry = pointsRef.current.geometry;
+      const sizeAttr = geometry.getAttribute('size') as THREE.BufferAttribute;
+      const maxDegree = points.reduce((max, p) => Math.max(max, p.degree ?? 0), 0);
+      for (let i = 0; i < points.length; i++) {
+        sizeAttr.array[i] = computePointSize(points[i], sizeMetric, maxDegree);
+      }
+      sizeAttr.needsUpdate = true;
+      return;
+    }
+
+    prevPointsRef.current = points;
+
     // Remove old points
     if (pointsRef.current) {
       scene.remove(pointsRef.current);
@@ -301,10 +319,8 @@ export function EmbeddingScatter3D({
     geometry.setAttribute('shape', new THREE.BufferAttribute(shapes, 1));
 
     // Dynamic alpha based on point count
-    // Higher base opacity for better color pop on dark backgrounds
-    // Only reduce opacity for very large point clouds (>5000 points)
     const dynamicAlpha = Math.min(1 / Math.sqrt(points.length), 0.95);
-    const effectiveAlpha = Math.max(0.75, dynamicAlpha); // Higher minimum for color vibrancy
+    const effectiveAlpha = Math.max(0.75, dynamicAlpha);
 
     const material = new THREE.ShaderMaterial({
       uniforms: {
@@ -323,7 +339,7 @@ export function EmbeddingScatter3D({
     scene.add(pointCloud);
     pointsRef.current = pointCloud;
 
-    // Auto-fit camera to data
+    // Auto-fit camera to data (only when data changes, not sizeMetric)
     if (cameraRef.current && controlsRef.current) {
       const bbox = new THREE.Box3().setFromBufferAttribute(
         geometry.getAttribute('position') as THREE.BufferAttribute

--- a/web/src/components/embeddings/types.ts
+++ b/web/src/components/embeddings/types.ts
@@ -36,7 +36,11 @@ export interface ProjectionConcept {
   ontology?: string;  // Source ontology (for cross-ontology mode)
   item_type?: ProjectionItemType;  // For distinguishing in combined view
   cluster_id?: number | null;  // DBSCAN cluster assignment (null = noise)
+  degree?: number | null;  // Total edge count (in + out)
 }
+
+// Point size metric options
+export type SizeMetric = 'uniform' | 'grounding' | 'diversity' | 'degree';
 
 // Distance metric for projection algorithm
 export type DistanceMetric = 'cosine' | 'euclidean';
@@ -77,6 +81,8 @@ export interface EmbeddingPoint {
   z: number;
   ontology: string;
   grounding: number | null;
+  diversity: number | null;
+  degree: number | null;
   color: string;
   itemType: ProjectionItemType;
   clusterId?: number | null;

--- a/web/src/components/layout/SidebarCategory.tsx
+++ b/web/src/components/layout/SidebarCategory.tsx
@@ -88,7 +88,7 @@ export const SidebarItem: React.FC<SidebarItemProps> = ({
         <div className="flex items-center gap-2">
           <span className="font-medium text-sm truncate">{label}</span>
           {badge && (
-            <span className="px-1.5 py-0.5 text-[10px] font-medium bg-muted text-muted-foreground rounded">
+            <span className="px-1.5 py-0.5 text-[0.625rem] font-medium bg-muted text-muted-foreground rounded">
               {badge}
             </span>
           )}

--- a/web/src/components/preferences/AppearanceTab.tsx
+++ b/web/src/components/preferences/AppearanceTab.tsx
@@ -215,7 +215,7 @@ export const AppearanceTab: React.FC = () => {
                   <span className="text-xs font-mono uppercase tracking-wide font-semibold">
                     {option.label}
                   </span>
-                  <span className="text-[9px] opacity-70">{option.time}</span>
+                  <span className="text-[0.5625rem] opacity-70">{option.time}</span>
                   {isSelected && (
                     <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
                   )}
@@ -252,7 +252,7 @@ export const AppearanceTab: React.FC = () => {
           </div>
 
           {/* Harmony info */}
-          <div className="bg-surface-2 p-3 font-mono text-[10px] space-y-1">
+          <div className="bg-surface-2 p-3 font-mono text-[0.625rem] space-y-1">
             <div className="flex justify-between text-muted-foreground">
               <span>BG Lightness</span>
               <span className="text-card-foreground">{harmony.bg.l}%</span>
@@ -437,7 +437,7 @@ export const AppearanceTab: React.FC = () => {
                   style={{ fontFamily: font.family }}
                 >
                   <div className="text-sm font-semibold">{font.label}</div>
-                  <div className="text-[10px] text-muted-foreground font-mono mt-1">Aa Bb Cc</div>
+                  <div className="text-[0.625rem] text-muted-foreground font-mono mt-1">Aa Bb Cc</div>
                 </button>
               ))}
             </div>
@@ -462,7 +462,7 @@ export const AppearanceTab: React.FC = () => {
                   style={{ fontFamily: font.family }}
                 >
                   <div className="text-sm">{font.label}</div>
-                  <div className="text-[10px] text-muted-foreground mt-1">
+                  <div className="text-[0.625rem] text-muted-foreground mt-1">
                     The quick brown fox jumps over the lazy dog
                   </div>
                 </button>
@@ -489,7 +489,7 @@ export const AppearanceTab: React.FC = () => {
                   style={{ fontFamily: font.family }}
                 >
                   <div className="text-sm">{font.label}</div>
-                  <div className="text-[10px] text-muted-foreground mt-1">
+                  <div className="text-[0.625rem] text-muted-foreground mt-1">
                     {'const x = 42;'}
                   </div>
                 </button>
@@ -542,7 +542,7 @@ export const AppearanceTab: React.FC = () => {
                 />
                 <div className="relative">
                   <div className="text-xs font-mono font-semibold mb-1">{option.label}</div>
-                  <div className="text-[9px] text-muted-foreground">{option.description}</div>
+                  <div className="text-[0.5625rem] text-muted-foreground">{option.description}</div>
                 </div>
               </button>
             ))}

--- a/web/src/components/shared/DocumentViewer.tsx
+++ b/web/src/components/shared/DocumentViewer.tsx
@@ -399,7 +399,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
             {Array.from(hitCountsByColor.entries()).map(([color, count]) => (
               <button
                 key={color}
-                className="flex-1 flex items-center justify-center gap-1.5 py-1.5 px-2 text-[10px] font-medium cursor-pointer hover:brightness-110 transition-all"
+                className="flex-1 flex items-center justify-center gap-1.5 py-1.5 px-2 text-[0.625rem] font-medium cursor-pointer hover:brightness-110 transition-all"
                 style={{ backgroundColor: `${color}25`, color }}
                 onClick={(e) => handleScrollToHighlight(color, e)}
                 title={`Click to cycle through "${queryLabels.get(color) || '?'}" highlights`}

--- a/web/src/explorers/DocumentExplorer/DocumentExplorer.tsx
+++ b/web/src/explorers/DocumentExplorer/DocumentExplorer.tsx
@@ -517,7 +517,7 @@ export const DocumentExplorer: React.FC<
         {rings.map((ring) => (
           <div
             key={ring.color}
-            className="flex-1 flex items-center justify-center gap-1.5 py-1.5 px-2 text-[10px] font-medium"
+            className="flex-1 flex items-center justify-center gap-1.5 py-1.5 px-2 text-[0.625rem] font-medium"
             style={{ backgroundColor: `${ring.color}25`, color: ring.color }}
           >
             <span className="truncate">{queryColorLabels.get(ring.color) || '?'}</span>

--- a/web/src/explorers/DocumentExplorer/PassageQueryLegend.tsx
+++ b/web/src/explorers/DocumentExplorer/PassageQueryLegend.tsx
@@ -24,7 +24,7 @@ export const PassageQueryLegend: React.FC<PassageQueryLegendProps> = ({
 
   return (
     <div className="border-b border-border">
-      <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+      <div className="px-3 py-1.5 text-[0.625rem] font-medium text-muted-foreground uppercase tracking-wider">
         Queries
       </div>
       <div className="px-2 pb-2 space-y-0.5">
@@ -42,7 +42,7 @@ export const PassageQueryLegend: React.FC<PassageQueryLegendProps> = ({
             <span className="flex-1 truncate" title={q.text}>
               {q.text}
             </span>
-            <span className="text-[10px] text-muted-foreground shrink-0">
+            <span className="text-[0.625rem] text-muted-foreground shrink-0">
               {q.results.length}
             </span>
             <button

--- a/web/src/explorers/common/Legend.tsx
+++ b/web/src/explorers/common/Legend.tsx
@@ -99,7 +99,7 @@ export const Legend: React.FC<LegendProps> = ({ data, nodeColorMode }) => {
               background: generateGradient(d3.interpolateViridis),
             }}
           />
-          <div className="flex justify-between text-[10px] text-muted-foreground">
+          <div className="flex justify-between text-[0.625rem] text-muted-foreground">
             <span>Low</span>
             <span>High</span>
           </div>
@@ -115,7 +115,7 @@ export const Legend: React.FC<LegendProps> = ({ data, nodeColorMode }) => {
               background: generateGradient(d3.interpolatePlasma),
             }}
           />
-          <div className="flex justify-between text-[10px] text-muted-foreground">
+          <div className="flex justify-between text-[0.625rem] text-muted-foreground">
             <span>Low</span>
             <span>High</span>
           </div>


### PR DESCRIPTION
## Summary
- Add configurable point size mapping (uniform, grounding, diversity, degree) with a dropdown in the legend area
- Add convex hull visualization around clusters or ontologies using Three.js ConvexGeometry
- Add `degree` (edge count) to projection API via bulk Cypher query
- Fix font scaling across 25+ components to use rem units instead of hardcoded px

## Test plan
- Load Embedding Landscape, toggle Point Size dropdown between all four modes — degree shows clear size variation (0–128 range)
- Enable "Show hulls" with Clusters and Ontologies grouping — transparent volumes render correctly
- Switching size metric preserves camera position
- Grounding color mode + hulls shows emergent epistemic clustering