### PR TITLE
feat(web): startup auto-zoom + Force Graph / Document Explorer parity

### DIFF
--- a/web/src/explorers/DocumentExplorer/DocumentExplorer.tsx
+++ b/web/src/explorers/DocumentExplorer/DocumentExplorer.tsx
@@ -501,6 +501,7 @@ export const DocumentExplorer: React.FC<
               ? (settings?.projection ?? '3D') === '3D'
               : (settings?.visual?.lighting ?? 'flat') === 'lit'
           }
+          orientPullback={0.45}
           enableDrag
           enableZoom={settings?.interaction?.enableZoom !== false}
           enablePan={settings?.interaction?.enablePan !== false}

--- a/web/src/explorers/DocumentExplorer/DocumentExplorer.tsx
+++ b/web/src/explorers/DocumentExplorer/DocumentExplorer.tsx
@@ -29,6 +29,7 @@ import type {
 import { useThemeStore } from '../../store/themeStore';
 import { StatsPanel, PanelStack } from '../common';
 import { Scene } from '../ForceGraph/scene/Scene';
+import { shapeGeometryByClass, type ShapeName } from '../ForceGraph/scene/shapes';
 import { DIM_MODEL } from '../ForceGraph/scene/dimModel';
 import type { EngineNode, EngineEdge } from '../ForceGraph/types';
 import type { ForceSimHandle } from '../ForceGraph/scene/useForceSim';
@@ -48,10 +49,14 @@ const COLORS: Record<DocNodeType, string> = {
   'extended-concept': '#6366f1',
 };
 
-const NODE_CLASS_BY_TYPE: Record<DocNodeType, 'document' | 'concept'> = {
-  'document':         'document',
-  'query-concept':    'concept',
-  'extended-concept': 'concept',
+// Document Explorer has *named* node types, so shape is a genuine second
+// axis here (unlike Force Graph, where it currently mirrors ontology).
+// A stable explicit map — NOT shapeFor()'s hash — so adding a future
+// type can't silently re-bucket the existing three.
+const TYPE_SHAPE: Record<DocNodeType, ShapeName> = {
+  'document':         'dodecahedron',
+  'query-concept':    'octahedron',
+  'extended-concept': 'tetrahedron',
 };
 
 // ---------------------------------------------------------------------------
@@ -166,20 +171,16 @@ export const DocumentExplorer: React.FC<
   const nodeClasses = useMemo(() => {
     return engineData.nodes.map((n) => {
       const type = nodeType(n.id) ?? 'extended-concept';
-      return NODE_CLASS_BY_TYPE[type];
+      return TYPE_SHAPE[type];
     });
   }, [engineData, nodeType]);
 
-  // Both documents and concepts render as the same icosahedron geometry —
-  // the d3 implementation drew documents as larger circles too (with a
-  // small white file-glyph overlay; that overlay is the only detail
-  // dropped on the engine port). Size + color do the visual distinction.
-  // `geometryByClass` is wired so this stays single-source if we want to
-  // re-add a glyph (textured plane / instanced sprite) on documents later.
-  const geometryByClass = useMemo(() => ({
-    document: <icosahedronGeometry args={[1, 2]} />,
-    concept: <icosahedronGeometry args={[1, 1]} />,
-  }), []);
+  // Platonic-solid glyph per node type (the shared engine partitions one
+  // InstancedMesh per class). Documents → dodecahedron, query-concepts →
+  // octahedron, extended-concepts → tetrahedron: shape now carries the
+  // node-type axis, with the faceted/lit material doing the rest. Size
+  // (documentSize) is still handled per-instance via nodeScales.
+  const geometryByClass = useMemo(() => shapeGeometryByClass(), []);
 
   // ---------------------------------------------------------------------------
   // Dim state — hover and focus drive the same engine `activeIds` /
@@ -491,10 +492,15 @@ export const DocumentExplorer: React.FC<
           dimLabelOpacity={dimState?.alpha ?? 1}
           showArrows={false}
           showEdgeLabels={false}
-          showNodeLabels={settings?.visual?.showLabels !== false}
+          showNodeLabels={settings?.visual?.showNodeLabels !== false}
           edgeOpacity={settings?.visual?.showEdges === false ? 0 : 0.45}
           linkWidth={1}
           nodeSize={settings?.visual?.nodeSize ?? 1}
+          lit={
+            (settings?.visual?.lightingFollowsProjection ?? false)
+              ? (settings?.projection ?? '3D') === '3D'
+              : (settings?.visual?.lighting ?? 'flat') === 'lit'
+          }
           enableDrag
           enableZoom={settings?.interaction?.enableZoom !== false}
           enablePan={settings?.interaction?.enablePan !== false}

--- a/web/src/explorers/DocumentExplorer/ProfilePanel.tsx
+++ b/web/src/explorers/DocumentExplorer/ProfilePanel.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { SettingsPanelProps } from '../../types/explorer';
 import type { DocumentExplorerSettings } from './types';
 import { SLIDER_RANGES } from './types';
+import { VisualControls } from '../common';
 
 export const ProfilePanel: React.FC<SettingsPanelProps<DocumentExplorerSettings>> = ({
   settings,
@@ -22,9 +23,8 @@ export const ProfilePanel: React.FC<SettingsPanelProps<DocumentExplorerSettings>
     );
   }
 
-  const updateVisual = (key: keyof typeof settings.visual, value: boolean | number) => {
-    onChange({ ...settings, visual: { ...settings.visual, [key]: value } });
-  };
+  const updateVisual = (patch: Partial<DocumentExplorerSettings['visual']>) =>
+    onChange({ ...settings, visual: { ...settings.visual, ...patch } });
 
   const updateLayout = (key: keyof typeof settings.layout, value: number) => {
     onChange({ ...settings, layout: { ...settings.layout, [key]: value } });
@@ -62,39 +62,36 @@ export const ProfilePanel: React.FC<SettingsPanelProps<DocumentExplorerSettings>
           Visual
         </h4>
         <div className="space-y-3">
-          <label className="flex items-center justify-between text-sm">
-            <span>Show labels</span>
+          {/* Shared visual controls — same component Force Graph uses, so
+              the two explorers can't silently drift apart. */}
+          <VisualControls
+            showNodeLabels={settings.visual.showNodeLabels !== false}
+            nodeSize={settings.visual.nodeSize ?? 1}
+            lighting={settings.visual.lighting ?? 'flat'}
+            lightingFollowsProjection={
+              settings.visual.lightingFollowsProjection ?? false
+            }
+            nodeSizeRange={SLIDER_RANGES.visual.nodeSize}
+            onShowNodeLabels={(v) => updateVisual({ showNodeLabels: v })}
+            onNodeSize={(v) => updateVisual({ nodeSize: v })}
+            onLighting={(v) => updateVisual({ lighting: v })}
+            onLightingFollowsProjection={(v) =>
+              updateVisual({ lightingFollowsProjection: v })
+            }
+          />
+          {/* Document Explorer-specific: edge visibility toggle. */}
+          <label className="flex items-center gap-2 text-xs text-card-foreground">
+            <span className="flex-1 min-w-0 truncate">Show edges</span>
+            <span className="font-mono text-muted-foreground tabular-nums w-12 text-right text-[10px]">
+              {settings.visual.showEdges !== false ? 'on' : 'off'}
+            </span>
             <input
               type="checkbox"
-              checked={settings.visual.showLabels}
-              onChange={(e) => updateVisual('showLabels', e.target.checked)}
-              className="rounded"
+              className="ml-auto"
+              checked={settings.visual.showEdges !== false}
+              onChange={(e) => updateVisual({ showEdges: e.target.checked })}
             />
           </label>
-          <label className="flex items-center justify-between text-sm">
-            <span>Show edges</span>
-            <input
-              type="checkbox"
-              checked={settings.visual.showEdges}
-              onChange={(e) => updateVisual('showEdges', e.target.checked)}
-              className="rounded"
-            />
-          </label>
-          <div>
-            <div className="flex items-center justify-between text-sm mb-1">
-              <span>Node size</span>
-              <span className="text-xs text-muted-foreground">{settings.visual.nodeSize.toFixed(1)}x</span>
-            </div>
-            <input
-              type="range"
-              min={SLIDER_RANGES.visual.nodeSize.min}
-              max={SLIDER_RANGES.visual.nodeSize.max}
-              step={SLIDER_RANGES.visual.nodeSize.step}
-              value={settings.visual.nodeSize}
-              onChange={(e) => updateVisual('nodeSize', parseFloat(e.target.value))}
-              className="w-full h-1.5 rounded-lg appearance-none bg-border accent-amber-500"
-            />
-          </div>
         </div>
       </section>
 

--- a/web/src/explorers/DocumentExplorer/types.ts
+++ b/web/src/explorers/DocumentExplorer/types.ts
@@ -18,9 +18,19 @@ export interface DocumentExplorerSettings {
    *  sim axis count from this value. */
   projection: Projection;
   visual: {
-    showLabels: boolean;
+    /** Renamed from showLabels for vocabulary parity with Force Graph
+     *  (its showLabels means *edge* labels; node labels are
+     *  showNodeLabels). Persisted blobs predating the rename simply
+     *  fall back to the default — all reads are `!== false`. */
+    showNodeLabels: boolean;
     showEdges: boolean;
     nodeSize: number;           // Base size multiplier
+    /** Parity with Force Graph. 'flat' = unlit two-tone (default);
+     *  'lit' = real Lambert with a camera-tracked key light. */
+    lighting: 'flat' | 'lit';
+    /** Parity with Force Graph. When true: 2D ⇒ flat, 3D ⇒ lit;
+     *  overrides `lighting`. Default false. */
+    lightingFollowsProjection: boolean;
   };
   layout: {
     documentSize: number;       // Document node base scale (relative to concept dots)
@@ -35,9 +45,11 @@ export interface DocumentExplorerSettings {
 export const DEFAULT_SETTINGS: DocumentExplorerSettings = {
   projection: '3D',
   visual: {
-    showLabels: true,
+    showNodeLabels: true,
     showEdges: true,
     nodeSize: 1.0,
+    lighting: 'flat',
+    lightingFollowsProjection: false,
   },
   layout: {
     documentSize: 24,

--- a/web/src/explorers/ForceGraph/SettingsPanel.tsx
+++ b/web/src/explorers/ForceGraph/SettingsPanel.tsx
@@ -17,6 +17,7 @@ import type { ForceGraphSettings } from './types';
 import { SLIDER_RANGES } from './types';
 import { simBackend } from './scene/useSim';
 import { useGraphStore, type FilterOption } from '../../store/graphStore';
+import { VisualControls } from '../common';
 
 type Section = 'physics' | 'visual' | 'interaction' | 'filters';
 
@@ -271,11 +272,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraphSettings>> = (
               settings.visual.showLabels ? 'on' : 'off',
               toggle_(settings.visual.showLabels, (v) => updateVisual({ showLabels: v }))
             )}
-            {row(
-              'Show node labels',
-              settings.visual.showNodeLabels ? 'on' : 'off',
-              toggle_(settings.visual.showNodeLabels, (v) => updateVisual({ showNodeLabels: v }))
-            )}
             <label className="flex items-center gap-2 text-xs text-card-foreground">
               <span className="flex-1 min-w-0 truncate">Node color</span>
               <select
@@ -305,48 +301,22 @@ export const SettingsPanel: React.FC<SettingsPanelProps<ForceGraphSettings>> = (
                 <option value="uniform">Uniform</option>
               </select>
             </label>
-            <label
-              className={`flex items-center gap-2 text-xs text-card-foreground ${
-                settings.visual.lightingFollowsProjection ? 'opacity-50' : ''
-              }`}
-            >
-              <span className="flex-1 min-w-0 truncate">
-                {settings.visual.lightingFollowsProjection
-                  ? 'Shading (follows view)'
-                  : 'Shading'}
-              </span>
-              <select
-                className="flex-[2] bg-card border border-border rounded px-1 py-0.5 text-xs"
-                value={settings.visual.lighting}
-                disabled={settings.visual.lightingFollowsProjection}
-                onChange={(e) =>
-                  updateVisual({
-                    lighting: e.target.value as ForceGraphSettings['visual']['lighting'],
-                  })
-                }
-              >
-                <option value="flat">Flat (two-tone)</option>
-                <option value="lit">Lit (3D light)</option>
-              </select>
-            </label>
-            {row(
-              'Shading follows view',
-              settings.visual.lightingFollowsProjection ? 'on' : 'off',
-              toggle_(settings.visual.lightingFollowsProjection, (v) =>
+            {/* Shared visual controls — node labels, shading, node size.
+                Force Graph-specific controls (colour-by, link width,
+                label sizes/radius) stay above/below. */}
+            <VisualControls
+              showNodeLabels={settings.visual.showNodeLabels}
+              nodeSize={settings.visual.nodeSize}
+              lighting={settings.visual.lighting}
+              lightingFollowsProjection={settings.visual.lightingFollowsProjection}
+              nodeSizeRange={SLIDER_RANGES.visual.nodeSize}
+              onShowNodeLabels={(v) => updateVisual({ showNodeLabels: v })}
+              onNodeSize={(v) => updateVisual({ nodeSize: v })}
+              onLighting={(v) => updateVisual({ lighting: v })}
+              onLightingFollowsProjection={(v) =>
                 updateVisual({ lightingFollowsProjection: v })
-              )
-            )}
-            {row(
-              'Node size',
-              settings.visual.nodeSize.toFixed(2),
-              slider(
-                settings.visual.nodeSize,
-                SLIDER_RANGES.visual.nodeSize.min,
-                SLIDER_RANGES.visual.nodeSize.max,
-                SLIDER_RANGES.visual.nodeSize.step,
-                (v) => updateVisual({ nodeSize: v })
-              )
-            )}
+              }
+            />
             {row(
               'Link width',
               settings.visual.linkWidth.toFixed(1),

--- a/web/src/explorers/ForceGraph/scene/Arrows.tsx
+++ b/web/src/explorers/ForceGraph/scene/Arrows.tsx
@@ -236,6 +236,13 @@ export function Arrows({
       key={usableCount}
       ref={meshRef}
       args={[undefined, undefined, usableCount]}
+      // Same stale-bounds cull as Edges (see Edges.tsx): instances are
+      // placed via instanceMatrix each frame, but the cull volume stays
+      // the unit-cone geometry sphere at the origin (no InstancedMesh
+      // boundingSphere is maintained, and unlike Nodes there's no
+      // periodic refresh), so arrows get culled when the camera wheels
+      // in close. Opt out — one instanced draw call, nothing to gain.
+      frustumCulled={false}
     >
       {/* Unit cone — radius ARROW_RADIUS_RATIO, height 1. Per-instance
           scale multiplies by the computed arrow length. */}

--- a/web/src/explorers/ForceGraph/scene/Edges.tsx
+++ b/web/src/explorers/ForceGraph/scene/Edges.tsx
@@ -332,5 +332,22 @@ export function Edges({
     posAttr.needsUpdate = true;
   });
 
-  return <lineSegments ref={lineRef} geometry={geometry} material={material} />;
+  // frustumCulled=false: the position buffer is rewritten in place every
+  // frame (useFrame above) but geometry.boundingSphere is computed by
+  // THREE only once — lazily, from the all-zero initial buffer. The sim
+  // then moves the graph far from that frozen origin sphere, so when the
+  // camera wheels in close the narrow frustum no longer intersects the
+  // stale sphere and the entire batch gets culled (edges vanish up close,
+  // reappear when zoomed out). Recomputing the sphere per frame is a full
+  // extra vertex pass at 10k-edge scale for no gain — this is one draw
+  // call, so culling it only ever helps when every edge is off-screen.
+  // Opting out is the correct trade for CPU-animated batched geometry.
+  return (
+    <lineSegments
+      ref={lineRef}
+      geometry={geometry}
+      material={material}
+      frustumCulled={false}
+    />
+  );
 }

--- a/web/src/explorers/ForceGraph/scene/Nodes.tsx
+++ b/web/src/explorers/ForceGraph/scene/Nodes.tsx
@@ -64,6 +64,10 @@ export interface NodesProps {
   lit?: boolean;
   selectedId?: string | null;
   onSelect?: (id: string | null) => void;
+  /** Left double-click on a node (two clicks <300ms, same node, not a
+   *  drag). Drives the orient-and-frame focus action. Independent of
+   *  onSelect — the double doesn't re-toggle selection. */
+  onNodeDoubleClick?: (id: string) => void;
   onHover?: (id: string | null) => void;
   onContextMenu?: (id: string, event: PointerEvent) => void;
   onDragStart?: DragHandlers['onDragStart'];
@@ -166,6 +170,7 @@ function NodeClassMesh({
   nodeSize = 1,
   selectedId,
   onSelect,
+  onNodeDoubleClick,
   onHover,
   onContextMenu,
   onDragStart,
@@ -263,6 +268,11 @@ function NodeClassMesh({
   // down and up still resolves as a click rather than a drag.
   const downRef = useRef<{ id: string; x: number; y: number; moved: boolean } | null>(null);
   const DRAG_THRESHOLD = 4;
+  // Last resolved single-click, for double-click detection: a second
+  // click on the same node within this window is a double-click (fires
+  // focus instead of re-toggling selection).
+  const lastClickRef = useRef<{ id: string; t: number } | null>(null);
+  const DOUBLE_CLICK_MS = 300;
 
   const localToNodeId = (local: number | null | undefined): string | null => {
     if (local == null) return null;
@@ -312,9 +322,23 @@ function NodeClassMesh({
       e.stopPropagation();
       onDragEnd?.(e);
     } else if (clickedId) {
-      // Treated as a click — toggle selection.
-      if (!hiddenIds || !hiddenIds.has(clickedId)) {
+      if (hiddenIds && hiddenIds.has(clickedId)) return;
+      const now = Date.now();
+      const prev = lastClickRef.current;
+      if (
+        onNodeDoubleClick &&
+        prev &&
+        prev.id === clickedId &&
+        now - prev.t < DOUBLE_CLICK_MS
+      ) {
+        // Double-click: focus the camera on this node. Don't re-toggle
+        // selection (the first click already set it); consume the pair.
+        lastClickRef.current = null;
+        onNodeDoubleClick(clickedId);
+      } else {
+        // Single click — toggle selection; arm double-click detection.
         onSelect?.(selectedId === clickedId ? null : clickedId);
+        lastClickRef.current = { id: clickedId, t: now };
       }
     }
   };

--- a/web/src/explorers/ForceGraph/scene/Nodes.tsx
+++ b/web/src/explorers/ForceGraph/scene/Nodes.tsx
@@ -323,7 +323,9 @@ function NodeClassMesh({
       onDragEnd?.(e);
     } else if (clickedId) {
       if (hiddenIds && hiddenIds.has(clickedId)) return;
-      const now = Date.now();
+      // Monotonic clock (matches the orient tween); Date.now() can jump
+      // backwards on an NTP step and falsely split/merge a click pair.
+      const now = performance.now();
       const prev = lastClickRef.current;
       if (
         onNodeDoubleClick &&
@@ -331,9 +333,12 @@ function NodeClassMesh({
         prev.id === clickedId &&
         now - prev.t < DOUBLE_CLICK_MS
       ) {
-        // Double-click: focus the camera on this node. Don't re-toggle
-        // selection (the first click already set it); consume the pair.
+        // Double-click: focus the camera on this node. The first click
+        // of the pair may have toggled selection either way; force the
+        // focused node selected so focus always leaves it highlighted
+        // (coherent regardless of its pre-click state). Consume the pair.
         lastClickRef.current = null;
+        if (selectedId !== clickedId) onSelect?.(clickedId);
         onNodeDoubleClick(clickedId);
       } else {
         // Single click — toggle selection; arm double-click detection.

--- a/web/src/explorers/ForceGraph/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph/scene/Scene.tsx
@@ -277,6 +277,7 @@ export function Scene({
         nodeSize={nodeSize}
         selectedId={selectedId}
         onSelect={onSelect}
+        onNodeDoubleClick={orientAction.focus}
         onHover={onHover}
         onContextMenu={onContextMenu}
         onDragStart={enableDrag ? drag.onDragStart : undefined}

--- a/web/src/explorers/ForceGraph/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph/scene/Scene.tsx
@@ -21,6 +21,7 @@ import { CaretMarker, NodeLabel } from './Overlays';
 import { NodeInfoOverlay, type NodeInfoData } from './NodeInfoOverlay';
 import { useSim } from './useSim';
 import { useDragHandler } from './useDragHandler';
+import { useFitCamera } from './useFitCamera';
 import type { ForceSimHandle, ForceSimParams } from './useForceSim';
 
 // Stable references used when the plugin doesn't wire pinnedIds — hooks
@@ -201,6 +202,11 @@ export function Scene({
   // panel that lives in the plugin component). useImperativeHandle is
   // the idiomatic way even though we pass a MutableRefObject ourselves.
   useImperativeHandle(simHandleRef, () => sim, [sim]);
+
+  // Auto-frame the layout once it settles (and on every dataset change),
+  // so the graph fills the view instead of mounting tiny and off-centre.
+  // Shared here ⇒ Force Graph and Document Explorer both get it.
+  useFitCamera(sim.positionsRef, nodes, hiddenIds);
 
   // Note: re-seeding and demand-mode kick on data change are now owned by
   // the sim hook (useForceSim / useGpuForceSim). It carries surviving

--- a/web/src/explorers/ForceGraph/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph/scene/Scene.tsx
@@ -126,6 +126,12 @@ export interface SceneProps {
   /** Shading mode. false (default) = flat unlit two-tone; true = real
    *  Lambert lighting with a camera-tracked key light. */
   lit?: boolean;
+  /** First-load orient closeness (see useOrientAndFrame's pullback): 0 =
+   *  camera at the cluster's near face, higher backs off. Per-explorer
+   *  because node scale/layout differ — Document Explorer's large
+   *  document nodes need more pull-back than Force Graph. Omit ⇒ the
+   *  hook's Force-Graph-tuned default. */
+  orientPullback?: number;
 }
 
 /** Scene composition — physics + rendering + camera controls.  @verified c17bbeb9 */
@@ -170,6 +176,7 @@ export function Scene({
   simHandleRef,
   projection = '3D',
   lit = false,
+  orientPullback,
 }: SceneProps) {
   const sim = useSim(nodes, edges, {
     ...physics,
@@ -213,6 +220,7 @@ export function Scene({
     hiddenIds,
     edges,
     projection,
+    pullback: orientPullback,
   });
 
   // Fit once on the graph's first appearance (only): wait for physics to

--- a/web/src/explorers/ForceGraph/scene/Scene.tsx
+++ b/web/src/explorers/ForceGraph/scene/Scene.tsx
@@ -22,6 +22,7 @@ import { NodeInfoOverlay, type NodeInfoData } from './NodeInfoOverlay';
 import { useSim } from './useSim';
 import { useDragHandler } from './useDragHandler';
 import { useFitCamera } from './useFitCamera';
+import { useOrientAndFrame } from './useOrientAndFrame';
 import type { ForceSimHandle, ForceSimParams } from './useForceSim';
 
 // Stable references used when the plugin doesn't wire pinnedIds — hooks
@@ -203,10 +204,20 @@ export function Scene({
   // the idiomatic way even though we pass a MutableRefObject ourselves.
   useImperativeHandle(simHandleRef, () => sim, [sim]);
 
-  // Auto-frame the layout once it settles (and on every dataset change),
-  // so the graph fills the view instead of mounting tiny and off-centre.
-  // Shared here ⇒ Force Graph and Document Explorer both get it.
-  useFitCamera(sim.positionsRef, nodes, hiddenIds);
+  // The shared PCA tangent-orient action: rotate to the graph's broad
+  // face and ease in. Created here so both consumers share one instance
+  // and one tween loop — first-load fake-zoom-extents (useFitCamera) and
+  // (next) a double-click focus on a node. Shared Scene ⇒ Force Graph
+  // and Document Explorer both get it from one implementation.
+  const orientAction = useOrientAndFrame(sim.positionsRef, nodes, {
+    hiddenIds,
+    edges,
+    projection,
+  });
+
+  // Fit once on the graph's first appearance (only): wait for physics to
+  // settle, then fire the whole-graph orient as a "fake zoom-extents".
+  useFitCamera(orientAction.orient, nodes);
 
   // Note: re-seeding and demand-mode kick on data change are now owned by
   // the sim hook (useForceSim / useGpuForceSim). It carries surviving

--- a/web/src/explorers/ForceGraph/scene/orientView.test.ts
+++ b/web/src/explorers/ForceGraph/scene/orientView.test.ts
@@ -78,6 +78,22 @@ describe('orientedPerspectiveView', () => {
     expect(pose.position[2]).toBeCloseTo(41, 5);
   });
 
+  it('pullback eases the camera back by a fraction of the face-on fit', () => {
+    // Deep cluster so the depth anchor dominates. exactFit=10.
+    const tight = orientedPerspectiveView(frame(10, 10, 40), {
+      ...SQUARE,
+      fill: 0.2,
+    }); // pullback default 0 ⇒ 40 + 1
+    const eased = orientedPerspectiveView(frame(10, 10, 40), {
+      ...SQUARE,
+      fill: 0.2,
+      pullback: 0.2,
+    }); // + exactFit(10) × 0.2 = +2
+    expect(tight.position[2]).toBeCloseTo(41, 5);
+    expect(eased.position[2]).toBeCloseTo(43, 5);
+    expect(eased.position[2] - tight.position[2]).toBeCloseTo(2, 5);
+  });
+
   it('viewport floor catches a flat cluster instead of collapsing', () => {
     // Flat cluster (hMinor=0): depth anchor = 0+1 = 1 would drop the
     // camera into the focal node. exactFit=10, fill=0.2 ⇒ floor=2 wins,

--- a/web/src/explorers/ForceGraph/scene/orientView.test.ts
+++ b/web/src/explorers/ForceGraph/scene/orientView.test.ts
@@ -67,20 +67,33 @@ describe('orientedPerspectiveView', () => {
     expect(pose.position[2]).toBeGreaterThan(0);
   });
 
-  it('fit distance = tighter screen axis × fill + minor half-depth', () => {
-    // hMajor=hMid=10 ⇒ fit=10 each; fill=1; hMinor=3 ⇒ dist=10+3.
-    const pose = orientedPerspectiveView(frame(10, 10, 3), SQUARE);
-    expect(pose.position[2]).toBeCloseTo(13, 5);
+  it('depth-anchored: a deep cluster stands at its near face (hMinor+guard)', () => {
+    // Deep cluster (hMinor=40), small floor (fill=0.2). exactFit=10 ⇒
+    // floor=2; depth anchor = 40 + NEAR_GUARD(1) = 41 dominates. This is
+    // the "fills the viewport, spills slightly" framing the user picked.
+    const pose = orientedPerspectiveView(frame(10, 10, 40), {
+      ...SQUARE,
+      fill: 0.2,
+    });
+    expect(pose.position[2]).toBeCloseTo(41, 5);
   });
 
-  it('overscan (fill<1) pulls the camera closer', () => {
-    const far = orientedPerspectiveView(frame(10, 10, 0), SQUARE).position[2];
-    const near = orientedPerspectiveView(frame(10, 10, 0), {
+  it('viewport floor catches a flat cluster instead of collapsing', () => {
+    // Flat cluster (hMinor=0): depth anchor = 0+1 = 1 would drop the
+    // camera into the focal node. exactFit=10, fill=0.2 ⇒ floor=2 wins,
+    // so the camera is held at a viewport-sane distance, not 1.
+    const flat = orientedPerspectiveView(frame(10, 10, 0), {
       ...SQUARE,
-      fill: 0.8,
-    }).position[2];
-    expect(near).toBeLessThan(far);
-    expect(near).toBeCloseTo(8, 5); // 10 * 0.8
+      fill: 0.2,
+    });
+    expect(flat.position[2]).toBeCloseTo(2, 5);
+    // And the floor scales with fill (it is `fill × exactFit`).
+    const tighter = orientedPerspectiveView(frame(10, 10, 0), {
+      ...SQUARE,
+      fill: 0.1,
+    });
+    expect(tighter.position[2]).toBeCloseTo(1, 5);
+    expect(tighter.position[2]).toBeLessThan(flat.position[2]);
   });
 
   it('non-focus: currentOffset picks the side the camera is already on', () => {

--- a/web/src/explorers/ForceGraph/scene/orientView.test.ts
+++ b/web/src/explorers/ForceGraph/scene/orientView.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for orientView — PCA frame → perspective camera pose.
+ *
+ * These lock down the non-obvious geometry: the camera looks along the
+ * minor axis with the mid axis up (deterministic roll), the fit distance
+ * honours the tighter of the two screen axes plus overscan, and — the
+ * part the user cares about most — focus mode puts the clicked node in
+ * front with the bulk behind it, flipping sides when the node is on the
+ * far face even if that "whips the camera around".
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  orientedPerspectiveView,
+  isNearSpherical,
+  type OrientViewOptions,
+} from './orientView';
+import type { PcaFrame, Vec3 } from './pcaFrame';
+
+/** A world-aligned PCA frame: major→X, mid→Y, minor→Z, centred at C. */
+function frame(
+  hx: number,
+  hy: number,
+  hz: number,
+  center: Vec3 = [0, 0, 0],
+  variances: [number, number, number] = [9, 4, 1]
+): PcaFrame {
+  return {
+    center,
+    axes: [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ],
+    variances,
+    bounds: { min: [-hx, -hy, -hz], max: [hx, hy, hz] },
+  };
+}
+
+// fov=90° ⇒ tan(vFov/2)=1; aspect=1 ⇒ hFov=vFov. With hMajor=hMid=R the
+// fit distance is exactly R on each axis → easy to assert in closed form.
+const SQUARE: OrientViewOptions = { fovDeg: 90, aspect: 1, fill: 1 };
+
+describe('isNearSpherical', () => {
+  it('flags a ball-shaped cloud (variances within ratio)', () => {
+    expect(isNearSpherical(frame(1, 1, 1, [0, 0, 0], [1.2, 1.1, 1]))).toBe(true);
+  });
+  it('passes an elongated cloud (well-defined broad face)', () => {
+    expect(isNearSpherical(frame(1, 1, 1, [0, 0, 0], [10, 4, 2]))).toBe(false);
+  });
+  it('treats a flat slab (zero minor variance) as well-defined', () => {
+    expect(isNearSpherical(frame(1, 1, 0, [0, 0, 0], [10, 5, 0]))).toBe(false);
+  });
+  it('treats a no-spread cloud as degenerate', () => {
+    expect(isNearSpherical(frame(0, 0, 0, [0, 0, 0], [0, 0, 0]))).toBe(true);
+  });
+});
+
+describe('orientedPerspectiveView', () => {
+  it('looks along the minor axis with the mid axis up', () => {
+    const pose = orientedPerspectiveView(frame(10, 10, 0), SQUARE);
+    expect(pose.up).toEqual([0, 1, 0]); // mid → screen-up
+    expect(pose.target).toEqual([0, 0, 0]); // box centre
+    // Camera on +Z (default side), looking back toward origin.
+    expect(pose.position[0]).toBeCloseTo(0, 6);
+    expect(pose.position[1]).toBeCloseTo(0, 6);
+    expect(pose.position[2]).toBeGreaterThan(0);
+  });
+
+  it('fit distance = tighter screen axis × fill + minor half-depth', () => {
+    // hMajor=hMid=10 ⇒ fit=10 each; fill=1; hMinor=3 ⇒ dist=10+3.
+    const pose = orientedPerspectiveView(frame(10, 10, 3), SQUARE);
+    expect(pose.position[2]).toBeCloseTo(13, 5);
+  });
+
+  it('overscan (fill<1) pulls the camera closer', () => {
+    const far = orientedPerspectiveView(frame(10, 10, 0), SQUARE).position[2];
+    const near = orientedPerspectiveView(frame(10, 10, 0), {
+      ...SQUARE,
+      fill: 0.8,
+    }).position[2];
+    expect(near).toBeLessThan(far);
+    expect(near).toBeCloseTo(8, 5); // 10 * 0.8
+  });
+
+  it('non-focus: currentOffset picks the side the camera is already on', () => {
+    const back = orientedPerspectiveView(frame(10, 10, 0), {
+      ...SQUARE,
+      currentOffset: [0, 0, -50],
+    });
+    expect(back.position[2]).toBeLessThan(0); // stayed on −Z side
+  });
+
+  it('focus: clicked node is centred and nearest, bulk behind it', () => {
+    // Centroid at origin; clicked node displaced toward +Z. Camera must
+    // sit beyond the node on +Z so the node is closest and the bulk
+    // (around origin) is behind it.
+    const node: Vec3 = [2, 0, 8];
+    const pose = orientedPerspectiveView(frame(10, 10, 1), {
+      ...SQUARE,
+      focusPoint: node,
+    });
+    expect(pose.target).toEqual(node); // looks AT the node
+    expect(pose.position[2]).toBeGreaterThan(node[2]); // camera beyond node
+    // Node sits between camera and the bulk centroid (origin).
+    expect(node[2]).toBeGreaterThan(0);
+  });
+
+  it('focus: node on the far face flips the camera around', () => {
+    // Same orientation, but the node is on the −Z face. The user
+    // explicitly accepts the camera "whipping around" so the node is
+    // still the nearest, bulk-behind point.
+    const node: Vec3 = [0, 0, -8];
+    const pose = orientedPerspectiveView(frame(10, 10, 1), {
+      ...SQUARE,
+      focusPoint: node,
+      currentOffset: [0, 0, +50], // would say +Z; focus must override
+    });
+    expect(pose.position[2]).toBeLessThan(node[2]); // flipped to −Z
+  });
+});

--- a/web/src/explorers/ForceGraph/scene/orientView.ts
+++ b/web/src/explorers/ForceGraph/scene/orientView.ts
@@ -1,0 +1,160 @@
+/**
+ * From a PCA frame to a camera pose — the pure half of orientAndFrame.
+ *
+ * pcaFrame answers "where is the cloud, which way does it face, how big
+ * is the part to frame". This turns that into a concrete perspective
+ * camera pose: a position, a look-at target, and an up vector that puts
+ * the broad face square to the screen and fills the viewport with the
+ * caller's intended overscan.
+ *
+ * Kept pure and three.js-free so it unit-tests in isolation (like
+ * pcaFrame / positions): the hook (useOrientAndFrame) owns the tween,
+ * useThree wiring, OrbitControls cancellation, and the 2D/degenerate
+ * fallbacks — this file owns only the geometry, which is the part with
+ * non-obvious math worth locking down with tests.
+ *
+ * @verified 726f5d45
+ */
+
+import type { PcaFrame, Vec3 } from './pcaFrame';
+
+/** A camera pose: where to stand, what to look at, which way is up.  @verified 726f5d45 */
+export interface CameraPose {
+  position: Vec3;
+  target: Vec3;
+  /** Up vector — the cloud's mid axis, so screen roll is deterministic. */
+  up: Vec3;
+}
+
+/** Inputs describing the viewport + the caller's framing intent.  @verified 726f5d45 */
+export interface OrientViewOptions {
+  /** Vertical field of view, degrees (THREE.PerspectiveCamera.fov). */
+  fovDeg: number;
+  /** Viewport aspect (width / height). */
+  aspect: number;
+  /**
+   * Overscan factor (<1 = closer, graph spills past the edges). The user
+   * wants the graph to fill the view with ~15% spilling off-screen, so
+   * the default pulls the camera ~20% inside an exact fit. Tunable; this
+   * is the single knob that replaced the old useFitCamera FILL constant.
+   */
+  fill?: number;
+  /**
+   * The current camera position MINUS the box centre, in world space.
+   * Used only on a non-focus orient (first-load / whole-graph): its
+   * minor-axis component picks which side of the broad face the camera
+   * lands on, so re-framing keeps the user roughly where they were.
+   * Omit (or zero) on first load → deterministic +minor.
+   */
+  currentOffset?: Vec3;
+  /**
+   * Focus mode (double-click a node). The clicked node's world position.
+   * When set it overrides `currentOffset` and changes the intent: the
+   * camera looks AT this node (it becomes the centred, nearest point)
+   * and the side is chosen so the *bulk of the graph orients behind it*
+   * — camera on the side the node is displaced toward, away from the
+   * orientation centroid. A near-centroid node (≈50/50 split) can't be
+   * "in front" of anything; we take the deterministic side and let the
+   * tween carry the user through the possibly-large swing without them
+   * getting lost (user's stated intent).
+   */
+  focusPoint?: Vec3;
+}
+
+const dot = (a: Vec3, b: Vec3) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+const scale = (a: Vec3, s: number): Vec3 => [a[0] * s, a[1] * s, a[2] * s];
+
+/**
+ * Is the cloud too round for a meaningful broad face?
+ *
+ * When the largest and smallest variances are within `ratio` of each
+ * other the blob is roughly spherical: the eigenvectors are numerically
+ * unstable and Jacobi will hand back a basis that jitters between calls,
+ * so every first-load would orient differently. The hook uses this to
+ * fall back to a deterministic angle instead of a PCA one.
+ *
+ * @verified 726f5d45
+ */
+export function isNearSpherical(frame: PcaFrame, ratio = 1.5): boolean {
+  const [vMax, , vMin] = frame.variances;
+  if (vMax <= 1e-9) return true; // no spread at all → degenerate
+  if (vMin <= 1e-9) return false; // flat/linear → broad face is well-defined
+  return vMax / vMin < ratio;
+}
+
+/**
+ * Compute the perspective camera pose that frames the PCA extent box
+ * face-on with overscan.
+ *
+ * The camera looks along the minor axis (perpendicular to the broad
+ * face); `up` is the mid axis so screen roll is fixed; the major axis
+ * therefore runs across the screen horizontally. Distance is whichever
+ * of the horizontal/vertical fits is tighter, scaled by `fill`, plus the
+ * box's own minor-axis half-depth so it never clips the near side.
+ *
+ * Assumes the caller has already ruled out the near-spherical case
+ * (isNearSpherical) — here the axes are taken as meaningful.
+ *
+ * @verified 726f5d45
+ */
+export function orientedPerspectiveView(
+  frame: PcaFrame,
+  opts: OrientViewOptions
+): CameraPose {
+  const { center, axes, bounds } = frame;
+  const [major, mid, minor] = axes;
+  const fill = opts.fill ?? 0.8;
+
+  // Box centre in world space: orientation centroid + the extent box's
+  // offset along each axis (the extent set need not be centred on it).
+  const mid0 = (bounds.min[0] + bounds.max[0]) / 2;
+  const mid1 = (bounds.min[1] + bounds.max[1]) / 2;
+  const mid2 = (bounds.min[2] + bounds.max[2]) / 2;
+  const boxCenter = add(
+    center,
+    add(add(scale(major, mid0), scale(mid, mid1)), scale(minor, mid2))
+  );
+
+  // Half-extents along major (screen-horizontal), mid (screen-vertical),
+  // minor (toward camera). Floor so a single-node focus still frames.
+  const hMajor = Math.max((bounds.max[0] - bounds.min[0]) / 2, 0.5);
+  const hMid = Math.max((bounds.max[1] - bounds.min[1]) / 2, 0.5);
+  const hMinor = Math.max((bounds.max[2] - bounds.min[2]) / 2, 0);
+
+  const vFov = (opts.fovDeg * Math.PI) / 180;
+  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * opts.aspect);
+  // Distance at which the box just fits each screen axis; take the
+  // tighter (larger) so neither axis overflows, then apply overscan.
+  const fitV = hMid / Math.tan(vFov / 2);
+  const fitH = hMajor / Math.tan(hFov / 2);
+  const dist = Math.max(fitV, fitH) * fill + hMinor;
+
+  // Side selection.
+  //  - Focus (a node was clicked): put the camera on the side the node
+  //    is displaced toward relative to the orientation centroid, so the
+  //    node is nearest and the bulk falls behind it. dot ≈ 0 ⇒ the node
+  //    sits in the middle (≈50/50) ⇒ deterministic +side, tween covers
+  //    the swing.
+  //  - Otherwise: stay on whichever side the camera is already on
+  //    (default +minor on first load when no offset given).
+  let side: number;
+  if (opts.focusPoint) {
+    const fx = opts.focusPoint[0] - center[0];
+    const fy = opts.focusPoint[1] - center[1];
+    const fz = opts.focusPoint[2] - center[2];
+    side = fx * minor[0] + fy * minor[1] + fz * minor[2] < 0 ? -1 : 1;
+  } else {
+    side = opts.currentOffset && dot(opts.currentOffset, minor) < 0 ? -1 : 1;
+  }
+
+  // Focus looks AT the clicked node (centred, nearest); a whole-graph
+  // orient looks at the extent box centre.
+  const target = opts.focusPoint ?? boxCenter;
+
+  return {
+    position: add(target, scale(minor, side * dist)),
+    target,
+    up: mid,
+  };
+}

--- a/web/src/explorers/ForceGraph/scene/orientView.ts
+++ b/web/src/explorers/ForceGraph/scene/orientView.ts
@@ -46,6 +46,16 @@ export interface OrientViewOptions {
    */
   fill?: number;
   /**
+   * Pull-back margin, as a fraction of the exact face-on fit, added on
+   * top of the depth anchor. This is the knob that actually tunes
+   * first-load closeness now that `fill` is only the floor: 0 = camera
+   * sits right at the cluster's near face (tightest), higher backs the
+   * camera off by that fraction of a full fit. Viewport-aware (scales
+   * with graph size + viewport), so one value behaves across datasets.
+   * Default DEFAULT_PULLBACK in useOrientAndFrame.
+   */
+  pullback?: number;
+  /**
    * The current camera position MINUS the box centre, in world space.
    * Used only on a non-focus orient (first-load / whole-graph): its
    * minor-axis component picks which side of the broad face the camera
@@ -111,6 +121,7 @@ export function orientedPerspectiveView(
   const { center, axes, bounds } = frame;
   const [major, mid, minor] = axes;
   const fill = opts.fill ?? 0.2;
+  const pullback = opts.pullback ?? 0;
 
   // Box centre in world space: orientation centroid + the extent box's
   // offset along each axis (the extent set need not be centred on it).
@@ -140,7 +151,10 @@ export function orientedPerspectiveView(
   // focal node's own surface. This is the tight "fills the viewport,
   // spills slightly" framing the user selected.
   const NEAR_GUARD = 1;
-  const depthAnchored = hMinor + NEAR_GUARD;
+  // Depth anchor + viewport-aware pull-back. pullback=0 ⇒ camera right
+  // at the near face (tightest); >0 backs off by that fraction of the
+  // exact face-on fit, so it eases out uniformly across graph sizes.
+  const depthAnchored = hMinor + NEAR_GUARD + exactFit * pullback;
   // Viewport-aware floor: a flat/tiny cluster has hMinor≈0, so the depth
   // anchor alone would drop the camera into the focal node. Never come
   // closer than `fill ×` the exact face-on fit — for a normal blobby

--- a/web/src/explorers/ForceGraph/scene/orientView.ts
+++ b/web/src/explorers/ForceGraph/scene/orientView.ts
@@ -33,10 +33,16 @@ export interface OrientViewOptions {
   /** Viewport aspect (width / height). */
   aspect: number;
   /**
-   * Overscan factor (<1 = closer, graph spills past the edges). The user
-   * wants the graph to fill the view with ~15% spilling off-screen, so
-   * the default pulls the camera ~20% inside an exact fit. Tunable; this
-   * is the single knob that replaced the old useFitCamera FILL constant.
+   * Viewport-aware minimum-distance fraction (the safety *floor*, not the
+   * primary distance). The framing is depth-anchored: the camera stands
+   * at the cluster's near face (≈ its minor-axis half-depth), which is
+   * the tight, fills-the-viewport look the user picked. That term alone
+   * collapses to ~0 for a flat or tiny cluster (hMinor→0), dropping the
+   * camera into a node. `fill` is the guard: distance is never closer
+   * than `fill ×` the exact face-on fit, so a degenerate cluster still
+   * gets a viewport-sane frame while normal blobby graphs are unaffected
+   * (their depth anchor dominates the floor). Lower = the floor allows
+   * closer before it kicks in. Default DEFAULT_FILL in useOrientAndFrame.
    */
   fill?: number;
   /**
@@ -104,7 +110,7 @@ export function orientedPerspectiveView(
 ): CameraPose {
   const { center, axes, bounds } = frame;
   const [major, mid, minor] = axes;
-  const fill = opts.fill ?? 0.8;
+  const fill = opts.fill ?? 0.2;
 
   // Box centre in world space: orientation centroid + the extent box's
   // offset along each axis (the extent set need not be centred on it).
@@ -124,11 +130,23 @@ export function orientedPerspectiveView(
 
   const vFov = (opts.fovDeg * Math.PI) / 180;
   const hFov = 2 * Math.atan(Math.tan(vFov / 2) * opts.aspect);
-  // Distance at which the box just fits each screen axis; take the
-  // tighter (larger) so neither axis overflows, then apply overscan.
+  // Distance at which the box exactly fits each screen axis; the tighter
+  // (larger) of the two is an exact face-on fit.
   const fitV = hMid / Math.tan(vFov / 2);
   const fitH = hMajor / Math.tan(hFov / 2);
-  const dist = Math.max(fitV, fitH) * fill + hMinor;
+  const exactFit = Math.max(fitV, fitH);
+  // Depth-anchored: stand at the cluster's near face — its minor-axis
+  // half-depth, plus a small guard so the camera never sits on the
+  // focal node's own surface. This is the tight "fills the viewport,
+  // spills slightly" framing the user selected.
+  const NEAR_GUARD = 1;
+  const depthAnchored = hMinor + NEAR_GUARD;
+  // Viewport-aware floor: a flat/tiny cluster has hMinor≈0, so the depth
+  // anchor alone would drop the camera into the focal node. Never come
+  // closer than `fill ×` the exact face-on fit — for a normal blobby
+  // graph the depth anchor is larger and dominates (look unchanged);
+  // for a degenerate one the floor produces a sane frame instead.
+  const dist = Math.max(depthAnchored, exactFit * fill);
 
   // Side selection.
   //  - Focus (a node was clicked): put the camera on the side the node

--- a/web/src/explorers/ForceGraph/scene/pcaFrame.test.ts
+++ b/web/src/explorers/ForceGraph/scene/pcaFrame.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for pcaFrame — the geometry that orients the camera to the
+ * graph's broad face.
+ *
+ * What these lock down: the minor axis really is the thinnest direction
+ * (look along it ⇒ face the bulk), the axes stay orthonormal even on
+ * degenerate clouds, and the Hybrid split holds — orientation from one
+ * point set, extent bounds from another, centred on the orientation
+ * centroid (so a focus click tightens without spinning the view).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pcaFrame, type Vec3 } from './pcaFrame';
+
+/** |a·b| — sign of eigenvectors is arbitrary, so compare absolute alignment. */
+const absDot = (a: Vec3, b: Vec3) =>
+  Math.abs(a[0] * b[0] + a[1] * b[1] + a[2] * b[2]);
+const len = (a: Vec3) => Math.hypot(a[0], a[1], a[2]);
+
+describe('pcaFrame', () => {
+  it('puts the minor axis along the thinnest direction (flat XY slab)', () => {
+    // Wide in X, medium in Y, ~flat in Z → major≈X, mid≈Y, minor≈Z.
+    const pts: number[] = [];
+    for (let x = -10; x <= 10; x += 2)
+      for (let y = -4; y <= 4; y += 2) pts.push(x, y, 0);
+    const f = pcaFrame(pts);
+
+    expect(absDot(f.axes[0], [1, 0, 0])).toBeGreaterThan(0.99); // major → X
+    expect(absDot(f.axes[1], [0, 1, 0])).toBeGreaterThan(0.99); // mid   → Y
+    expect(absDot(f.axes[2], [0, 0, 1])).toBeGreaterThan(0.99); // minor → Z
+    expect(f.variances[0]).toBeGreaterThan(f.variances[1]);
+    expect(f.variances[1]).toBeGreaterThan(f.variances[2]);
+    expect(f.variances[2]).toBeCloseTo(0, 6); // perfectly flat ⇒ no Z spread
+  });
+
+  it('keeps axes orthonormal and centre correct', () => {
+    const pts = [1, 2, 3, 5, 1, 0, -3, 4, 2, 2, -2, 7, 0, 0, 0];
+    const f = pcaFrame(pts);
+    const [a, b, c] = f.axes;
+    for (const v of f.axes) expect(len(v)).toBeCloseTo(1, 6);
+    expect(absDot(a, b)).toBeCloseTo(0, 6);
+    expect(absDot(b, c)).toBeCloseTo(0, 6);
+    expect(absDot(a, c)).toBeCloseTo(0, 6);
+    // Centroid of the 5 points.
+    expect(f.center[0]).toBeCloseTo((1 + 5 - 3 + 2 + 0) / 5, 6);
+    expect(f.center[1]).toBeCloseTo((2 + 1 + 4 - 2 + 0) / 5, 6);
+    expect(f.center[2]).toBeCloseTo((3 + 0 + 2 + 7 + 0) / 5, 6);
+  });
+
+  it('survives a degenerate cloud (single point) with a sane basis', () => {
+    const f = pcaFrame([4, 4, 4]);
+    for (const v of f.axes) expect(len(v)).toBeCloseTo(1, 6);
+    expect(f.variances).toEqual([0, 0, 0]);
+    expect(f.center).toEqual([4, 4, 4]);
+    // Bounds collapse to the centre (zero-size box at the point).
+    expect(f.bounds.min).toEqual([0, 0, 0]);
+    expect(f.bounds.max).toEqual([0, 0, 0]);
+  });
+
+  it('Hybrid: orientation from the full cloud, extent from a subset', () => {
+    // Full cloud is wide in X (defines the axes + centroid). The extent
+    // subset is a tight pair near +X — bounds must reflect only those,
+    // while the axes/centre still come from the whole cloud.
+    const pts: number[] = [];
+    for (let x = -20; x <= 20; x += 1) pts.push(x, 0, 0); // 41 nodes on X
+    const all = pts.length / 3;
+    const orient = Array.from({ length: all }, (_, i) => i);
+    // Subset = the two right-most nodes (x = 19, 20 → indices 39,40).
+    const extent = [39, 40];
+
+    const f = pcaFrame(pts, orient, extent);
+
+    expect(absDot(f.axes[0], [1, 0, 0])).toBeGreaterThan(0.99); // global major
+    expect(f.center[0]).toBeCloseTo(0, 6); // global centroid (symmetric)
+
+    // Extent bounds along the major axis: nodes 39,40 sit at x=19,20,
+    // i.e. projection 19 and 20 relative to centre 0.
+    const lo = Math.min(f.bounds.min[0], f.bounds.max[0]);
+    const hi = Math.max(f.bounds.min[0], f.bounds.max[0]);
+    expect(lo).toBeCloseTo(19, 5);
+    expect(hi).toBeCloseTo(20, 5);
+    // Off-axis spread of the subset is zero.
+    expect(f.bounds.max[1] - f.bounds.min[1]).toBeCloseTo(0, 6);
+  });
+
+  it('handles a line cloud: one dominant axis, two collapsed', () => {
+    // Points along the (1,1,0)/√2 direction → major along it, the other
+    // two variances ~0 but axes still orthonormal.
+    const pts: number[] = [];
+    for (let t = -10; t <= 10; t++) pts.push(t, t, 0);
+    const f = pcaFrame(pts);
+    expect(absDot(f.axes[0], [Math.SQRT1_2, Math.SQRT1_2, 0])).toBeGreaterThan(
+      0.99
+    );
+    expect(f.variances[0]).toBeGreaterThan(1);
+    expect(f.variances[1]).toBeCloseTo(0, 6);
+    expect(f.variances[2]).toBeCloseTo(0, 6);
+    const [a, b, c] = f.axes;
+    expect(absDot(a, b)).toBeCloseTo(0, 6);
+    expect(absDot(b, c)).toBeCloseTo(0, 6);
+    expect(absDot(a, c)).toBeCloseTo(0, 6);
+  });
+});

--- a/web/src/explorers/ForceGraph/scene/pcaFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/pcaFrame.ts
@@ -1,0 +1,267 @@
+/**
+ * Principal-component framing — the geometry behind "orient the camera to
+ * the best perpendicular tangent to the bulk of the graph".
+ *
+ * A force layout settles into an irregular blob with a natural broad
+ * face. Framing it by its bounding *sphere* (what useFitCamera does today)
+ * over-estimates and leaves the graph small; worse, it ignores the blob's
+ * shape, so a flat, wide layout is viewed edge-on as often as face-on.
+ *
+ * pcaFrame finds that shape. It computes the covariance of the point
+ * cloud and eigen-decomposes it: the eigenvectors are the cloud's own
+ * axes, sorted by variance. The two high-variance axes span the broad
+ * face; the lowest-variance (minor) axis is the thinnest direction —
+ * looking *along* it puts the camera square to the broad face, which is
+ * exactly "perpendicular tangent to the bulk".
+ *
+ * Hybrid focus (ADR-tracked task #29): orientation and extent are
+ * decoupled. Pass the whole visible cloud as the orientation set so the
+ * viewing angle stays globally stable, and a subset (a clicked node's
+ * neighbourhood) as the extent set so the framing tightens onto that
+ * region without spinning the camera. For a whole-graph fit, omit the
+ * subset and the two coincide.
+ *
+ * Pure geometry, no three.js: the camera placement, sign choice, and
+ * fill/overscan live in orientAndFrame (task #26). This file only answers
+ * "where is the cloud, which way does it face, and how big is the part we
+ * want to frame" — and is unit-tested in isolation like positions.ts.
+ *
+ * @verified f8ee93b9
+ */
+
+/** A 3-vector as a plain tuple — keeps this module three.js-free.  @verified f8ee93b9 */
+export type Vec3 = [number, number, number];
+
+/** The cloud's intrinsic frame plus the bounds of the part to be framed.  @verified f8ee93b9 */
+export interface PcaFrame {
+  /** Centroid of the orientation point set, world space. */
+  center: Vec3;
+  /**
+   * Orthonormal eigenvectors of the orientation set's covariance, sorted
+   * by variance DESC: [major, mid, minor]. major×mid span the broad
+   * face; minor is the thinnest direction — the camera looks along it.
+   */
+  axes: [Vec3, Vec3, Vec3];
+  /** Eigenvalues (variances) parallel to `axes`, DESC. ~0 ⇒ degenerate. */
+  variances: [number, number, number];
+  /**
+   * Bounds of the EXTENT set in the PCA frame: min/max projection of each
+   * extent point onto each axis, measured relative to `center` (the
+   * orientation centroid, which the extent set need not be centred on).
+   * orientAndFrame turns these into a world-space box centre + radius.
+   */
+  bounds: { min: Vec3; max: Vec3 };
+}
+
+/** Number of cyclic Jacobi sweeps — 3×3 symmetric converges well under 10.  @verified f8ee93b9 */
+const JACOBI_SWEEPS = 12;
+
+/**
+ * Eigen-decompose a symmetric 3×3 matrix via cyclic Jacobi rotation.
+ * Returns eigenvalues and column eigenvectors (`vectors[k]` is the k-th
+ * eigenvector). Robust on degenerate (planar/linear/point) clouds where a
+ * closed-form solver divides by zero — there the zero-variance axes come
+ * back as an arbitrary-but-orthonormal basis, which is exactly what a
+ * degenerate frame needs.
+ *
+ * @verified f8ee93b9
+ */
+function jacobiEigen(m: number[][]): { values: number[]; vectors: Vec3[] } {
+  // Working copy of the (symmetric) matrix; a accumulates as it diagonalises.
+  const a = [
+    [m[0][0], m[0][1], m[0][2]],
+    [m[1][0], m[1][1], m[1][2]],
+    [m[2][0], m[2][1], m[2][2]],
+  ];
+  // Eigenvector accumulator, starts as identity.
+  const v = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+  ];
+
+  for (let sweep = 0; sweep < JACOBI_SWEEPS; sweep++) {
+    // Zero the largest off-diagonal each (p,q) in the upper triangle.
+    for (let p = 0; p < 2; p++) {
+      for (let q = p + 1; q < 3; q++) {
+        const apq = a[p][q];
+        if (Math.abs(apq) < 1e-12) continue;
+        const app = a[p][p];
+        const aqq = a[q][q];
+        // Rotation angle that annihilates a[p][q].
+        const phi = 0.5 * Math.atan2(2 * apq, aqq - app);
+        const c = Math.cos(phi);
+        const s = Math.sin(phi);
+
+        // a := Rᵀ a R, exploiting symmetry (only p,q rows/cols change).
+        for (let k = 0; k < 3; k++) {
+          const akp = a[k][p];
+          const akq = a[k][q];
+          a[k][p] = c * akp - s * akq;
+          a[k][q] = s * akp + c * akq;
+        }
+        for (let k = 0; k < 3; k++) {
+          const apk = a[p][k];
+          const aqk = a[q][k];
+          a[p][k] = c * apk - s * aqk;
+          a[q][k] = s * apk + c * aqk;
+        }
+        // Accumulate the rotation into the eigenvectors.
+        for (let k = 0; k < 3; k++) {
+          const vkp = v[k][p];
+          const vkq = v[k][q];
+          v[k][p] = c * vkp - s * vkq;
+          v[k][q] = s * vkp + c * vkq;
+        }
+      }
+    }
+  }
+
+  const values = [a[0][0], a[1][1], a[2][2]];
+  // Columns of v are the eigenvectors.
+  const vectors: Vec3[] = [
+    [v[0][0], v[1][0], v[2][0]],
+    [v[0][1], v[1][1], v[2][1]],
+    [v[0][2], v[1][2], v[2][2]],
+  ];
+  return { values, vectors };
+}
+
+/** Project (x,y,z) minus origin onto a unit axis.  @verified f8ee93b9 */
+function project(
+  x: number,
+  y: number,
+  z: number,
+  ox: number,
+  oy: number,
+  oz: number,
+  axis: Vec3
+): number {
+  return (x - ox) * axis[0] + (y - oy) * axis[1] + (z - oz) * axis[2];
+}
+
+/**
+ * Compute the PCA frame of a point cloud.
+ *
+ * `positions` is a flat xyz buffer (length ≥ 3·N). `orientIndices`
+ * selects the points whose covariance defines the viewing axes — pass
+ * the whole visible graph for a globally-stable angle. `extentIndices`
+ * selects the points to actually frame (e.g. a node's neighbourhood);
+ * omit it to frame the orientation set itself. Indices are *node*
+ * indices (the i-th node is positions[3i..3i+2]); when omitted the set
+ * is all of `0..count-1` where count = positions.length/3.
+ *
+ * Degenerate inputs (0–1 points, or a perfectly co-planar/linear cloud)
+ * return an orthonormal basis with zero variances on the collapsed axes
+ * and bounds reduced to the points' actual spread; orientAndFrame floors
+ * the resulting radius so the camera still gets a sane frame.
+ *
+ * @verified f8ee93b9
+ */
+export function pcaFrame(
+  positions: Float32Array | number[],
+  orientIndices?: ArrayLike<number>,
+  extentIndices?: ArrayLike<number>
+): PcaFrame {
+  const count = Math.floor(positions.length / 3);
+  const orient = orientIndices ?? defaultRange(count);
+  const extent = extentIndices ?? orient;
+  const nOrient = orient.length;
+
+  // Centroid of the orientation set.
+  let cx = 0;
+  let cy = 0;
+  let cz = 0;
+  for (let k = 0; k < nOrient; k++) {
+    const i = orient[k];
+    cx += positions[i * 3];
+    cy += positions[i * 3 + 1];
+    cz += positions[i * 3 + 2];
+  }
+  if (nOrient > 0) {
+    cx /= nOrient;
+    cy /= nOrient;
+    cz /= nOrient;
+  }
+  const center: Vec3 = [cx, cy, cz];
+
+  // Covariance (symmetric; population form — scale is irrelevant to the
+  // eigenvectors and we never compare variances across different clouds).
+  let xx = 0;
+  let xy = 0;
+  let xz = 0;
+  let yy = 0;
+  let yz = 0;
+  let zz = 0;
+  for (let k = 0; k < nOrient; k++) {
+    const i = orient[k];
+    const dx = positions[i * 3] - cx;
+    const dy = positions[i * 3 + 1] - cy;
+    const dz = positions[i * 3 + 2] - cz;
+    xx += dx * dx;
+    xy += dx * dy;
+    xz += dx * dz;
+    yy += dy * dy;
+    yz += dy * dz;
+    zz += dz * dz;
+  }
+  const inv = nOrient > 0 ? 1 / nOrient : 0;
+  const cov = [
+    [xx * inv, xy * inv, xz * inv],
+    [xy * inv, yy * inv, yz * inv],
+    [xz * inv, yz * inv, zz * inv],
+  ];
+
+  const { values, vectors } = jacobiEigen(cov);
+
+  // Sort axes by variance DESC → [major, mid, minor].
+  const order = [0, 1, 2].sort((p, q) => values[q] - values[p]);
+  const axes: [Vec3, Vec3, Vec3] = [
+    normalize(vectors[order[0]]),
+    normalize(vectors[order[1]]),
+    normalize(vectors[order[2]]),
+  ];
+  const variances: [number, number, number] = [
+    Math.max(values[order[0]], 0),
+    Math.max(values[order[1]], 0),
+    Math.max(values[order[2]], 0),
+  ];
+
+  // Bounds of the EXTENT set, projected onto the axes relative to center.
+  const min: Vec3 = [Infinity, Infinity, Infinity];
+  const max: Vec3 = [-Infinity, -Infinity, -Infinity];
+  for (let k = 0; k < extent.length; k++) {
+    const i = extent[k];
+    const x = positions[i * 3];
+    const y = positions[i * 3 + 1];
+    const z = positions[i * 3 + 2];
+    for (let ax = 0; ax < 3; ax++) {
+      const p = project(x, y, z, cx, cy, cz, axes[ax]);
+      if (p < min[ax]) min[ax] = p;
+      if (p > max[ax]) max[ax] = p;
+    }
+  }
+  // Empty extent set ⇒ collapse bounds to the centre (zero-size box).
+  for (let ax = 0; ax < 3; ax++) {
+    if (!Number.isFinite(min[ax])) {
+      min[ax] = 0;
+      max[ax] = 0;
+    }
+  }
+
+  return { center, axes, variances, bounds: { min, max } };
+}
+
+/** 0..count-1, the implicit "all nodes" index set.  @verified f8ee93b9 */
+function defaultRange(count: number): number[] {
+  const r = new Array<number>(count);
+  for (let i = 0; i < count; i++) r[i] = i;
+  return r;
+}
+
+/** Unit-length copy; falls back to +X for a zero vector (degenerate axis).  @verified f8ee93b9 */
+function normalize(v: Vec3): Vec3 {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  if (len < 1e-12) return [1, 0, 0];
+  return [v[0] / len, v[1] / len, v[2] / len];
+}

--- a/web/src/explorers/ForceGraph/scene/useFitCamera.ts
+++ b/web/src/explorers/ForceGraph/scene/useFitCamera.ts
@@ -1,178 +1,89 @@
 /**
- * Auto-frame the camera on first layout (and on every dataset change).
+ * First-load camera fit — "fake zoom-extents".
  *
  * The camera mounts at a fixed distance; a freshly-seeded graph settles
- * into a cluster that is usually tiny and off-centre in that fixed view,
- * so the user has to manually zoom every time. This hook waits for the
- * layout to stop moving, then frames the visible nodes — perspective by
- * distance, orthographic by zoom — and re-points the orbit/pan target at
- * the cluster centre so rotation pivots correctly.
+ * into a cluster that is tiny and off-centre in that fixed view, so the
+ * user had to manually zoom every time. On the first appearance of nodes
+ * this fires the shared orientAndFrame action once: it rotates to the
+ * graph's broad face and eases in (orientView/useOrientAndFrame own that
+ * geometry + tween — this hook owns only *when*).
  *
- * Settle detection is a bounding-radius delta, not a sim-alpha read: it
- * is mode-agnostic (works while simmering, reheated, or idle, and
- * survives future sim modes) and needs no sim internals — "the thing I
- * am framing has stopped growing" is exactly the signal. A frame cap
- * guarantees a fit even if the layout never fully stabilises.
+ * Two deliberate constraints:
+ *
+ *  - First load ONLY. We arm on a 0→N transition (first appearance, or a
+ *    fresh graph after the prior was cleared). Incremental growth (Add
+ *    Adjacent), filters, and follow keep N>0 throughout, so they never
+ *    re-arm and the camera stays where the user left it — re-fitting on
+ *    every change is the camera-side of the "sproing" trap PR #371 fixed
+ *    for the sim. A manual Fit/Reheat is the intended escape hatch.
+ *
+ *  - Settle by time, not by a radius heuristic. We wait a fixed window
+ *    (SETTLE_MS) for the force layout to relax before framing it, rather
+ *    than watching the bounding radius: the user asked for a predictable
+ *    "let physics settle ~2s, then zoom", and a fixed timer is robust
+ *    under the demand frameloop where a frame-delta heuristic misfires.
+ *    We keep the demand loop pumping while armed so the window actually
+ *    elapses even after the sim quiesces and stops invalidating.
  *
  * Lives in the shared Scene, so Force Graph and Document Explorer both
  * get it from one implementation.
  *
- * @verified 50606a37
+ * @verified 3e3afbcd
  */
 
 import { useEffect, useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
-import * as THREE from 'three';
 import type { EngineNode } from '../types';
 
-/** Consecutive near-stable frames before we accept the layout as settled. */
-const STABLE_FRAMES = 5;
-/** Hard cap so a never-settling layout still gets framed (~10s at 60fps). */
-const MAX_FRAMES = 600;
 /**
- * View-fill factor. We frame the cluster's bounding *sphere* (half the
- * box diagonal), which over-estimates a typically-irregular force layout
- * — fitting that sphere exactly already leaves the visible graph small
- * with padding. The user wants the opposite: the graph filling the view
- * and spilling ~15% past the edges. <1 is deliberate overscan; 0.7
- * pulls the camera ~30% closer than a pure sphere-fit so the actual
- * node spread fills the viewport and the outermost nodes/labels sit
- * just outside it. Tunable to taste — lower = closer. Provisional: the
- * planned PCA tangent-orient action will compute the true projected
- * extent and largely supersede this single-constant heuristic.
+ * How long to let the force layout relax before framing it. The user's
+ * stated intent ("wait some amount of time for physics to settle ...
+ * say, 2000 msec"); also comfortably longer than drei's controls take to
+ * mount, so the orient tween has a target to lerp by the time it fires.
  */
-const FILL = 0.5;
+const SETTLE_MS = 2000;
 
-const tmpMin = new THREE.Vector3();
-const tmpMax = new THREE.Vector3();
-const tmpCenter = new THREE.Vector3();
-const tmpDir = new THREE.Vector3();
-
-/** Auto-frames the visible nodes once the layout settles.  @verified 50606a37 */
-export function useFitCamera(
-  positionsRef: React.MutableRefObject<Float32Array | null>,
-  nodes: EngineNode[],
-  hiddenIds?: Set<string>
-): void {
-  const camera = useThree((s) => s.camera);
-  const controls = useThree((s) => s.controls) as
-    | (THREE.EventDispatcher & { target: THREE.Vector3; update: () => void })
-    | null;
-  const size = useThree((s) => s.size);
+/**
+ * Arm a one-shot orient on the graph's first appearance.
+ *
+ * `orient` is the whole-graph branch of the shared orientAndFrame action
+ * (Scene wires `useOrientAndFrame().orient`). Idempotent under
+ * StrictMode's double-invoked effects: the 0→N guard only arms once per
+ * real transition.
+ *
+ * @verified 3e3afbcd
+ */
+export function useFitCamera(orient: () => void, nodes: EngineNode[]): void {
   const invalidate = useThree((s) => s.invalidate);
 
-  const armedRef = useRef(true);
-  const framesRef = useRef(0);
-  const lastRadiusRef = useRef(-1);
-  const stableRef = useRef(0);
-  // Whether the previous render had any nodes. We fit only on a 0→N
-  // transition: first appearance, or a fresh graph after the prior one
-  // was cleared (search/replace). Incremental growth (Add Adjacent),
-  // filters, and follow keep N>0 throughout, so they never re-arm —
-  // the camera stays where the user left it (a manual "Fit view" is the
-  // intended escape hatch). Re-fitting on every change would yank the
-  // view ~when the layout re-settles, the camera-side of the trap
-  // incremental physics (PR #371) fixed for the sim.
+  const armedRef = useRef(false);
+  const firedRef = useRef(false);
+  const armedAtRef = useRef(0);
+  // Whether the previous render had any nodes — the 0→N edge is the
+  // "first load" signal (see header). StrictMode re-runs the effect with
+  // the same nodes.length; once this is true a re-run won't re-arm.
   const hadNodesRef = useRef(false);
 
   useEffect(() => {
     const has = nodes.length > 0;
     if (has && !hadNodesRef.current) {
       armedRef.current = true;
-      framesRef.current = 0;
-      lastRadiusRef.current = -1;
-      stableRef.current = 0;
+      firedRef.current = false;
+      armedAtRef.current = performance.now();
       invalidate();
     }
     hadNodesRef.current = has;
   }, [nodes.length, invalidate]);
 
   useFrame(() => {
-    if (!armedRef.current) return;
-    // Keep demand-frameloop pumping while we're waiting to fit. The sim
-    // stops invalidating once it quiesces; without this, settle/timeout
-    // could be reached after frames have already stopped and the fit
-    // would never fire. Cleared implicitly when we disarm below.
+    if (!armedRef.current || firedRef.current) return;
+    // Keep the demand frameloop alive until the settle window elapses —
+    // the sim stops invalidating once it quiesces, and without this the
+    // timer check would never run again and the fit would never fire.
     invalidate();
-    const positions = positionsRef.current;
-    const n = nodes.length;
-    if (!positions || n === 0 || positions.length < n * 3) return;
-
-    const hasHidden = !!hiddenIds && hiddenIds.size > 0;
-    tmpMin.set(Infinity, Infinity, Infinity);
-    tmpMax.set(-Infinity, -Infinity, -Infinity);
-    let visible = 0;
-    for (let i = 0; i < n; i++) {
-      if (hasHidden && hiddenIds!.has(nodes[i].id)) continue;
-      const x = positions[i * 3];
-      const y = positions[i * 3 + 1];
-      const z = positions[i * 3 + 2];
-      if (x < tmpMin.x) tmpMin.x = x;
-      if (y < tmpMin.y) tmpMin.y = y;
-      if (z < tmpMin.z) tmpMin.z = z;
-      if (x > tmpMax.x) tmpMax.x = x;
-      if (y > tmpMax.y) tmpMax.y = y;
-      if (z > tmpMax.z) tmpMax.z = z;
-      visible++;
-    }
-    if (visible === 0) return;
-
-    tmpCenter.addVectors(tmpMin, tmpMax).multiplyScalar(0.5);
-    // Bounding-sphere radius from the box centre; floor so a single node
-    // (or a degenerate co-located cluster) still yields a sane frame.
-    const radius = Math.max(0.5 * tmpMax.distanceTo(tmpMin), 1);
-
-    framesRef.current++;
-    const last = lastRadiusRef.current;
-    lastRadiusRef.current = radius;
-    // Relative delta so the threshold scales with graph size.
-    if (last > 0 && Math.abs(radius - last) / radius < 0.01) {
-      stableRef.current++;
-    } else {
-      stableRef.current = 0;
-    }
-
-    const settled = stableRef.current >= STABLE_FRAMES;
-    const timedOut = framesRef.current >= MAX_FRAMES;
-    if (!settled && !timedOut) return;
-    // Orbit/pan target must be re-pointed for the framing to read right,
-    // so prefer waiting for drei's controls to mount — but only briefly
-    // (~2s). If they're still absent we fit anyway with a lookAt
-    // fallback rather than stall forever.
-    if (!controls && framesRef.current < 120 && !timedOut) return;
-
-    if (camera instanceof THREE.OrthographicCamera) {
-      // r3f's ortho frustum is the canvas in pixels; zoom = pixels per
-      // world unit. Fit the sphere's diameter into the smaller viewport
-      // axis with margin.
-      const minPx = Math.min(size.width, size.height);
-      camera.zoom = minPx / (2 * radius * FILL);
-      camera.position.set(tmpCenter.x, tmpCenter.y, camera.position.z);
-      camera.updateProjectionMatrix();
-    } else if (camera instanceof THREE.PerspectiveCamera) {
-      const vFov = (camera.fov * Math.PI) / 180;
-      const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
-      const dist =
-        Math.max(radius / Math.sin(vFov / 2), radius / Math.sin(hFov / 2)) *
-        FILL;
-      // Preserve the current viewing direction; fall back to looking
-      // down -Z if the camera and target coincide.
-      tmpDir.copy(camera.position);
-      if (controls) tmpDir.sub(controls.target);
-      if (tmpDir.lengthSq() < 1e-6) tmpDir.set(0, 0, 1);
-      tmpDir.normalize();
-      camera.position.copy(tmpCenter).addScaledVector(tmpDir, dist);
-      camera.updateProjectionMatrix();
-    }
-
-    if (controls) {
-      controls.target.copy(tmpCenter);
-      controls.update();
-    } else {
-      camera.lookAt(tmpCenter);
-    }
-
+    if (performance.now() - armedAtRef.current < SETTLE_MS) return;
+    firedRef.current = true;
     armedRef.current = false;
-    invalidate();
+    orient();
   });
 }

--- a/web/src/explorers/ForceGraph/scene/useFitCamera.ts
+++ b/web/src/explorers/ForceGraph/scene/useFitCamera.ts
@@ -33,6 +33,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
+import type { EventDispatcher } from 'three';
 import type { EngineNode } from '../types';
 
 /**
@@ -55,6 +56,7 @@ const SETTLE_MS = 2000;
  */
 export function useFitCamera(orient: () => void, nodes: EngineNode[]): void {
   const invalidate = useThree((s) => s.invalidate);
+  const controls = useThree((s) => s.controls) as EventDispatcher | null;
 
   const armedRef = useRef(false);
   const firedRef = useRef(false);
@@ -74,6 +76,24 @@ export function useFitCamera(orient: () => void, nodes: EngineNode[]): void {
     }
     hadNodesRef.current = has;
   }, [nodes.length, invalidate]);
+
+  // If the user grabs the camera during the settle window, abandon the
+  // pending fit — firing it at t=2s anyway would yank the view out from
+  // under them (the same "sproing" this hook's header says it avoids,
+  // just on the first-load path). The orient tween has its own cancel;
+  // this guards the trigger that hasn't fired yet. firedRef doubles as
+  // "spent" so it never arms again this lifetime.
+  useEffect(() => {
+    if (!controls) return;
+    const abort = () => {
+      if (armedRef.current && !firedRef.current) {
+        armedRef.current = false;
+        firedRef.current = true;
+      }
+    };
+    controls.addEventListener('start', abort);
+    return () => controls.removeEventListener('start', abort);
+  }, [controls]);
 
   useFrame(() => {
     if (!armedRef.current || firedRef.current) return;

--- a/web/src/explorers/ForceGraph/scene/useFitCamera.ts
+++ b/web/src/explorers/ForceGraph/scene/useFitCamera.ts
@@ -54,16 +54,26 @@ export function useFitCamera(
   const framesRef = useRef(0);
   const lastRadiusRef = useRef(-1);
   const stableRef = useRef(0);
+  // Whether the previous render had any nodes. We fit only on a 0→N
+  // transition: first appearance, or a fresh graph after the prior one
+  // was cleared (search/replace). Incremental growth (Add Adjacent),
+  // filters, and follow keep N>0 throughout, so they never re-arm —
+  // the camera stays where the user left it (a manual "Fit view" is the
+  // intended escape hatch). Re-fitting on every change would yank the
+  // view ~when the layout re-settles, the camera-side of the trap
+  // incremental physics (PR #371) fixed for the sim.
+  const hadNodesRef = useRef(false);
 
-  // Arm on every dataset change (count is the cheap proxy; a full swap of
-  // the same count still re-seeds and re-settles, so the radius-delta
-  // path will still converge and re-fit).
   useEffect(() => {
-    armedRef.current = true;
-    framesRef.current = 0;
-    lastRadiusRef.current = -1;
-    stableRef.current = 0;
-    invalidate();
+    const has = nodes.length > 0;
+    if (has && !hadNodesRef.current) {
+      armedRef.current = true;
+      framesRef.current = 0;
+      lastRadiusRef.current = -1;
+      stableRef.current = 0;
+      invalidate();
+    }
+    hadNodesRef.current = has;
   }, [nodes.length, invalidate]);
 
   useFrame(() => {

--- a/web/src/explorers/ForceGraph/scene/useFitCamera.ts
+++ b/web/src/explorers/ForceGraph/scene/useFitCamera.ts
@@ -37,9 +37,11 @@ const MAX_FRAMES = 600;
  * and spilling ~15% past the edges. <1 is deliberate overscan; 0.7
  * pulls the camera ~30% closer than a pure sphere-fit so the actual
  * node spread fills the viewport and the outermost nodes/labels sit
- * just outside it. Tunable to taste.
+ * just outside it. Tunable to taste — lower = closer. Provisional: the
+ * planned PCA tangent-orient action will compute the true projected
+ * extent and largely supersede this single-constant heuristic.
  */
-const FILL = 0.7;
+const FILL = 0.5;
 
 const tmpMin = new THREE.Vector3();
 const tmpMax = new THREE.Vector3();

--- a/web/src/explorers/ForceGraph/scene/useFitCamera.ts
+++ b/web/src/explorers/ForceGraph/scene/useFitCamera.ts
@@ -29,8 +29,17 @@ import type { EngineNode } from '../types';
 const STABLE_FRAMES = 5;
 /** Hard cap so a never-settling layout still gets framed (~10s at 60fps). */
 const MAX_FRAMES = 600;
-/** Padding so the cluster doesn't touch the viewport edges. */
-const MARGIN = 1.25;
+/**
+ * View-fill factor. We frame the cluster's bounding *sphere* (half the
+ * box diagonal), which over-estimates a typically-irregular force layout
+ * — fitting that sphere exactly already leaves the visible graph small
+ * with padding. The user wants the opposite: the graph filling the view
+ * and spilling ~15% past the edges. <1 is deliberate overscan; 0.7
+ * pulls the camera ~30% closer than a pure sphere-fit so the actual
+ * node spread fills the viewport and the outermost nodes/labels sit
+ * just outside it. Tunable to taste.
+ */
+const FILL = 0.7;
 
 const tmpMin = new THREE.Vector3();
 const tmpMax = new THREE.Vector3();
@@ -78,6 +87,11 @@ export function useFitCamera(
 
   useFrame(() => {
     if (!armedRef.current) return;
+    // Keep demand-frameloop pumping while we're waiting to fit. The sim
+    // stops invalidating once it quiesces; without this, settle/timeout
+    // could be reached after frames have already stopped and the fit
+    // would never fire. Cleared implicitly when we disarm below.
+    invalidate();
     const positions = positionsRef.current;
     const n = nodes.length;
     if (!positions || n === 0 || positions.length < n * 3) return;
@@ -119,16 +133,18 @@ export function useFitCamera(
     const settled = stableRef.current >= STABLE_FRAMES;
     const timedOut = framesRef.current >= MAX_FRAMES;
     if (!settled && !timedOut) return;
-    // Orbit/pan target must be re-pointed for the framing to read right;
-    // wait for drei's controls to mount unless we've hit the hard cap.
-    if (!controls && !timedOut) return;
+    // Orbit/pan target must be re-pointed for the framing to read right,
+    // so prefer waiting for drei's controls to mount — but only briefly
+    // (~2s). If they're still absent we fit anyway with a lookAt
+    // fallback rather than stall forever.
+    if (!controls && framesRef.current < 120 && !timedOut) return;
 
     if (camera instanceof THREE.OrthographicCamera) {
       // r3f's ortho frustum is the canvas in pixels; zoom = pixels per
       // world unit. Fit the sphere's diameter into the smaller viewport
       // axis with margin.
       const minPx = Math.min(size.width, size.height);
-      camera.zoom = minPx / (2 * radius * MARGIN);
+      camera.zoom = minPx / (2 * radius * FILL);
       camera.position.set(tmpCenter.x, tmpCenter.y, camera.position.z);
       camera.updateProjectionMatrix();
     } else if (camera instanceof THREE.PerspectiveCamera) {
@@ -136,7 +152,7 @@ export function useFitCamera(
       const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
       const dist =
         Math.max(radius / Math.sin(vFov / 2), radius / Math.sin(hFov / 2)) *
-        MARGIN;
+        FILL;
       // Preserve the current viewing direction; fall back to looking
       // down -Z if the camera and target coincide.
       tmpDir.copy(camera.position);

--- a/web/src/explorers/ForceGraph/scene/useFitCamera.ts
+++ b/web/src/explorers/ForceGraph/scene/useFitCamera.ts
@@ -1,0 +1,150 @@
+/**
+ * Auto-frame the camera on first layout (and on every dataset change).
+ *
+ * The camera mounts at a fixed distance; a freshly-seeded graph settles
+ * into a cluster that is usually tiny and off-centre in that fixed view,
+ * so the user has to manually zoom every time. This hook waits for the
+ * layout to stop moving, then frames the visible nodes — perspective by
+ * distance, orthographic by zoom — and re-points the orbit/pan target at
+ * the cluster centre so rotation pivots correctly.
+ *
+ * Settle detection is a bounding-radius delta, not a sim-alpha read: it
+ * is mode-agnostic (works while simmering, reheated, or idle, and
+ * survives future sim modes) and needs no sim internals — "the thing I
+ * am framing has stopped growing" is exactly the signal. A frame cap
+ * guarantees a fit even if the layout never fully stabilises.
+ *
+ * Lives in the shared Scene, so Force Graph and Document Explorer both
+ * get it from one implementation.
+ *
+ * @verified 50606a37
+ */
+
+import { useEffect, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { EngineNode } from '../types';
+
+/** Consecutive near-stable frames before we accept the layout as settled. */
+const STABLE_FRAMES = 5;
+/** Hard cap so a never-settling layout still gets framed (~10s at 60fps). */
+const MAX_FRAMES = 600;
+/** Padding so the cluster doesn't touch the viewport edges. */
+const MARGIN = 1.25;
+
+const tmpMin = new THREE.Vector3();
+const tmpMax = new THREE.Vector3();
+const tmpCenter = new THREE.Vector3();
+const tmpDir = new THREE.Vector3();
+
+/** Auto-frames the visible nodes once the layout settles.  @verified 50606a37 */
+export function useFitCamera(
+  positionsRef: React.MutableRefObject<Float32Array | null>,
+  nodes: EngineNode[],
+  hiddenIds?: Set<string>
+): void {
+  const camera = useThree((s) => s.camera);
+  const controls = useThree((s) => s.controls) as
+    | (THREE.EventDispatcher & { target: THREE.Vector3; update: () => void })
+    | null;
+  const size = useThree((s) => s.size);
+  const invalidate = useThree((s) => s.invalidate);
+
+  const armedRef = useRef(true);
+  const framesRef = useRef(0);
+  const lastRadiusRef = useRef(-1);
+  const stableRef = useRef(0);
+
+  // Arm on every dataset change (count is the cheap proxy; a full swap of
+  // the same count still re-seeds and re-settles, so the radius-delta
+  // path will still converge and re-fit).
+  useEffect(() => {
+    armedRef.current = true;
+    framesRef.current = 0;
+    lastRadiusRef.current = -1;
+    stableRef.current = 0;
+    invalidate();
+  }, [nodes.length, invalidate]);
+
+  useFrame(() => {
+    if (!armedRef.current) return;
+    const positions = positionsRef.current;
+    const n = nodes.length;
+    if (!positions || n === 0 || positions.length < n * 3) return;
+
+    const hasHidden = !!hiddenIds && hiddenIds.size > 0;
+    tmpMin.set(Infinity, Infinity, Infinity);
+    tmpMax.set(-Infinity, -Infinity, -Infinity);
+    let visible = 0;
+    for (let i = 0; i < n; i++) {
+      if (hasHidden && hiddenIds!.has(nodes[i].id)) continue;
+      const x = positions[i * 3];
+      const y = positions[i * 3 + 1];
+      const z = positions[i * 3 + 2];
+      if (x < tmpMin.x) tmpMin.x = x;
+      if (y < tmpMin.y) tmpMin.y = y;
+      if (z < tmpMin.z) tmpMin.z = z;
+      if (x > tmpMax.x) tmpMax.x = x;
+      if (y > tmpMax.y) tmpMax.y = y;
+      if (z > tmpMax.z) tmpMax.z = z;
+      visible++;
+    }
+    if (visible === 0) return;
+
+    tmpCenter.addVectors(tmpMin, tmpMax).multiplyScalar(0.5);
+    // Bounding-sphere radius from the box centre; floor so a single node
+    // (or a degenerate co-located cluster) still yields a sane frame.
+    const radius = Math.max(0.5 * tmpMax.distanceTo(tmpMin), 1);
+
+    framesRef.current++;
+    const last = lastRadiusRef.current;
+    lastRadiusRef.current = radius;
+    // Relative delta so the threshold scales with graph size.
+    if (last > 0 && Math.abs(radius - last) / radius < 0.01) {
+      stableRef.current++;
+    } else {
+      stableRef.current = 0;
+    }
+
+    const settled = stableRef.current >= STABLE_FRAMES;
+    const timedOut = framesRef.current >= MAX_FRAMES;
+    if (!settled && !timedOut) return;
+    // Orbit/pan target must be re-pointed for the framing to read right;
+    // wait for drei's controls to mount unless we've hit the hard cap.
+    if (!controls && !timedOut) return;
+
+    if (camera instanceof THREE.OrthographicCamera) {
+      // r3f's ortho frustum is the canvas in pixels; zoom = pixels per
+      // world unit. Fit the sphere's diameter into the smaller viewport
+      // axis with margin.
+      const minPx = Math.min(size.width, size.height);
+      camera.zoom = minPx / (2 * radius * MARGIN);
+      camera.position.set(tmpCenter.x, tmpCenter.y, camera.position.z);
+      camera.updateProjectionMatrix();
+    } else if (camera instanceof THREE.PerspectiveCamera) {
+      const vFov = (camera.fov * Math.PI) / 180;
+      const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
+      const dist =
+        Math.max(radius / Math.sin(vFov / 2), radius / Math.sin(hFov / 2)) *
+        MARGIN;
+      // Preserve the current viewing direction; fall back to looking
+      // down -Z if the camera and target coincide.
+      tmpDir.copy(camera.position);
+      if (controls) tmpDir.sub(controls.target);
+      if (tmpDir.lengthSq() < 1e-6) tmpDir.set(0, 0, 1);
+      tmpDir.normalize();
+      camera.position.copy(tmpCenter).addScaledVector(tmpDir, dist);
+      camera.updateProjectionMatrix();
+    }
+
+    if (controls) {
+      controls.target.copy(tmpCenter);
+      controls.update();
+    } else {
+      camera.lookAt(tmpCenter);
+    }
+
+    armedRef.current = false;
+    invalidate();
+  });
+}

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -12,10 +12,14 @@
  * the user grabs the controls. That all lives here.
  *
  * Decisions baked in (tasks #29/#30, user-confirmed):
- *  - Hybrid focus: orientation axes come from the whole visible graph
- *    (stable angle) while the framed extent is the clicked node's
- *    1-hop neighbourhood (tightens onto the region). The clicked node
- *    becomes the centred, nearest point with the bulk behind it.
+ *  - Focus = whole-graph, re-aimed (revised #29). Orientation axes AND
+ *    framing extent both come from the whole visible graph, so every
+ *    focus lands at the same comfortable zoom — the clicked node just
+ *    becomes the centred, nearest point with the bulk swung behind it.
+ *    The earlier "frame the clicked node's 1-hop neighbourhood" made
+ *    successive double-clicks creep closer (a tiny local extent, and
+ *    the still-relaxing sim contracting it further each click). The
+ *    1-hop adjacency that fed that is retained but unused — see #375.
  *  - Tweened for both: even first-load eases in (consistent motion),
  *    ~0.45s easeInOutCubic, cancellable on any controls interaction.
  *  - Near-spherical / 2D: no meaningful broad face → don't rotate, just
@@ -122,8 +126,19 @@ export function useOrientAndFrame(
     pullback = DEFAULT_PULLBACK,
   } = opts;
 
-  // 1-hop adjacency for Hybrid focus extents. Rebuilt only when the edge
-  // set changes; a focus click reads it without touching the sim.
+  // 1-hop adjacency map, intentionally RETAINED but not consumed.
+  //
+  // It originally fed the Hybrid focus extent; that was dropped (focus
+  // now frames the whole graph — see the header / #29 revision) because
+  // a per-click local extent crept closer each double-click. The map is
+  // kept built because it is the graph-traversal substrate for the
+  // planned "visual narration" feature (issue #375): pick a path through
+  // the graph, use the node positions as Catmull-Rom control points, and
+  // glide the camera along that spline node→node. Keeping it here, where
+  // that camera action will live, means the future work starts from a
+  // maintained base rather than re-deriving adjacency. Cheap: rebuilt
+  // only when `edges` changes.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const adjacency = useMemo(() => {
     const adj = new Map<string, Set<string>>();
     if (!edges) return adj;
@@ -257,26 +272,27 @@ export function useOrientAndFrame(
       const orientIdx = visibleIndices();
       if (orientIdx.length === 0) return;
 
-      // Extent set: focus → clicked node + its 1-hop neighbours (Hybrid);
-      // whole-graph → the visible set itself.
-      let extentIdx = orientIdx;
+      // Extent set is always the whole visible graph — focus reuses the
+      // exact same frame as a whole-graph orient (so the zoom level is
+      // identical every time, no creep) and only differs by aiming at
+      // the clicked node. focusPoint drives target + side; the rest of
+      // the pose is the stable whole-graph PCA.
+      const extentIdx = orientIdx;
       let focusPoint: Vec3T | undefined;
       if (focusNodeId) {
-        const idById = new Map<string, number>();
-        for (const i of orientIdx) idById.set(nodes[i].id, i);
-        const fi = idById.get(focusNodeId);
-        if (fi != null) {
+        let fi = -1;
+        for (const i of orientIdx) {
+          if (nodes[i].id === focusNodeId) {
+            fi = i;
+            break;
+          }
+        }
+        if (fi >= 0) {
           focusPoint = [
             positions[fi * 3],
             positions[fi * 3 + 1],
             positions[fi * 3 + 2],
           ];
-          const set = new Set<number>([fi]);
-          for (const nid of adjacency.get(focusNodeId) ?? []) {
-            const ni = idById.get(nid);
-            if (ni != null) set.add(ni);
-          }
-          extentIdx = [...set];
         }
       }
 
@@ -313,7 +329,6 @@ export function useOrientAndFrame(
     [
       positionsRef,
       nodes,
-      adjacency,
       visibleIndices,
       projection,
       camera,

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -49,12 +49,24 @@ const TWEEN_MS = 450;
  */
 const DEFAULT_FILL = 0.2;
 
+/**
+ * First-load closeness knob (the one that actually tunes it now). Added
+ * on top of the depth anchor as this fraction of the exact face-on fit:
+ * 0 = camera right at the cluster's near face (tightest — what the user
+ * first saw and found "a bit too close"); higher backs the camera off,
+ * uniformly across graph sizes. 0.15 ≈ "near face, eased back ~15% of a
+ * full fit". This is the value to tune for first-load zoom, not FILL.
+ */
+const DEFAULT_PULLBACK = 0.15;
+
 export interface OrientAndFrameOptions {
   hiddenIds?: Set<string>;
   edges?: EngineEdge[];
   projection?: Projection;
-  /** Overscan factor (<1 = closer / more spill). Defaults to DEFAULT_FILL. */
+  /** Viewport-aware minimum-distance floor. Defaults to DEFAULT_FILL. */
   fill?: number;
+  /** First-load pull-back margin (see DEFAULT_PULLBACK). */
+  pullback?: number;
 }
 
 /** The reusable camera action: whole-graph orient, or focus on a node.  @verified 726f5d45 */
@@ -102,7 +114,13 @@ export function useOrientAndFrame(
   const size = useThree((s) => s.size);
   const invalidate = useThree((s) => s.invalidate);
 
-  const { hiddenIds, edges, projection = '3D', fill = DEFAULT_FILL } = opts;
+  const {
+    hiddenIds,
+    edges,
+    projection = '3D',
+    fill = DEFAULT_FILL,
+    pullback = DEFAULT_PULLBACK,
+  } = opts;
 
   // 1-hop adjacency for Hybrid focus extents. Rebuilt only when the edge
   // set changes; a focus click reads it without touching the sim.
@@ -286,6 +304,7 @@ export function useOrientAndFrame(
         fovDeg: cam.fov,
         aspect: cam.aspect,
         fill,
+        pullback,
         currentOffset,
         focusPoint,
       });
@@ -299,6 +318,7 @@ export function useOrientAndFrame(
       projection,
       camera,
       fill,
+      pullback,
       frameAlongCurrentDir,
       startTween,
     ]

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -135,21 +135,26 @@ export function useOrientAndFrame(
   // Translate a target pose into a tween from the camera's current pose.
   const startTween = useCallback(
     (pose: CameraPose, zoom: number) => {
+      // Deliberately DO NOT adopt pose.up (the cloud's mid axis). A force
+      // layout has no inherent orientation, so the user's mental model is
+      // "Y is up". Snapping camera.up to the PCA mid axis would (1) roll
+      // the view instantly at t=0 — the exact disorientation the tween
+      // exists to prevent — and (2) leave OrbitControls with a tilted
+      // orbit pole, so all later rotation feels off-gravity. Keeping
+      // world-Y up and letting lookAt resolve roll costs only a slightly
+      // conservative fit (a touch more spill), which is harmless.
+      // pose.up stays part of the geometric contract (and orientView's
+      // tests) as the broad-face up; the hook just doesn't apply it.
       if (!controls) {
         // No controls yet (early first-load) — snap; the tween loop has
         // nothing to lerp the target against. Rare; caller retries.
         camera.position.set(...pose.position);
-        camera.up.set(...pose.up);
         camera.lookAt(...pose.target);
         if (camera instanceof THREE.OrthographicCamera) camera.zoom = zoom;
         camera.updateProjectionMatrix();
         invalidate();
         return;
       }
-      // up changes the lookAt basis; tweening it fights the position
-      // lerp. Set it once up-front — the roll delta is small and the
-      // position/target ease carries the visible motion.
-      camera.up.set(...pose.up);
       tweenRef.current = {
         fromPos: camera.position.clone(),
         toPos: new THREE.Vector3(...pose.position),

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -37,8 +37,13 @@ import {
 
 /** Tween duration — long enough to track the swing, short enough not to drag. */
 const TWEEN_MS = 450;
-/** Default overscan: graph fills the view, ~15% spilling off (user's ideal). */
-const DEFAULT_FILL = 0.82;
+/**
+ * Default overscan: multiplier on the face-on fit distance. <1 pulls the
+ * camera closer so the graph overfills and spills past the edges (the
+ * user's stated ideal: graph fills the view, the outermost ~15% off
+ * screen). Lower = closer. This is the single first-load zoom knob.
+ */
+const DEFAULT_FILL = 0.65;
 
 export interface OrientAndFrameOptions {
   hiddenIds?: Set<string>;

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -63,6 +63,18 @@ const DEFAULT_FILL = 0.2;
  */
 const DEFAULT_PULLBACK = 0.15;
 
+/**
+ * Overscan for the no-rotate fallback (2D ortho + near-spherical 3D),
+ * which frames by bounding *sphere*, not the depth-anchored formula.
+ * This is a plain multiplier on the exact sphere fit: 1 = graph exactly
+ * fits, <1 = closer / slight spill. NOTE this is deliberately NOT
+ * `fill`: `fill` is the depth-anchor *floor fraction* (~0.2) and means
+ * something different — using 0.2 as a sphere-fit multiplier would put
+ * the camera at 1/5 the fit distance (inside the cluster) / 5× ortho
+ * zoom. Separate constant, separate semantics.
+ */
+const FALLBACK_FILL = 0.8;
+
 export interface OrientAndFrameOptions {
   hiddenIds?: Set<string>;
   edges?: EngineEdge[];
@@ -231,7 +243,7 @@ export function useOrientAndFrame(
 
       if (camera instanceof THREE.OrthographicCamera) {
         const minPx = Math.min(size.width, size.height);
-        const zoom = minPx / (2 * radius * fill);
+        const zoom = minPx / (2 * radius * FALLBACK_FILL);
         startTween(
           {
             position: [center.x, center.y, camera.position.z],
@@ -247,7 +259,7 @@ export function useOrientAndFrame(
       const hFov = 2 * Math.atan(Math.tan(vFov / 2) * cam.aspect);
       const dist =
         Math.max(radius / Math.sin(vFov / 2), radius / Math.sin(hFov / 2)) *
-        fill;
+        FALLBACK_FILL;
       const dir = cam.position.clone();
       if (controls) dir.sub(controls.target);
       if (dir.lengthSq() < 1e-6) dir.set(0, 0, 1);
@@ -262,7 +274,7 @@ export function useOrientAndFrame(
         camera.zoom
       );
     },
-    [camera, controls, size, fill, startTween]
+    [camera, controls, size, startTween]
   );
 
   const run = useCallback(

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -43,7 +43,7 @@ const TWEEN_MS = 450;
  * user's stated ideal: graph fills the view, the outermost ~15% off
  * screen). Lower = closer. This is the single first-load zoom knob.
  */
-const DEFAULT_FILL = 0.2;
+const DEFAULT_FILL = 0;
 
 export interface OrientAndFrameOptions {
   hiddenIds?: Set<string>;

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -38,12 +38,16 @@ import {
 /** Tween duration — long enough to track the swing, short enough not to drag. */
 const TWEEN_MS = 450;
 /**
- * Default overscan: multiplier on the face-on fit distance. <1 pulls the
- * camera closer so the graph overfills and spills past the edges (the
- * user's stated ideal: graph fills the view, the outermost ~15% off
- * screen). Lower = closer. This is the single first-load zoom knob.
+ * Viewport-aware minimum-distance floor (see orientView's `fill` doc).
+ * The first-load framing is depth-anchored — the camera stands at the
+ * cluster's near face, which is the tight, fills-the-viewport look the
+ * user picked (it's what the old literal fill=0 produced, now made
+ * non-degenerate). This value only guards the pathological case: a flat
+ * or tiny cluster whose depth anchor → 0; then the camera is held at
+ * 0.2× the exact face-on fit instead of collapsing into a node. Normal
+ * graphs never hit the floor, so this knob doesn't affect their look.
  */
-const DEFAULT_FILL = 0;
+const DEFAULT_FILL = 0.2;
 
 export interface OrientAndFrameOptions {
   hiddenIds?: Set<string>;

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -1,0 +1,318 @@
+/**
+ * orientAndFrame — the reusable camera action.
+ *
+ * One verb, two callers: first-load fires `orient()` once as a "fake
+ * zoom-extents" (task #27); a double-click fires `focus(id)` on the
+ * clicked node (task #28). Both rotate the camera to face the graph's
+ * broad face (pcaFrame + orientView) and ease into the new pose.
+ *
+ * Why a hook and not a helper: the pose math is pure (orientView, tested
+ * separately), but the *action* needs live three state (camera, drei
+ * controls, viewport) and owns a tween loop that must cancel the instant
+ * the user grabs the controls. That all lives here.
+ *
+ * Decisions baked in (tasks #29/#30, user-confirmed):
+ *  - Hybrid focus: orientation axes come from the whole visible graph
+ *    (stable angle) while the framed extent is the clicked node's
+ *    1-hop neighbourhood (tightens onto the region). The clicked node
+ *    becomes the centred, nearest point with the bulk behind it.
+ *  - Tweened for both: even first-load eases in (consistent motion),
+ *    ~0.45s easeInOutCubic, cancellable on any controls interaction.
+ *  - Near-spherical / 2D: no meaningful broad face → don't rotate, just
+ *    reframe along the current view direction (deterministic, no jitter).
+ *
+ * @verified 726f5d45
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { EngineNode, EngineEdge, Projection } from '../types';
+import { pcaFrame } from './pcaFrame';
+import {
+  orientedPerspectiveView,
+  isNearSpherical,
+  type CameraPose,
+} from './orientView';
+
+/** Tween duration — long enough to track the swing, short enough not to drag. */
+const TWEEN_MS = 450;
+/** Default overscan: graph fills the view, ~15% spilling off (user's ideal). */
+const DEFAULT_FILL = 0.82;
+
+export interface OrientAndFrameOptions {
+  hiddenIds?: Set<string>;
+  edges?: EngineEdge[];
+  projection?: Projection;
+  /** Overscan factor (<1 = closer / more spill). Defaults to DEFAULT_FILL. */
+  fill?: number;
+}
+
+/** The reusable camera action: whole-graph orient, or focus on a node.  @verified 726f5d45 */
+export interface OrientAndFrame {
+  /** Whole-graph orient — first-load fake-zoom-extents / fit view. */
+  orient(): void;
+  /** Focus orient on a node id — double-click target. */
+  focus(nodeId: string): void;
+}
+
+type Vec3T = [number, number, number];
+
+const easeInOutCubic = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+interface Tween {
+  fromPos: THREE.Vector3;
+  toPos: THREE.Vector3;
+  fromTarget: THREE.Vector3;
+  toTarget: THREE.Vector3;
+  fromZoom: number;
+  toZoom: number;
+  start: number;
+}
+
+/**
+ * Build the action. The hook owns a single tween loop driven off
+ * useFrame; it invalidates the demand loop while a tween is live and
+ * stops dead the moment OrbitControls emits `start` (user grabbed it).
+ *
+ * @verified 726f5d45
+ */
+export function useOrientAndFrame(
+  positionsRef: React.MutableRefObject<Float32Array | null>,
+  nodes: EngineNode[],
+  opts: OrientAndFrameOptions = {}
+): OrientAndFrame {
+  const camera = useThree((s) => s.camera);
+  const controls = useThree((s) => s.controls) as
+    | (THREE.EventDispatcher & {
+        target: THREE.Vector3;
+        update: () => void;
+      })
+    | null;
+  const size = useThree((s) => s.size);
+  const invalidate = useThree((s) => s.invalidate);
+
+  const { hiddenIds, edges, projection = '3D', fill = DEFAULT_FILL } = opts;
+
+  // 1-hop adjacency for Hybrid focus extents. Rebuilt only when the edge
+  // set changes; a focus click reads it without touching the sim.
+  const adjacency = useMemo(() => {
+    const adj = new Map<string, Set<string>>();
+    if (!edges) return adj;
+    for (const e of edges) {
+      (adj.get(e.from) ?? adj.set(e.from, new Set()).get(e.from)!).add(e.to);
+      (adj.get(e.to) ?? adj.set(e.to, new Set()).get(e.to)!).add(e.from);
+    }
+    return adj;
+  }, [edges]);
+
+  const tweenRef = useRef<Tween | null>(null);
+
+  // Cancel an in-flight tween the instant the user touches the controls,
+  // and whenever a new orient supersedes it. drei's controls emit a
+  // 'start' event on the first interaction of a gesture.
+  useEffect(() => {
+    if (!controls) return;
+    const cancel = () => {
+      tweenRef.current = null;
+    };
+    controls.addEventListener('start', cancel);
+    return () => controls.removeEventListener('start', cancel);
+  }, [controls]);
+
+  // Indices of nodes that are actually visible (drive orientation PCA).
+  const visibleIndices = useCallback((): number[] => {
+    const has = !!hiddenIds && hiddenIds.size > 0;
+    const out: number[] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      if (has && hiddenIds!.has(nodes[i].id)) continue;
+      out.push(i);
+    }
+    return out;
+  }, [nodes, hiddenIds]);
+
+  // Translate a target pose into a tween from the camera's current pose.
+  const startTween = useCallback(
+    (pose: CameraPose, zoom: number) => {
+      if (!controls) {
+        // No controls yet (early first-load) — snap; the tween loop has
+        // nothing to lerp the target against. Rare; caller retries.
+        camera.position.set(...pose.position);
+        camera.up.set(...pose.up);
+        camera.lookAt(...pose.target);
+        if (camera instanceof THREE.OrthographicCamera) camera.zoom = zoom;
+        camera.updateProjectionMatrix();
+        invalidate();
+        return;
+      }
+      // up changes the lookAt basis; tweening it fights the position
+      // lerp. Set it once up-front — the roll delta is small and the
+      // position/target ease carries the visible motion.
+      camera.up.set(...pose.up);
+      tweenRef.current = {
+        fromPos: camera.position.clone(),
+        toPos: new THREE.Vector3(...pose.position),
+        fromTarget: controls.target.clone(),
+        toTarget: new THREE.Vector3(...pose.target),
+        fromZoom: camera.zoom,
+        toZoom: zoom,
+        start: performance.now(),
+      };
+      invalidate();
+    },
+    [camera, controls, invalidate]
+  );
+
+  // Frame-only fallback (2D ortho, or a near-spherical 3D blob): don't
+  // rotate — keep the current view direction, just re-fit distance/zoom
+  // to the extent set's bounding sphere along that direction.
+  const frameAlongCurrentDir = useCallback(
+    (extentIdx: number[], positions: Float32Array): void => {
+      const min = new THREE.Vector3(Infinity, Infinity, Infinity);
+      const max = new THREE.Vector3(-Infinity, -Infinity, -Infinity);
+      for (const i of extentIdx) {
+        const x = positions[i * 3];
+        const y = positions[i * 3 + 1];
+        const z = positions[i * 3 + 2];
+        min.min(new THREE.Vector3(x, y, z));
+        max.max(new THREE.Vector3(x, y, z));
+      }
+      if (!Number.isFinite(min.x)) return;
+      const center = min.clone().add(max).multiplyScalar(0.5);
+      const radius = Math.max(0.5 * min.distanceTo(max), 1);
+
+      if (camera instanceof THREE.OrthographicCamera) {
+        const minPx = Math.min(size.width, size.height);
+        const zoom = minPx / (2 * radius * fill);
+        startTween(
+          {
+            position: [center.x, center.y, camera.position.z],
+            target: [center.x, center.y, 0],
+            up: [camera.up.x, camera.up.y, camera.up.z],
+          },
+          zoom
+        );
+        return;
+      }
+      const cam = camera as THREE.PerspectiveCamera;
+      const vFov = (cam.fov * Math.PI) / 180;
+      const hFov = 2 * Math.atan(Math.tan(vFov / 2) * cam.aspect);
+      const dist =
+        Math.max(radius / Math.sin(vFov / 2), radius / Math.sin(hFov / 2)) *
+        fill;
+      const dir = cam.position.clone();
+      if (controls) dir.sub(controls.target);
+      if (dir.lengthSq() < 1e-6) dir.set(0, 0, 1);
+      dir.normalize();
+      const pos = center.clone().addScaledVector(dir, dist);
+      startTween(
+        {
+          position: [pos.x, pos.y, pos.z],
+          target: [center.x, center.y, center.z],
+          up: [camera.up.x, camera.up.y, camera.up.z],
+        },
+        camera.zoom
+      );
+    },
+    [camera, controls, size, fill, startTween]
+  );
+
+  const run = useCallback(
+    (focusNodeId?: string): void => {
+      const positions = positionsRef.current;
+      if (!positions) return;
+      const orientIdx = visibleIndices();
+      if (orientIdx.length === 0) return;
+
+      // Extent set: focus → clicked node + its 1-hop neighbours (Hybrid);
+      // whole-graph → the visible set itself.
+      let extentIdx = orientIdx;
+      let focusPoint: Vec3T | undefined;
+      if (focusNodeId) {
+        const idById = new Map<string, number>();
+        for (const i of orientIdx) idById.set(nodes[i].id, i);
+        const fi = idById.get(focusNodeId);
+        if (fi != null) {
+          focusPoint = [
+            positions[fi * 3],
+            positions[fi * 3 + 1],
+            positions[fi * 3 + 2],
+          ];
+          const set = new Set<number>([fi]);
+          for (const nid of adjacency.get(focusNodeId) ?? []) {
+            const ni = idById.get(nid);
+            if (ni != null) set.add(ni);
+          }
+          extentIdx = [...set];
+        }
+      }
+
+      // 2D is z-flat: no broad face to find — frame only, never rotate
+      // (rotating an ortho/pan view breaks its semantics).
+      if (projection === '2D' || camera instanceof THREE.OrthographicCamera) {
+        frameAlongCurrentDir(extentIdx, positions);
+        return;
+      }
+
+      const frame = pcaFrame(positions, orientIdx, extentIdx);
+      if (isNearSpherical(frame)) {
+        // Ball-shaped: eigenvectors jitter between calls → don't rotate.
+        frameAlongCurrentDir(extentIdx, positions);
+        return;
+      }
+
+      const cam = camera as THREE.PerspectiveCamera;
+      const currentOffset: Vec3T = [
+        camera.position.x - frame.center[0],
+        camera.position.y - frame.center[1],
+        camera.position.z - frame.center[2],
+      ];
+      const pose = orientedPerspectiveView(frame, {
+        fovDeg: cam.fov,
+        aspect: cam.aspect,
+        fill,
+        currentOffset,
+        focusPoint,
+      });
+      startTween(pose, camera.zoom);
+    },
+    [
+      positionsRef,
+      nodes,
+      adjacency,
+      visibleIndices,
+      projection,
+      camera,
+      fill,
+      frameAlongCurrentDir,
+      startTween,
+    ]
+  );
+
+  useFrame(() => {
+    const tw = tweenRef.current;
+    if (!tw) return;
+    const t = Math.min(1, (performance.now() - tw.start) / TWEEN_MS);
+    const e = easeInOutCubic(t);
+    camera.position.lerpVectors(tw.fromPos, tw.toPos, e);
+    if (controls) {
+      controls.target.lerpVectors(tw.fromTarget, tw.toTarget, e);
+    }
+    if (camera instanceof THREE.OrthographicCamera) {
+      camera.zoom = tw.fromZoom + (tw.toZoom - tw.fromZoom) * e;
+    }
+    camera.updateProjectionMatrix();
+    controls?.update();
+    if (t >= 1) tweenRef.current = null;
+    invalidate(); // keep the demand loop pumping until the ease completes
+  });
+
+  return useMemo<OrientAndFrame>(
+    () => ({
+      orient: () => run(),
+      focus: (nodeId: string) => run(nodeId),
+    }),
+    [run]
+  );
+}

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -43,7 +43,7 @@ const TWEEN_MS = 450;
  * user's stated ideal: graph fills the view, the outermost ~15% off
  * screen). Lower = closer. This is the single first-load zoom knob.
  */
-const DEFAULT_FILL = 0.65;
+const DEFAULT_FILL = 0.5;
 
 export interface OrientAndFrameOptions {
   hiddenIds?: Set<string>;

--- a/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
+++ b/web/src/explorers/ForceGraph/scene/useOrientAndFrame.ts
@@ -43,7 +43,7 @@ const TWEEN_MS = 450;
  * user's stated ideal: graph fills the view, the outermost ~15% off
  * screen). Lower = closer. This is the single first-load zoom knob.
  */
-const DEFAULT_FILL = 0.5;
+const DEFAULT_FILL = 0.2;
 
 export interface OrientAndFrameOptions {
   hiddenIds?: Set<string>;

--- a/web/src/explorers/common/VisualControls.tsx
+++ b/web/src/explorers/common/VisualControls.tsx
@@ -1,0 +1,114 @@
+/**
+ * Shared visual-settings controls.
+ *
+ * The Force Graph and Document Explorer panels were drifting apart —
+ * each hand-rolled its own visual section, so a control added to one
+ * (e.g. the lighting toggle) silently skipped the other. This component
+ * owns the visual controls both explorers share, so adding one here adds
+ * it to both. Explorer-specific controls (Force Graph's colour-by,
+ * Document Explorer's documentSize, etc.) stay in their own panels
+ * around this block.
+ *
+ * Presentational + adapter: it takes a normalised value + per-field
+ * callbacks rather than a settings object, so it never has to know
+ * either explorer's settings shape. Each panel maps its own settings to
+ * these props. The markup mirrors the existing row/slider/toggle/select
+ * idiom so the panels stay visually consistent.
+ *
+ * @verified 50606a37
+ */
+
+import React from 'react';
+
+export interface VisualControlsValue {
+  showNodeLabels: boolean;
+  nodeSize: number;
+  lighting: 'flat' | 'lit';
+  lightingFollowsProjection: boolean;
+}
+
+export interface VisualControlsProps extends VisualControlsValue {
+  nodeSizeRange: { min: number; max: number; step: number };
+  onShowNodeLabels: (v: boolean) => void;
+  onNodeSize: (v: number) => void;
+  onLighting: (v: 'flat' | 'lit') => void;
+  onLightingFollowsProjection: (v: boolean) => void;
+}
+
+const rowCls = 'flex items-center gap-2 text-xs text-card-foreground';
+const valCls =
+  'font-mono text-muted-foreground tabular-nums w-12 text-right text-[10px]';
+
+/** Visual controls shared by every graph explorer.  @verified 50606a37 */
+export const VisualControls: React.FC<VisualControlsProps> = ({
+  showNodeLabels,
+  nodeSize,
+  lighting,
+  lightingFollowsProjection,
+  nodeSizeRange,
+  onShowNodeLabels,
+  onNodeSize,
+  onLighting,
+  onLightingFollowsProjection,
+}) => {
+  return (
+    <>
+      <label className={rowCls}>
+        <span className="flex-1 min-w-0 truncate">Show node labels</span>
+        <span className={valCls}>{showNodeLabels ? 'on' : 'off'}</span>
+        <input
+          type="checkbox"
+          className="ml-auto"
+          checked={showNodeLabels}
+          onChange={(e) => onShowNodeLabels(e.target.checked)}
+        />
+      </label>
+
+      <label
+        className={`${rowCls} ${
+          lightingFollowsProjection ? 'opacity-50' : ''
+        }`}
+      >
+        <span className="flex-1 min-w-0 truncate">
+          {lightingFollowsProjection ? 'Shading (follows view)' : 'Shading'}
+        </span>
+        <select
+          className="flex-[2] bg-card border border-border rounded px-1 py-0.5 text-xs"
+          value={lighting}
+          disabled={lightingFollowsProjection}
+          onChange={(e) => onLighting(e.target.value as 'flat' | 'lit')}
+        >
+          <option value="flat">Flat (two-tone)</option>
+          <option value="lit">Lit (3D light)</option>
+        </select>
+      </label>
+
+      <label className={rowCls}>
+        <span className="flex-1 min-w-0 truncate">Shading follows view</span>
+        <span className={valCls}>
+          {lightingFollowsProjection ? 'on' : 'off'}
+        </span>
+        <input
+          type="checkbox"
+          className="ml-auto"
+          checked={lightingFollowsProjection}
+          onChange={(e) => onLightingFollowsProjection(e.target.checked)}
+        />
+      </label>
+
+      <label className={rowCls}>
+        <span className="flex-1 min-w-0 truncate">Node size</span>
+        <span className={valCls}>{nodeSize.toFixed(2)}</span>
+        <input
+          type="range"
+          className="flex-[2]"
+          min={nodeSizeRange.min}
+          max={nodeSizeRange.max}
+          step={nodeSizeRange.step}
+          value={nodeSize}
+          onChange={(e) => onNodeSize(parseFloat(e.target.value))}
+        />
+      </label>
+    </>
+  );
+};

--- a/web/src/explorers/common/index.ts
+++ b/web/src/explorers/common/index.ts
@@ -8,6 +8,11 @@ export { EdgeInfoBox, type EdgeInfoBoxProps } from './EdgeInfoBox';
 export { StatsPanel, type StatsPanelProps } from './StatsPanel';
 export { Legend } from './Legend';
 export { PanelStack } from './PanelStack';
+export {
+  VisualControls,
+  type VisualControlsProps,
+  type VisualControlsValue,
+} from './VisualControls';
 export { formatGrounding, getRelationshipTextColor } from './utils';
 export { explorerTheme, type ExplorerTheme } from './styles';
 export {


### PR DESCRIPTION
## Summary

Startup auto-zoom for both graph explorers, converged visual controls, and a reusable PCA "tangent-orient" camera action — plus two bug fixes found along the way.

## What's in it

**Startup framing (the original ask: "I have to zoom every time")**
- Camera auto-frames on **first load only** (0→N transition; Add Adjacent / filter / follow never re-arm — preserves the PR #371 anti-"sproing" behaviour for the camera).
- Waits ~2s for physics to settle, then eases in (tweened).

**PCA tangent-orient action (`pcaFrame` → `orientView` → `useOrientAndFrame`)**
- Rotates the camera to face the graph's broad face (covariance eigen-decomposition; look along the minor axis). Pure math is unit-tested (30 scene tests).
- **Depth-anchored framing + viewport-aware floor + `pullback` knob**: closeness is the cluster's near face, with a graph-scaled floor so flat/tiny graphs can't collapse the camera into a node. `pullback` is the single tuning knob; per-explorer (Force Graph default, Document Explorer 0.45 — larger glyphs).
- World-Y up (no roll-snap / tilted orbit pole).
- **Double-click a node** → same whole-graph frame, re-aimed so the node is centred/nearest with the bulk swung behind it. Whole-graph (not local-neighbourhood) so successive clicks don't creep closer.
- Lives in the shared `Scene` → Force Graph **and** Document Explorer both get it.

**Explorer convergence**
- Shared `VisualControls` component; Document Explorer gains type-differentiated platonic shapes + lighting parity. Anti-divergence.

**Bug fixes**
- Edges/arrows no longer frustum-culled when the camera wheels in close (stale origin bounding sphere on CPU-animated batched geometry → `frustumCulled={false}`).

## Follow-ups (not in this PR)

- Issue #375 — visual-narration camera spline-path hop (the retained 1-hop adjacency in `useOrientAndFrame` is its substrate).
- Live verification still owed: tween-cancel after 2D↔3D switch; Document Explorer pullback value; double-click consistency.

## Testing

- 30 ForceGraph scene unit tests green (`pcaFrame`, `orientView`, plus existing positions/shapes/facetedMaterial).
- `tsc` + `eslint` clean except 2 **pre-existing** errors (`BlockPalette.tsx`, `dataTransformer.ts`) unrelated to this branch.
- Integration paths (tween/cancel, dblclick, per-explorer wiring) are glue — not unit-tested anywhere in the codebase; verified by live use.
