### PR TITLE
feat(web): add 2D projection to the unified engine (force-2d-v2)

### DIFF
--- a/.claude/ways/kg/web/evolution/evolution.md
+++ b/.claude/ways/kg/web/evolution/evolution.md
@@ -1,0 +1,91 @@
+---
+pattern: unified.?engine|v1.?v2|v2.?v1|transitional|legacy.*route|redirect.*route|promot(e|ion).*canonical|cosmetic|polish|backwards.?compat|engine.*converge|retire.*explorer
+files: web/src/explorers/|web/src/views/|web/src/components/layout/
+description: Engineering judgement for web refactors — engine convergence over polish, scrub transitional V1/V2 framing post-promotion, skip redirects for never-public routes
+vocabulary: evolution refactor unified engine convergence v1 v2 transitional canonical promote polish redirect deprecation
+scope: agent, subagent
+---
+# Web Evolution Way
+
+Notes for navigating web refactors — especially the unified force-graph
+engine evolution (ADR-702) and similar transitional work where two
+implementations coexist for a while before one wins.
+
+## Engine Convergence Before Polish
+
+When working toward a unified engine (e.g., one force-graph plugin
+serving 2D + 3D + future projections), prefer architectural
+unification over visual polish. Cosmetic items defer until the engine
+has converged.
+
+- Don't bikeshed colors, easing, or chrome while the API surface is
+  still moving — that work will be rewritten when the engine settles.
+- If a polish idea is worth keeping, file a GitHub issue and link it.
+  Memory entries and design notes accumulate; issues close when work
+  lands.
+- "Does this belong in the eventual unified engine?" is the test for
+  whether to port a feature now during transition. Yes → add once;
+  both 2D and 3D get it for free. That's the architectural leverage
+  ADR-702 is buying — take it.
+
+## Drop Transitional Framing Post-Promotion
+
+When a `V2` (or `-experimental`, `-next`, etc.) variant gets promoted
+to canonical, scrub the historical framing in the same PR or the
+follow-up:
+
+- On-canvas labels like "ForceGraph3D V2" → drop the suffix.
+- Comments like `// V1 has X / V2 has Y` → either delete or rewrite as
+  unconditional behaviour.
+- File/symbol names that carry the suffix (`*V2.tsx`, `V2SettingsPanel`)
+  → rename when the V1 is removed.
+
+Once promoted, the V1/V2 distinction is anachronistic. Readers
+arriving fresh have no V1 to compare against, and the lingering
+language slows them down.
+
+## Skip Redirects for Never-Public Routes
+
+Transitional routes that were never publicly stable — `/explore/3d-v2`,
+`/foo-experimental`, anything with a development-only suffix — don't
+need redirect shims when they're folded into the canonical route.
+There are no bookmarks to honour. Dead redirect code is just dead code.
+
+Add redirects only when the source URL was actually shipped to users
+or referenced in external docs.
+
+## When Two Plugins Share One Component
+
+During the coexistence window of a unified-engine migration, two
+explorer plugin entries can share the same component but differ in
+`config` (id, name, icon) and `defaultSettings`. Use a small factory:
+
+```ts
+function createForceGraphPlugin(
+  type: VisualizationType,
+  name: string,
+  description: string,
+  icon: ComponentType<{ className?: string }>,
+  projection: Projection,
+): ExplorerPlugin<Data, Settings> {
+  return {
+    config: { id: type, type, name, description, icon, requiredDataShape: 'graph' },
+    component: ForceGraph3D,
+    settingsPanel: SettingsPanel,
+    dataTransformer: transformForEngine,
+    defaultSettings: { ...DEFAULT_SETTINGS, projection },
+  };
+}
+```
+
+This is the transitional shape — once the legacy variant retires, the
+factory collapses to a single plugin with the projection toggle as the
+user-facing affordance.
+
+## Reference
+
+- ADR-702 (`docs/architecture/user-interfaces/ADR-702-unified-graph-rendering-engine.md`)
+- PR #363 — action-layer unification (style for atomic multi-commit
+  refactor PRs)
+- PR #365 — Phase A: V1-3D retirement
+- PR #366 — Phase B: 2D projection + parity controls

--- a/.claude/ways/kg/web/explorers/explorers.md
+++ b/.claude/ways/kg/web/explorers/explorers.md
@@ -1,0 +1,99 @@
+---
+pattern: ForceGraph2D|ForceGraph3D|OrbitControls|MapControls|drei|@react-three|explorer.*plugin|force.?graph|3d.?view|2d.?view|orthographic|perspective.*camera
+files: web/src/explorers/
+description: Force-graph explorer plugins (2D/3D) — R3F camera/controls choices and the d3 ForceGraph2D interaction reference
+vocabulary: explorer force graph 2d 3d three r3f orbit map controls camera pan zoom rotate context menu interaction projection
+scope: agent, subagent
+---
+# Force-Graph Explorers Way
+
+Explorer plugins live in `web/src/explorers/`. The unified-engine
+direction (ADR-702) is collapsing the 2D and 3D variants onto one R3F
+engine; until that lands, both worlds coexist and their interaction
+defaults need to agree.
+
+## Interaction Model: d3 ForceGraph2D is the Reference
+
+For any 2D force-graph explorer in this project, the d3-based
+`ForceGraph2D` defines the expected interaction defaults:
+
+| Input | Action |
+|-------|--------|
+| Left-click drag on canvas | Pan view |
+| Right-click on node | Context menu |
+| Right-click on background | Background context menu |
+| Scroll wheel | Zoom |
+
+Any new 2D-projection explorer (including R3F top-down ortho variants)
+should match this — left-pan, right-context — so muscle memory carries
+across plugins. If you find yourself with a different default, that's
+the bug, not a feature.
+
+## R3F Top-Down 2D: OrbitControls, Not MapControls
+
+When using R3F (`@react-three/fiber` + `drei`) for a top-down 2D
+projection — orthographic camera at `+Z` looking down `-Z` over a
+`z=0` layout plane — pick `<OrbitControls enableRotate={false}>`,
+not `<MapControls>`.
+
+MapControls' default `screenSpacePanning=false` assumes a Y-up
+ground-plane model. Vertical pan ends up along world-Z (perpendicular
+to the screen) and the view doesn't move. OrbitControls defaults
+`screenSpacePanning=true` and pans along the camera's screen-aligned
+up axis — what a top-down ortho camera actually wants.
+
+To match the d3 interaction model on top:
+
+```tsx
+<OrbitControls
+  makeDefault
+  enableRotate={false}
+  enableZoom={enableZoom}
+  enablePan={enablePan}
+  mouseButtons={{
+    LEFT: THREE.MOUSE.PAN,
+    MIDDLE: THREE.MOUSE.DOLLY,
+    // RIGHT mapped to ROTATE but gated off via enableRotate=false —
+    // leaves right-click un-consumed so the wrapper div's onContextMenu
+    // can open the explorer's context menu.
+    RIGHT: THREE.MOUSE.ROTATE,
+  }}
+/>
+```
+
+## Projection-Aware Labels in 2D
+
+3D edge labels orient along the edge direction (readable from any
+camera angle). In 2D the camera is locked so edge-aligned labels
+become tilted or upside-down. When `projection === '2D'`, use a
+screen-aligned basis (world X/Y/Z) for edge labels so text always
+reads left-to-right.
+
+Distance-culling labels in 2D also needs a tweak: the orthographic
+camera is z-locked at a fixed offset from the layout plane, so `dz`
+is constant >> any sensible `visibilityRadius`. Cull on XY-plane
+distance only — `visibilityRadius` then means "world units from the
+viewport centre".
+
+## WebGL Feature Support: State It Empirically
+
+Driver support for WebGL features varies (Mesa, ANGLE, Metal, …).
+When commenting on features like `LineBasicMaterial.linewidth`, state
+the empirical situation plus the spec — not the worst case:
+
+> "Honoured by drivers that support it; the WebGL spec doesn't
+> require widths > 1, so effect varies by platform."
+
+Not:
+
+> "Clamped to 1px on most drivers."
+
+The first lets the next reader test on their platform and trust the
+comment. The second overclaims and ages badly the moment someone runs
+on a driver that does honour it.
+
+## Reference
+
+- ADR-702 (`docs/architecture/user-interfaces/ADR-702-unified-graph-rendering-engine.md`) — the unified-engine commitment
+- ADR-034 — the ExplorerPlugin contract every explorer follows
+- `web/src/explorers/ForceGraph3D/scene/` — engine primitives (Scene, Nodes, Edges, Arrows, NodeLabels, EdgeLabels, useSim, useForceSim, useGpuForceSim, useDragHandler)

--- a/.claude/ways/kg/web/way.md
+++ b/.claude/ways/kg/web/way.md
@@ -43,10 +43,16 @@ export const useMyStore = create<MyStore>()(
 
 ## After Web Changes
 
+`kg-web-dev` runs Vite with HMR — code changes hot-reload automatically.
+No container restart needed in dev mode. See `kg/devmode/way.md`.
+
 ```bash
-cd web && npm run build  # Check for TypeScript errors
-./operator.sh restart web
+cd web && npx tsc --noEmit  # Check for TypeScript errors (run anytime)
+cd web && npm test           # Run the vitest suite
 ```
+
+Restart `kg-web-dev` only when changing build config (vite.config.ts,
+package.json, tsconfig*.json) — those aren't watched by HMR.
 
 ## API-First with localStorage Fallback
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -126,6 +126,7 @@ const AppContent: React.FC = () => {
 
         {/* Explorers */}
         <Route path="/explore/2d" element={<ExplorerView explorerType="force-2d" />} />
+        <Route path="/explore/2d-v2" element={<ExplorerView explorerType="force-2d-v2" />} />
         <Route path="/explore/3d" element={<ExplorerView explorerType="force-3d" />} />
         <Route path="/explore/documents" element={<DocumentExplorerWorkspace />} />
 

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -75,6 +75,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const getWorkspaceName = () => {
     const path = location.pathname;
     if (path === '/') return 'Home';
+    if (path === '/explore/2d-v2') return '2D Force Graph (V2)';
     if (path.startsWith('/explore/2d')) return '2D Force Graph';
     if (path.startsWith('/explore/3d')) return '3D Force Graph';
     if (path.startsWith('/explore/documents')) return 'Document Explorer';

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -28,6 +28,7 @@ import {
   Shield,
   Network,
   Boxes,
+  Map,
   GitBranch,
   FlaskConical,
   Home,
@@ -129,8 +130,14 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
             <SidebarItem
               icon={Network}
               label="2D Force Graph"
-              isActive={isActive('/explore/2d')}
+              isActive={location.pathname === '/explore/2d'}
               onClick={() => navigate('/explore/2d')}
+            />
+            <SidebarItem
+              icon={Map}
+              label="2D Force Graph (V2)"
+              isActive={location.pathname === '/explore/2d-v2'}
+              onClick={() => navigate('/explore/2d-v2')}
             />
             <SidebarItem
               icon={Boxes}

--- a/web/src/explorers/ForceGraph3D/ForceGraph3D.tsx
+++ b/web/src/explorers/ForceGraph3D/ForceGraph3D.tsx
@@ -168,17 +168,7 @@ export const ForceGraph3D: React.FC<
   }, [data?.nodes]);
   const nodeColorBy = settings?.visual?.nodeColorBy ?? 'ontology';
 
-  // kg-specific edge palette: relationship_type → vocabulary category →
-  // hex via categoryColors.ts. Passed to the engine as an opaque
-  // (edgeType: string) => hex function.
   const vocabStore = useVocabularyStore();
-  const edgePalette = useMemo(() => {
-    if ((settings?.visual?.edgeColorBy ?? 'type') !== 'type') return undefined;
-    return (edgeType: string): string => {
-      const category = vocabStore.getCategory(edgeType);
-      return getCategoryColor(category || undefined);
-    };
-  }, [vocabStore, settings?.visual?.edgeColorBy]);
 
   // Resolve an edge's category with a 3-level fallback (matches the chain
   // used by the 2D explorer's transformForD3): vocabulary lookup →
@@ -201,6 +191,32 @@ export const ForceGraph3D: React.FC<
     const edges = data.edges.filter((e) => visibleEdgeCategories.has(edgeCategory(e)));
     return { ...data, edges };
   }, [data, visibleEdgeCategories, edgeCategory]);
