### PR TITLE
feat(web): platonic-solid glyph nodes with two-tone faceted material

### DIFF
--- a/web/src/explorers/ForceGraph/ForceGraph.tsx
+++ b/web/src/explorers/ForceGraph/ForceGraph.tsx
@@ -20,6 +20,7 @@ import { Flame } from 'lucide-react';
 import type { ExplorerProps } from '../../types/explorer';
 import type { ForceGraphData, ForceGraphSettings } from './types';
 import { Scene } from './scene/Scene';
+import { shapeFor, shapeGeometryByClass } from './scene/shapes';
 import type { NodeInfoData } from './scene/NodeInfoOverlay';
 import { simBackend } from './scene/useSim';
 import { DIM_MODEL } from './scene/dimModel';
@@ -351,6 +352,17 @@ export const ForceGraph: React.FC<
     });
   }, [baseNodeColors, dimState, filteredData, canvasBg]);
 
+  // Platonic-solid glyph encoding. Shape is derived from the same
+  // ontology string colour uses (per ADR-203's no-schema rendering step
+  // — shape becomes a second axis once the node-class facet exists).
+  // nodeClasses is parallel to the SAME node array Scene renders;
+  // geometryByClass is static (one unit solid per shape name).
+  const nodeShapeClasses = useMemo(
+    () => (filteredData?.nodes ?? []).map((n) => shapeFor(n.category)),
+    [filteredData]
+  );
+  const shapeGeometries = useMemo(() => shapeGeometryByClass(), []);
+
   // Synthesize the GraphData shape the shared Legend component expects.
   // Legend reads `nodes[*].{group,color}` and `links[*].{category,color}`;
   // EngineNode/EngineEdge don't carry computed colors (they're applied
@@ -472,6 +484,8 @@ export const ForceGraph: React.FC<
           nodes={filteredData?.nodes ?? []}
           edges={filteredData?.edges ?? []}
           colors={nodeColors}
+          nodeClasses={nodeShapeClasses}
+          geometryByClass={shapeGeometries}
           edgeColors={edgeColors}
           physics={{
             enabled: settings?.physics?.enabled ?? true,

--- a/web/src/explorers/ForceGraph/ForceGraph.tsx
+++ b/web/src/explorers/ForceGraph/ForceGraph.tsx
@@ -495,6 +495,11 @@ export const ForceGraph: React.FC<
             damping: settings?.physics?.damping,
           }}
           projection={settings?.projection ?? '3D'}
+          lit={
+            (settings?.visual?.lightingFollowsProjection ?? false)
+              ? (settings?.projection ?? '3D') === '3D'
+              : (settings?.visual?.lighting ?? 'flat') === 'lit'
+          }
           nodeSize={settings?.visual?.nodeSize ?? 1}
           edgeOpacity={0.7}
           linkWidth={settings?.visual?.linkWidth ?? 1}

