### PR TITLE
fix(cli): narrow axios response headers to string at use sites

### DIFF
--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -1178,16 +1178,18 @@ export class KnowledgeGraphClient {
       responseType: 'stream'
     });
 
-    // Extract filename from Content-Disposition header
-    const contentDisposition = response.headers['content-disposition'];
+    // Extract filename from Content-Disposition header.
+    // Axios types `headers[x]` as the union `string | number | true | string[] | AxiosHeaders`,
+    // but for HTTP response headers we always get strings — narrow at the boundary.
+    const contentDisposition = response.headers['content-disposition'] as string | undefined;
     const filenameMatch = contentDisposition?.match(/filename=(.+)/);
     // Default based on content type (archive is now default)
-    const contentType = response.headers['content-type'] || '';
+    const contentType = (response.headers['content-type'] as string | undefined) || '';
     const defaultFilename = contentType.includes('gzip') ? 'backup.tar.gz' : 'backup.json';
     const filename = filenameMatch ? filenameMatch[1] : defaultFilename;
 
     // Get content length if available
-    const totalBytes = parseInt(response.headers['content-length'] || '0', 10);
+    const totalBytes = parseInt((response.headers['content-length'] as string | undefined) || '0', 10);
 
     // Create write stream
     const writer = fs.createWriteStream(savePath);

--- a/cli/src/cli/config.ts
+++ b/cli/src/cli/config.ts
@@ -23,8 +23,10 @@ async function testApiUrl(url: string): Promise<boolean> {
       validateStatus: () => true // Don't throw on any status
     });
 
-    // Check if response is JSON and looks like our API
-    const contentType = response.headers['content-type'] || '';
+    // Check if response is JSON and looks like our API.
+    // Axios's header union is broader than HTTP responses actually return —
+    // narrow to string at the boundary.
+    const contentType = (response.headers['content-type'] as string | undefined) || '';
     if (!contentType.includes('application/json')) {
       return false;
     }

--- a/cli/src/cli/login.ts
+++ b/cli/src/cli/login.ts
@@ -26,7 +26,8 @@ async function testApiUrl(url: string): Promise<boolean> {
       timeout: 5000,
       validateStatus: () => true
     });
-    const contentType = response.headers['content-type'] || '';
+    // Narrow axios's broader header union to string at the boundary.
+    const contentType = (response.headers['content-type'] as string | undefined) || '';
     if (!contentType.includes('application/json')) {
       return false;
     }


### PR DESCRIPTION
## What

Three call sites in the CLI access response headers with `.includes(...)` or `parseInt(...)`:

- `cli/src/api/client.ts` — Content-Disposition match, Content-Type sniff, Content-Length parse
- `cli/src/cli/config.ts` — Content-Type sniff for API discovery
- `cli/src/cli/login.ts` — same Content-Type sniff

Axios types `response.headers[x]` as `string | number | true | string[] | AxiosHeaders`, but HTTP responses always return strings. The broader union breaks type-checking. Cast to `string | undefined` at each boundary.

## Why now

Pre-existing TypeScript Build Check failure on main (seen on PR #360 V2 merge). Unblocks CI for the upcoming exploration-action-layer refactor PR.

## Risk

Zero behavioral change — all sites already assumed string semantics at runtime.