+
+  // Per-edge colors driven by edgeColorBy. Parallel to filteredData.edges
+  // by index. Undefined means "use endpoint gradient" — the engine's
+  // default. Centralising the mode dispatch here keeps Edges, Arrows, and
+  // EdgeLabels uniform: they consume a string[] regardless of mode.
+  const edgeColorBy = settings?.visual?.edgeColorBy ?? 'type';
+  const edgeColors = useMemo<string[] | undefined>(() => {
+    const es = filteredData?.edges;
+    if (!es) return undefined;
+    if (edgeColorBy === 'endpoint') return undefined;
+    if (edgeColorBy === 'uniform') return es.map(() => '#888888');
+    if (edgeColorBy === 'confidence') {
+      return es.map((e) => {
+        // weight ∈ [0,1] (set from API confidence). Hue 0=red, 120=green
+        // matches the d3 2D explorer's scale so cross-view comparison reads.
+        const w = typeof e.weight === 'number' ? e.weight : 0.5;
+        const hue = Math.max(0, Math.min(1, w)) * 120;
+        return `hsl(${hue}, 70%, 50%)`;
+      });
+    }
+    // 'type' — relationship → vocabulary category → category color.
+    return es.map((e) => {
+      const category = vocabStore.getCategory(e.type);
+      return getCategoryColor(category || undefined);
+    });
+  }, [filteredData, edgeColorBy, vocabStore]);
 
   const counts = useMemo(
     () => ({
@@ -294,7 +310,7 @@ export const ForceGraph3D: React.FC<
       size: 10,
       search_terms: [],
     }));
-    const ls = engineEdges.map((e) => {
+    const ls = engineEdges.map((e, i) => {
       const category = edgeCategory(e);
       return {
         from_id: e.from,
@@ -304,12 +320,15 @@ export const ForceGraph3D: React.FC<
         type: e.type,
         relationship_type: e.type,
         category,
-        color: edgePalette ? edgePalette(e.type) : getCategoryColor(category),
+        // Legend swatch follows the rendered edge colour when one is
+        // computed, falling back to the category palette so endpoint
+        // mode still produces a meaningful swatch.
+        color: edgeColors?.[i] ?? getCategoryColor(category),
         value: 1,
       };
     });
     return { nodes: ns, links: ls } as unknown as GraphData;
-  }, [filteredData, palette, edgePalette, edgeCategory]);
+  }, [filteredData, palette, edgeColors, edgeCategory]);
 
   // Build the context-menu item list using the shared helper — produces
   // the same Follow / Add / Remove / Pin / Focus / Origin / Destination /
@@ -394,7 +413,7 @@ export const ForceGraph3D: React.FC<
           nodes={filteredData?.nodes ?? []}
           edges={filteredData?.edges ?? []}
           colors={nodeColors}
-          edgePalette={edgePalette}
+          edgeColors={edgeColors}
           physics={{
             enabled: settings?.physics?.enabled ?? true,
             repulsion: settings?.physics?.repulsion,

--- a/web/src/explorers/ForceGraph3D/ForceGraph3D.tsx
+++ b/web/src/explorers/ForceGraph3D/ForceGraph3D.tsx
@@ -73,6 +73,10 @@ export const ForceGraph3D: React.FC<
 
   const mergeRawGraphData = useGraphStore((s) => s.mergeRawGraphData);
   const visibleEdgeCategories = useGraphStore((s) => s.filters.visibleEdgeCategories);
+  // Universal filters live in the store so every explorer sees the same
+  // filtered data. Reading them via individual selectors keeps zustand's
+  // shallow equality from re-rendering on unrelated store updates.
+  const minConfidence = useGraphStore((s) => s.filters.minConfidence);
   const appliedTheme = useThemeStore((s) => s.appliedTheme);
   const canvasBg = explorerTheme.canvas3D[appliedTheme];
   const {
@@ -184,13 +188,21 @@ export const ForceGraph3D: React.FC<
     [vocabStore]
   );
 
-  // Apply the edge-category filter from the shared store. Empty set means
-  // "show all" — keep data untouched to skip allocations on the common path.
+  // Apply shared-store filters. Both are universal — every explorer
+  // reads from the same store fields, so a filter set in one place
+  // applies everywhere. Empty / zero means "show all".
   const filteredData = useMemo(() => {
-    if (!data || visibleEdgeCategories.size === 0) return data;
-    const edges = data.edges.filter((e) => visibleEdgeCategories.has(edgeCategory(e)));
+    if (!data) return data;
+    const hasCatFilter = visibleEdgeCategories.size > 0;
+    const hasConfFilter = minConfidence > 0;
+    if (!hasCatFilter && !hasConfFilter) return data;
+    const edges = data.edges.filter((e) => {
+      if (hasCatFilter && !visibleEdgeCategories.has(edgeCategory(e))) return false;
+      if (hasConfFilter && (e.weight ?? 1) < minConfidence) return false;
+      return true;
+    });
     return { ...data, edges };
-  }, [data, visibleEdgeCategories, edgeCategory]);
+  }, [data, visibleEdgeCategories, minConfidence, edgeCategory]);
 
   // Per-edge colors driven by edgeColorBy. Parallel to filteredData.edges
   // by index. Undefined means "use endpoint gradient" — the engine's
@@ -424,6 +436,9 @@ export const ForceGraph3D: React.FC<
           projection={settings?.projection ?? '3D'}
           nodeSize={settings?.visual?.nodeSize ?? 1}
           edgeOpacity={0.7}
+          linkWidth={settings?.visual?.linkWidth ?? 1}
+          nodeLabelSize={settings?.visual?.nodeLabelSize ?? 1}
+          edgeLabelSize={settings?.visual?.edgeLabelSize ?? 1}
           showArrows={settings?.visual?.showArrows ?? true}
           showEdgeLabels={settings?.visual?.showLabels ?? true}
           showNodeLabels={settings?.visual?.showNodeLabels ?? true}

--- a/web/src/explorers/ForceGraph3D/ForceGraph3D.tsx
+++ b/web/src/explorers/ForceGraph3D/ForceGraph3D.tsx
@@ -372,7 +372,19 @@ export const ForceGraph3D: React.FC<
       onContextMenu={handleBackgroundContextMenu}
     >
       <Canvas
-        camera={{ position: [0, 0, 400], fov: 60, near: 0.1, far: 5000 }}
+        // Projection dispatch picks the camera flavor: perspective for 3D
+        // (looking down -Z from z=400) and orthographic for 2D (frustum
+        // computed from canvas aspect, zoom drives world-units-per-pixel).
+        // `key` forces a Canvas remount on projection change so r3f
+        // instantiates the right camera class — the `orthographic` prop
+        // is read once at mount.
+        key={settings?.projection ?? '3D'}
+        camera={
+          (settings?.projection ?? '3D') === '2D'
+            ? { position: [0, 0, 400], near: 0.1, far: 5000, zoom: 2.5 }
+            : { position: [0, 0, 400], fov: 60, near: 0.1, far: 5000 }
+        }
+        orthographic={(settings?.projection ?? '3D') === '2D'}
         gl={{ antialias: true }}
         frameloop="demand"
         style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
@@ -390,6 +402,7 @@ export const ForceGraph3D: React.FC<
             centerGravity: settings?.physics?.centerGravity,
             damping: settings?.physics?.damping,
           }}
+          projection={settings?.projection ?? '3D'}
           nodeSize={settings?.visual?.nodeSize ?? 1}
           edgeOpacity={0.7}
           showArrows={settings?.visual?.showArrows ?? true}

--- a/web/src/explorers/ForceGraph3D/SettingsPanel.tsx
+++ b/web/src/explorers/ForceGraph3D/SettingsPanel.tsx
@@ -219,7 +219,9 @@ export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraph3DSettings>> =
                 }
               >
                 <option value="type">By edge type</option>
+                <option value="confidence">By confidence</option>
                 <option value="endpoint">Endpoint gradient</option>
