### PR TITLE
chore(ways): refresh project-local way frontmatter to embed-aware schema

### DIFF
--- a/.claude/.ways-embed
+++ b/.claude/.ways-embed
@@ -1,0 +1,1 @@
+include

--- a/.claude/ways/kg/adr/way.md
+++ b/.claude/ways/kg/adr/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: \badr\b|ADR-\d|architecture.*decision|docs/architecture/ADR
 files: docs/architecture/ADR
+description: Architecture decision records with domain-based numbering for the knowledge graph system
+vocabulary: adr architecture decision record proposal design rationale domain numbering
+scope: agent, subagent
 ---
 # KG ADR Supplement
 

--- a/.claude/ways/kg/api/way.md
+++ b/.claude/ways/kg/api/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: \bapi\b|AGEClient|routes/|FastAPI|endpoint|backend
 files: api/app/
+description: FastAPI backend structure, query safety via GraphFacade, and endpoint patterns for the knowledge graph API
+vocabulary: api endpoint route fastapi backend rest query facade age client permission
+scope: agent, subagent
 ---
 # API Way
 

--- a/.claude/ways/kg/cli/way.md
+++ b/.claude/ways/kg/cli/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: kg\s+(cli|command|tool)|\bcli\b.*kg|mcp.*tool|MCP.*server|knowledge.?graph.*cli
 commands: kg\s
+description: CLI commands and MCP server tools for interacting with the knowledge graph from the terminal
+vocabulary: cli command mcp tool kg terminal typescript install build
+scope: agent, subagent
 ---
 # CLI & MCP Way
 

--- a/.claude/ways/kg/database/way.md
+++ b/.claude/ways/kg/database/way.md
@@ -1,8 +1,9 @@
 ---
-match: regex
 pattern: \bpostgres\b|\bpsql\b|database.*query|run.*SQL|kg_admin|SELECT\s.*FROM|INSERT\s+INTO|UPDATE\s+kg_|DELETE\s+FROM|schema_migrations
 commands: docker\s+exec.*(postgres|psql)|psql\s+-U
 scope: agent, subagent
+description: Database access via operator.sh query, PostgreSQL schemas, and why docker exec fails
+vocabulary: database postgres psql sql query schema migration table select insert
 ---
 # Database Way
 

--- a/.claude/ways/kg/devmode/way.md
+++ b/.claude/ways/kg/devmode/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: hot.?reload|dev.?mode|live.?reload|volume.?mount|container.*watch|rebuild.*container|code.*change.*container
 commands: operator\.sh\s+(start|restart|init)
+description: Dev mode volume mounts, hot reload behavior, and when container rebuilds are needed
+vocabulary: dev mode hot reload volume mount container restart rebuild watch live
+scope: agent, subagent
 ---
 # Dev Mode Way
 

--- a/.claude/ways/kg/graph-accel/way.md
+++ b/.claude/ways/kg/graph-accel/way.md
@@ -1,8 +1,10 @@
 ---
-match: regex
 pattern: \bgraph.accel\b|\bgraph_accel\b|\.so\b.*pgrx|pgrx|traversal\.rs|bfs_neighborhood|graph_accel_load|graph_accel_neighborhood|graph_accel_path|graph_accel_subgraph|graph_accel_degree
 files: graph-accel/
 commands: cargo\s+(test|build|pgrx)
+description: Rust pgrx PostgreSQL extension for in-memory graph traversal acceleration with BFS and k-shortest paths
+vocabulary: graph accel rust pgrx extension traversal bfs neighborhood pathfinding guc generation cache
+scope: agent, subagent
 ---
 # graph_accel Way
 

--- a/.claude/ways/kg/make/way.md
+++ b/.claude/ways/kg/make/way.md
@@ -1,8 +1,9 @@
 ---
-match: regex
 pattern: \bmake\b|makefile|run.*(test|suite|lint)|docstring.?coverage|scan.?for.*(antipattern|slop)|\bpytest\b|python3?\s.*pytest|PYTHONPATH|\.?/?venv|pip\s+install|npm\s+(test|run)|cargo\s+(test|pgrx)|docker\s+exec\s+kg-
 commands: ^make\s|^pytest|^python3?\s|^PYTHONPATH|^docker exec kg-|^npm (test|run)|^cargo (test|pgrx)
 scope: agent, subagent
+description: Makefile targets that wrap test, lint, and coverage commands for consistent project builds
+vocabulary: make target build test lint coverage slopscan pytest npm cargo
 ---
 # Make Targets Way
 

--- a/.claude/ways/kg/operator/way.md
+++ b/.claude/ways/kg/operator/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: \boperator\b|docker.*kg|container|\.sh.*(start|stop|restart|status)
 commands: operator\.sh|docker\s
+description: operator.sh lifecycle commands for managing knowledge graph containers, configuration, and secrets
+vocabulary: operator container docker start stop restart status init setup deploy upgrade teardown
+scope: agent, subagent
 ---
 # Operator Way
 

--- a/.claude/ways/kg/schema/way.md
+++ b/.claude/ways/kg/schema/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: \bschema\b|migration|\.sql|Cypher|openCypher|AGE|database.*table
 files: schema/
+description: SQL schema structure, migration workflow, openCypher graph data model, and namespace conventions
+vocabulary: schema migration sql cypher opencypher age graph model concept source instance namespace
+scope: agent, subagent
 ---
 # Schema Way
 

--- a/.claude/ways/kg/testing/way.md
+++ b/.claude/ways/kg/testing/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: \bpytest\b|\bjest\b|\btest\b.*run|coverage|conftest
 commands: pytest|npm\s+test|tests/run
+description: Test execution, pytest markers, fixtures, and coverage for the knowledge graph platform
+vocabulary: test pytest jest coverage fixture marker unit integration api security conftest
+scope: agent, subagent
 ---
 # Testing Way
 

--- a/.claude/ways/kg/web/way.md
+++ b/.claude/ways/kg/web/way.md
@@ -1,7 +1,9 @@
 ---
-match: regex
 pattern: \bweb\b|frontend|Zustand|React.*component|Next\.js
 files: web/src/
+description: React frontend with Zustand state management, explorer plugins, and API-first persistence
+vocabulary: web frontend react zustand component store view explorer vite typescript ui
+scope: agent, subagent
 ---
 # Web Way
 


### PR DESCRIPTION
## What

Project-local ways under `.claude/ways/kg/*/way.md` get an updated frontmatter shape:

- Adds `description`, `vocabulary`, and `scope` fields used by the embedding-based way matcher.
- Drops `match: regex` (now the default).

Also adds `.claude/.ways-embed` — the opt-in marker for the embed indexer.

## Why

These edits have been sitting in the working tree across sessions. Landing them as a clean chore keeps the next refactor branch from carrying the noise.

## Risk

Zero behavioral change to the codebase — `.claude/` is editor-side tooling configuration.