--- a/web/src/explorers/ForceGraph/SettingsPanel.tsx
+++ b/web/src/explorers/ForceGraph/SettingsPanel.tsx
@@ -305,6 +305,37 @@ export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraphSettings>> = (
                 <option value="uniform">Uniform</option>
               </select>
             </label>
+            <label
+              className={`flex items-center gap-2 text-xs text-card-foreground ${
+                settings.visual.lightingFollowsProjection ? 'opacity-50' : ''
+              }`}
+            >
+              <span className="flex-1 min-w-0 truncate">
+                {settings.visual.lightingFollowsProjection
+                  ? 'Shading (follows view)'
+                  : 'Shading'}
+              </span>
+              <select
+                className="flex-[2] bg-card border border-border rounded px-1 py-0.5 text-xs"
+                value={settings.visual.lighting}
+                disabled={settings.visual.lightingFollowsProjection}
+                onChange={(e) =>
+                  updateVisual({
+                    lighting: e.target.value as ForceGraphSettings['visual']['lighting'],
+                  })
+                }
+              >
+                <option value="flat">Flat (two-tone)</option>
+                <option value="lit">Lit (3D light)</option>
+              </select>
+            </label>
+            {row(
+              'Shading follows view',
+              settings.visual.lightingFollowsProjection ? 'on' : 'off',
+              toggle_(settings.visual.lightingFollowsProjection, (v) =>
+                updateVisual({ lightingFollowsProjection: v })
+              )
+            )}
             {row(
               'Node size',
               settings.visual.nodeSize.toFixed(2),

--- a/web/src/explorers/ForceGraph/scene/Nodes.tsx
+++ b/web/src/explorers/ForceGraph/scene/Nodes.tsx
@@ -16,11 +16,18 @@
  * resolves to the global node id via a class-local index map.
  */
 
-import { useEffect, useMemo, useRef, type ReactElement } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type ReactElement,
+} from 'react';
 import { useFrame, useThree, type ThreeEvent } from '@react-three/fiber';
 import type { DragHandlers } from './useDragHandler';
 import * as THREE from 'three';
 import type { EngineNode } from '../types';
+import { createFacetedNodeMaterial, ensureBarycentric } from './facetedMaterial';
 
 const DEFAULT_CLASS = '__default__';
 
@@ -62,13 +69,9 @@ export interface NodesProps {
 
 /** Instanced node meshes — one draw call per geometry class.  @verified c17bbeb9 */
 export function Nodes(props: NodesProps) {
-  const {
-    nodes,
-    nodeClasses,
-    geometryByClass,
-    nodeScales,
-    nodeSize = 1,
-  } = props;
+  // nodeSize is intentionally not destructured here — each NodeClassMesh
+  // reads it from the spread props and applies it per-frame.
+  const { nodes, nodeClasses, geometryByClass, nodeScales } = props;
 
   // Partition nodes by class. Single-class fallback keeps the default
   // path identical to the pre-multi-class behaviour.
@@ -106,6 +109,16 @@ export function Nodes(props: NodesProps) {
     return out;
   }, [nodes, nodeScales]);
 
+  // One shared faceted material backs every class mesh — it carries no
+  // per-instance state (colour is instanceColor, structure is the
+  // barycentric attribute), so a single instance is correct and cheapest.
+  // Deliberately NOT disposed on unmount: under React StrictMode the
+  // effect cleanup fires while useMemo keeps returning the same handle,
+  // so a dispose() here would hand every later render a dead material
+  // (black / failed program compile). One material lives for the app's
+  // lifetime — the standard pattern for a shared three material.
+  const material = useMemo(() => createFacetedNodeMaterial(), []);
+
   return (
     <>
       {partitions.map((partition) => (
@@ -115,6 +128,7 @@ export function Nodes(props: NodesProps) {
           indices={partition.indices}
           baseScales={baseScales}
           geometry={geometryByClass?.[partition.key]}
+          material={material}
           {...props}
         />
       ))}
@@ -128,6 +142,8 @@ interface NodeClassMeshProps extends NodesProps {
   indices: Uint32Array;
   baseScales: Float32Array;
   geometry?: ReactElement;
+  /** Shared faceted two-tone material (see facetedMaterial.ts). */
+  material: THREE.MeshBasicMaterial;
 }
 
 function NodeClassMesh({
@@ -135,6 +151,7 @@ function NodeClassMesh({
   indices,
   baseScales,
   geometry,
+  material,
   nodes,
   positionsRef,
   colors,
@@ -152,6 +169,31 @@ function NodeClassMesh({
   const meshRef = useRef<THREE.InstancedMesh>(null);
   const invalidate = useThree((state) => state.invalidate);
   const count = indices.length;
+
+  // The faceted material's wireframe needs a per-triangle barycentric
+  // attribute on non-indexed geometry. r3f sets the JSX geometry
+  // declaratively; we swap in a non-indexed, annotated clone right after
+  // mount (layout effect = before first paint/raycast). The mesh remounts
+  // on the `${classKey}-${count}` key, so this re-runs with fresh
+  // geometry whenever the partition resizes. Idempotent via
+  // ensureBarycentric's own aBary guard.
+  useLayoutEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    const original = mesh.geometry;
+    const annotated = ensureBarycentric(original);
+    if (annotated === original) return;
+    mesh.geometry = annotated;
+    // Dispose the detached JSX geometry now (idempotent — r3f also
+    // disposes it on unmount; three's dispose just re-dispatches a
+    // harmless event). Do NOT dispose `annotated` in cleanup: under
+    // StrictMode the effect runs → cleanup → runs again against the
+    // SAME mesh, whose geometry is now `annotated` with aBary already
+    // present, so ensureBarycentric early-returns and the mesh would be
+    // left rendering a disposed geometry. Leaking one BufferGeometry per
+    // class unmount (rare, bounded) is the safe asymmetry.
+    original.dispose();
+  }, []);
 
   // Bounding-sphere refresh cadence — three.js InstancedMesh.raycast()
   // early-outs against the bounding sphere before testing instances.
@@ -303,11 +345,11 @@ function NodeClassMesh({
       onContextMenu={handleContextMenu}
     >
       {geometry ?? <icosahedronGeometry args={[1, 1]} />}
-      {/* vertexColors=false is intentional: per-instance colors come from
-          setColorAt/instanceColor, which three injects via the
-          USE_INSTANCING_COLOR shader chunk independent of the vertexColors
-          flag. Switching to a lit material silently breaks this. */}
-      <meshBasicMaterial vertexColors={false} />
+      {/* Shared faceted two-tone material (facetedMaterial.ts). It's a
+          patched MeshBasicMaterial so per-instance instanceColor still
+          works; the layout effect above swaps in the barycentric
+          geometry the material's wireframe needs. */}
+      <primitive object={material} attach="material" />
     </instancedMesh>
   );
 }

--- a/web/src/explorers/ForceGraph/scene/Nodes.tsx
+++ b/web/src/explorers/ForceGraph/scene/Nodes.tsx
@@ -27,7 +27,7 @@ import { useFrame, useThree, type ThreeEvent } from '@react-three/fiber';
 import type { DragHandlers } from './useDragHandler';
 import * as THREE from 'three';
 import type { EngineNode } from '../types';
-import { createFacetedNodeMaterial, ensureBarycentric } from './facetedMaterial';
+import { createFacetedNodeMaterial, ensureFacetGeometry } from './facetedMaterial';
 
 const DEFAULT_CLASS = '__default__';
 
@@ -58,6 +58,10 @@ export interface NodesProps {
   hiddenIds?: Set<string>;
   highlightedIds?: Set<string>;
   nodeSize?: number;
+  /** Shading mode. false (default) = flat unlit two-tone (original
+   *  engine look); true = real Lambert lighting (needs a scene light,
+   *  which Scene adds camera-tracked). */
+  lit?: boolean;
   selectedId?: string | null;
   onSelect?: (id: string | null) => void;
   onHover?: (id: string | null) => void;
@@ -71,7 +75,7 @@ export interface NodesProps {
 export function Nodes(props: NodesProps) {
   // nodeSize is intentionally not destructured here — each NodeClassMesh
   // reads it from the spread props and applies it per-frame.
-  const { nodes, nodeClasses, geometryByClass, nodeScales } = props;
+  const { nodes, nodeClasses, geometryByClass, nodeScales, lit = false } = props;
 
   // Partition nodes by class. Single-class fallback keeps the default
   // path identical to the pre-multi-class behaviour.
@@ -112,12 +116,13 @@ export function Nodes(props: NodesProps) {
   // One shared faceted material backs every class mesh — it carries no
   // per-instance state (colour is instanceColor, structure is the
   // barycentric attribute), so a single instance is correct and cheapest.
-  // Deliberately NOT disposed on unmount: under React StrictMode the
-  // effect cleanup fires while useMemo keeps returning the same handle,
-  // so a dispose() here would hand every later render a dead material
-  // (black / failed program compile). One material lives for the app's
-  // lifetime — the standard pattern for a shared three material.
-  const material = useMemo(() => createFacetedNodeMaterial(), []);
+  // Re-created only when the shading mode flips (flat↔lit) — that's a
+  // different material class (Basic vs Lambert). Deliberately NOT disposed
+  // on unmount: under React StrictMode the effect cleanup fires while
+  // useMemo keeps returning the same handle, so a dispose() would hand
+  // every later render a dead material. One material per mode lives for
+  // the app's lifetime — the standard pattern for a shared three material.
+  const material = useMemo(() => createFacetedNodeMaterial(lit), [lit]);
 
   return (
     <>
@@ -142,8 +147,9 @@ interface NodeClassMeshProps extends NodesProps {
   indices: Uint32Array;
   baseScales: Float32Array;
   geometry?: ReactElement;
-  /** Shared faceted two-tone material (see facetedMaterial.ts). */
-  material: THREE.MeshBasicMaterial;
+  /** Shared faceted two-tone material (see facetedMaterial.ts) — Basic
+   *  in flat mode, Lambert in lit mode. */
+  material: THREE.MeshBasicMaterial | THREE.MeshLambertMaterial;
 }
 
 function NodeClassMesh({
@@ -170,18 +176,18 @@ function NodeClassMesh({
   const invalidate = useThree((state) => state.invalidate);
   const count = indices.length;
 
-  // The faceted material's wireframe needs a per-triangle barycentric
-  // attribute on non-indexed geometry. r3f sets the JSX geometry
-  // declaratively; we swap in a non-indexed, annotated clone right after
+  // The material's hard-edge wireframe + per-face normals need a
+  // non-indexed geometry carrying aBary/aEdgeHide. r3f sets the JSX
+  // geometry declaratively; we swap in the annotated clone right after
   // mount (layout effect = before first paint/raycast). The mesh remounts
   // on the `${classKey}-${count}` key, so this re-runs with fresh
   // geometry whenever the partition resizes. Idempotent via
-  // ensureBarycentric's own aBary guard.
+  // ensureFacetGeometry's own aBary guard.
   useLayoutEffect(() => {
     const mesh = meshRef.current;
     if (!mesh) return;
     const original = mesh.geometry;
-    const annotated = ensureBarycentric(original);
+    const annotated = ensureFacetGeometry(original);
     if (annotated === original) return;
     mesh.geometry = annotated;
     // Dispose the detached JSX geometry now (idempotent — r3f also
@@ -189,7 +195,7 @@ function NodeClassMesh({
     // harmless event). Do NOT dispose `annotated` in cleanup: under
     // StrictMode the effect runs → cleanup → runs again against the
     // SAME mesh, whose geometry is now `annotated` with aBary already
-    // present, so ensureBarycentric early-returns and the mesh would be
+    // present, so ensureFacetGeometry early-returns and the mesh would be
     // left rendering a disposed geometry. Leaking one BufferGeometry per
     // class unmount (rare, bounded) is the safe asymmetry.
     original.dispose();
@@ -344,11 +350,17 @@ function NodeClassMesh({
       onPointerUp={handlePointerUp}
       onContextMenu={handleContextMenu}
     >
-      {geometry ?? <icosahedronGeometry args={[1, 1]} />}
-      {/* Shared faceted two-tone material (facetedMaterial.ts). It's a
-          patched MeshBasicMaterial so per-instance instanceColor still
-          works; the layout effect above swaps in the barycentric
-          geometry the material's wireframe needs. */}
+      {/* Default (no per-class geometry) = a geodesic icosphere: a
+          detail-4 subdivided icosahedron. Its facet dihedrals are far
+          below the hard-edge threshold, so it carries no wireframe and
+          keeps its smooth interpolated normals — a clean round ball in
+          lit mode, a flat disc in flat mode. The hashed platonic solids
+          arrive via geometryByClass. */}
+      {geometry ?? <icosahedronGeometry args={[1, 4]} />}
+      {/* Shared faceted two-tone material (facetedMaterial.ts) — patched
+          Basic (flat) or Lambert (lit); both keep per-instance
+          instanceColor. The layout effect swaps in the annotated
+          geometry the material needs. */}
       <primitive object={material} attach="material" />
     </instancedMesh>
   );

--- a/web/src/explorers/ForceGraph/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph/scene/Scene.tsx
@@ -7,8 +7,9 @@
  * (pan + zoom, no rotation).
  */
 
-import { useImperativeHandle, useMemo, type ReactElement } from 'react';
+import { useImperativeHandle, useMemo, useRef, type ReactElement } from 'react';
 import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import type { EngineNode, EngineEdge, Projection } from '../types';
 import { Nodes } from './Nodes';
@@ -27,6 +28,27 @@ import type { ForceSimHandle, ForceSimParams } from './useForceSim';
 const EMPTY_SET: Set<string> = new Set();
 const NOOP_SET_SETTER: (s: Set<string>) => void = () => {};
 const EMPTY_INFOS: NodeInfoData[] = [];
+
+/**
+ * Directional key light pinned to the camera. Each frame it copies the
+ * camera position; its target stays at the world origin (the graph is
+ * roughly centred there), so the lit side always faces the viewer as
+ * they orbit — a static world-space light would look glued to one face
+ * when the graph rotates. Only meaningful for the lit (Lambert)
+ * material; rendered solely in lit mode so flat mode pays no per-frame
+ * cost. Paired with the scene's ambient so the far side isn't black.
+ */
+function CameraKeyLight() {
+  const lightRef = useRef<THREE.DirectionalLight>(null);
+  useFrame(({ camera }) => {
+    lightRef.current?.position.copy(camera.position);
+  });
+  // The light's default target sits at the world origin with an identity
+  // matrix, so direction = origin − cameraPos resolves correctly without
+  // a target.updateMatrixWorld() call. If a future change moves the
+  // target off origin, that update becomes required here.
+  return <directionalLight ref={lightRef} intensity={1.1} />;
+}
 
 export interface SceneProps {
   nodes: EngineNode[];
@@ -99,6 +121,9 @@ export interface SceneProps {
   /** Camera + sim projection. Drives camera-controls flavor, sim
    *  dimensionality, and drag-plane construction. Defaults '3D'. */
   projection?: Projection;
+  /** Shading mode. false (default) = flat unlit two-tone; true = real
+   *  Lambert lighting with a camera-tracked key light. */
+  lit?: boolean;
 }
 
 /** Scene composition — physics + rendering + camera controls.  @verified c17bbeb9 */
@@ -142,6 +167,7 @@ export function Scene({
   onDismissNodeInfo,
   simHandleRef,
   projection = '3D',
+  lit = false,
 }: SceneProps) {
   const sim = useSim(nodes, edges, {
     ...physics,
@@ -187,6 +213,7 @@ export function Scene({
   return (
     <>
       <ambientLight intensity={0.5} />
+      {lit && <CameraKeyLight />}
       <Edges
         nodes={nodes}
         edges={edges}
@@ -219,6 +246,7 @@ export function Scene({
         nodeClasses={nodeClasses}
         geometryByClass={geometryByClass}
         nodeScales={resolvedNodeScales}
+        lit={lit}
         hiddenIds={hiddenIds}
         highlightedIds={highlightedIds}
         nodeSize={nodeSize}

--- a/web/src/explorers/ForceGraph/scene/facetedMaterial.test.ts
+++ b/web/src/explorers/ForceGraph/scene/facetedMaterial.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for ensureFacetGeometry's hard-edge extraction.
+ *
+ * The regression that matters is exactly the user's own example: a cube
+ * face is two triangles sharing a diagonal; that diagonal is a
+ * triangulation artefact, NOT a principal edge, and must be masked
+ * (soft) while the 12 real cube edges stay hard. The icosphere case
+ * locks the smooth-default partition the sphere look depends on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { ensureFacetGeometry } from './facetedMaterial';
+
+// aEdgeHide channels are 0 for a hard (principal) edge, a large constant
+// (~10) for a soft/hidden one. Test in thresholds so the private HIDE
+// constant isn't imported.
+const isHard = (v: number) => v < 0.5;
+
+function hideTriples(geo: THREE.BufferGeometry): Array<[boolean, boolean, boolean]> {
+  const a = geo.getAttribute('aEdgeHide') as THREE.BufferAttribute;
+  const triCount = a.count / 3;
+  const out: Array<[boolean, boolean, boolean]> = [];
+  for (let t = 0; t < triCount; t++) {
+    // Flat per triangle — vertex 0 of each tri carries the values.
+    const i = t * 3;
+    out.push([isHard(a.getX(i)), isHard(a.getY(i)), isHard(a.getZ(i))]);
+  }
+  return out;
+}
+
+describe('ensureFacetGeometry — hard-edge extraction', () => {
+  it('a cube keeps its 12 edges, masks the 6 face diagonals', () => {
+    const g = ensureFacetGeometry(new THREE.BoxGeometry(1, 1, 1));
+    const tris = hideTriples(g);
+    // Box = 6 faces × 2 triangles. Per triangle: the two legs are real
+    // cube edges (hard), the hypotenuse is the shared face diagonal
+    // (soft). So every triangle has exactly two hard channels + one soft.
+    expect(tris).toHaveLength(12);
+    for (const [x, y, z] of tris) {
+      const hard = [x, y, z].filter(Boolean).length;
+      expect(hard).toBe(2);
+    }
+    // Total soft channels = 12 (one per triangle) = the 6 diagonals
+    // counted from both adjacent triangles.
+    const soft = tris.reduce(
+      (n, [x, y, z]) => n + [x, y, z].filter((h) => !h).length,
+      0
+    );
+    expect(soft).toBe(12);
+  });
+
+  it('a geodesic icosphere has no hard edges (smooth, no wireframe)', () => {
+    // detail 3 → facet dihedrals well under the 25° threshold.
+    const g = ensureFacetGeometry(new THREE.IcosahedronGeometry(1, 3));
+    const tris = hideTriples(g);
+    const anyHard = tris.some(([x, y, z]) => x || y || z);
+    expect(anyHard).toBe(false);
+  });
+
+  it('a bare icosahedron is all hard edges (faceted)', () => {
+    const g = ensureFacetGeometry(new THREE.IcosahedronGeometry(1, 0));
+    const tris = hideTriples(g);
+    // Every one of the 20 faces borders non-coplanar neighbours.
+    for (const [x, y, z] of tris) {
+      expect([x, y, z].every(Boolean)).toBe(true);
+    }
+  });
+
+  it('attaches aBary + normals and is idempotent', () => {
+    const g = ensureFacetGeometry(new THREE.OctahedronGeometry(1, 0));
+    expect(g.getAttribute('aBary')).toBeTruthy();
+    expect(g.getAttribute('aEdgeHide')).toBeTruthy();
+    expect(g.getAttribute('normal')).toBeTruthy();
+    // Second pass is a no-op (same object back, attrs intact).
+    expect(ensureFacetGeometry(g)).toBe(g);
+  });
+});

--- a/web/src/explorers/ForceGraph/scene/facetedMaterial.ts
+++ b/web/src/explorers/ForceGraph/scene/facetedMaterial.ts
@@ -1,34 +1,41 @@
 /**
- * Two-tone faceted node material.
+ * Two-tone faceted node material — principal edges only, flat or lit.
  *
- * Each node renders in its per-instance colour, with the solid's edges
- * and vertices darkened toward a lower-luminance shade of that same
- * colour — a two-tone, same-hue look that reads the polyhedral structure
- * without lighting. The darkening is a barycentric in-shader wireframe:
- * an `aBary` attribute carries (1,0,0)/(0,1,0)/(0,0,1) per triangle
- * vertex, the fragment shader takes the min barycentric (→0 on edges,
- * →0 at vertices where two go to zero) and lerps the fragment toward a
- * scaled-down copy of itself.
+ * Each node renders in its per-instance colour with the solid's *true*
+ * edges and vertices darkened toward a lower-luminance shade of that same
+ * colour. "True" is the point: the darkening traces only the polyhedron's
+ * principal edges (sharp dihedral angles), never the triangulation edges
+ * a mesher adds — a cube shows 12 edges, not the 6 face diagonals; an
+ * icosphere shows none and reads as a smooth ball.
  *
- * Why this technique:
- * - One draw call, no extra geometry/lines — works with InstancedMesh.
- * - Built on MeshBasicMaterial via onBeforeCompile so three's
- *   USE_INSTANCING_COLOR chunk (per-instance colour) is untouched. The
- *   engine deliberately stays on an unlit basic material (see Nodes.tsx);
- *   switching to a lit material silently breaks instance colour.
- * - The effect intensifies on complex solids for free: a dodecahedron
- *   has 5× the edges of a tetrahedron, so more dark structure per
- *   silhouette — exactly the requested behaviour.
+ * Mechanism — a hard-edge barycentric wireframe, one draw call,
+ * instancing-safe:
+ * - `aBary` carries (1,0,0)/(0,1,0)/(0,0,1) per triangle vertex.
+ * - `aEdgeHide` (flat per triangle) pushes the barycentric channel of any
+ *   *soft* (coplanar / sub-triangulation) edge far out of range so the
+ *   shader's min() never selects it. Only hard edges — and the vertices
+ *   where two hard edges meet — darken.
+ * - Hard/soft is decided by the dihedral angle between the two triangles
+ *   sharing an edge, computed on a position-quantised adjacency map (so
+ *   the toNonIndexed vertex duplication doesn't hide the sharing).
  *
- * Same-chroma claim: `rgb * uDark` is a *uniform* RGB scale. In HSL that
- * is identical hue and identical saturation with lower lightness (the
- * max/min channel ratios that define H and S are preserved) — so the
- * dark tone genuinely is the same colour, just dimmer, never black.
+ * Shading is selectable (ADR-pending UI toggle):
+ * - **flat** — MeshBasicMaterial, unlit. Colour + two-tone edges only;
+ *   the original engine look.
+ * - **lit** — MeshLambertMaterial + a camera-tracking light (added in
+ *   Scene). Faceted solids get genuine per-face shading (face normals);
+ *   the icosphere gets smooth shading (its interpolated normals are kept).
  *
- * The edge AA uses fwidth(), which is core in WebGL2 (GLSL ES 3.00).
- * This codebase already requires WebGL2 for the GPU force sim, and r3f's
- * Canvas is WebGL2 on every current browser, so no derivatives-extension
- * guard is needed.
+ * Per-instance colour survives both: three's color_vertex / color_fragment
+ * chunks (USE_INSTANCING_COLOR → vColor → diffuseColor) are identical in
+ * MeshBasic and MeshLambert — verified in three's ShaderLib — so the old
+ * "a lit material breaks instanceColor" caveat does not apply here.
+ *
+ * Same-chroma: `rgb * uDark` is a *uniform* RGB scale = identical hue and
+ * saturation in HSL, only lower lightness. Dimmer, never black.
+ *
+ * fwidth() is core in WebGL2 (GLSL ES 3.00); this codebase already
+ * requires WebGL2 for the GPU sim, so no derivatives-extension guard.
  *
  * @verified 7b87c133
  */
@@ -36,89 +43,190 @@
 import * as THREE from 'three';
 
 /** Edge softness in pixels — fwidth-scaled so the dark line stays a
- *  crisp ~1.5px at any zoom instead of aliasing when far / bloating when
- *  near. */
+ *  crisp ~1.5px at any zoom. */
 const EDGE_PX = 1.5;
 
-/** Luminance multiplier for the dark tone. Below 1 so edges/vertices
- *  recede; well above 0 so they read as "darker colour", not black. */
+/** Luminance multiplier for the dark tone (same hue, lower lightness). */
 const DARK = 0.45;
 
+/** Dihedral angle (degrees) above which an edge is "hard" (principal).
+ *  Platonic solids: smallest is the icosahedron at ~41° between adjacent
+ *  face normals — well above. A geodesic icosphere at detail ≥3 has
+ *  facet dihedrals < ~12°, so every edge is soft → no wireframe, smooth
+ *  ball. 25° sits cleanly between the two populations. */
+const HARD_EDGE_DEG = 25;
+
+/** Barycentric offset that removes a soft edge from the shader's min(). */
+const HIDE = 10.0;
+
+/** Quantise a coordinate so toNonIndexed's duplicated vertices rejoin
+ *  when building edge adjacency (1e-4 world units ≈ exact for unit
+ *  geometry). */
+function q(n: number): number {
+  return Math.round(n * 1e4);
+}
+
 /**
- * Add a per-triangle barycentric attribute (`aBary`). Indexed geometry
- * is converted to non-indexed first (a barycentric wireframe needs
- * unshared vertices), returning a NEW geometry — the caller owns
- * disposing the old one. Non-indexed input is annotated in place.
- * Idempotent: a geometry that already has `aBary` is returned as-is.
+ * Convert to non-indexed, attach `aBary` + `aEdgeHide` (principal-edge
+ * mask), and set normals for the chosen shading: face normals when the
+ * geometry has hard edges (faceted), input normals kept otherwise (a
+ * smooth icosphere stays smooth). Returns a NEW geometry for indexed
+ * input — caller disposes the old one. Idempotent via the `aBary` guard.
  *
  * @verified 7b87c133
  */
-export function ensureBarycentric(
+export function ensureFacetGeometry(
   geo: THREE.BufferGeometry
 ): THREE.BufferGeometry {
   if (geo.getAttribute('aBary')) return geo;
   const g = geo.index ? geo.toNonIndexed() : geo;
-  const count = g.getAttribute('position').count; // multiple of 3
-  const bary = new Float32Array(count * 3);
-  for (let i = 0; i < count; i += 3) {
-    // v0 = (1,0,0), v1 = (0,1,0), v2 = (0,0,1)
-    bary[i * 3 + 0] = 1;
-    bary[(i + 1) * 3 + 1] = 1;
-    bary[(i + 2) * 3 + 2] = 1;
+  const pos = g.getAttribute('position') as THREE.BufferAttribute;
+  const triCount = pos.count / 3;
+
+  // Per-triangle face normals + position-quantised edge → adjacent
+  // triangle map. Each undirected edge collects the indices of the
+  // triangles touching it.
+  const faceNormal: THREE.Vector3[] = new Array(triCount);
+  const edgeTris = new Map<string, number[]>();
+  const vA = new THREE.Vector3();
+  const vB = new THREE.Vector3();
+  const vC = new THREE.Vector3();
+  const e1 = new THREE.Vector3();
+  const e2 = new THREE.Vector3();
+
+  const key = (i: number) =>
+    `${q(pos.getX(i))},${q(pos.getY(i))},${q(pos.getZ(i))}`;
+  const edgeKey = (i: number, j: number) => {
+    const a = key(i);
+    const b = key(j);
+    return a < b ? `${a}|${b}` : `${b}|${a}`;
+  };
+
+  for (let t = 0; t < triCount; t++) {
+    const i0 = t * 3;
+    vA.fromBufferAttribute(pos, i0);
+    vB.fromBufferAttribute(pos, i0 + 1);
+    vC.fromBufferAttribute(pos, i0 + 2);
+    e1.subVectors(vB, vA);
+    e2.subVectors(vC, vA);
+    faceNormal[t] = new THREE.Vector3().crossVectors(e1, e2).normalize();
+    // edge opposite v0 = (v1,v2); opposite v1 = (v2,v0); opposite v2 = (v0,v1)
+    for (const [a, b] of [
+      [i0 + 1, i0 + 2],
+      [i0 + 2, i0],
+      [i0, i0 + 1],
+    ]) {
+      const k = edgeKey(a, b);
+      let arr = edgeTris.get(k);
+      if (!arr) edgeTris.set(k, (arr = []));
+      arr.push(t);
+    }
   }
+
+  const cosThresh = Math.cos((HARD_EDGE_DEG * Math.PI) / 180);
+  const isHard = (i: number, j: number, t: number): boolean => {
+    const tris = edgeTris.get(edgeKey(i, j));
+    if (!tris || tris.length < 2) return true; // boundary edge → keep
+    const other = tris.find((x) => x !== t);
+    if (other === undefined) return true;
+    // Hard when the two faces diverge past the threshold (dot below
+    // cos(threshold)). Coplanar sub-triangulation (dot ≈ 1) → soft.
+    return faceNormal[t].dot(faceNormal[other]) < cosThresh;
+  };
+
+  const count = pos.count;
+  const bary = new Float32Array(count * 3);
+  const hide = new Float32Array(count * 3);
+  let hardCount = 0;
+
+  for (let t = 0; t < triCount; t++) {
+    const i0 = t * 3;
+    bary[i0 * 3 + 0] = 1; // v0 → (1,0,0)
+    bary[(i0 + 1) * 3 + 1] = 1; // v1 → (0,1,0)
+    bary[(i0 + 2) * 3 + 2] = 1; // v2 → (0,0,1)
+
+    // channel x ↔ edge (v1,v2), y ↔ (v2,v0), z ↔ (v0,v1)
+    const hx = isHard(i0 + 1, i0 + 2, t) ? 0 : HIDE;
+    const hy = isHard(i0 + 2, i0, t) ? 0 : HIDE;
+    const hz = isHard(i0, i0 + 1, t) ? 0 : HIDE;
+    if (hx === 0) hardCount++;
+    if (hy === 0) hardCount++;
+    if (hz === 0) hardCount++;
+    for (let v = 0; v < 3; v++) {
+      hide[(i0 + v) * 3 + 0] = hx;
+      hide[(i0 + v) * 3 + 1] = hy;
+      hide[(i0 + v) * 3 + 2] = hz;
+    }
+  }
+
   g.setAttribute('aBary', new THREE.BufferAttribute(bary, 3));
+  g.setAttribute('aEdgeHide', new THREE.BufferAttribute(hide, 3));
+
+  // Faceted geometry → per-face normals so lit mode shades each facet
+  // flat. A geometry with no hard edges (icosphere) keeps its smooth
+  // input normals; only recompute when there's facet structure to show.
+  if (hardCount > 0 || !g.getAttribute('normal')) {
+    g.computeVertexNormals(); // non-indexed ⇒ each vertex = its face normal
+  }
   return g;
 }
 
-/**
- * Build the shared faceted material. Stateless across instances and
- * classes — one material can back every node mesh.
- *
- * @verified 7b87c133
- */
-export function createFacetedNodeMaterial(): THREE.MeshBasicMaterial {
-  // vertexColors=false is intentional: per-instance colour arrives via
-  // instanceColor / USE_INSTANCING_COLOR, which three injects
-  // independent of the vertexColors flag.
-  const material = new THREE.MeshBasicMaterial({ vertexColors: false });
+/** Back-compat alias — call sites updated to ensureFacetGeometry. */
+export const ensureBarycentric = ensureFacetGeometry;
 
+const VERT_PATCH = 'attribute vec3 aBary;\nattribute vec3 aEdgeHide;\nvarying vec3 vBary;\nvarying vec3 vEdgeHide;\n';
+const FRAG_PATCH = 'varying vec3 vBary;\nvarying vec3 vEdgeHide;\nuniform float uEdgePx;\nuniform float uDark;\n';
+const FRAG_BODY = `#include <opaque_fragment>
+{
+  // Soft edges get +HIDE on their channel so min() never picks them;
+  // only hard (principal) edges and the vertices where two meet stay
+  // near zero.
+  vec3 bw = vBary + vEdgeHide;
+  float b = min(min(bw.x, bw.y), bw.z);
+  float aa = max(fwidth(b) * uEdgePx, 1e-5);
+  float edge = 1.0 - smoothstep(0.0, aa, b);
+  // Degenerate guard: if aBary is absent it reads (0,0,0); don't paint
+  // the whole node dark.
+  if (vBary.x + vBary.y + vBary.z < 0.5) edge = 0.0;
+  gl_FragColor.rgb = mix(gl_FragColor.rgb, gl_FragColor.rgb * uDark, edge);
+}`;
+
+/** Apply the two-tone hard-edge patch to a basic OR lambert material. */
+function patchTwoTone(material: THREE.Material): void {
   material.onBeforeCompile = (shader) => {
     shader.uniforms.uEdgePx = { value: EDGE_PX };
     shader.uniforms.uDark = { value: DARK };
-
     shader.vertexShader =
-      'attribute vec3 aBary;\nvarying vec3 vBary;\n' +
+      VERT_PATCH +
       shader.vertexShader.replace(
         '#include <begin_vertex>',
-        '#include <begin_vertex>\n  vBary = aBary;'
+        '#include <begin_vertex>\n  vBary = aBary;\n  vEdgeHide = aEdgeHide;'
       );
-
     shader.fragmentShader =
-      'varying vec3 vBary;\nuniform float uEdgePx;\nuniform float uDark;\n' +
-      shader.fragmentShader.replace(
-        '#include <opaque_fragment>',
-        `#include <opaque_fragment>
-        {
-          // Distance to the nearest triangle edge in barycentric space;
-          // ~0 on an edge, exactly 0 at a vertex.
-          float b = min(min(vBary.x, vBary.y), vBary.z);
-          // fwidth() gives screen-space derivative → constant px width.
-          float aa = max(fwidth(b) * uEdgePx, 1e-5);
-          float edge = 1.0 - smoothstep(0.0, aa, b);
-          // If aBary is absent the attribute reads (0,0,0) → b=0 → fully
-          // darkened; the engine always injects it (Nodes.tsx), but guard
-          // anyway: a zero attribute would otherwise paint nodes solid
-          // dark. Treat the degenerate all-zero case as "no edge".
-          if (vBary.x + vBary.y + vBary.z < 0.5) edge = 0.0;
-          gl_FragColor.rgb = mix(gl_FragColor.rgb, gl_FragColor.rgb * uDark, edge);
-        }`
-      );
+      FRAG_PATCH +
+      shader.fragmentShader.replace('#include <opaque_fragment>', FRAG_BODY);
   };
+}
 
-  // onBeforeCompile patches can collide in three's program cache with an
-  // unpatched basic material; pin a distinct key. Bump the suffix if the
-  // shader body changes.
-  material.customProgramCacheKey = () => 'kg-two-tone-faceted-v1';
-
+/**
+ * Shared faceted material. `lit=false` → unlit MeshBasicMaterial (the
+ * default "flat" mode); `lit=true` → MeshLambertMaterial (real lighting,
+ * needs a light in the scene). Stateless across instances/classes — one
+ * per mode backs every node mesh. Distinct cache keys so three's program
+ * cache never serves one variant the other's compiled program.
+ *
+ * @verified 7b87c133
+ */
+export function createFacetedNodeMaterial(
+  lit = false
+): THREE.MeshBasicMaterial | THREE.MeshLambertMaterial {
+  // vertexColors=false is intentional: per-instance colour arrives via
+  // instanceColor / USE_INSTANCING_COLOR, independent of that flag.
+  const material = lit
+    ? new THREE.MeshLambertMaterial({ vertexColors: false })
+    : new THREE.MeshBasicMaterial({ vertexColors: false });
+  patchTwoTone(material);
+  const key = lit ? 'kg-two-tone-lit-v1' : 'kg-two-tone-flat-v1';
+  material.customProgramCacheKey = () => key;
   return material;
 }

--- a/web/src/explorers/ForceGraph/scene/facetedMaterial.ts
+++ b/web/src/explorers/ForceGraph/scene/facetedMaterial.ts
@@ -1,0 +1,124 @@
+/**
+ * Two-tone faceted node material.
+ *
+ * Each node renders in its per-instance colour, with the solid's edges
+ * and vertices darkened toward a lower-luminance shade of that same
+ * colour — a two-tone, same-hue look that reads the polyhedral structure
+ * without lighting. The darkening is a barycentric in-shader wireframe:
+ * an `aBary` attribute carries (1,0,0)/(0,1,0)/(0,0,1) per triangle
+ * vertex, the fragment shader takes the min barycentric (→0 on edges,
+ * →0 at vertices where two go to zero) and lerps the fragment toward a
+ * scaled-down copy of itself.
+ *
+ * Why this technique:
+ * - One draw call, no extra geometry/lines — works with InstancedMesh.
+ * - Built on MeshBasicMaterial via onBeforeCompile so three's
+ *   USE_INSTANCING_COLOR chunk (per-instance colour) is untouched. The
+ *   engine deliberately stays on an unlit basic material (see Nodes.tsx);
+ *   switching to a lit material silently breaks instance colour.
+ * - The effect intensifies on complex solids for free: a dodecahedron
+ *   has 5× the edges of a tetrahedron, so more dark structure per
+ *   silhouette — exactly the requested behaviour.
+ *
+ * Same-chroma claim: `rgb * uDark` is a *uniform* RGB scale. In HSL that
+ * is identical hue and identical saturation with lower lightness (the
+ * max/min channel ratios that define H and S are preserved) — so the
+ * dark tone genuinely is the same colour, just dimmer, never black.
+ *
+ * The edge AA uses fwidth(), which is core in WebGL2 (GLSL ES 3.00).
+ * This codebase already requires WebGL2 for the GPU force sim, and r3f's
+ * Canvas is WebGL2 on every current browser, so no derivatives-extension
+ * guard is needed.
+ *
+ * @verified 7b87c133
+ */
+
+import * as THREE from 'three';
+
+/** Edge softness in pixels — fwidth-scaled so the dark line stays a
+ *  crisp ~1.5px at any zoom instead of aliasing when far / bloating when
+ *  near. */
+const EDGE_PX = 1.5;
+
+/** Luminance multiplier for the dark tone. Below 1 so edges/vertices
+ *  recede; well above 0 so they read as "darker colour", not black. */
+const DARK = 0.45;
+
+/**
+ * Add a per-triangle barycentric attribute (`aBary`). Indexed geometry
+ * is converted to non-indexed first (a barycentric wireframe needs
+ * unshared vertices), returning a NEW geometry — the caller owns
+ * disposing the old one. Non-indexed input is annotated in place.
+ * Idempotent: a geometry that already has `aBary` is returned as-is.
+ *
+ * @verified 7b87c133
+ */
+export function ensureBarycentric(
+  geo: THREE.BufferGeometry
+): THREE.BufferGeometry {
+  if (geo.getAttribute('aBary')) return geo;
+  const g = geo.index ? geo.toNonIndexed() : geo;
+  const count = g.getAttribute('position').count; // multiple of 3
+  const bary = new Float32Array(count * 3);
+  for (let i = 0; i < count; i += 3) {
+    // v0 = (1,0,0), v1 = (0,1,0), v2 = (0,0,1)
+    bary[i * 3 + 0] = 1;
+    bary[(i + 1) * 3 + 1] = 1;
+    bary[(i + 2) * 3 + 2] = 1;
+  }
+  g.setAttribute('aBary', new THREE.BufferAttribute(bary, 3));
+  return g;
+}
+
+/**
+ * Build the shared faceted material. Stateless across instances and
+ * classes — one material can back every node mesh.
+ *
+ * @verified 7b87c133
+ */
+export function createFacetedNodeMaterial(): THREE.MeshBasicMaterial {
+  // vertexColors=false is intentional: per-instance colour arrives via
+  // instanceColor / USE_INSTANCING_COLOR, which three injects
+  // independent of the vertexColors flag.
+  const material = new THREE.MeshBasicMaterial({ vertexColors: false });
+
+  material.onBeforeCompile = (shader) => {
+    shader.uniforms.uEdgePx = { value: EDGE_PX };
+    shader.uniforms.uDark = { value: DARK };
+
+    shader.vertexShader =
+      'attribute vec3 aBary;\nvarying vec3 vBary;\n' +
+      shader.vertexShader.replace(
+        '#include <begin_vertex>',
+        '#include <begin_vertex>\n  vBary = aBary;'
+      );
+
+    shader.fragmentShader =
+      'varying vec3 vBary;\nuniform float uEdgePx;\nuniform float uDark;\n' +
+      shader.fragmentShader.replace(
+        '#include <opaque_fragment>',
+        `#include <opaque_fragment>
+        {
+          // Distance to the nearest triangle edge in barycentric space;
+          // ~0 on an edge, exactly 0 at a vertex.
+          float b = min(min(vBary.x, vBary.y), vBary.z);
+          // fwidth() gives screen-space derivative → constant px width.
+          float aa = max(fwidth(b) * uEdgePx, 1e-5);
+          float edge = 1.0 - smoothstep(0.0, aa, b);
+          // If aBary is absent the attribute reads (0,0,0) → b=0 → fully
+          // darkened; the engine always injects it (Nodes.tsx), but guard
+          // anyway: a zero attribute would otherwise paint nodes solid
+          // dark. Treat the degenerate all-zero case as "no edge".
+          if (vBary.x + vBary.y + vBary.z < 0.5) edge = 0.0;
+          gl_FragColor.rgb = mix(gl_FragColor.rgb, gl_FragColor.rgb * uDark, edge);
+        }`
+      );
+  };
+
+  // onBeforeCompile patches can collide in three's program cache with an
+  // unpatched basic material; pin a distinct key. Bump the suffix if the
+  // shader body changes.
+  material.customProgramCacheKey = () => 'kg-two-tone-faceted-v1';
+
+  return material;
+}

--- a/web/src/explorers/ForceGraph/scene/shapes.test.ts
+++ b/web/src/explorers/ForceGraph/scene/shapes.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the platonic-solid glyph mapping.
+ *
+ * Locks the two properties the visual encoding depends on: shapeFor is
+ * a pure deterministic function (same category → same solid, every
+ * reload), and it actually spreads categories across the family (a
+ * future "let's randomize / always icosahedron" regression breaks
+ * here). Also guards the legend-glyph table against drifting out of
+ * sync with SHAPE_NAMES.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SHAPE_NAMES,
+  SHAPE_GLYPH_POLYS,
+  shapeFor,
+} from './shapes';
+
+describe('shapeFor', () => {
+  it('is deterministic for a given category', () => {
+    expect(shapeFor('foo')).toBe(shapeFor('foo'));
+    expect(shapeFor('Software Engineering')).toBe(
+      shapeFor('Software Engineering')
+    );
+  });
+
+  it('always returns a member of the solid family', () => {
+    for (const c of ['', 'a', 'Watergate', 'ITSM', 'Φ', '🜁', 'Unknown']) {
+      expect(SHAPE_NAMES).toContain(shapeFor(c));
+    }
+  });
+
+  it('treats null/undefined as the empty category (no throw)', () => {
+    expect(SHAPE_NAMES).toContain(shapeFor(null));
+    expect(SHAPE_NAMES).toContain(shapeFor(undefined));
+    expect(shapeFor(null)).toBe(shapeFor(''));
+  });
+
+  it('distributes categories across more than one solid', () => {
+    const cats = [
+      'Alpha',
+      'Beta',
+      'Gamma',
+      'Delta',
+      'Epsilon',
+      'Zeta',
+      'Eta',
+      'Theta',
+      'Iota',
+      'Kappa',
+    ];
+    const distinct = new Set(cats.map((c) => shapeFor(c)));
+    // Not asserting all 4 (hash luck), just that it isn't degenerate.
+    expect(distinct.size).toBeGreaterThan(1);
+  });
+});
+
+describe('SHAPE_GLYPH_POLYS', () => {
+  it('has a silhouette for every solid in the family', () => {
+    for (const name of SHAPE_NAMES) {
+      expect(SHAPE_GLYPH_POLYS[name]).toBeTruthy();
+    }
+    expect(Object.keys(SHAPE_GLYPH_POLYS).sort()).toEqual(
+      [...SHAPE_NAMES].sort()
+    );
+  });
+});

--- a/web/src/explorers/ForceGraph/scene/shapes.ts
+++ b/web/src/explorers/ForceGraph/scene/shapes.ts
@@ -1,0 +1,89 @@
+/**
+ * Platonic-solid glyph encoding for graph nodes.
+ *
+ * Colour already carries the ontology palette; shape adds a second,
+ * lower-resolution read of the same axis so a graph reads as a coherent
+ * family of geometric solids rather than a field of identical dots. The
+ * solids were chosen for family resemblance — all read as "a solid" at
+ * similar visual mass — and they reduce cleanly to flat SVG silhouettes
+ * for legends and inline use.
+ *
+ * Scope (per ADR-203): until a node-class *facet* exists in the schema,
+ * shape is derived from the existing `category` (ontology) string — the
+ * same axis colour uses. This is the deliberate "no-schema rendering
+ * first" step; when the facet lands, `shapeFor` switches to keying off
+ * it and shape becomes a genuinely second axis.
+ *
+ * @verified 7b87c133
+ */
+
+import type { ReactElement } from 'react';
+import { createElement } from 'react';
+
+/** The solid family. Order is the hash codomain — appending a shape is
+ *  safe; reordering or removing one re-buckets every category. */
+export const SHAPE_NAMES = [
+  'icosahedron',
+  'octahedron',
+  'tetrahedron',
+  'dodecahedron',
+] as const;
+
+export type ShapeName = (typeof SHAPE_NAMES)[number];
+
+/** djb2 — small, fast, well-distributed string hash. Stable across
+ *  reloads and processes (pure function of the bytes) so a given
+ *  category always lands on the same solid. */
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return h >>> 0;
+}
+
+/** Map a category/ontology string to a stable solid. */
+export function shapeFor(category: string | null | undefined): ShapeName {
+  return SHAPE_NAMES[djb2(category || '') % SHAPE_NAMES.length];
+}
+
+/** Unit-radius geometry JSX for `geometryByClass`. Low subdivision on
+ *  purpose: the faceted two-tone material wants visible edges, and the
+ *  flat-ish facets are the point. Per-instance scale handles real size. */
+export function shapeGeometry(name: ShapeName): ReactElement {
+  switch (name) {
+    case 'octahedron':
+      return createElement('octahedronGeometry', { args: [1, 0] });
+    case 'tetrahedron':
+      return createElement('tetrahedronGeometry', { args: [1, 0] });
+    case 'dodecahedron':
+      return createElement('dodecahedronGeometry', { args: [1, 0] });
+    case 'icosahedron':
+    default:
+      // args[1]=1 keeps it identical to the engine's prior default
+      // icosahedron (and Document Explorer's concept glyph).
+      return createElement('icosahedronGeometry', { args: [1, 1] });
+  }
+}
+
+/** `geometryByClass` for the full solid family — pass straight to Scene. */
+export function shapeGeometryByClass(): Record<string, ReactElement> {
+  const out: Record<string, ReactElement> = {};
+  for (const name of SHAPE_NAMES) out[name] = shapeGeometry(name);
+  return out;
+}
+
+/**
+ * Flat 2D silhouettes (viewBox 0 0 12 12) for the Node Types legend and
+ * any inline list/web use. Projection-flat abstractions, not true
+ * orthographic renders — just enough to be self-documenting. If a solid
+ * is added to SHAPE_NAMES, add its silhouette here too.
+ */
+export const SHAPE_GLYPH_POLYS: Record<ShapeName, string> = {
+  // Hexagonal silhouette (icosahedron viewed face-on)
+  icosahedron: '6,1 11,4 11,8 6,11 1,8 1,4',
+  // Diamond (octahedron viewed point-up)
+  octahedron: '6,1 11,6 6,11 1,6',
+  // Triangle (tetrahedron viewed face-on)
+  tetrahedron: '6,1 11,11 1,11',
+  // Pentagonal silhouette (dodecahedron viewed face-on)
+  dodecahedron: '6,1 10,4 9,10 3,10 2,4',
+};

--- a/web/src/explorers/ForceGraph/scene/shapes.ts
+++ b/web/src/explorers/ForceGraph/scene/shapes.ts
@@ -45,9 +45,11 @@ export function shapeFor(category: string | null | undefined): ShapeName {
   return SHAPE_NAMES[djb2(category || '') % SHAPE_NAMES.length];
 }
 
-/** Unit-radius geometry JSX for `geometryByClass`. Low subdivision on
- *  purpose: the faceted two-tone material wants visible edges, and the
- *  flat-ish facets are the point. Per-instance scale handles real size. */
+/** Unit-radius geometry JSX for `geometryByClass`. Subdivision 0 (no
+ *  detail): the hard-edge material masks coplanar sub-triangulation
+ *  anyway, so extra triangles only cost fill rate — detail 0 keeps each
+ *  solid at its true face count and crisp principal edges. Per-instance
+ *  scale handles real size. */
 export function shapeGeometry(name: ShapeName): ReactElement {
   switch (name) {
     case 'octahedron':
@@ -58,9 +60,7 @@ export function shapeGeometry(name: ShapeName): ReactElement {
       return createElement('dodecahedronGeometry', { args: [1, 0] });
     case 'icosahedron':
     default:
-      // args[1]=1 keeps it identical to the engine's prior default
-      // icosahedron (and Document Explorer's concept glyph).
-      return createElement('icosahedronGeometry', { args: [1, 1] });
+      return createElement('icosahedronGeometry', { args: [1, 0] });
   }
 }
 

--- a/web/src/explorers/ForceGraph/types.ts
+++ b/web/src/explorers/ForceGraph/types.ts
@@ -97,6 +97,17 @@ export interface ForceGraphSettings {
     nodeLabelSize: number;
     /** Multiplier on edge label world-space height. 1.0 = default size. */
     edgeLabelSize: number;
+    /** Node shading. 'flat' (default) = unlit two-tone, the original
+     *  look; 'lit' = real Lambert lighting with a camera-tracked key
+     *  light (faceted solids shade per-face, the icosphere reads round).
+     *  Ignored when `lightingFollowsProjection` is true. */
+    lighting: 'flat' | 'lit';
+    /** When true, shading is coupled to the camera projection: 2D ⇒
+     *  flat (reads as a clean 2D diagram), 3D ⇒ lit (shaded depth) —
+     *  same 3D geometry either way. Overrides `lighting`. Default false
+     *  so the flat-default / lit-opt-in behaviour is unchanged until a
+     *  user opts into the coupling. */
+    lightingFollowsProjection: boolean;
   };
 
   interaction: {
@@ -128,6 +139,8 @@ export const DEFAULT_SETTINGS: ForceGraphSettings = {
     linkWidth: 1.0,
     nodeLabelSize: 1.0,
     edgeLabelSize: 1.0,
+    lighting: 'flat',
+    lightingFollowsProjection: false,
   },
   interaction: {
     enableDrag: true,


### PR DESCRIPTION
## What

Graph nodes render as a family of platonic solids (icosahedron / octahedron / tetrahedron / dodecahedron) assigned by a stable hash of the ontology, each in its per-instance colour, with a **two-tone same-hue darkening of the true edges/vertices only**. A toggle switches between flat (unlit, original look) and lit (real Lambert lighting).

## Principal edges only

The wireframe used to darken *every* triangle edge, including mesher triangulation (a cube face's diagonal). Now a position-quantised adjacency map classifies each edge by the dihedral angle between its two faces; an `aEdgeHide` attribute pushes soft (coplanar / sub-triangulation) edges out of the shader's `min()`, so only the polyhedron's real edges — and the vertices where two of them meet — darken. Threshold 25° cleanly separates platonic solids (≥41°) from geodesic spheres (<12°).

## Sphere default

The no-class fallback geometry is a detail-4 **icosphere**: zero hard edges → no wireframe, smooth interpolated normals kept → a clean round ball. Ontology-hashed solids stay; family solids dropped to subdivision 0 (the mask handles the rest, fewer triangles). Per the user's choice: sphere is the default only, solids stay for ontologies.

## Flat / lit toggle

The engine *was* deliberately unlit; this PR makes that a **choice**, not a constraint. One shared patch (`onBeforeCompile`) applies to `MeshBasicMaterial` (flat — the original two-tone look, default) **or** `MeshLambertMaterial` (real Lambert). Per-instance `instanceColor` is identical across both materials in three's ShaderLib (verified) — the old "lit breaks instanceColor" caveat doesn't apply. Separate program-cache keys per variant. Scene adds a camera-tracked directional key light, rendered in lit mode only. Faceted vs smooth is self-addressed by geometry: hard-edged geometry recomputes per-face normals (flat-shaded facets under Lambert); smooth input (icosphere) keeps its normals (round).

- `settings.visual.lighting`: `'flat'` (default) | `'lit'` — opt-in; no visible change for existing users until toggled.
- `settings.visual.lightingFollowsProjection`: when on, 2D ⇒ flat (reads as a clean diagram), 3D ⇒ lit (shaded depth) — same 3D geometry either way. When off, the manual select governs and lit shading is allowed in 2D too. Default off.
- Both exposed in `SettingsPanel` (Force Graph only; Document Explorer stays flat by not passing `lit`).

Engine-wide: both Force Graph and Document Explorer route through the shared `Nodes` renderer.

## Scope / ADR

No schema change. Shape is derived from the existing ontology string — the no-schema rendering step from **ADR-203** (PR #372, Draft). When the node-class facet lands, `shapeFor` switches to it and shape becomes a genuine second axis.

## StrictMode correctness

StrictMode is on. Two use-after-dispose traps stay closed: the shared material(s) are never disposed (one per mode for the app lifetime), and the swapped annotated geometry is not disposed in cleanup (deliberate bounded leak of one BufferGeometry per rare class unmount, vs. a use-after-dispose on the hot path).

## Verification

- `tsc -b`: changed files add **zero** errors (2 pre-existing in `BlockPalette.tsx`/`dataTransformer.ts`, on `main`, out of scope).
- `eslint`: all changed + new files clean.
- `vitest`: 14/14 ForceGraph tests. Hard-edge regression: a **cube → 12 hard edges, 6 face-diagonals masked** (the motivating example), an icosphere → zero hard edges, a bare icosahedron → all hard; plus `shapeFor` determinism/distribution and `seedWithCarryover`.
- **Visual**: confirmed by the author in lit mode — crisp principal edges, per-face faceted Lambert shading, the intended look.

## Follow-ups (not here)

- Node Types **legend** with the SVG `SHAPE_GLYPH_POLYS` (wired, not yet rendered in Legend).
- Per-shape edge-width / light-intensity tuning if any solid reads off at the shared constants.