+                <option value="uniform">Uniform</option>
               </select>
             </label>
             {row(

--- a/web/src/explorers/ForceGraph3D/SettingsPanel.tsx
+++ b/web/src/explorers/ForceGraph3D/SettingsPanel.tsx
@@ -16,14 +16,19 @@ import type { SettingsPanelProps } from '../../types/explorer';
 import type { ForceGraph3DSettings } from './types';
 import { SLIDER_RANGES } from './types';
 import { simBackend } from './scene/useSim';
+import { useGraphStore } from '../../store/graphStore';
 
-type Section = 'physics' | 'visual' | 'interaction';
+type Section = 'physics' | 'visual' | 'interaction' | 'filters';
 
 export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraph3DSettings>> = ({
   settings,
   onChange,
 }) => {
   const [expanded, setExpanded] = useState<Set<Section>>(new Set(['physics', 'visual']));
+  // Filters live in the shared store, not in per-plugin settings, so they
+  // apply universally across every explorer that consumes rawGraphData.
+  const minConfidence = useGraphStore((s) => s.filters.minConfidence);
+  const setFilters = useGraphStore((s) => s.setFilters);
 
   const toggle = (section: Section) =>
     setExpanded((prev) => {
@@ -236,6 +241,39 @@ export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraph3DSettings>> =
               )
             )}
             {row(
+              'Link width',
+              settings.visual.linkWidth.toFixed(1),
+              slider(
+                settings.visual.linkWidth,
+                SLIDER_RANGES.visual.linkWidth.min,
+                SLIDER_RANGES.visual.linkWidth.max,
+                SLIDER_RANGES.visual.linkWidth.step,
+                (v) => updateVisual({ linkWidth: v })
+              )
+            )}
+            {row(
+              'Node label size',
+              settings.visual.nodeLabelSize.toFixed(2),
+              slider(
+                settings.visual.nodeLabelSize,
+                SLIDER_RANGES.visual.nodeLabelSize.min,
+                SLIDER_RANGES.visual.nodeLabelSize.max,
+                SLIDER_RANGES.visual.nodeLabelSize.step,
+                (v) => updateVisual({ nodeLabelSize: v })
+              )
+            )}
+            {row(
+              'Edge label size',
+              settings.visual.edgeLabelSize.toFixed(2),
+              slider(
+                settings.visual.edgeLabelSize,
+                SLIDER_RANGES.visual.edgeLabelSize.min,
+                SLIDER_RANGES.visual.edgeLabelSize.max,
+                SLIDER_RANGES.visual.edgeLabelSize.step,
+                (v) => updateVisual({ edgeLabelSize: v })
+              )
+            )}
+            {row(
               'Label radius',
               settings.visual.labelVisibilityRadius.toFixed(0),
               slider(
@@ -246,6 +284,24 @@ export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraph3DSettings>> =
                 (v) => updateVisual({ labelVisibilityRadius: v })
               )
             )}
+          </div>
+        )}
+      </section>
+
+      {/* Filters — shared-store fields, universal across explorers */}
+      <section>
+        {sectionHeader('filters', 'Filters')}
+        {expanded.has('filters') && (
+          <div className="space-y-2 mt-1 pl-4">
+            {row(
+              'Min confidence',
+              minConfidence.toFixed(2),
+              slider(minConfidence, 0, 1, 0.01, (v) => setFilters({ minConfidence: v }))
+            )}
+            <p className="text-[10px] text-muted-foreground">
+              Filters edges by confidence (weight). Applies to every explorer
+              that reads from the shared graph data.
+            </p>
           </div>
         )}
       </section>

--- a/web/src/explorers/ForceGraph3D/SettingsPanel.tsx
+++ b/web/src/explorers/ForceGraph3D/SettingsPanel.tsx
@@ -87,6 +87,23 @@ export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraph3DSettings>> =
 
   return (
     <div className="space-y-3">
+      {/* Projection — top-level switch since it remounts the Canvas */}
+      <section>
+        <label className="flex items-center gap-2 text-xs text-card-foreground py-1.5">
+          <span className="flex-1 min-w-0 truncate font-medium">Projection</span>
+          <select
+            className="flex-[2] bg-card border border-border rounded px-1 py-0.5 text-xs"
+            value={settings.projection}
+            onChange={(e) =>
+              onChange({ ...settings, projection: e.target.value as ForceGraph3DSettings['projection'] })
+            }
+          >
+            <option value="3D">3D (perspective + orbit)</option>
+            <option value="2D">2D (orthographic + pan/zoom)</option>
+          </select>
+        </label>
+      </section>
+
       {/* Physics */}
       <section>
         {sectionHeader('physics', 'Physics')}

--- a/web/src/explorers/ForceGraph3D/dataTransformer.ts
+++ b/web/src/explorers/ForceGraph3D/dataTransformer.ts
@@ -38,6 +38,10 @@ export function transformForEngine(apiData: RawGraphData): ForceGraph3DData {
       from: l.from_id,
       to: l.to_id,
       type: l.relationship_type,
+      // Confidence flows through as `weight` — the engine's opaque
+      // per-edge scalar — so the explorer can drive confidence-coloured
+      // edges without re-reading the source link in the rendering path.
+      weight: l.confidence,
       source: l,
     }));
 

--- a/web/src/explorers/ForceGraph3D/index.ts
+++ b/web/src/explorers/ForceGraph3D/index.ts
@@ -1,37 +1,59 @@
 /**
- * ForceGraph3D — Plugin Definition
+ * ForceGraph — Plugin Definitions
+ *
+ * Two plugin entries share the same component, transformer, and
+ * settings panel; they differ only in `config` (id / name / icon) and
+ * `defaultSettings.projection`. This is the transitional shape during
+ * d3-2D coexistence: once `force-2d` (d3) retires, the `(V2)` suffix
+ * drops and these two entries can consolidate into a single "Force
+ * Graph" plugin with the projection toggle as the user-facing affordance.
  *
  * Follows ADR-034 Explorer Plugin Interface.
- * Built on the unified rendering engine per ADR-702 (r3f + instanced GPU
- * rendering + GPU-accelerated force simulation).
+ * Built on the unified rendering engine per ADR-702 (r3f + instanced
+ * GPU rendering + GPU-accelerated force simulation).
  */
 
-import { Boxes } from 'lucide-react';
-import type { ExplorerPlugin } from '../../types/explorer';
+import { Boxes, Map } from 'lucide-react';
+import type { ExplorerPlugin, VisualizationType } from '../../types/explorer';
+import type { ComponentType } from 'react';
 import { ForceGraph3D } from './ForceGraph3D';
 import { SettingsPanel } from './SettingsPanel';
-import type { ForceGraph3DData, ForceGraph3DSettings } from './types';
+import type { ForceGraph3DData, ForceGraph3DSettings, Projection } from './types';
 import { DEFAULT_SETTINGS } from './types';
 import { transformForEngine } from './dataTransformer';
 
-export const ForceGraph3DExplorer: ExplorerPlugin<
-  ForceGraph3DData,
-  ForceGraph3DSettings
-> = {
-  config: {
-    id: 'force-3d',
-    type: 'force-3d',
-    name: 'Force-Directed 3D',
-    description: 'Unified r3f + GPU engine — 3D with instanced nodes and shader-driven edges',
-    icon: Boxes,
-    requiredDataShape: 'graph',
-  },
+function createForceGraphPlugin(
+  type: VisualizationType,
+  name: string,
+  description: string,
+  icon: ComponentType<{ className?: string }>,
+  projection: Projection
+): ExplorerPlugin<ForceGraph3DData, ForceGraph3DSettings> {
+  return {
+    config: { id: type, type, name, description, icon, requiredDataShape: 'graph' },
+    component: ForceGraph3D,
+    settingsPanel: SettingsPanel,
+    dataTransformer: transformForEngine,
+    defaultSettings: { ...DEFAULT_SETTINGS, projection },
+  };
+}
 
-  component: ForceGraph3D,
-  settingsPanel: SettingsPanel,
-  dataTransformer: transformForEngine,
-  defaultSettings: DEFAULT_SETTINGS,
-};
+export const ForceGraph3DExplorer = createForceGraphPlugin(
+  'force-3d',
+  'Force-Directed 3D',
+  'Unified r3f + GPU engine — 3D with instanced nodes and shader-driven edges',
+  Boxes,
+  '3D'
+);
+
+export const ForceGraph2DV2Explorer = createForceGraphPlugin(
+  'force-2d-v2',
+  'Force-Directed 2D (V2)',
+  'Unified r3f + GPU engine — 2D projection on the same scene primitives',
+  Map,
+  '2D'
+);
 
 import { registerExplorer } from '../registry';
 registerExplorer(ForceGraph3DExplorer);
+registerExplorer(ForceGraph2DV2Explorer);

