### PR TITLE
feat(web): incremental graph physics — calm node growth on poke

### DIFF
--- a/web/src/explorers/ForceGraph/ForceGraph.tsx
+++ b/web/src/explorers/ForceGraph/ForceGraph.tsx
@@ -38,7 +38,7 @@ import { useThemeStore } from '../../store/themeStore';
 /** ForceGraph — r3f Canvas + scene composition.  @verified c17bbeb9 */
 export const ForceGraph: React.FC<
   ExplorerProps<ForceGraphData, ForceGraphSettings>
-> = ({ data, settings, onSettingsChange, onNodeClick, onSendToReports, className }) => {
+> = ({ data, settings, onSettingsChange, onSendToReports, className }) => {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [hiddenIds] = useState<Set<string>>(() => new Set());
@@ -72,8 +72,6 @@ export const ForceGraph: React.FC<
   const [focusedNode, setFocusedNode] = useState<string | null>(null);
   // Open node info panels — one per selected node, dismissable.
   const [activeNodeInfos, setActiveNodeInfos] = useState<NodeInfoData[]>([]);
-
-  const mergeRawGraphData = useGraphStore((s) => s.mergeRawGraphData);
   const visibleEdgeCategories = useGraphStore((s) => s.filters.visibleEdgeCategories);
   // Universal filters live in the store so every explorer sees the same
   // filtered data. Reading them via individual selectors keeps zustand's
@@ -179,10 +177,10 @@ export const ForceGraph: React.FC<
 
   const vocabStore = useVocabularyStore();
 
-  // Resolve an edge's category with a 3-level fallback (matches the chain
-  // used by the 2D explorer's transformForD3): vocabulary lookup →
-  // API-provided category → fallback. Keeping the chain in sync means the
-  // shared visibleEdgeCategories store stays consistent across explorers.
+  // Resolve an edge's category with a 3-level fallback: vocabulary lookup
+  // → API-provided category → fallback. Document Explorer resolves edge
+  // categories the same way; keeping the chain identical means the shared
+  // visibleEdgeCategories store stays consistent across both explorers.
   const edgeCategory = useCallback(
     (e: ForceGraphData['edges'][number]): string => {
       let cat = vocabStore.getCategory(e.type);
@@ -255,7 +253,7 @@ export const ForceGraph: React.FC<
     if (edgeColorBy === 'confidence') {
       return es.map((e) => {
         // weight ∈ [0,1] (set from API confidence). Hue 0=red, 120=green
-        // matches the d3 2D explorer's scale so cross-view comparison reads.
+        // — low confidence reads hot, high confidence cool.
         const w = typeof e.weight === 'number' ? e.weight : 0.5;
         const hue = Math.max(0, Math.min(1, w)) * 120;
         return `hsl(${hue}, 70%, 50%)`;
@@ -279,8 +277,8 @@ export const ForceGraph: React.FC<
   // Per-node colors. Engine consumes this as a string[] indexed by node
   // position; Legend consumes the same map shape via legendData below.
   // Computed against the filtered set so degree/centrality reflect what's
-  // currently visible — matches 2D's behavior except for centrality, which
-  // 2D computes against the unfiltered graph (deferred convergence).
+  // currently visible (degree/centrality recompute as filters narrow the
+  // graph, rather than staying pinned to the unfiltered topology).
   const nodeColorMap = useMemo(() => {
     const ns = filteredData?.nodes ?? [];
     const es = filteredData?.edges ?? [];

--- a/web/src/explorers/ForceGraph/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph/scene/Scene.tsx
@@ -7,7 +7,7 @@
  * (pan + zoom, no rotation).
  */
 
-import { useEffect, useImperativeHandle, useMemo, type ReactElement } from 'react';
+import { useImperativeHandle, useMemo, type ReactElement } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from '@react-three/drei';
 import type { EngineNode, EngineEdge, Projection } from '../types';
@@ -176,11 +176,13 @@ export function Scene({
   // the idiomatic way even though we pass a MutableRefObject ourselves.
   useImperativeHandle(simHandleRef, () => sim, [sim]);
 
-  useEffect(() => {
-    // Kick a frame when the data set changes so demand-mode picks up
-    // the reseeded buffers immediately rather than next user interaction.
-    sim.reheat();
-  }, [nodes.length]);
+  // Note: re-seeding and demand-mode kick on data change are now owned by
+  // the sim hook (useForceSim / useGpuForceSim). It carries surviving
+  // nodes' positions over and picks a gentle vs full reheat based on how
+  // much changed, then invalidate()s itself. The old unconditional
+  // sim.reheat() here slammed alpha to full on every poke — that was the
+  // whole-graph "sproing". The manual Reheat button still calls
+  // sim.reheat() for a deliberate full re-layout.
 
   return (
     <>

--- a/web/src/explorers/ForceGraph/scene/positions.test.ts
+++ b/web/src/explorers/ForceGraph/scene/positions.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for seedWithCarryover — the core of incremental layout.
+ *
+ * The behaviour these lock down is exactly what stops the whole-graph
+ * "sproing" on every poke: a node that survived a graph change must keep
+ * its prior position to the bit, only genuinely new nodes get a fresh
+ * sphere seed, and carriedCount must let the sim hook tell a fresh graph
+ * (full reheat) apart from an incremental poke (gentle reheat).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { seedWithCarryover } from './positions';
+
+const RADIUS = 120;
+
+describe('seedWithCarryover', () => {
+  it('treats an empty prior as a fresh graph (carriedCount 0)', () => {
+    const r = seedWithCarryover(['a', 'b', 'c'], [], null, RADIUS);
+    expect(r.carriedCount).toBe(0);
+    expect(r.positions).toHaveLength(9);
+    // Every node is sphere-seeded within the radius.
+    for (let i = 0; i < 3; i++) {
+      const d = Math.hypot(
+        r.positions[i * 3],
+        r.positions[i * 3 + 1],
+        r.positions[i * 3 + 2]
+      );
+      expect(d).toBeLessThanOrEqual(RADIUS + 1e-6);
+    }
+  });
+
+  it('carries every surviving node position to the bit', () => {
+    const priorIds = ['a', 'b'];
+    const priorPos = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const r = seedWithCarryover(['a', 'b'], priorIds, priorPos, RADIUS);
+    expect(r.carriedCount).toBe(2);
+    expect(Array.from(r.positions)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('keeps survivors exact and sphere-seeds only new nodes', () => {
+    const priorIds = ['a', 'b'];
+    const priorPos = new Float32Array([10, 11, 12, 20, 21, 22]);
+    // 'b' survives, 'a' dropped, 'c' is new — and order changed.
+    const r = seedWithCarryover(['c', 'b'], priorIds, priorPos, RADIUS);
+    expect(r.carriedCount).toBe(1);
+    // 'b' lands at its prior position regardless of its new index.
+    expect(Array.from(r.positions.subarray(3, 6))).toEqual([20, 21, 22]);
+    // 'c' is sphere-seeded (not zero, within radius).
+    const cDist = Math.hypot(r.positions[0], r.positions[1], r.positions[2]);
+    expect(cDist).toBeGreaterThan(0);
+    expect(cDist).toBeLessThanOrEqual(RADIUS + 1e-6);
+  });
+
+  it('falls back to a fresh seed when the prior buffer is undersized', () => {
+    // priorIds claims 2 nodes but the buffer only has room for 1 — a
+    // torn snapshot. Must not read out of bounds; treat as fresh.
+    const r = seedWithCarryover(
+      ['a', 'b'],
+      ['a', 'b'],
+      new Float32Array([1, 2, 3]),
+      RADIUS
+    );
+    expect(r.carriedCount).toBe(0);
+  });
+});

--- a/web/src/explorers/ForceGraph/scene/positions.test.ts
+++ b/web/src/explorers/ForceGraph/scene/positions.test.ts
@@ -51,6 +51,27 @@ describe('seedWithCarryover', () => {
     expect(cDist).toBeLessThanOrEqual(RADIUS + 1e-6);
   });
 
+  it('treats a full swap (prior exists, zero survivors) as fresh', () => {
+    // This is the discriminator the sim hooks key the gentle-vs-full
+    // reheat on: a prior generation existed, but the new node set
+    // shares nothing with it (e.g. a filter swap to a disjoint
+    // ontology). carriedCount must be 0 so the hook does a FULL reheat.
+    const priorIds = ['a', 'b'];
+    const priorPos = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const r = seedWithCarryover(['x', 'y', 'z'], priorIds, priorPos, RADIUS);
+    expect(r.carriedCount).toBe(0);
+    expect(r.positions).toHaveLength(9);
+    for (let i = 0; i < 3; i++) {
+      const d = Math.hypot(
+        r.positions[i * 3],
+        r.positions[i * 3 + 1],
+        r.positions[i * 3 + 2]
+      );
+      expect(d).toBeGreaterThan(0);
+      expect(d).toBeLessThanOrEqual(RADIUS + 1e-6);
+    }
+  });
+
   it('falls back to a fresh seed when the prior buffer is undersized', () => {
     // priorIds claims 2 nodes but the buffer only has room for 1 — a
     // torn snapshot. Must not read out of bounds; treat as fresh.

--- a/web/src/explorers/ForceGraph/scene/positions.ts
+++ b/web/src/explorers/ForceGraph/scene/positions.ts
@@ -36,7 +36,12 @@ export function seedSpherePositions(count: number, radius = 120): Float32Array {
 }
 
 /** Result of a carry-over seed: the buffer plus how many nodes kept
- *  their prior position (0 ⇒ nothing carried ⇒ treat as a fresh graph).
+ *  their prior position. carriedCount === 0 means *treat as a fresh
+ *  graph* (full reheat) — this intentionally covers not just "no prior
+ *  at all" but also "a prior existed yet nothing survived" (a full
+ *  filter swap, or the graph emptied then repopulated). Zero overlap is
+ *  a new layout by definition, so the gentle incremental reheat would
+ *  have nothing to preserve anyway.
  *  @verified f8ee93b9 */
 export interface CarryoverSeed {
   positions: Float32Array;

--- a/web/src/explorers/ForceGraph/scene/positions.ts
+++ b/web/src/explorers/ForceGraph/scene/positions.ts
@@ -6,25 +6,93 @@
  * seeds it once; M2 (CPU/GPU force sim) mutates it in place each frame.
  * z is always present — 2D mode (phase 2) will clamp z to 0 rather than
  * carry a separate buffer shape.
+ *
+ * Incremental layout (seedWithCarryover): when the graph is "poked" —
+ * a node expanded, a concept followed, a filter toggled — the node array
+ * is rebuilt and the sim hook re-seeds. Re-seeding every node from a
+ * fresh sphere is what caused the whole graph to explode on each change.
+ * seedWithCarryover keeps every node that survived the change at its
+ * settled position and only sphere-seeds genuinely new nodes, so the
+ * existing layout holds and new nodes fly in toward it.
  */
 
-/** Seed N positions uniformly inside a sphere.  @verified c17bbeb9 */
+/** Place one node's xyz at out[i*3..] uniformly inside a sphere.  @verified f8ee93b9 */
+function seedOne(out: Float32Array, i: number, radius: number): void {
+  const u = Math.random();
+  const v = Math.random();
+  const theta = 2 * Math.PI * u;
+  const phi = Math.acos(2 * v - 1);
+  const r = radius * Math.cbrt(Math.random());
+  out[i * 3] = r * Math.sin(phi) * Math.cos(theta);
+  out[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+  out[i * 3 + 2] = r * Math.cos(phi);
+}
+
+/** Seed N positions uniformly inside a sphere.  @verified f8ee93b9 */
 export function seedSpherePositions(count: number, radius = 120): Float32Array {
   const positions = new Float32Array(count * 3);
-  for (let i = 0; i < count; i++) {
-    const u = Math.random();
-    const v = Math.random();
-    const theta = 2 * Math.PI * u;
-    const phi = Math.acos(2 * v - 1);
-    const r = radius * Math.cbrt(Math.random());
-    positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
-    positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
-    positions[i * 3 + 2] = r * Math.cos(phi);
-  }
+  for (let i = 0; i < count; i++) seedOne(positions, i, radius);
   return positions;
 }
 
-/** Radius heuristic — grows gently with node count so graphs stay visible.  @verified c17bbeb9 */
+/** Result of a carry-over seed: the buffer plus how many nodes kept
+ *  their prior position (0 ⇒ nothing carried ⇒ treat as a fresh graph).
+ *  @verified f8ee93b9 */
+export interface CarryoverSeed {
+  positions: Float32Array;
+  carriedCount: number;
+}
+
+/**
+ * Seed a new node set, preserving prior positions for nodes that
+ * survived the change.
+ *
+ * `ids` is the new generation's node ids (index-parallel to the output
+ * buffer). `priorIds` / `priorPositions` are the previous generation's
+ * id list and its last-known flat xyz buffer. Any node whose id is in
+ * `priorIds` keeps that exact position; the rest are sphere-seeded so
+ * they animate in toward the settled layout. carriedCount lets the sim
+ * hook pick a gentle reheat (incremental) vs a full one (fresh graph).
+ *
+ * @verified f8ee93b9
+ */
+export function seedWithCarryover(
+  ids: string[],
+  priorIds: string[],
+  priorPositions: Float32Array | null,
+  radius: number
+): CarryoverSeed {
+  const n = ids.length;
+  const out = new Float32Array(n * 3);
+  const havePrior =
+    !!priorPositions &&
+    priorIds.length > 0 &&
+    priorPositions.length >= priorIds.length * 3;
+
+  if (!havePrior) {
+    for (let i = 0; i < n; i++) seedOne(out, i, radius);
+    return { positions: out, carriedCount: 0 };
+  }
+
+  const priorIndex = new Map<string, number>();
+  for (let i = 0; i < priorIds.length; i++) priorIndex.set(priorIds[i], i);
+
+  let carried = 0;
+  for (let i = 0; i < n; i++) {
+    const p = priorIndex.get(ids[i]);
+    if (p !== undefined) {
+      out[i * 3] = priorPositions![p * 3];
+      out[i * 3 + 1] = priorPositions![p * 3 + 1];
+      out[i * 3 + 2] = priorPositions![p * 3 + 2];
+      carried++;
+    } else {
+      seedOne(out, i, radius);
+    }
+  }
+  return { positions: out, carriedCount: carried };
+}
+
+/** Radius heuristic — grows gently with node count so graphs stay visible.  @verified f8ee93b9 */
 export function defaultSeedRadius(count: number): number {
   return Math.max(120, Math.cbrt(count) * 15);
 }

--- a/web/src/explorers/ForceGraph/scene/useForceSim.ts
+++ b/web/src/explorers/ForceGraph/scene/useForceSim.ts
@@ -19,7 +19,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
-import { seedSpherePositions, defaultSeedRadius } from './positions';
+import { seedWithCarryover, defaultSeedRadius } from './positions';
 import type { EngineNode, EngineEdge } from '../types';
 
 /** Tunable simulation parameters; see DEFAULTS below for meaning.  @verified c17bbeb9 */
@@ -33,6 +33,12 @@ export interface PhysicsParams {
   alphaDecay: number;
   alphaMin: number;
   alphaInitial: number;
+  /** Reheat energy used when the node set changes but some nodes carried
+   *  over (incremental "poke"). Far below alphaInitial so the existing
+   *  layout barely moves while new nodes ease into place — this is what
+   *  stops the whole-graph "sproing" on every expand/filter. A fresh
+   *  graph (nothing carried) still uses the full alphaInitial. */
+  alphaIncremental: number;
   alphaSimmer: number;
   dampingSimmer: number;
   centerGravitySimmer: number;
@@ -55,6 +61,7 @@ const DEFAULTS: PhysicsParams = {
   alphaDecay: 0.0228,
   alphaMin: 0.001,
   alphaInitial: 1.0,
+  alphaIncremental: 0.3,
   alphaSimmer: 0.08,
   dampingSimmer: 0.70,
   centerGravitySimmer: 0.03,
@@ -103,6 +110,11 @@ export function useForceSim(
   const positionsRef = useRef<Float32Array | null>(null);
   const velocitiesRef = useRef<Float32Array | null>(null);
   const edgeIndicesRef = useRef<Uint32Array | null>(null);
+  // Node ids of the generation currently in positionsRef, index-aligned
+  // with it. Read at the next re-seed to carry surviving nodes' positions
+  // over. Never reset outside the seed step (a stale snapshot is harmless;
+  // a lost one re-explodes the graph).
+  const priorIdsRef = useRef<string[]>([]);
   const alphaRef = useRef(cfg.alphaInitial);
   const [alphaDisplay, setAlphaDisplay] = useState(cfg.alphaInitial);
   const dirtyRef = useRef(false);
@@ -112,15 +124,44 @@ export function useForceSim(
   // so the cycle phase begins at "cold" each time the user enters simmer mode.
   const simmerStartRef = useRef(0);
 
-  // Seed positions when node count changes. useMemo keeps the allocation
-  // out of the render commit phase; we don't actually consume its return.
+  // Re-seed when the node set changes (count OR identity — a filter can
+  // swap nodes without changing the count). useMemo keeps the allocation
+  // out of the render commit phase; we don't consume its return.
+  //
+  // Carry-over: positionsRef still holds the OUTGOING generation's layout
+  // here (we reassign it below), index-aligned with priorIdsRef. So we
+  // snapshot it as the prior buffer — surviving nodes keep their settled
+  // (and drag-adjusted) positions, only new nodes sphere-seed, and the
+  // start alpha is gentle unless this is a genuinely fresh graph.
   useMemo(() => {
-    positionsRef.current = seedSpherePositions(nodeCount, defaultSeedRadius(nodeCount));
+    const ids = nodes.map((n) => n.id);
+    const { positions, carriedCount } = seedWithCarryover(
+      ids,
+      priorIdsRef.current,
+      positionsRef.current,
+      defaultSeedRadius(nodeCount)
+    );
+    positionsRef.current = positions;
     velocitiesRef.current = new Float32Array(nodeCount * 3);
-    alphaRef.current = cfg.alphaInitial;
-    setAlphaDisplay(cfg.alphaInitial);
+    priorIdsRef.current = ids;
+    // Nothing carried ⇒ fresh graph ⇒ full reheat. Anything carried ⇒
+    // incremental poke ⇒ gentle reheat so the existing layout holds.
+    const startAlpha = carriedCount === 0 ? cfg.alphaInitial : cfg.alphaIncremental;
+    alphaRef.current = startAlpha;
+    setAlphaDisplay(startAlpha);
+    // A data change cancels simmer — otherwise the thermal cycle would
+    // fight the gentle re-settle of newly added nodes.
+    simmerRef.current = false;
     dirtyRef.current = true;
-  }, [nodeCount, cfg.alphaInitial]);
+  }, [nodes, nodeCount, cfg.alphaInitial, cfg.alphaIncremental]);
+
+  // Kick a frame after every node-set change so demand-mode picks up the
+  // re-seeded buffers immediately. Post-commit (effect, not render) so we
+  // don't invalidate mid-render; replaces Scene's old reheat-on-length
+  // effect, which slammed alpha to full on every poke.
+  useEffect(() => {
+    invalidate();
+  }, [nodes, invalidate]);
 
   // Rebuild the edge index array whenever nodes or edges change. The sim
   // loop walks this flat Uint32Array pair-wise for cache-friendly access.

--- a/web/src/explorers/ForceGraph/scene/useGpuForceSim.ts
+++ b/web/src/explorers/ForceGraph/scene/useGpuForceSim.ts
@@ -21,7 +21,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { GPUComputationRenderer } from 'three/examples/jsm/misc/GPUComputationRenderer.js';
-import { seedSpherePositions, defaultSeedRadius } from './positions';
+import { seedWithCarryover, defaultSeedRadius } from './positions';
 import { velShaderBody, posShaderBody } from './gpuShaders';
 import { buildNeighborCSR } from './neighborCsr';
 import type { EngineNode, EngineEdge } from '../types';
@@ -37,6 +37,7 @@ const DEFAULTS: PhysicsParams = {
   alphaDecay: 0.0228,
   alphaMin: 0.001,
   alphaInitial: 1.0,
+  alphaIncremental: 0.3,
   alphaSimmer: 0.08,
   dampingSimmer: 0.70,
   centerGravitySimmer: 0.03,
@@ -95,6 +96,11 @@ export function useGpuForceSim(
   const nodeCount = nodes.length;
 
   const positionsRef = useRef<Float32Array | null>(null);
+  // Node ids of the generation currently in positionsRef, index-aligned.
+  // Read at the next rebuild to carry surviving nodes' positions over.
+  // Never reset in the effect cleanup (cleanup runs before the new
+  // effect — clearing it there would lose the snapshot we need).
+  const priorIdsRef = useRef<string[]>([]);
   const dirtyRef = useRef(false);
   const alphaRef = useRef(cfg.alphaInitial);
   const [alphaDisplay, setAlphaDisplay] = useState(cfg.alphaInitial);
@@ -106,6 +112,7 @@ export function useGpuForceSim(
   useEffect(() => {
     if (nodeCount === 0) {
       positionsRef.current = new Float32Array(0);
+      priorIdsRef.current = [];
       gpuStateRef.current = null;
       return;
     }
@@ -115,10 +122,25 @@ export function useGpuForceSim(
     const texH = texSize;
     const totalTexels = texW * texH;
 
-    const seed = seedSpherePositions(nodeCount, defaultSeedRadius(nodeCount));
+    // Carry-over: positionsRef still holds the OUTGOING generation's last
+    // GPU readback (useFrame hasn't run for the new generation yet — this
+    // effect runs before the next frame), index-aligned with priorIdsRef.
+    // Surviving nodes keep their settled positions; only new nodes
+    // sphere-seed and ease in, instead of the whole graph re-exploding.
+    const ids = nodes.map((n) => n.id);
+    const { positions: seed, carriedCount } = seedWithCarryover(
+      ids,
+      priorIdsRef.current,
+      positionsRef.current,
+      defaultSeedRadius(nodeCount)
+    );
     const posOut = new Float32Array(nodeCount * 3);
     posOut.set(seed);
     positionsRef.current = posOut;
+    priorIdsRef.current = ids;
+    // Nothing carried ⇒ fresh graph ⇒ full reheat. Anything carried ⇒
+    // incremental poke ⇒ gentle reheat so the existing layout holds.
+    const startAlpha = carriedCount === 0 ? cfg.alphaInitial : cfg.alphaIncremental;
 
     const gpuCompute = new GPUComputationRenderer(texW, texH, gl);
     const posInit = gpuCompute.createTexture();
@@ -194,7 +216,7 @@ export function useGpuForceSim(
     gpuCompute.setVariableDependencies(posVar, [velVar, posVar]);
 
     const vU = velVar.material.uniforms;
-    vU.alpha = { value: cfg.alphaInitial };
+    vU.alpha = { value: startAlpha };
     vU.repulsion = { value: cfg.repulsion };
     vU.attraction = { value: cfg.attraction };
     vU.damping = { value: cfg.damping };
@@ -242,10 +264,16 @@ export function useGpuForceSim(
 
     const readbackBuf = new Float32Array(totalTexels * 4);
 
-    alphaRef.current = cfg.alphaInitial;
-    setAlphaDisplay(cfg.alphaInitial);
+    alphaRef.current = startAlpha;
+    setAlphaDisplay(startAlpha);
+    // A data change cancels simmer — otherwise the thermal cycle would
+    // fight the gentle re-settle of newly added nodes.
+    simmerRef.current = false;
     dirtyRef.current = true;
     frameCounterRef.current = 0;
+    // Kick a frame so demand-mode picks up the rebuilt state immediately
+    // (replaces Scene's old reheat-on-length effect).
+    invalidate();
 
     gpuStateRef.current = {
       gpuCompute,


### PR DESCRIPTION
## Problem

Any time the graph was "poked" — expand a node, follow a concept, toggle a filter — the CPU and GPU force-sim hooks re-seeded **every** node from a fresh sphere and reset alpha to full (1.0). The entire graph exploded and re-settled on every change.

## Fix

`seedWithCarryover` (new, in `positions.ts`): keeps every node that survived the change at its settled — and drag-adjusted — position, and only sphere-seeds genuinely new nodes so they ease in toward the existing layout. `carriedCount` lets the sim hook pick:

- **nothing carried** → genuinely fresh graph → full `alphaInitial` (1.0)
- **anything carried** → incremental poke → gentle `alphaIncremental` (0.3)

The outgoing layout is snapshotted straight from `positionsRef` at re-seed time (it still holds the previous generation there, index-aligned with a `priorIdsRef`), so there is **zero per-frame cost**. Scene's old unconditional `reheat()`-on-length effect — the thing that slammed alpha to full on every poke — is removed; the hooks now own re-seed + the demand-mode frame kick.

## Scope

Both **Force Graph** and **Document Explorer** benefit — they share the `Scene → useSim` engine, and 2D vs 3D is just the `dimensions` param to the same CPU/GPU hooks. There is no separate D3 physics canvas.

The manual **Reheat** button still does a deliberate full re-layout (`alphaInitial`), unchanged.

## Also in this PR

- Unit test for `seedWithCarryover` (fresh / full carry / partial+reorder / torn-snapshot guard) — 4 tests, passing.
- Reworded three stale `transformForD3` / "2D explorer" comments in `ForceGraph.tsx` (no D3 explorer exists; the rationale is kept, the dead reference dropped).
- Fixed two pre-existing unused-var lint errors in `ForceGraph.tsx` (`onNodeClick`, `mergeRawGraphData`).

## Verification

- `tsc -b`: changed files add **zero** type errors (2 errors remain in `BlockPalette.tsx` / `dataTransformer.ts` — pre-existing on `main`, out of scope).
- `eslint`: all changed + new files clean.
- `vitest`: `positions.test.ts` 4/4 pass.
- **Visual**: confirmed by the author — poking the graph (right-click → add adjacent) now grows calmly instead of exploding.

## Follow-ups (not in this PR)

- GPU hook still fully rebuilds `GPUComputationRenderer` on edge-only changes (calm now, but rebuild cost unchanged). In-place neighbor-texture update is the natural next step if perf matters.
- New nodes spawn from the central sphere region and fly in. If spawning near the connecting node is preferred, that's a separate change.