--- a/web/src/explorers/ForceGraph3D/scene/Arrows.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Arrows.tsx
@@ -44,10 +44,12 @@ export interface ArrowsProps {
   edges: EngineEdge[];
   positionsRef: React.MutableRefObject<Float32Array | null>;
   /** Per-node colors, parallel to `nodes` by index. Used as the arrow
-   *  color (target node) when edgePalette isn't provided. */
+   *  color (target node) when edgeColors isn't provided. */
   colors: string[];
-  /** If provided, color arrows by edge type; otherwise use target node color. */
-  edgePalette?: (edgeType: string) => string;
+  /** Optional per-edge flat colors, parallel to `edges` by index. When
+   *  provided each arrow takes its colour from this array; otherwise
+   *  the target node's colour is used. */
+  edgeColors?: string[];
   hiddenIds?: Set<string>;
   opacity?: number;
   /** Turn off arrow rendering entirely; default true per ADR-702. */
@@ -67,7 +69,7 @@ export function Arrows({
   edges,
   positionsRef,
   colors,
-  edgePalette,
+  edgeColors,
   hiddenIds,
   opacity = 0.9,
   enabled = true,
@@ -78,10 +80,18 @@ export function Arrows({
   const meshRef = useRef<THREE.InstancedMesh>(null);
   const invalidate = useThree((state) => state.invalidate);
 
-  const { indexPairs, curveAngles, curveMags, usableCount, usableEdges } = useMemo(() => {
+  const { indexPairs, curveAngles, curveMags, usableCount, originalIndices } = useMemo(() => {
     const nodeIndex = new Map<string, number>();
     for (let i = 0; i < nodes.length; i++) nodeIndex.set(nodes[i].id, i);
-    const usable = edges.filter((e) => nodeIndex.has(e.from) && nodeIndex.has(e.to));
+    const usable: EngineEdge[] = [];
+    const origIdx: number[] = [];
+    for (let i = 0; i < edges.length; i++) {
+      const e = edges[i];
+      if (nodeIndex.has(e.from) && nodeIndex.has(e.to)) {
+        usable.push(e);
+        origIdx.push(i);
+      }
+    }
     const pairs = new Uint32Array(usable.length * 2);
     for (let i = 0; i < usable.length; i++) {
       pairs[i * 2] = nodeIndex.get(usable[i].from)!;
@@ -93,13 +103,14 @@ export function Arrows({
       curveAngles: angles,
       curveMags: magnitudes,
       usableCount: usable.length,
-      usableEdges: usable,
+      originalIndices: origIdx,
     };
   }, [nodes, edges]);
 
-  // Color: edgePalette by edge type if available, else target node's category.
-  // Dimmed arrows multiply their color by dimAlpha when either endpoint
-  // isn't in the active set.
+  // Color: edgeColors[i] takes precedence (flat colour for type/confidence/
+  // uniform modes); otherwise the arrow takes the target node's colour.
+  // Dimmed arrows multiply by dimAlpha when either endpoint isn't in the
+  // active set.
   useEffect(() => {
     const mesh = meshRef.current;
     if (!mesh) return;
@@ -111,8 +122,8 @@ export function Arrows({
         hasActive && (!activeIds!.has(nodes[si].id) || !activeIds!.has(nodes[ti].id))
           ? dimAlpha
           : 1;
-      if (edgePalette) {
-        tmpColor.set(edgePalette(usableEdges[i].type));
+      if (edgeColors) {
+        tmpColor.set(edgeColors[originalIndices[i]] ?? colors[ti] ?? '#888888');
       } else {
         tmpColor.set(colors[ti] ?? '#888888');
       }
@@ -121,7 +132,7 @@ export function Arrows({
     }
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
     invalidate();
-  }, [usableCount, indexPairs, nodes, colors, edgePalette, usableEdges, activeIds, dimAlpha, invalidate]);
+  }, [usableCount, indexPairs, nodes, colors, edgeColors, originalIndices, activeIds, dimAlpha, invalidate]);
 
   useFrame(() => {
     const mesh = meshRef.current;

--- a/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
@@ -31,12 +31,9 @@ const FALLBACK = new THREE.Vector3(1, 0, 0);
 const RESCAN_MS = 200;
 /** Upper bound on simultaneously-mounted labels to bound per-frame cost. */
 const MAX_LABELS = 80;
-/** Label height in world units. Width is derived from the texture aspect. */
-const LABEL_HEIGHT_WORLD = 1.25;
-/** World-space offset along the label's local +Y so it sits above the edge
- *  line instead of on it. Just over half the label height keeps the bottom
- *  of the text from overlapping the line. */
-const LABEL_OFFSET_LOCAL_Y = LABEL_HEIGHT_WORLD * 0.5;
+/** Base label height in world units. Multiplied by the caller's
+ *  sizeMultiplier prop to compute the actual mesh scale. */
+const BASE_LABEL_HEIGHT_WORLD = 1.25;
 /** Canvas font size for text rendering (high-res for crisp scaling). */
 const TEXT_FONT_PX = 32;
 const TEXT_PADDING_PX = 8;
@@ -88,6 +85,8 @@ export interface EdgeLabelsProps {
   activeIds?: Set<string>;
   /** Drives the distance-culling axis count. 2D ignores Z. Default '3D'. */
   projection?: Projection;
+  /** Multiplier on the base label world-space height. Default 1. */
+  sizeMultiplier?: number;
 }
 
 interface EdgeMeta {
@@ -115,6 +114,7 @@ export function EdgeLabels({
   edgeColors,
   activeIds,
   projection = '3D',
+  sizeMultiplier = 1,
 }: EdgeLabelsProps) {
   const camera = useThree((state) => state.camera);
 
@@ -202,10 +202,11 @@ export function EdgeLabels({
         mat.needsUpdate = true;
       }
       if (mesh) {
-        mesh.scale.set(entry.aspect * LABEL_HEIGHT_WORLD, LABEL_HEIGHT_WORLD, 1);
+        const h = BASE_LABEL_HEIGHT_WORLD * sizeMultiplier;
+        mesh.scale.set(entry.aspect * h, h, 1);
       }
     }
-  }, [visibleIndices, edgeMeta, edgeColors, enabled, activeIds, nodes]);
+  }, [visibleIndices, edgeMeta, edgeColors, enabled, activeIds, nodes, sizeMultiplier]);
 
   // Scratch vectors reused across the frame loop.
   const scratch = useMemo(
@@ -316,7 +317,7 @@ export function EdgeLabels({
       // the label sits above the edge instead of crossing it.
       mesh.position
         .copy(scratch.mid)
-        .addScaledVector(scratch.up, LABEL_OFFSET_LOCAL_Y);
+        .addScaledVector(scratch.up, BASE_LABEL_HEIGHT_WORLD * sizeMultiplier * 0.5);
       mesh.quaternion.setFromRotationMatrix(scratch.basis);
     }
 

--- a/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
@@ -317,8 +317,8 @@ export function EdgeLabels({
     // In 2D the camera is z-locked at a fixed offset from the layout plane,
     // so dz is a constant >> visibilityRadius. Culling on the XY-plane
     // distance makes `visibilityRadius` mean "world units from the viewport
-    // centre", which is what a 2D viewer wants.
-    const is2D = projection === '2D';
+    // centre", which is what a 2D viewer wants. is2D is already defined
+    // above for the orientation branch.
     const candidates: { idx: number; dist2: number }[] = [];
     for (let i = 0; i < edgeMeta.length; i++) {
       const m = edgeMeta[i];

--- a/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
@@ -80,8 +80,9 @@ export interface EdgeLabelsProps {
    *  In 2D the distance is computed in the XY plane only. */
   visibilityRadius?: number;
   enabled?: boolean;
-  /** If provided, color label border by edge type. */
-  edgePalette?: (edgeType: string) => string;
+  /** Optional per-edge label colours, parallel to `edges` by index.
+   *  Falls back to a neutral grey when absent. */
+  edgeColors?: string[];
   /** When defined, labels for edges whose endpoints aren't both in this set
    *  are dimmed (material opacity reduced). */
   activeIds?: Set<string>;
@@ -90,7 +91,9 @@ export interface EdgeLabelsProps {
 }
 
 interface EdgeMeta {
-  edgeIndex: number;
+  /** Index of this edge in the caller's input `edges` array. Used to look
+   *  up edgeColors[origIdx] for the per-edge label colour. */
+  origIdx: number;
   si: number;
   ti: number;
   curveAngle: number;
@@ -109,7 +112,7 @@ export function EdgeLabels({
   hiddenIds,
   visibilityRadius = 250,
   enabled = true,
-  edgePalette,
+  edgeColors,
   activeIds,
   projection = '3D',
 }: EdgeLabelsProps) {
@@ -118,10 +121,18 @@ export function EdgeLabels({
   const edgeMeta: EdgeMeta[] = useMemo(() => {
     const nodeIndex = new Map<string, number>();
     for (let i = 0; i < nodes.length; i++) nodeIndex.set(nodes[i].id, i);
-    const usable = edges.filter((e) => nodeIndex.has(e.from) && nodeIndex.has(e.to));
+    const usable: typeof edges = [];
+    const origIdx: number[] = [];
+    for (let i = 0; i < edges.length; i++) {
+      const e = edges[i];
+      if (nodeIndex.has(e.from) && nodeIndex.has(e.to)) {
+        usable.push(e);
+        origIdx.push(i);
+      }
+    }
     const { angles, magnitudes } = computeBundles(usable);
     return usable.map((e, i) => ({
-      edgeIndex: i,
+      origIdx: origIdx[i],
       si: nodeIndex.get(e.from)!,
       ti: nodeIndex.get(e.to)!,
       curveAngle: angles[i],
@@ -173,7 +184,7 @@ export function EdgeLabels({
     for (let slot = 0; slot < visibleIndices.length; slot++) {
       const meta = edgeMeta[visibleIndices[slot]];
       if (!meta) continue;
-      const color = edgePalette ? edgePalette(meta.type) : '#8899aa';
+      const color = edgeColors?.[meta.origIdx] ?? '#8899aa';
       const key = `${meta.type}|${color}`;
       let entry = textureCache.current.get(key);
       if (!entry) {
@@ -194,7 +205,7 @@ export function EdgeLabels({
         mesh.scale.set(entry.aspect * LABEL_HEIGHT_WORLD, LABEL_HEIGHT_WORLD, 1);
       }
     }
-  }, [visibleIndices, edgeMeta, edgePalette, enabled, activeIds, nodes]);
+  }, [visibleIndices, edgeMeta, edgeColors, enabled, activeIds, nodes]);
 
   // Scratch vectors reused across the frame loop.
   const scratch = useMemo(

--- a/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
@@ -22,7 +22,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { EngineNode, EngineEdge } from '../types';
+import type { EngineNode, EngineEdge, Projection } from '../types';
 import { computeBundles, perpendicularBasis } from './bundles';
 
 const UP = new THREE.Vector3(0, 1, 0);
@@ -76,7 +76,8 @@ export interface EdgeLabelsProps {
   edges: EngineEdge[];
   positionsRef: React.MutableRefObject<Float32Array | null>;
   hiddenIds?: Set<string>;
-  /** Labels past this world-space distance from the camera are unmounted. */
+  /** Labels past this world-space distance from the camera are unmounted.
+   *  In 2D the distance is computed in the XY plane only. */
   visibilityRadius?: number;
   enabled?: boolean;
   /** If provided, color label border by edge type. */
@@ -84,6 +85,8 @@ export interface EdgeLabelsProps {
   /** When defined, labels for edges whose endpoints aren't both in this set
    *  are dimmed (material opacity reduced). */
   activeIds?: Set<string>;
+  /** Drives the distance-culling axis count. 2D ignores Z. Default '3D'. */
+  projection?: Projection;
 }
 
 interface EdgeMeta {
@@ -108,6 +111,7 @@ export function EdgeLabels({
   enabled = true,
   edgePalette,
   activeIds,
+  projection = '3D',
 }: EdgeLabelsProps) {
   const camera = useThree((state) => state.camera);
 
@@ -298,6 +302,11 @@ export function EdgeLabels({
     if (nowMs - lastScanRef.current < RESCAN_MS) return;
     lastScanRef.current = nowMs;
 
+    // In 2D the camera is z-locked at a fixed offset from the layout plane,
+    // so dz is a constant >> visibilityRadius. Culling on the XY-plane
+    // distance makes `visibilityRadius` mean "world units from the viewport
+    // centre", which is what a 2D viewer wants.
+    const is2D = projection === '2D';
     const candidates: { idx: number; dist2: number }[] = [];
     for (let i = 0; i < edgeMeta.length; i++) {
       const m = edgeMeta[i];
@@ -309,7 +318,7 @@ export function EdgeLabels({
       const mz = (positions[a + 2] + positions[b + 2]) * 0.5;
       const dx = mx - scratch.camPos.x;
       const dy = my - scratch.camPos.y;
-      const dz = mz - scratch.camPos.z;
+      const dz = is2D ? 0 : mz - scratch.camPos.z;
       const d2 = dx * dx + dy * dy + dz * dz;
       if (d2 < radius2) candidates.push({ idx: i, dist2: d2 });
     }

--- a/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/EdgeLabels.tsx
@@ -223,6 +223,7 @@ export function EdgeLabels({
     camera.getWorldPosition(scratch.camPos);
     const radius2 = visibilityRadius * visibilityRadius;
     const hasHidden = !!hiddenIds && hiddenIds.size > 0;
+    const is2D = projection === '2D';
 
     // Per-frame: position + orient currently-visible meshes.
     for (let slot = 0; slot < visibleIndices.length; slot++) {
@@ -271,20 +272,31 @@ export function EdgeLabels({
           .addScaledVector(scratch.t, 0.25);
       }
 
-      // Camera-facing roll around the edge axis: pick the perpendicular-
-      // to-edge direction that points most toward the camera as the plane
-      // normal. When the edge is nearly aligned with the view direction
-      // the projection collapses; fall back to a world-axis perpendicular.
-      scratch.toCam.subVectors(scratch.camPos, scratch.mid);
-      const dotEC = scratch.toCam.dot(scratch.edgeDir);
-      scratch.normal.copy(scratch.toCam).addScaledVector(scratch.edgeDir, -dotEC);
-      if (scratch.normal.lengthSq() < 1e-6) {
-        const fb = Math.abs(scratch.edgeDir.y) > 0.99 ? FALLBACK : UP;
-        scratch.normal.copy(fb).addScaledVector(scratch.edgeDir, -fb.dot(scratch.edgeDir));
+      if (is2D) {
+        // 2D: screen-aligned basis so text always reads left-to-right
+        // regardless of edge direction. The orthographic camera is
+        // top-down with rotation locked, so the world axes coincide
+        // with the screen axes.
+        scratch.edgeDir.set(1, 0, 0);
+        scratch.up.set(0, 1, 0);
+        scratch.normal.set(0, 0, 1);
+      } else {
+        // 3D: camera-facing roll around the edge axis. Pick the
+        // perpendicular-to-edge direction that points most toward the
+        // camera as the plane normal. When the edge is nearly aligned
+        // with the view direction the projection collapses; fall back
+        // to a world-axis perpendicular.
+        scratch.toCam.subVectors(scratch.camPos, scratch.mid);
+        const dotEC = scratch.toCam.dot(scratch.edgeDir);
+        scratch.normal.copy(scratch.toCam).addScaledVector(scratch.edgeDir, -dotEC);
+        if (scratch.normal.lengthSq() < 1e-6) {
+          const fb = Math.abs(scratch.edgeDir.y) > 0.99 ? FALLBACK : UP;
+          scratch.normal.copy(fb).addScaledVector(scratch.edgeDir, -fb.dot(scratch.edgeDir));
+        }
+        scratch.normal.normalize();
+        // up = normal × right (right-handed: right × up = normal).
+        scratch.up.copy(scratch.normal).cross(scratch.edgeDir);
       }
-      scratch.normal.normalize();
-      // up = normal × right (right-handed: right × up = normal).
-      scratch.up.copy(scratch.normal).cross(scratch.edgeDir);
 
       scratch.basis.makeBasis(scratch.edgeDir, scratch.up, scratch.normal);
       mesh.visible = true;

--- a/web/src/explorers/ForceGraph3D/scene/Edges.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Edges.tsx
@@ -51,8 +51,9 @@ export interface EdgesProps {
   edgeColors?: string[];
   hiddenIds?: Set<string>;
   opacity?: number;
-  /** Line width in pixels. WebGL's LineBasicMaterial clamps to 1px on
-   *  most drivers, so values above 1 may have limited visual effect. */
+  /** Line width in pixels. Honoured by LineBasicMaterial on drivers
+   *  that support it; the WebGL spec doesn't require widths > 1, so
+   *  the effect varies by platform. */
   linkWidth?: number;
   /** When defined, edges with at least one endpoint NOT in this set are
    *  dimmed by dimAlpha. Drives hover/focus dim. */

--- a/web/src/explorers/ForceGraph3D/scene/Edges.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Edges.tsx
@@ -51,6 +51,9 @@ export interface EdgesProps {
   edgeColors?: string[];
   hiddenIds?: Set<string>;
   opacity?: number;
+  /** Line width in pixels. WebGL's LineBasicMaterial clamps to 1px on
+   *  most drivers, so values above 1 may have limited visual effect. */
+  linkWidth?: number;
   /** When defined, edges with at least one endpoint NOT in this set are
    *  dimmed by dimAlpha. Drives hover/focus dim. */
   activeIds?: Set<string>;
@@ -66,6 +69,7 @@ export function Edges({
   edgeColors,
   hiddenIds,
   opacity = 0.7,
+  linkWidth = 1,
   activeIds,
   dimAlpha = 1,
 }: EdgesProps) {
@@ -117,6 +121,7 @@ export function Edges({
       transparent: true,
       opacity,
       depthWrite: false,
+      linewidth: linkWidth,
     });
 
     return {
@@ -128,7 +133,7 @@ export function Edges({
       segments: segs,
       originalIndices: origIdx,
     };
-  }, [nodes, edges, opacity]);
+  }, [nodes, edges, opacity, linkWidth]);
 
   useEffect(() => {
     return () => {

--- a/web/src/explorers/ForceGraph3D/scene/Edges.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Edges.tsx
@@ -42,10 +42,13 @@ export interface EdgesProps {
   edges: EngineEdge[];
   positionsRef: React.MutableRefObject<Float32Array | null>;
   /** Per-node colors, parallel to `nodes` by index. Used for endpoint
-   *  gradient when edgePalette isn't provided. */
+   *  gradient when edgeColors isn't provided. */
   colors: string[];
-  /** If provided, color edges by edge type instead of endpoint gradient. */
-  edgePalette?: (edgeType: string) => string;
+  /** Optional per-edge flat colors, parallel to `edges` by index. When
+   *  provided, each edge renders as a uniform color along its length
+   *  (used by edgeColorBy type / confidence / uniform). When omitted,
+   *  edges render an endpoint-category gradient. */
+  edgeColors?: string[];
   hiddenIds?: Set<string>;
   opacity?: number;
   /** When defined, edges with at least one endpoint NOT in this set are
@@ -60,7 +63,7 @@ export function Edges({
   edges,
   positionsRef,
   colors,
-  edgePalette,
+  edgeColors,
   hiddenIds,
   opacity = 0.7,
   activeIds,
@@ -69,11 +72,23 @@ export function Edges({
   const lineRef = useRef<THREE.LineSegments>(null);
   const invalidate = useThree((state) => state.invalidate);
 
-  const { geometry, material, indexPairs, curveAngles, curveMags, segments, usableEdges } = useMemo(() => {
+  const { geometry, material, indexPairs, curveAngles, curveMags, segments, originalIndices } = useMemo(() => {
     const nodeIndex = new Map<string, number>();
     for (let i = 0; i < nodes.length; i++) nodeIndex.set(nodes[i].id, i);
 
-    const usable = edges.filter((e) => nodeIndex.has(e.from) && nodeIndex.has(e.to));
+    // Filter to renderable edges (endpoints present) while remembering each
+    // survivor's index in the input array. The caller passes edgeColors
+    // parallel to the input — we use originalIndices[i] to look up the
+    // colour for the i-th renderable edge.
+    const usable: EngineEdge[] = [];
+    const origIdx: number[] = [];
+    for (let i = 0; i < edges.length; i++) {
+      const e = edges[i];
+      if (nodeIndex.has(e.from) && nodeIndex.has(e.to)) {
+        usable.push(e);
+        origIdx.push(i);
+      }
+    }
     const { angles, magnitudes, maxBundleSize } = computeBundles(usable);
     const segs = maxBundleSize > 1 ? SEGMENTS_CURVED : 1;
 
@@ -111,7 +126,7 @@ export function Edges({
       curveAngles: angles,
       curveMags: magnitudes,
       segments: segs,
-      usableEdges: usable,
+      originalIndices: origIdx,
     };
   }, [nodes, edges, opacity]);
 
@@ -123,8 +138,8 @@ export function Edges({
   }, [geometry, material]);
 
   // Coloring. Two modes:
-  //   - edgePalette provided → every vertex of an edge gets the same color
-  //     derived from the edge's relationship type (flat edge coloring).
+  //   - edgeColors[i] provided → every vertex of an edge gets the same
+  //     color (flat edge coloring; covers type / confidence / uniform).
   //   - otherwise → endpoint-category gradient across the curve.
   useEffect(() => {
     const colAttr = geometry.getAttribute('color') as THREE.BufferAttribute;
@@ -150,8 +165,8 @@ export function Edges({
           ? dimAlpha
           : 1;
 
-      if (edgePalette) {
-        ec.set(edgePalette(usableEdges[i].type)).multiplyScalar(edgeDim);
+      if (edgeColors) {
+        ec.set(edgeColors[originalIndices[i]] ?? '#888888').multiplyScalar(edgeDim);
         for (let v = 0; v < vertsPerEdge; v++) {
           const off = base + v * 3;
           arr[off] = ec.r;
@@ -179,7 +194,7 @@ export function Edges({
     }
     colAttr.needsUpdate = true;
     invalidate();
-  }, [geometry, indexPairs, nodes, colors, edgePalette, usableEdges, segments, activeIds, dimAlpha, invalidate]);
+  }, [geometry, indexPairs, nodes, colors, edgeColors, originalIndices, segments, activeIds, dimAlpha, invalidate]);
 
   useFrame(() => {
     const line = lineRef.current;

--- a/web/src/explorers/ForceGraph3D/scene/NodeLabels.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/NodeLabels.tsx
@@ -22,8 +22,9 @@ import type { EngineNode, Projection } from '../types';
 const RESCAN_MS = 200;
 /** Upper bound on simultaneously-mounted labels to bound per-frame cost. */
 const MAX_LABELS = 120;
-/** Label height in world units. Width derived from texture aspect. */
-const LABEL_HEIGHT_WORLD = 1.0;
+/** Base label height in world units. Multiplied by the caller's
+ *  sizeMultiplier prop to compute the actual mesh scale. */
+const BASE_LABEL_HEIGHT_WORLD = 1.0;
 /** Vertical offset above the node (world up before billboard rotation). */
 const LABEL_OFFSET_ABOVE = 1.4;
 /** Canvas font size for text rendering (high-res for crisp scaling). */
@@ -78,6 +79,8 @@ export interface NodeLabelsProps {
   activeIds?: Set<string>;
   /** Drives the distance-culling axis count. 2D ignores Z. Default '3D'. */
   projection?: Projection;
+  /** Multiplier on the base label world-space height. Default 1. */
+  sizeMultiplier?: number;
 }
 
 /** Dim opacity applied to labels for nodes outside activeIds. */
@@ -93,6 +96,7 @@ export function NodeLabels({
   enabled = true,
   activeIds,
   projection = '3D',
+  sizeMultiplier = 1,
 }: NodeLabelsProps) {
   const camera = useThree((state) => state.camera);
 
@@ -149,10 +153,11 @@ export function NodeLabels({
         mat.needsUpdate = true;
       }
       if (mesh) {
-        mesh.scale.set(entry.aspect * LABEL_HEIGHT_WORLD, LABEL_HEIGHT_WORLD, 1);
+        const h = BASE_LABEL_HEIGHT_WORLD * sizeMultiplier;
+        mesh.scale.set(entry.aspect * h, h, 1);
       }
     }
-  }, [visibleIndices, nodes, colors, enabled, activeIds]);
+  }, [visibleIndices, nodes, colors, enabled, activeIds, sizeMultiplier]);
 
   const scratch = useMemo(
     () => ({

--- a/web/src/explorers/ForceGraph3D/scene/NodeLabels.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/NodeLabels.tsx
@@ -16,7 +16,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { EngineNode } from '../types';
+import type { EngineNode, Projection } from '../types';
 
 /** Throttle for re-scanning which nodes qualify; ~5 Hz is imperceptible. */
 const RESCAN_MS = 200;
@@ -69,11 +69,15 @@ export interface NodeLabelsProps {
   /** Per-node colors, parallel to `nodes` by index. */
   colors: string[];
   hiddenIds?: Set<string>;
-  /** Labels past this world-space distance from the camera are unmounted. */
+  /** Labels past this world-space distance from the camera are unmounted.
+   *  In 2D the distance is computed in the XY plane only — the camera's
+   *  fixed Z-offset to the layout plane shouldn't bias culling. */
   visibilityRadius?: number;
   enabled?: boolean;
   /** When defined, labels for nodes not in this set are dimmed. */
   activeIds?: Set<string>;
+  /** Drives the distance-culling axis count. 2D ignores Z. Default '3D'. */
+  projection?: Projection;
 }
 
 /** Dim opacity applied to labels for nodes outside activeIds. */
@@ -88,6 +92,7 @@ export function NodeLabels({
   visibilityRadius = 250,
   enabled = true,
   activeIds,
+  projection = '3D',
 }: NodeLabelsProps) {
   const camera = useThree((state) => state.camera);
 
@@ -219,13 +224,18 @@ export function NodeLabels({
     if (nowMs - lastScanRef.current < RESCAN_MS) return;
     lastScanRef.current = nowMs;
 
+    // In 2D the camera is z-locked at a fixed offset from the layout plane,
+    // so dz is a constant >> visibilityRadius. Culling on the XY-plane
+    // distance makes `visibilityRadius` mean "world units from the viewport
+    // centre", which is what a 2D viewer wants.
+    const is2D = projection === '2D';
     const candidates: { idx: number; dist2: number }[] = [];
     for (let i = 0; i < nodes.length; i++) {
       if (hasHidden && hiddenIds!.has(nodes[i].id)) continue;
       const a = i * 3;
       const dx = positions[a] - scratch.camPos.x;
       const dy = positions[a + 1] - scratch.camPos.y;
-      const dz = positions[a + 2] - scratch.camPos.z;
+      const dz = is2D ? 0 : positions[a + 2] - scratch.camPos.z;
       const d2 = dx * dx + dy * dy + dz * dz;
       if (d2 < radius2) candidates.push({ idx: i, dist2: d2 });
     }

--- a/web/src/explorers/ForceGraph3D/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Scene.tsx
@@ -177,6 +177,7 @@ export function Scene({
         visibilityRadius={labelVisibilityRadius}
         edgePalette={edgePalette}
         activeIds={activeIds}
+        projection={projection}
       />
       <NodeLabels
         nodes={nodes}
@@ -186,6 +187,7 @@ export function Scene({
         enabled={showNodeLabels}
         visibilityRadius={labelVisibilityRadius}
         activeIds={activeIds}
+        projection={projection}
       />
       {activeNodeInfos.map((info) => (
         <NodeInfoOverlay

--- a/web/src/explorers/ForceGraph3D/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Scene.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useImperativeHandle } from 'react';
+import * as THREE from 'three';
 import { OrbitControls } from '@react-three/drei';
 import type { EngineNode, EngineEdge, Projection } from '../types';
 import { Nodes } from './Nodes';
@@ -209,20 +210,27 @@ export function Scene({
         />
       )}
       {projection === '2D' ? (
-        // OrbitControls with rotation disabled gives us pan + zoom on
-        // an orthographic camera. MapControls is the wrong abstraction
-        // here — its screenSpacePanning=false default assumes a Y-up
-        // ground-plane model where vertical pan moves along world Z,
-        // which is perpendicular to our screen and produces no visible
-        // motion. OrbitControls' default screenSpacePanning=true pans
-        // along the camera's screen-aligned up axis. Node-mesh pointer
-        // handlers stopPropagation on a node hit, so left-click on a
-        // node drives drag/select while left-click on background pans.
+        // 2D bindings match the d3 force-graph viewer: left-click drag
+        // pans, scroll-wheel zooms, right-click reserved for the
+        // explorer's context menu. Rotation is disabled (z-locked
+        // layout). The default OrbitControls binding (LEFT=ROTATE,
+        // RIGHT=PAN) doesn't fit a 2D viewer, so we remap. Node-mesh
+        // pointer handlers stopPropagation on a node hit, so left-click
+        // on a node drives drag/select while left-click on background
+        // pans.
         <OrbitControls
           makeDefault
           enableZoom={enableZoom}
           enablePan={enablePan}
           enableRotate={false}
+          mouseButtons={{
+            LEFT: THREE.MOUSE.PAN,
+            MIDDLE: THREE.MOUSE.DOLLY,
+            // RIGHT mapped to ROTATE, then gated off by enableRotate=false
+            // — leaves right-click un-consumed so the wrapper div's
+            // onContextMenu can open the explorer's context menu.
+            RIGHT: THREE.MOUSE.ROTATE,
+          }}
         />
       ) : (
         <OrbitControls makeDefault enableZoom={enableZoom} enablePan={enablePan} />

--- a/web/src/explorers/ForceGraph3D/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Scene.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useEffect, useImperativeHandle } from 'react';
-import { MapControls, OrbitControls } from '@react-three/drei';
+import { OrbitControls } from '@react-three/drei';
 import type { EngineNode, EngineEdge, Projection } from '../types';
 import { Nodes } from './Nodes';
 import { Edges } from './Edges';
@@ -209,13 +209,16 @@ export function Scene({
         />
       )}
       {projection === '2D' ? (
-        // MapControls = pan + zoom on an orthographic camera. Rotation
-        // is disabled (z-locked layout, nothing to rotate). Node-mesh
-        // pointer handlers stopPropagation on a node hit, so left-click
-        // on a node drives drag/select while left-click on background
-        // pans. Right-click contextmenu bubbles to the wrapper div for
-        // the shared context menu.
-        <MapControls
+        // OrbitControls with rotation disabled gives us pan + zoom on
+        // an orthographic camera. MapControls is the wrong abstraction
+        // here — its screenSpacePanning=false default assumes a Y-up
+        // ground-plane model where vertical pan moves along world Z,
+        // which is perpendicular to our screen and produces no visible
+        // motion. OrbitControls' default screenSpacePanning=true pans
+        // along the camera's screen-aligned up axis. Node-mesh pointer
+        // handlers stopPropagation on a node hit, so left-click on a
+        // node drives drag/select while left-click on background pans.
+        <OrbitControls
           makeDefault
           enableZoom={enableZoom}
           enablePan={enablePan}

--- a/web/src/explorers/ForceGraph3D/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Scene.tsx
@@ -209,9 +209,18 @@ export function Scene({
         />
       )}
       {projection === '2D' ? (
-        // MapControls = pan + zoom on an orthographic camera. No
-        // rotation, no orbit — feels like a 2D map viewer.
-        <MapControls makeDefault enableZoom={enableZoom} enablePan={enablePan} />
+        // MapControls = pan + zoom on an orthographic camera. Rotation
+        // is disabled (z-locked layout, nothing to rotate). Node-mesh
+        // pointer handlers stopPropagation on a node hit, so left-click
+        // on a node drives drag/select while left-click on background
+        // pans. Right-click contextmenu bubbles to the wrapper div for
+        // the shared context menu.
+        <MapControls
+          makeDefault
+          enableZoom={enableZoom}
+          enablePan={enablePan}
+          enableRotate={false}
+        />
       ) : (
         <OrbitControls makeDefault enableZoom={enableZoom} enablePan={enablePan} />
       )}

--- a/web/src/explorers/ForceGraph3D/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Scene.tsx
@@ -35,7 +35,7 @@ export interface SceneProps {
    *  whatever dimension (ontology/degree/centrality/...) they choose. */
   colors: string[];
   /** Optional edge-type palette; when provided, edges and arrows color by type. */
-  edgePalette?: (edgeType: string) => string;
+  edgeColors?: string[];
   hiddenIds?: Set<string>;
   pinnedIds?: Set<string>;
   highlightedIds?: Set<string>;
@@ -75,7 +75,7 @@ export function Scene({
   nodes,
   edges,
   colors,
-  edgePalette,
+  edgeColors,
   hiddenIds,
   pinnedIds,
   highlightedIds,
@@ -135,7 +135,7 @@ export function Scene({
         edges={edges}
         positionsRef={sim.positionsRef}
         colors={colors}
-        edgePalette={edgePalette}
+        edgeColors={edgeColors}
         hiddenIds={hiddenIds}
         opacity={edgeOpacity}
         activeIds={activeIds}
@@ -146,7 +146,7 @@ export function Scene({
         edges={edges}
         positionsRef={sim.positionsRef}
         colors={colors}
-        edgePalette={edgePalette}
+        edgeColors={edgeColors}
         hiddenIds={hiddenIds}
         enabled={showArrows}
         nodeSize={nodeSize}
@@ -175,7 +175,7 @@ export function Scene({
         hiddenIds={hiddenIds}
         enabled={showEdgeLabels}
         visibilityRadius={labelVisibilityRadius}
-        edgePalette={edgePalette}
+        edgeColors={edgeColors}
         activeIds={activeIds}
         projection={projection}
       />

--- a/web/src/explorers/ForceGraph3D/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Scene.tsx
@@ -47,6 +47,11 @@ export interface SceneProps {
   dimAlpha?: number;
   nodeSize?: number;
   edgeOpacity?: number;
+  linkWidth?: number;
+  /** Multiplier on the base world-space node-label height. Default 1. */
+  nodeLabelSize?: number;
+  /** Multiplier on the base world-space edge-label height. Default 1. */
+  edgeLabelSize?: number;
   showArrows?: boolean;
   showEdgeLabels?: boolean;
   showNodeLabels?: boolean;
@@ -83,6 +88,9 @@ export function Scene({
   dimAlpha = 1,
   nodeSize,
   edgeOpacity,
+  linkWidth,
+  nodeLabelSize = 1,
+  edgeLabelSize = 1,
   showArrows = true,
   showEdgeLabels = true,
   showNodeLabels = true,
@@ -138,6 +146,7 @@ export function Scene({
         edgeColors={edgeColors}
         hiddenIds={hiddenIds}
         opacity={edgeOpacity}
+        linkWidth={linkWidth}
         activeIds={activeIds}
         dimAlpha={dimAlpha}
       />
@@ -178,6 +187,7 @@ export function Scene({
         edgeColors={edgeColors}
         activeIds={activeIds}
         projection={projection}
+        sizeMultiplier={edgeLabelSize}
       />
       <NodeLabels
         nodes={nodes}
@@ -188,6 +198,7 @@ export function Scene({
         visibilityRadius={labelVisibilityRadius}
         activeIds={activeIds}
         projection={projection}
+        sizeMultiplier={nodeLabelSize}
       />
       {activeNodeInfos.map((info) => (
         <NodeInfoOverlay

--- a/web/src/explorers/ForceGraph3D/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph3D/scene/Scene.tsx
@@ -2,14 +2,14 @@
  * Scene composition — Nodes + Edges + camera controls + lighting.
  *
  * Owns the physics sim; the sim owns the positions buffer that Nodes
- * and Edges read. M2 task #8 adds CPU force sim; M2 task #9 adds the
- * GPU sim and a dispatcher. Both expose the same handle shape so the
- * scene composition doesn't change between them.
+ * and Edges read. Projection dispatch picks the camera-controls flavor:
+ * OrbitControls for 3D (rotate + zoom + pan) and MapControls for 2D
+ * (pan + zoom, no rotation).
  */
 
 import { useEffect, useImperativeHandle } from 'react';
-import { OrbitControls } from '@react-three/drei';
-import type { EngineNode, EngineEdge } from '../types';
+import { MapControls, OrbitControls } from '@react-three/drei';
+import type { EngineNode, EngineEdge, Projection } from '../types';
 import { Nodes } from './Nodes';
 import { Edges } from './Edges';
 import { Arrows } from './Arrows';
@@ -64,6 +64,9 @@ export interface SceneProps {
   onDismissNodeInfo?: (nodeId: string) => void;
   /** Optional external handle to drive reheat/freeze/simmer from outside Canvas. */
   simHandleRef?: React.MutableRefObject<ForceSimHandle | null>;
+  /** Camera + sim projection. Drives camera-controls flavor, sim
+   *  dimensionality, and drag-plane construction. Defaults '3D'. */
+  projection?: Projection;
 }
 
 /** V2 scene composition — physics + rendering + orbit controls.  @verified c17bbeb9 */
@@ -96,13 +99,20 @@ export function Scene({
   activeNodeInfos = EMPTY_INFOS,
   onDismissNodeInfo,
   simHandleRef,
+  projection = '3D',
 }: SceneProps) {
-  const sim = useSim(nodes, edges, { ...physics, hiddenIds, pinnedIds });
+  const sim = useSim(nodes, edges, {
+    ...physics,
+    hiddenIds,
+    pinnedIds,
+    dimensions: projection === '2D' ? 2 : 3,
+  });
   const drag = useDragHandler({
     nodes,
     positionsRef: sim.positionsRef,
     pinnedIds: pinnedIds ?? EMPTY_SET,
     setPinnedIds: onPinnedIdsChange ?? NOOP_SET_SETTER,
+    projection,
   });
 
   // Expose the sim handle outside the Canvas tree (e.g. to a settings
@@ -198,7 +208,13 @@ export function Scene({
           variant={selectedId ? 'selected' : 'hover'}
         />
       )}
-      <OrbitControls makeDefault enableZoom={enableZoom} enablePan={enablePan} />
+      {projection === '2D' ? (
+        // MapControls = pan + zoom on an orthographic camera. No
+        // rotation, no orbit — feels like a 2D map viewer.
+        <MapControls makeDefault enableZoom={enableZoom} enablePan={enablePan} />
+      ) : (
+        <OrbitControls makeDefault enableZoom={enableZoom} enablePan={enablePan} />
+      )}
     </>
   );
 }

--- a/web/src/explorers/ForceGraph3D/scene/gpuShaders.ts
+++ b/web/src/explorers/ForceGraph3D/scene/gpuShaders.ts
@@ -14,6 +14,7 @@ uniform float damping;
 uniform float centerGravity;
 uniform float maxForce;
 uniform float velStop;
+uniform float zClamp;
 uniform int nodeCount;
 uniform sampler2D neighborOffsetCount;
 uniform sampler2D neighborList;
@@ -82,12 +83,16 @@ void main() {
 
   vec3 newVel = (vel + force) * damping;
   if (velStop > 0.0 && length(newVel) < velStop) newVel = vec3(0.0);
+  // zClamp = 1 in 3D, 0 in 2D — zeroes the Z velocity so the layout
+  // flattens onto z=0 over the first frame.
+  newVel.z *= zClamp;
   gl_FragColor = vec4(newVel, 1.0);
 }
 `;
 
 export const posShaderBody = /* glsl */ `
 uniform float dt;
+uniform float zClamp;
 uniform int nodeCount;
 uniform sampler2D hiddenMask;
 
@@ -100,10 +105,15 @@ void main() {
     return;
   }
   if (texture2D(hiddenMask, uv).r < 0.5) {
-    gl_FragColor = vec4(pos, 1.0);
+    // Hidden/pinned nodes still respect the projection — clamp Z to 0
+    // in 2D so they don't sit at their seeded Z while everything else
+    // flattens.
+    gl_FragColor = vec4(pos.xy, pos.z * zClamp, 1.0);
     return;
   }
   vec3 vel = texture2D(textureVelocity, uv).xyz;
-  gl_FragColor = vec4(pos + vel * dt, 1.0);
+  vec3 newPos = pos + vel * dt;
+  newPos.z *= zClamp;
+  gl_FragColor = vec4(newPos, 1.0);
 }
 `;

--- a/web/src/explorers/ForceGraph3D/scene/useDragHandler.ts
+++ b/web/src/explorers/ForceGraph3D/scene/useDragHandler.ts
@@ -16,7 +16,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useThree, type ThreeEvent } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { EngineNode } from '../types';
+import type { EngineNode, Projection } from '../types';
 
 export interface DragHandlers {
   onDragStart: (id: string, event: ThreeEvent<PointerEvent>) => void;
@@ -29,6 +29,10 @@ export interface UseDragHandlerParams {
   positionsRef: React.MutableRefObject<Float32Array | null>;
   pinnedIds: Set<string>;
   setPinnedIds: (next: Set<string>) => void;
+  /** Projection mode. Drives the drag-plane construction: in 3D the
+   *  plane is camera-perpendicular through the node's current depth;
+   *  in 2D it's fixed at Z=0 with normal +Z. Default '3D'. */
+  projection?: Projection;
 }
 
 /** Drag handlers that pin a node and follow the cursor on a camera plane.  @verified c17bbeb9 */
@@ -37,6 +41,7 @@ export function useDragHandler({
   positionsRef,
   pinnedIds,
   setPinnedIds,
+  projection = '3D',
 }: UseDragHandlerParams): DragHandlers {
   const camera = useThree((state) => state.camera);
   const gl = useThree((state) => state.gl);
@@ -65,10 +70,19 @@ export function useDragHandler({
         positions[idx * 3 + 1],
         positions[idx * 3 + 2]
       );
-      // Plane perpendicular to the camera view direction, through the node.
-      const normal = new THREE.Vector3();
-      camera.getWorldDirection(normal).negate();
-      const plane = new THREE.Plane(normal, -normal.dot(pos));
+      // Drag-plane construction dispatches on projection. 2D pins all
+      // motion to z=0 with a +Z normal so the cursor unproject lands
+      // on the layout plane regardless of camera distance. 3D uses a
+      // camera-perpendicular plane through the node's current depth so
+      // depth-relative motion feels natural.
+      let plane: THREE.Plane;
+      if (projection === '2D') {
+        plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+      } else {
+        const normal = new THREE.Vector3();
+        camera.getWorldDirection(normal).negate();
+        plane = new THREE.Plane(normal, -normal.dot(pos));
+      }
       dragRef.current = {
         id,
         idx,
@@ -81,7 +95,7 @@ export function useDragHandler({
       next.add(id);
       setPinnedIds(next);
     },
-    [camera, nodeIndex, pinnedIds, positionsRef, setPinnedIds]
+    [camera, nodeIndex, pinnedIds, positionsRef, setPinnedIds, projection]
   );
 
   const onDragMove = useCallback(

--- a/web/src/explorers/ForceGraph3D/scene/useForceSim.ts
+++ b/web/src/explorers/ForceGraph3D/scene/useForceSim.ts
@@ -70,6 +70,10 @@ export interface ForceSimParams extends Partial<PhysicsParams> {
   pinnedIds?: Set<string>;
   /** When false, the sim halts entirely — positions hold, no frames pump. */
   enabled?: boolean;
+  /** Dimensionality of the layout. 3 = full 3D; 2 = z-pinned to zero for
+   *  2D projection. Engine ignores this until the dispatching scene
+   *  consumes it. */
+  dimensions?: 2 | 3;
 }
 
 /** Handle returned by useForceSim; drives the sim and exposes its buffer.  @verified c17bbeb9 */
@@ -88,8 +92,11 @@ export function useForceSim(
   edges: EngineEdge[],
   params: ForceSimParams = {}
 ): ForceSimHandle {
-  const { hiddenIds, pinnedIds, enabled = true, ...tuning } = params;
+  const { hiddenIds, pinnedIds, enabled = true, dimensions = 3, ...tuning } = params;
   const cfg: PhysicsParams = { ...DEFAULTS, ...tuning };
+  // Z-clamp factor — 1 in 3D, 0 in 2D. Multiplied into the integrated
+  // Z-component each frame so 2D mode flattens the layout onto z=0.
+  const zClamp = dimensions === 2 ? 0 : 1;
   const nodeCount = nodes.length;
   const invalidate = useThree((state) => state.invalidate);
 
@@ -252,10 +259,10 @@ export function useForceSim(
       }
       velocities[ix3] = nvx;
       velocities[ix3 + 1] = nvy;
-      velocities[ix3 + 2] = nvz;
+      velocities[ix3 + 2] = nvz * zClamp;
       positions[ix3] += nvx * dt;
       positions[ix3 + 1] += nvy * dt;
-      positions[ix3 + 2] += nvz * dt;
+      positions[ix3 + 2] = (positions[ix3 + 2] + nvz * dt) * zClamp;
     }
 
     if (simmerRef.current) {

--- a/web/src/explorers/ForceGraph3D/scene/useGpuForceSim.ts
+++ b/web/src/explorers/ForceGraph3D/scene/useGpuForceSim.ts
@@ -88,7 +88,7 @@ export function useGpuForceSim(
   edges: EngineEdge[],
   params: ForceSimParams = {}
 ): ForceSimHandle {
-  const { hiddenIds, pinnedIds, enabled = true, ...tuning } = params;
+  const { hiddenIds, pinnedIds, enabled = true, dimensions = 3, ...tuning } = params;
   const cfg: PhysicsParams = { ...DEFAULTS, ...tuning };
   const gl = useThree((state) => state.gl);
   const invalidate = useThree((state) => state.invalidate);
@@ -211,6 +211,11 @@ export function useGpuForceSim(
     pU.dt = { value: cfg.dt };
     pU.nodeCount = { value: nodeCount };
     pU.hiddenMask = { value: hiddenMaskTex };
+    // zClamp flattens the Z output to zero in 2D mode. Same value lives
+    // on the velocity shader so vel.z also collapses; together that
+    // pins the layout to the z=0 plane within a single frame.
+    pU.zClamp = { value: dimensions === 2 ? 0 : 1 };
+    vU.zClamp = { value: dimensions === 2 ? 0 : 1 };
 
     const err = gpuCompute.init();
     if (err) {
@@ -312,6 +317,8 @@ export function useGpuForceSim(
     u.damping.value = simmerRef.current ? cfg.dampingSimmer : cfg.damping;
     u.centerGravity.value = simmerRef.current ? cfg.centerGravitySimmer : cfg.centerGravity;
     u.velStop.value = simmerRef.current ? cfg.velStopSimmer : 0;
+    u.zClamp.value = dimensions === 2 ? 0 : 1;
+    s.posVar.material.uniforms.zClamp.value = dimensions === 2 ? 0 : 1;
 
     // Compute current frame, then read back the alternate target (last
     // frame's output). One-frame lag keeps CPU and GPU overlapped —

--- a/web/src/explorers/ForceGraph3D/types.ts
+++ b/web/src/explorers/ForceGraph3D/types.ts
@@ -89,6 +89,14 @@ export interface ForceGraph3DSettings {
     edgeColorBy: EdgeColorMode;
     labelVisibilityRadius: number;
     nodeSize: number;
+    /** Edge line width. Note: WebGL's LineBasicMaterial clamps linewidth
+     *  to 1px on most drivers, so values above 1 have limited visual
+     *  effect. Tracked for parity; a thick-line shader is a follow-up. */
+    linkWidth: number;
+    /** Multiplier on node label world-space height. 1.0 = default size. */
+    nodeLabelSize: number;
+    /** Multiplier on edge label world-space height. 1.0 = default size. */
+    edgeLabelSize: number;
   };
 
   interaction: {
@@ -117,6 +125,9 @@ export const DEFAULT_SETTINGS: ForceGraph3DSettings = {
     edgeColorBy: 'type',
     labelVisibilityRadius: 250,
     nodeSize: 1.0,
+    linkWidth: 1.0,
+    nodeLabelSize: 1.0,
+    edgeLabelSize: 1.0,
   },
   interaction: {
     enableDrag: true,
@@ -136,5 +147,8 @@ export const SLIDER_RANGES = {
   visual: {
     labelVisibilityRadius: { min: 50, max: 1000, step: 10 },
     nodeSize: { min: 0.3, max: 3, step: 0.1 },
+    linkWidth: { min: 0.5, max: 5, step: 0.1 },
+    nodeLabelSize: { min: 0.5, max: 3, step: 0.1 },
+    edgeLabelSize: { min: 0.5, max: 3, step: 0.1 },
   },
 };

--- a/web/src/explorers/ForceGraph3D/types.ts
+++ b/web/src/explorers/ForceGraph3D/types.ts
@@ -89,9 +89,10 @@ export interface ForceGraph3DSettings {
     edgeColorBy: EdgeColorMode;
     labelVisibilityRadius: number;
     nodeSize: number;
-    /** Edge line width. Note: WebGL's LineBasicMaterial clamps linewidth
-     *  to 1px on most drivers, so values above 1 have limited visual
-     *  effect. Tracked for parity; a thick-line shader is a follow-up. */
+    /** Edge line width. Honoured by LineBasicMaterial on drivers that
+     *  support it (renders fine on Linux Chrome / Mesa). The WebGL
+     *  spec doesn't require widths > 1, so the visible effect varies
+     *  by platform. A thick-line shader would make it guaranteed. */
     linkWidth: number;
     /** Multiplier on node label world-space height. 1.0 = default size. */
     nodeLabelSize: number;

--- a/web/src/explorers/ForceGraph3D/types.ts
+++ b/web/src/explorers/ForceGraph3D/types.ts
@@ -51,8 +51,25 @@ export interface ForceGraph3DData {
 export type PhysicsBackend = 'auto' | 'cpu' | 'gpu';
 export type EdgeColorMode = 'endpoint' | 'type';
 
+/**
+ * Camera + sim projection mode.
+ *
+ * Today: '2D' (orthographic camera, z-locked sim, pan/zoom only) and
+ * '3D' (perspective camera, full 3D sim, orbit controls).
+ *
+ * The type stays a string union so the engine can grow new projections
+ * (e.g. hyperbolic, globe) as case-style dispatches in the scene
+ * composition without breaking the plugin contract.
+ */
+export type Projection = '2D' | '3D';
+
 /** Runtime settings for the ForceGraph3D explorer plugin.  @verified c17bbeb9 */
 export interface ForceGraph3DSettings {
+  /** Camera + sim projection mode. Drives camera type, sim axis count,
+   *  and drag-plane construction. Plugin defaults this; users may toggle
+   *  it at runtime. */
+  projection: Projection;
+
   physics: {
     enabled: boolean;
     repulsion: number;
@@ -83,6 +100,7 @@ export interface ForceGraph3DSettings {
 }
 
 export const DEFAULT_SETTINGS: ForceGraph3DSettings = {
+  projection: '3D',
   physics: {
     enabled: true,
     repulsion: 120,

--- a/web/src/explorers/ForceGraph3D/types.ts
+++ b/web/src/explorers/ForceGraph3D/types.ts
@@ -49,7 +49,7 @@ export interface ForceGraph3DData {
 }
 
 export type PhysicsBackend = 'auto' | 'cpu' | 'gpu';
-export type EdgeColorMode = 'endpoint' | 'type';
+export type EdgeColorMode = 'endpoint' | 'type' | 'confidence' | 'uniform';
 
 /**
  * Camera + sim projection mode.

--- a/web/src/explorers/index.ts
+++ b/web/src/explorers/index.ts
@@ -6,7 +6,7 @@
 
 export * from './registry';
 export { ForceGraph2DExplorer } from './ForceGraph2D';
-export { ForceGraph3DExplorer } from './ForceGraph3D';
+export { ForceGraph3DExplorer, ForceGraph2DV2Explorer } from './ForceGraph3D';
 export { DocumentExplorerPlugin } from './DocumentExplorer';
 
 // Import explorers to trigger auto-registration

--- a/web/src/types/explorer.ts
+++ b/web/src/types/explorer.ts
@@ -10,6 +10,7 @@ import type { RawGraphData } from '../utils/cypherResultMapper';
 
 export type VisualizationType =
   | 'force-2d'
+  | 'force-2d-v2'
   | 'force-3d'
   | 'document'
   | 'hierarchy'


### PR DESCRIPTION
**Stacks on #365** — base branch is \`refactor/promote-v2-canonical-force3d\`. Re-target to \`main\` once #365 lands.

## Summary

ADR-702 phase 2: extend the unified force-graph engine with an
orthographic 2D projection. Same component, same scene composition,
same physics — the camera, drag plane, sim dimensionality, and
camera-controls flavor dispatch on a new \`projection\` setting.

Registers a second plugin entry \`force-2d-v2\` that shares the engine
component with \`force-3d\` but defaults \`projection: '2D'\`. The
discoverable surface in the sidebar parallels Phase A: V2 enters
alongside the d3 \`force-2d\` while parity is verified, then promotes
to canonical \`force-2d\` in a follow-up PR retiring the d3 explorer.

## Affirms

- **ADR-702** — one engine, two projections. The plugin contract from
  ADR-034 lets us register the same component twice with different
  \`defaultSettings\` and config metadata; no engine-level abstraction
  for projections needed, just case-style dispatches in the scene.
- The \`Projection\` union type stays open so future projections
  (hyperbolic, globe, the Utah teapot) become case additions, not API
  breaks.

## User-visible changes

- New sidebar entry **2D Force Graph (V2)** between the d3 2D and the 3D
  entries. \`Map\` icon (matches MapControls metaphor: pan + zoom, no
  rotation). Routes to \`/explore/2d-v2\`.
- A **Projection** select in the settings panel of either entry —
  switching flips the Canvas to the appropriate camera type. (See
  trade-off below.)
- Existing \`/explore/3d\` and \`/explore/2d\` unchanged.

## Mechanism changes

- \`types.ts\` — \`Projection\` union (\`'2D' | '3D'\`); top-level
  \`projection\` on \`ForceGraph3DSettings\`.
- \`ForceGraph3D.tsx\` — Canvas \`key\`s on projection so r3f remounts
  with the right camera class. Orthographic + zoom for 2D, perspective
  + fov for 3D.
- \`Scene.tsx\` — \`MapControls\` (pan + zoom, rotation disabled) when
  2D; \`OrbitControls\` when 3D. Pipes \`projection\` to sim
  (\`dimensions: 2 | 3\`) and drag handler.
- \`useDragHandler\` — 2D drag uses a fixed \`z=0\` plane with \`+Z\`
  normal; the pointer unproject lands on the layout plane regardless
  of camera distance. 3D keeps the camera-perpendicular plane.
- \`useForceSim\` (CPU) — \`zClamp\` factor multiplies the Z component
  of integrated position and velocity each frame, flattening to z=0.
- \`useGpuForceSim\` + \`gpuShaders\` — \`zClamp\` uniform on both
  fragment shaders zeroes the Z output in 2D. Pushed each frame so a
  runtime toggle takes effect immediately.
- \`SettingsPanel\` — top-level Projection select for in-explorer
  switching.
- \`index.ts\` — factory wraps both plugin entries; \`ForceGraph3DExplorer\`
  (default '3D') and \`ForceGraph2DV2Explorer\` (default '2D').
- \`App.tsx\` — \`/explore/2d-v2\` route.
- \`AppLayout.tsx\` — sidebar entry + page-title branch.

## Trade-offs documented

- **Canvas remount on projection toggle.** The \`key\` strategy is what
  makes the toggle work — r3f's \`orthographic\` prop is mount-time.
  Cost: the user loses any drag-pinned layout when flipping the toggle.
  Acceptable for an MVP; if it becomes painful, the fix is to persist
  position snapshots across the remount.
- **Orthographic zoom heuristic.** \`zoom: 2.5\` is reasonable for the
  seed radius (~120 units). Very large graphs may render as a tight
  cluster on first load until the user scrolls to zoom out. A
  fit-to-content first-render could land later.
- **Plugin coexistence.** Two registrations of the same component is
  the transitional shape, not the end state. When d3 \`force-2d\`
  retires, this consolidates to one "Force Graph" plugin with the
  projection toggle as the user-facing affordance.

## Tests + author-verification

- \`tsc --noEmit\` clean.
- 10-test \`useExplorationActions\` suite green (projection logic
  doesn't touch the action layer).
- HMR reloads cleanly through the work.
- **UI verification handed to the author** at \`/explore/2d-v2\`:
  golden 2D path (search → explore → drag → pan/zoom → right-click
  background → right-click node) and the in-explorer projection toggle.

## Commits

\`\`\`
2ddc932e chore(web): polish 2D map controls and page title
b03ca553 feat(web): register force-2d-v2 plugin entry alongside force-3d
8e00f65d feat(web): add 2D projection to the unified force-graph engine
\`\`\`

## Test plan

- [ ] /explore/2d-v2 renders 2D layout — flat in the XY plane, nodes
      visible, edges/arrows/labels intact
- [ ] Left-click + drag on background pans
- [ ] Mouse wheel zooms
- [ ] Left-click on node selects + opens NodeInfoOverlay
- [ ] Left-click + drag on a node moves it (drag plane Z=0)
- [ ] Right-click on node opens context menu
- [ ] Right-click on background opens background context menu
- [ ] Settings panel Projection select flips 2D ↔ 3D (Canvas remounts)
- [ ] /explore/3d still works unchanged
- [ ] /explore/2d (d3) still works unchanged
- [ ] 10-test useExplorationActions suite green