### PR TITLE
feat: uniform DB-driven provider configuration contract (ADR-801)

### DIFF
--- a/.claude/ways/kg/operator/way.md
+++ b/.claude/ways/kg/operator/way.md
@@ -2,7 +2,7 @@
 pattern: \boperator\b|docker.*kg|container|\.sh.*(start|stop|restart|status)
 commands: operator\.sh|docker\s
 description: operator.sh lifecycle commands for managing knowledge graph containers, configuration, and secrets
-vocabulary: operator container docker start stop restart status init setup deploy upgrade teardown
+vocabulary: operator container docker start stop restart status init setup deploy upgrade teardown llamacpp ollama llama.cpp hot reload migrate migration base_url local inference vulkan rocm
 scope: agent, subagent
 ---
 # Operator Way
@@ -79,6 +79,42 @@ Or directly:
 ./operator.sh garage init        # Initialize Garage buckets
 ./operator.sh garage repair      # Repair Garage state
 ```
+
+## Local Inference Providers (llama.cpp / Ollama)
+
+A local inference server must join the API's docker network — it is
+reached **by service name**, not host loopback (the host firewall drops
+bridge→host traffic, so loopback is unreliable by construction). This is
+the same way the API reaches Postgres/Garage. See ADR-801.
+
+- The compose file lives in the **separate llama.cpp repo**, NOT this
+  repo: it is hardware/host-specific (GPU passthrough) and must never
+  become a persistent container definition here.
+- Join the externally-managed network: `networks: { kg: { external: true,
+  name: knowledge-graph-network } }`.
+- DB `base_url` for the provider = `http://kg-llamacpp:8080/v1`
+  (service name + port), set via the AI Providers UI or config.
+- **AMD GPUs:** use the Vulkan image (`ghcr.io/ggml-org/llama.cpp:
+  server-vulkan`), NOT ROCm — ROCm SIGSEGV crash-loops inside the
+  container. Needs only `/dev/dri`. `group_add` must use **numeric host
+  GIDs** (container `/etc/group` lacks `render`/`video`, so names don't
+  resolve) — re-check the host with `getent group render video`.
+
+Bring up / tear down the inference container from its own repo
+(`docker compose up -d` / `down`); KG only consumes it by URL.
+
+## Gotchas
+
+- **The `kg-api-dev` container does NOT hot-reload Python.** After any
+  edit under `api/`, run `./operator.sh restart api` before testing —
+  otherwise the old code is still serving. (`kg-web-dev` *does*
+  hot-reload via Vite; web edits need no restart.)
+- **Apply pending schema migrations:**
+  ```bash
+  docker exec kg-operator bash -lc '/workspace/operator/database/migrate-db.sh -y'
+  ```
+  `./operator.sh upgrade` also migrates; use the direct command in dev
+  when you only changed `schema/migrations/`.
 
 ## Teardown
 

--- a/api/app/constants.py
+++ b/api/app/constants.py
@@ -131,19 +131,29 @@ COGNITIVE_LEAP_LEVELS: Set[str] = {
 EXTRACTION_PROVIDERS: Set[str] = {
     "openai",      # OpenAI API (GPT-4o, etc.)
     "anthropic",   # Anthropic API (Claude Sonnet, etc.)
+    "openrouter",  # OpenRouter unified gateway to 200+ models (ADR-800)
     "ollama",      # Local inference via Ollama (ADR-042)
+    "llamacpp",    # Local inference via llama.cpp OpenAI-compatible server
     "vllm",        # Local inference via vLLM (ADR-042 Phase 4)
 }
 
-# Providers that require API keys
+# Providers that require API keys.
+#
+# NOTE: This is the set of cloud providers the system knows how to validate a
+# key format for and test on save. It is *not* the authoritative list the web
+# UI renders — the UI derives its provider list dynamically from configured
+# keys and the model catalog (ADR-800). Keep this in sync with the providers
+# handled in api_key_validator and the admin set_api_key test branches.
 API_KEY_PROVIDERS: Set[str] = {
     "openai",
     "anthropic",
+    "openrouter",  # ADR-800: single key, 200+ models via unified gateway
 }
 
 # Local inference providers (no API keys needed)
 LOCAL_PROVIDERS: Set[str] = {
     "ollama",
+    "llamacpp",
     "vllm",
 }
 

--- a/api/app/lib/ai_extraction_config.py
+++ b/api/app/lib/ai_extraction_config.py
@@ -140,17 +140,23 @@ def load_provider_config(provider: str) -> Optional[Dict[str, Any]]:
 
 def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> bool:
     """
-    Save AI extraction configuration to the database.
+    Upsert one provider's AI extraction config (per-provider row, ADR-800 #8).
 
-    Deactivates any existing active config and creates a new one.
+    ON CONFLICT(provider): every optional field is COALESCEd against the
+    stored value, so omitted keys are LEFT ALONE rather than nulled — a
+    partial save (e.g. only base_url) never wipes the rest of the row.
+    `config['active']` (default True) controls the active pointer only:
+    True activates this provider and deactivates the others; False persists
+    config without touching which provider is active.
 
     Args:
-        config: Configuration dict with keys:
-            - provider: "openai" or "anthropic" (required)
-            - model_name: Model identifier (e.g., "gpt-4o", "claude-sonnet-4-20250514")
-            - supports_vision: True/False (optional)
-            - supports_json_mode: True/False (optional)
-            - max_tokens: Maximum token limit (optional)
+        config: Configuration dict. Only `provider` and `model_name` are
+            required (model_name may be "" to seed a not-yet-chosen row).
+            Any of supports_vision, supports_json_mode, max_tokens, base_url,
+            temperature, top_p, gpu_layers, num_threads, thinking_mode,
+            max_concurrent_requests, max_retries that are present are saved;
+            absent ones retain their stored value (or column default on a
+            brand-new row). `active`: bool — activate this provider or not.
         updated_by: User/admin who made the change
 
     Returns:
@@ -180,6 +186,20 @@ def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> b
                         WHERE active = TRUE AND provider <> %s
                     """, (config['provider'],))
 
+                # Partial-save safety (#8): every optional field is COALESCEd
+                # against the stored value, so a caller that omits a field
+                # (Pydantic `exclude_none=True`, or the per-provider config
+                # endpoint sending only base_url) LEAVES IT ALONE rather than
+                # nulling it. This structurally prevents the "activate wipes
+                # base_url" / "save config wipes model" bug class for every
+                # present and future caller — the fix lives at this one layer,
+                # not threaded through each endpoint. Absent fields are passed
+                # as NULL so brand-new rows fall to column defaults
+                # (supports_* , thinking_mode='off', active=TRUE).
+                #
+                # model_name is special: '' is the new-row sentinel (NOT NULL
+                # column) but must never overwrite a real stored model — hence
+                # NULLIF(EXCLUDED.model_name, '').
                 cur.execute("""
                     INSERT INTO kg_api.ai_extraction_config (
                         provider, model_name, supports_vision, supports_json_mode,
@@ -191,27 +211,51 @@ def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> b
                         %s, %s, %s, %s, %s, %s, %s, %s
                     )
                     ON CONFLICT (provider) DO UPDATE SET
-                        model_name = EXCLUDED.model_name,
-                        supports_vision = EXCLUDED.supports_vision,
-                        supports_json_mode = EXCLUDED.supports_json_mode,
-                        max_tokens = EXCLUDED.max_tokens,
+                        model_name = COALESCE(
+                            NULLIF(EXCLUDED.model_name, ''),
+                            kg_api.ai_extraction_config.model_name),
+                        supports_vision = COALESCE(
+                            EXCLUDED.supports_vision,
+                            kg_api.ai_extraction_config.supports_vision),
+                        supports_json_mode = COALESCE(
+                            EXCLUDED.supports_json_mode,
+                            kg_api.ai_extraction_config.supports_json_mode),
+                        max_tokens = COALESCE(
+                            EXCLUDED.max_tokens,
+                            kg_api.ai_extraction_config.max_tokens),
                         updated_by = EXCLUDED.updated_by,
                         active = CASE WHEN %s THEN TRUE
                                       ELSE kg_api.ai_extraction_config.active END,
-                        base_url = EXCLUDED.base_url,
-                        temperature = EXCLUDED.temperature,
-                        top_p = EXCLUDED.top_p,
-                        gpu_layers = EXCLUDED.gpu_layers,
-                        num_threads = EXCLUDED.num_threads,
-                        thinking_mode = EXCLUDED.thinking_mode,
-                        max_concurrent_requests = EXCLUDED.max_concurrent_requests,
-                        max_retries = EXCLUDED.max_retries,
+                        base_url = COALESCE(
+                            EXCLUDED.base_url,
+                            kg_api.ai_extraction_config.base_url),
+                        temperature = COALESCE(
+                            EXCLUDED.temperature,
+                            kg_api.ai_extraction_config.temperature),
+                        top_p = COALESCE(
+                            EXCLUDED.top_p,
+                            kg_api.ai_extraction_config.top_p),
+                        gpu_layers = COALESCE(
+                            EXCLUDED.gpu_layers,
+                            kg_api.ai_extraction_config.gpu_layers),
+                        num_threads = COALESCE(
+                            EXCLUDED.num_threads,
+                            kg_api.ai_extraction_config.num_threads),
+                        thinking_mode = COALESCE(
+                            EXCLUDED.thinking_mode,
+                            kg_api.ai_extraction_config.thinking_mode),
+                        max_concurrent_requests = COALESCE(
+                            EXCLUDED.max_concurrent_requests,
+                            kg_api.ai_extraction_config.max_concurrent_requests),
+                        max_retries = COALESCE(
+                            EXCLUDED.max_retries,
+                            kg_api.ai_extraction_config.max_retries),
                         updated_at = NOW()
                 """, (
                     config['provider'],
                     config['model_name'],
-                    config.get('supports_vision', False),
-                    config.get('supports_json_mode', True),
+                    config.get('supports_vision'),
+                    config.get('supports_json_mode'),
                     config.get('max_tokens'),
                     updated_by,
                     activate,
@@ -220,7 +264,7 @@ def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> b
                     config.get('top_p'),
                     config.get('gpu_layers'),
                     config.get('num_threads'),
-                    config.get('thinking_mode', 'off'),
+                    config.get('thinking_mode'),
                     config.get('max_concurrent_requests'),
                     config.get('max_retries'),
                     activate,

--- a/api/app/lib/ai_extraction_config.py
+++ b/api/app/lib/ai_extraction_config.py
@@ -91,6 +91,53 @@ def load_active_extraction_config() -> Optional[Dict[str, Any]]:
         return None
 
 
+def load_provider_config(provider: str) -> Optional[Dict[str, Any]]:
+    """
+    Load a specific provider's saved config row, regardless of whether it is
+    the active provider (#8 — DB-backed per-provider config).
+
+    Lets get_provider() resolve base_url / reasoning params for a provider
+    that is configured but not currently active (e.g. a catalog refresh /
+    "Get models" against a not-yet-activated local provider).
+    """
+    from .age_client import AGEClient
+
+    try:
+        client = AGEClient()
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT
+                        id, provider, model_name, supports_vision,
+                        supports_json_mode, max_tokens,
+                        created_at, updated_at, updated_by, active,
+                        base_url, temperature, top_p, gpu_layers, num_threads,
+                        thinking_mode, max_concurrent_requests, max_retries
+                    FROM kg_api.ai_extraction_config
+                    WHERE provider = %s
+                    LIMIT 1
+                """, (provider,))
+                row = cur.fetchone()
+                if not row:
+                    return None
+                return {
+                    "id": row[0], "provider": row[1], "model_name": row[2],
+                    "supports_vision": row[3], "supports_json_mode": row[4],
+                    "max_tokens": row[5], "created_at": row[6],
+                    "updated_at": row[7], "updated_by": row[8], "active": row[9],
+                    "base_url": row[10], "temperature": row[11], "top_p": row[12],
+                    "gpu_layers": row[13], "num_threads": row[14],
+                    "thinking_mode": row[15], "max_concurrent_requests": row[16],
+                    "max_retries": row[17],
+                }
+        finally:
+            client.pool.putconn(conn)
+    except Exception as e:
+        logger.error(f"Failed to load provider config for {provider}: {e}")
+        return None
+
+
 def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> bool:
     """
     Save AI extraction configuration to the database.
@@ -116,18 +163,23 @@ def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> b
         conn = client.pool.getconn()
 
         try:
+            # Per-provider upsert (migration 062: provider is UNIQUE).
+            # `activate` (default True — backward compat with callers that
+            # save+activate in one step) controls whether this provider
+            # becomes the single live one. activate=False persists the
+            # provider's config without changing which provider is active.
+            activate = config.get('active', True)
+
             with conn.cursor() as cur:
-                # Start transaction
                 cur.execute("BEGIN")
 
-                # Deactivate all existing configs
-                cur.execute("""
-                    UPDATE kg_api.ai_extraction_config
-                    SET active = FALSE
-                    WHERE active = TRUE
-                """)
+                if activate:
+                    cur.execute("""
+                        UPDATE kg_api.ai_extraction_config
+                        SET active = FALSE
+                        WHERE active = TRUE AND provider <> %s
+                    """, (config['provider'],))
 
-                # Insert new config as active
                 cur.execute("""
                     INSERT INTO kg_api.ai_extraction_config (
                         provider, model_name, supports_vision, supports_json_mode,
@@ -135,9 +187,26 @@ def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> b
                         base_url, temperature, top_p, gpu_layers, num_threads,
                         thinking_mode, max_concurrent_requests, max_retries
                     ) VALUES (
-                        %s, %s, %s, %s, %s, %s, TRUE,
+                        %s, %s, %s, %s, %s, %s, %s,
                         %s, %s, %s, %s, %s, %s, %s, %s
                     )
+                    ON CONFLICT (provider) DO UPDATE SET
+                        model_name = EXCLUDED.model_name,
+                        supports_vision = EXCLUDED.supports_vision,
+                        supports_json_mode = EXCLUDED.supports_json_mode,
+                        max_tokens = EXCLUDED.max_tokens,
+                        updated_by = EXCLUDED.updated_by,
+                        active = CASE WHEN %s THEN TRUE
+                                      ELSE kg_api.ai_extraction_config.active END,
+                        base_url = EXCLUDED.base_url,
+                        temperature = EXCLUDED.temperature,
+                        top_p = EXCLUDED.top_p,
+                        gpu_layers = EXCLUDED.gpu_layers,
+                        num_threads = EXCLUDED.num_threads,
+                        thinking_mode = EXCLUDED.thinking_mode,
+                        max_concurrent_requests = EXCLUDED.max_concurrent_requests,
+                        max_retries = EXCLUDED.max_retries,
+                        updated_at = NOW()
                 """, (
                     config['provider'],
                     config['model_name'],
@@ -145,6 +214,7 @@ def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> b
                     config.get('supports_json_mode', True),
                     config.get('max_tokens'),
                     updated_by,
+                    activate,
                     config.get('base_url'),
                     config.get('temperature'),
                     config.get('top_p'),
@@ -152,10 +222,10 @@ def save_extraction_config(config: Dict[str, Any], updated_by: str = "api") -> b
                     config.get('num_threads'),
                     config.get('thinking_mode', 'off'),
                     config.get('max_concurrent_requests'),
-                    config.get('max_retries')
+                    config.get('max_retries'),
+                    activate,
                 ))
 
-                # Commit transaction
                 cur.execute("COMMIT")
 
                 logger.info(f"✅ Saved AI extraction config: {config['provider']} / {config.get('model_name', 'N/A')}")

--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -922,32 +922,61 @@ class AnthropicProvider(AIProvider):
         return AVAILABLE_MODELS["anthropic"]
 
     def fetch_model_catalog(self) -> List[Dict[str, Any]]:
-        """Return hardcoded Anthropic model catalog with known pricing (ADR-800)."""
-        models = [
-            ("claude-sonnet-4-20250514", "Claude Sonnet 4", 200000, True, 3.00, 15.00),
-            ("claude-3-5-sonnet-20241022", "Claude 3.5 Sonnet", 200000, True, 3.00, 15.00),
-            ("claude-3-opus-20240229", "Claude 3 Opus", 200000, True, 15.00, 75.00),
-            ("claude-3-sonnet-20240229", "Claude 3 Sonnet", 200000, True, 3.00, 15.00),
-            ("claude-3-haiku-20240307", "Claude 3 Haiku", 200000, True, 0.25, 1.25),
-        ]
-        return [
-            {
-                "provider": "anthropic",
-                "model_id": mid,
-                "display_name": name,
-                "category": "extraction",
-                "context_length": ctx,
-                "supports_vision": vision,
-                "supports_json_mode": True,
-                "supports_tool_use": True,
-                "supports_streaming": True,
-                "price_prompt_per_m": prompt_cost,
-                "price_completion_per_m": comp_cost,
-                "upstream_provider": None,
-                "raw_metadata": None,
-            }
-            for mid, name, ctx, vision, prompt_cost, comp_cost in models
-        ]
+        """Fetch models from the Anthropic API and return catalog entries (ADR-800).
+
+        Enumerates live via the SDK's models.list() — the same dynamic
+        pattern OpenAIProvider uses — rather than a hardcoded list, so new
+        Claude generations (4.x and beyond) appear without a code change.
+        Hardcoded model lists are exactly the drift ADR-800 removes.
+        """
+        # Pricing (USD per 1M tokens) is not exposed by the API; key by a
+        # stable family prefix so dated model ids still match. Unknown models
+        # still surface (price None) — visibility beats omission.
+        known_pricing = {
+            "claude-opus-4": (15.00, 75.00),
+            "claude-sonnet-4": (3.00, 15.00),
+            "claude-haiku-4": (1.00, 5.00),
+            "claude-3-5-sonnet": (3.00, 15.00),
+            "claude-3-5-haiku": (0.80, 4.00),
+            "claude-3-opus": (15.00, 75.00),
+            "claude-3-sonnet": (3.00, 15.00),
+            "claude-3-haiku": (0.25, 1.25),
+        }
+
+        def _price(mid: str):
+            for prefix, p in known_pricing.items():
+                if mid.startswith(prefix):
+                    return p
+            return (None, None)
+
+        entries: List[Dict[str, Any]] = []
+        try:
+            models_response = self.client.models.list(limit=1000)
+            for model in models_response.data:
+                mid = model.id
+                prompt_cost, comp_cost = _price(mid)
+                entries.append({
+                    "provider": "anthropic",
+                    "model_id": mid,
+                    "display_name": getattr(model, "display_name", None) or mid,
+                    "category": "extraction",  # Anthropic serves no embeddings
+                    "context_length": 200000,
+                    "supports_vision": True,
+                    "supports_json_mode": True,
+                    "supports_tool_use": True,
+                    "supports_streaming": True,
+                    "price_prompt_per_m": prompt_cost,
+                    "price_completion_per_m": comp_cost,
+                    "upstream_provider": None,
+                    "raw_metadata": {
+                        "id": mid,
+                        "created_at": str(getattr(model, "created_at", "")) or None,
+                    },
+                })
+        except Exception as e:
+            logger.warning(f"Failed to fetch Anthropic model catalog: {e}")
+
+        return entries
 
 
 class OpenRouterProvider(AIProvider):

--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -902,14 +902,13 @@ class AnthropicProvider(AIProvider):
         return self.extraction_model
 
     def validate_api_key(self) -> bool:
-        """Validate Anthropic API key by making a simple API call"""
+        """Validate Anthropic API key model-agnostically (ADR-800).
+
+        Lists models rather than calling messages.create() with a specific
+        model — a stale extraction_model previously 404'd valid keys.
+        """
         try:
-            # Try to create a minimal message (lightweight check)
-            self.client.messages.create(
-                model=self.extraction_model,
-                max_tokens=10,
-                messages=[{"role": "user", "content": "test"}]
-            )
+            self.client.models.list(limit=1)
             return True
         except Exception as e:
             logger.error(f"Anthropic API key validation failed: {e}")
@@ -1796,6 +1795,153 @@ def get_embedding_provider() -> Optional[AIProvider]:
         return None
 
 
+class LlamaCppProvider(OpenAIProvider):
+    """llama.cpp local-server provider (OpenAI-compatible).
+
+    Talks to a llama.cpp ``llama-server`` via its OpenAI-compatible API
+    (default http://localhost:8080/v1). It is local, so no API key is
+    required — "validation" is a connectivity check. Concept extraction,
+    translation and vision logic are inherited from OpenAIProvider; only
+    construction, identity, validation and model enumeration differ. The
+    embedder stays separate (delegated), as with every reasoning provider.
+    """
+
+    DEFAULT_BASE_URL = "http://localhost:8080/v1"
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        extraction_model: Optional[str] = None,
+        embedding_provider: Optional[AIProvider] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ):
+        from openai import OpenAI
+
+        self.base_url = base_url or os.getenv("LLAMACPP_BASE_URL", self.DEFAULT_BASE_URL)
+        # llama.cpp ignores the key, but the OpenAI SDK requires a non-empty string.
+        self.api_key = "llama.cpp-local"
+        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url, timeout=120.0)
+
+        self.extraction_model = extraction_model or os.getenv("LLAMACPP_EXTRACTION_MODEL", "")
+        self.max_tokens = max_tokens
+        self.temperature = 0.1 if temperature is None else temperature
+
+        # Embeddings are always a separate provider — never served from here.
+        self.embedding_provider = embedding_provider
+        self.embedding_model = ""
+        logger.info(f"llama.cpp client configured at {self.base_url}")
+
+    def get_provider_name(self) -> str:
+        return "llama.cpp"
+
+    def validate_api_key(self) -> bool:
+        """Connectivity check (local server, no key) — list models."""
+        try:
+            self.client.models.list()
+            return True
+        except Exception as e:
+            logger.error(f"llama.cpp connectivity check failed at {self.base_url}: {e}")
+            return False
+
+    def list_available_models(self) -> Dict[str, List[str]]:
+        try:
+            resp = self.client.models.list()
+            return {"extraction": [m.id for m in resp.data], "embedding": []}
+        except Exception:
+            return {"extraction": [], "embedding": []}
+
+    def fetch_model_catalog(self) -> List[Dict[str, Any]]:
+        """Enumerate models the running llama.cpp server actually exposes."""
+        entries: List[Dict[str, Any]] = []
+        try:
+            resp = self.client.models.list()
+            for m in resp.data:
+                entries.append({
+                    "provider": "llamacpp",
+                    "model_id": m.id,
+                    "display_name": m.id,
+                    "category": "extraction",
+                    "context_length": None,
+                    "max_completion_tokens": None,
+                    "supports_vision": False,
+                    "supports_json_mode": True,
+                    "supports_tool_use": False,
+                    "supports_streaming": True,
+                    "price_prompt_per_m": 0,
+                    "price_completion_per_m": 0,
+                    "price_cache_read_per_m": None,
+                    "upstream_provider": None,
+                    "raw_metadata": m.model_dump() if hasattr(m, "model_dump") else {},
+                })
+        except Exception as e:
+            logger.warning(f"Failed to fetch llama.cpp model catalog: {e}")
+        return entries
+
+
+def validate_provider_key(provider: str, api_key: str) -> tuple[bool, Optional[str]]:
+    """
+    Validate a candidate API key for a provider, model-agnostically (ADR-800).
+
+    This is the single source of truth for "does this key work" — the admin
+    key route and the startup validator both delegate here rather than
+    carrying their own (previously hardcoded-model) logic. Each branch uses
+    an authenticated endpoint that does NOT depend on a specific model name,
+    so a stale model can never fail a valid key.
+
+    Args:
+        provider: 'openai', 'anthropic', or 'openrouter'
+        api_key: The candidate key to test (not yet stored)
+
+    Returns:
+        (True, None) if the key authenticates, else (False, error_message).
+        Never raises.
+    """
+    try:
+        if provider == "openai":
+            from openai import OpenAI
+            OpenAI(api_key=api_key, timeout=30.0).models.list()
+            return (True, None)
+
+        if provider == "anthropic":
+            from anthropic import Anthropic
+            # Models API authenticates without a model name (SDK >= 0.40).
+            Anthropic(api_key=api_key, timeout=30.0).models.list(limit=1)
+            return (True, None)
+
+        if provider == "openrouter":
+            import requests
+            # OpenRouter's /models is unauthenticated; /key is the real
+            # authenticated check (zero token cost, 401 on a bad key).
+            resp = requests.get(
+                f"{OpenRouterProvider.OPENROUTER_BASE_URL}/key",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                return (True, None)
+            if resp.status_code in (401, 403):
+                return (False, f"Authentication failed: HTTP {resp.status_code}")
+            if resp.status_code == 429:
+                logger.warning("OpenRouter rate limit hit during validation")
+                return (True, None)
+            return (False, f"Validation error: HTTP {resp.status_code}")
+
+        if provider == "llamacpp":
+            # Local server — no key. "Validation" is a connectivity check
+            # against the configured base_url (lists models).
+            ok = LlamaCppProvider().validate_api_key()
+            return (True, None) if ok else (
+                False,
+                f"Cannot reach llama.cpp server at {LlamaCppProvider().base_url}",
+            )
+
+        return (False, f"No validation available for provider '{provider}'")
+
+    except Exception as e:
+        return (False, f"Validation error: {str(e)}")
+
+
 def get_provider(provider_name: Optional[str] = None) -> AIProvider:
     """
     Factory function to get the configured AI provider (ADR-041).
@@ -1850,9 +1996,18 @@ def get_provider(provider_name: Optional[str] = None) -> AIProvider:
         logger.debug(f"[DEV MODE] Using .env configuration: provider={provider_name}")
     else:
         # Production mode: Load from database
-        from .ai_extraction_config import load_active_extraction_config
+        from .ai_extraction_config import load_active_extraction_config, load_provider_config
 
         config = load_active_extraction_config()
+
+        # #8: if a specific provider is requested and it isn't the active one,
+        # use THAT provider's saved config row (base_url / reasoning params)
+        # so "Get models" / refresh works for a configured-but-not-active
+        # provider instead of falling back to defaults (the localhost:8080 bug).
+        if provider_name and (not config or config.get('provider') != provider_name):
+            pc = load_provider_config(provider_name)
+            if pc:
+                config = pc
 
         if not config:
             raise RuntimeError(
@@ -1911,12 +2066,29 @@ def get_provider(provider_name: Optional[str] = None) -> AIProvider:
             embedding_provider=embedding_provider,
             max_tokens=max_tokens,
         )
+    elif provider_name == "llamacpp":
+        if is_development_mode():
+            base_url = os.getenv("LLAMACPP_BASE_URL", LlamaCppProvider.DEFAULT_BASE_URL)
+            temperature = float(os.getenv("LLAMACPP_TEMPERATURE", "0.1"))
+        else:
+            # DB is the source of truth for the API container — base_url and
+            # reasoning params come from the (per-provider) config, not env.
+            base_url = config.get('base_url') or LlamaCppProvider.DEFAULT_BASE_URL
+            temperature = config.get('temperature')
+            temperature = 0.1 if temperature is None else temperature
+        return LlamaCppProvider(
+            base_url=base_url,
+            extraction_model=extraction_model,
+            embedding_provider=embedding_provider,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
     elif provider_name == "mock":
         from .mock_ai_provider import MockAIProvider
         mock_mode = os.getenv("MOCK_MODE", "default")
         return MockAIProvider(mode=mock_mode)
     else:
-        raise ValueError(f"Unknown AI provider: {provider_name}. Use 'openai', 'anthropic', 'ollama', 'openrouter', or 'mock'")
+        raise ValueError(f"Unknown AI provider: {provider_name}. Use 'openai', 'anthropic', 'ollama', 'openrouter', 'llamacpp', or 'mock'")
 
 
 # Model configurations for reference

--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -507,16 +507,26 @@ class OpenAIProvider(AIProvider):
             "text-embedding-ada-002": (0.10, None),
         }
 
+        # Denylist KNOWN non-extraction families rather than allowlisting a
+        # few chat ones — so new chat/reasoning families (o3, o4, gpt-5, …)
+        # appear with no code change (ADR-800: no hardcoded model drift).
+        # models.list() also returns audio/image/moderation/legacy-base
+        # models that cannot be used for concept extraction.
+        non_extraction = (
+            "whisper", "tts", "dall-e", "dalle", "moderation",
+            "image", "audio", "realtime", "transcribe",
+            "babbage", "davinci",
+        )
+
         entries = []
         try:
             models_response = self.client.models.list()
             for model in models_response.data:
                 mid = model.id
-                # Filter to models we care about
-                is_extraction = any(x in mid for x in ["gpt-4", "gpt-3.5", "o1"])
                 is_embedding = "embedding" in mid
-
-                if not is_extraction and not is_embedding:
+                # Embeddings are a real category; everything that isn't a
+                # known non-extraction model is treated as extraction-capable.
+                if not is_embedding and any(x in mid for x in non_extraction):
                     continue
 
                 category = "embedding" if is_embedding else "extraction"

--- a/api/app/lib/api_key_validator.py
+++ b/api/app/lib/api_key_validator.py
@@ -12,78 +12,27 @@ from datetime import datetime
 logger = logging.getLogger(__name__)
 
 
+# Key validation lives in the connector layer (ADR-800). These thin wrappers
+# preserve the historical function names while delegating to the single
+# source of truth so there is exactly one place that knows how to
+# authenticate each provider, model-agnostically.
+
 def validate_openai_key(api_key: str) -> tuple[bool, Optional[str]]:
-    """
-    Validate OpenAI API key by making a minimal API call.
-
-    Args:
-        api_key: The OpenAI API key to validate
-
-    Returns:
-        Tuple of (is_valid, error_message)
-        - (True, None) if key is valid
-        - (False, error_message) if key is invalid
-    """
-    try:
-        import openai
-        client = openai.OpenAI(api_key=api_key)
-
-        # Make minimal API call (1 token)
-        client.chat.completions.create(
-            model="gpt-4o-mini",
-            max_tokens=1,
-            messages=[{"role": "user", "content": "test"}]
-        )
-
-        return (True, None)
-
-    except openai.AuthenticationError as e:
-        return (False, f"Authentication failed: {str(e)}")
-    except openai.PermissionDeniedError as e:
-        return (False, f"Permission denied: {str(e)}")
-    except openai.RateLimitError as e:
-        # Rate limit means the key is valid, just throttled
-        logger.warning(f"OpenAI rate limit hit during validation: {e}")
-        return (True, None)
-    except Exception as e:
-        return (False, f"Validation error: {str(e)}")
+    """Validate an OpenAI API key. Delegates to the connector layer."""
+    from .ai_providers import validate_provider_key
+    return validate_provider_key("openai", api_key)
 
 
 def validate_anthropic_key(api_key: str) -> tuple[bool, Optional[str]]:
-    """
-    Validate Anthropic API key by making a minimal API call.
+    """Validate an Anthropic API key. Delegates to the connector layer."""
+    from .ai_providers import validate_provider_key
+    return validate_provider_key("anthropic", api_key)
 
-    Args:
-        api_key: The Anthropic API key to validate
 
-    Returns:
-        Tuple of (is_valid, error_message)
-        - (True, None) if key is valid
-        - (False, error_message) if key is invalid
-    """
-    try:
-        import anthropic
-        client = anthropic.Anthropic(api_key=api_key)
-
-        # Make minimal API call (1 token)
-        client.messages.create(
-            model="claude-3-5-sonnet-20241022",
-            max_tokens=1,
-            messages=[{"role": "user", "content": "test"}]
-        )
-
-        return (True, None)
-
-    except anthropic.AuthenticationError as e:
-        return (False, f"Authentication failed: {str(e)}")
-    except anthropic.PermissionDeniedError as e:
-        return (False, f"Permission denied: {str(e)}")
-    except anthropic.RateLimitError as e:
-        # Rate limit means the key is valid, just throttled
-        logger.warning(f"Anthropic rate limit hit during validation: {e}")
-        return (True, None)
-    except Exception as e:
-        return (False, f"Validation error: {str(e)}")
+def validate_openrouter_key(api_key: str) -> tuple[bool, Optional[str]]:
+    """Validate an OpenRouter API key. Delegates to the connector layer."""
+    from .ai_providers import validate_provider_key
+    return validate_provider_key("openrouter", api_key)
 
 
 def validate_api_keys_at_startup() -> Dict[str, bool]:
@@ -141,6 +90,8 @@ def validate_api_keys_at_startup() -> Dict[str, bool]:
                         is_valid, error_msg = validate_openai_key(api_key)
                     elif provider == 'anthropic':
                         is_valid, error_msg = validate_anthropic_key(api_key)
+                    elif provider == 'openrouter':
+                        is_valid, error_msg = validate_openrouter_key(api_key)
                     elif provider == 'garage':
                         # Garage credentials are "access_key:secret_key" format
                         # No API validation available, just check format

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -12,6 +12,7 @@ Note: Database reset removed from API (too dangerous).
       Use ./scripts/setup/initialize-platform.sh option 0 instead.
 """
 
+import re
 import uuid
 import shutil
 import tempfile
@@ -41,7 +42,8 @@ from ..lib.backup_archive import stream_backup_archive, extract_backup_archive, 
 from ..lib.backup_integrity import check_backup_integrity
 from ..lib.age_client import AGEClient
 from ..lib.encrypted_keys import EncryptedKeyStore
-from ..constants import API_KEY_PROVIDERS
+from pydantic import BaseModel
+from ..constants import API_KEY_PROVIDERS, LOCAL_PROVIDERS, EXTRACTION_PROVIDERS
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 logger = logging.getLogger(__name__)
@@ -616,42 +618,16 @@ async def set_api_key(
             detail=f"Invalid provider. Must be one of: {valid_list}"
         )
 
-    # Validate key format
-    if provider == "anthropic":
-        if not api_key.startswith("sk-ant-"):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid Anthropic API key format (must start with 'sk-ant-')"
-            )
-    elif provider == "openai":
-        if not api_key.startswith("sk-"):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid OpenAI API key format (must start with 'sk-')"
-            )
+    # Test the key via the connector layer's single source of truth — no
+    # inline per-provider SDK calls, no hardcoded model names, no key-format
+    # prefix guessing. The connector authenticates model-agnostically (ADR-800).
+    from ..lib.ai_providers import validate_provider_key
 
-    # Test the key by making a minimal API call
-    try:
-        if provider == "anthropic":
-            import anthropic
-            client = anthropic.Anthropic(api_key=api_key)
-            client.messages.create(
-                model="claude-3-5-sonnet-20241022",
-                max_tokens=1,
-                messages=[{"role": "user", "content": "test"}]
-            )
-        else:  # openai
-            import openai
-            client = openai.OpenAI(api_key=api_key)
-            client.chat.completions.create(
-                model="gpt-4o-mini",
-                max_tokens=1,
-                messages=[{"role": "user", "content": "test"}]
-            )
-    except Exception as e:
+    is_valid, error_msg = validate_provider_key(provider, api_key)
+    if not is_valid:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"API key validation failed: {str(e)}"
+            detail=f"API key validation failed: {error_msg}"
         )
 
     # Store encrypted
@@ -688,6 +664,83 @@ async def set_api_key(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error storing API key"
         )
+
+
+@router.get("/providers")
+async def list_providers(
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("api_keys", "read"))
+):
+    """
+    Canonical list of supported AI/reasoning providers (ADR-800).
+
+    This is the single source of truth the UI uses to render one provider
+    card each — derived from EXTRACTION_PROVIDERS with per-provider metadata
+    so the frontend hardcodes nothing:
+
+    - `requires_key`: provider needs an API key (cloud)
+    - `is_local`: local inference server, no key (connectivity-tested)
+
+    Providers without a wired connector (e.g. vllm — ADR-042 Phase 4) are
+    omitted so every card maps to something that actually works.
+
+    **Authorization:** Requires `api_keys:read` permission
+    """
+    # vllm is in EXTRACTION_PROVIDERS as a placeholder but has no connector
+    # in get_provider() yet — don't surface a card that can't function.
+    unimplemented = {"vllm"}
+
+    providers = [
+        {
+            "provider": name,
+            "requires_key": name in API_KEY_PROVIDERS,
+            "is_local": name in LOCAL_PROVIDERS,
+        }
+        for name in sorted(EXTRACTION_PROVIDERS)
+        if name not in unimplemented
+    ]
+    return {"providers": providers}
+
+
+class ProviderConfigRequest(BaseModel):
+    """Per-provider config (#8) — saved without activating the provider."""
+    base_url: Optional[str] = None
+    model_name: Optional[str] = None
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+
+
+@router.post("/providers/{provider}/config")
+async def save_provider_config(
+    provider: str,
+    body: ProviderConfigRequest,
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("extraction_config", "write"))
+):
+    """
+    Persist a provider's config (base_url, model, reasoning params) WITHOUT
+    activating it (#8 — DB-backed per-provider config decoupled from the
+    active pointer). Lets the UI configure an endpoint, then "Get models"
+    / activate against that saved base_url.
+
+    **Authorization:** Requires `extraction_config:write` permission
+    """
+    from ..lib.ai_extraction_config import save_extraction_config
+
+    ok = save_extraction_config({
+        "provider": provider,
+        "model_name": body.model_name or "",
+        "base_url": body.base_url,
+        "temperature": body.temperature,
+        "max_tokens": body.max_tokens,
+        "active": False,
+    }, updated_by="web-admin")
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to save config for provider '{provider}'"
+        )
+    return {"status": "success", "provider": provider}
 
 
 @router.get("/keys")
@@ -750,9 +803,27 @@ async def list_api_keys(
                 logger.info(f"Encryption key not configured: {e}")
                 configured = []
 
-            # Return all possible providers, marking which are configured
-            all_providers = sorted(API_KEY_PROVIDERS)
+            # This endpoint lists *AI* provider keys only. A provider is an AI
+            # provider if the system knows how to validate it
+            # (API_KEY_PROVIDERS) or it appears in the model catalog. This
+            # surfaces arbitrarily-configured AI providers (e.g. openrouter
+            # via the CLI) without leaking non-AI key holders such as the
+            # `garage` storage credentials, which also live in
+            # system_api_keys but are not reasoning providers (ADR-800).
             configured_map = {p['provider']: p for p in configured}
+            try:
+                from ..lib.model_catalog import list_catalog
+                catalog_providers = {row['provider'] for row in list_catalog(conn)}
+            except Exception as e:
+                logger.warning(f"Could not load catalog providers: {e}")
+                catalog_providers = set()
+
+            # Key-requiring AI providers only: drop local providers (ollama,
+            # llamacpp — no key; they surface in the UI as local cards via
+            # the catalog) and non-AI key holders (garage).
+            ai_key_providers = (set(API_KEY_PROVIDERS) | catalog_providers) - set(LOCAL_PROVIDERS)
+            configured_ai = {p for p in configured_map if p in ai_key_providers}
+            all_providers = sorted(ai_key_providers | configured_ai)
 
             return [
                 {
@@ -799,12 +870,14 @@ async def delete_api_key(
 
     Returns success if key was deleted, 404 if key wasn't configured.
     """
-    # Validate provider
-    if provider not in API_KEY_PROVIDERS:
-        valid_list = ', '.join(f"'{p}'" for p in sorted(API_KEY_PROVIDERS))
+    # Provider is a stored identifier, not restricted to API_KEY_PROVIDERS:
+    # any provider that has a key (including ones configured via the CLI)
+    # must be deletable. A non-configured provider falls through to 404
+    # below. Reject only obviously malformed identifiers (ADR-800).
+    if not provider or not re.fullmatch(r"[a-z0-9._-]{1,50}", provider):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid provider. Must be one of: {valid_list}"
+            detail="Invalid provider identifier"
         )
 
     try:

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -702,6 +702,19 @@ async def list_providers(
     return {"providers": providers}
 
 
+def _validate_provider_id(provider: str) -> None:
+    """Reject obviously-malformed provider identifiers (ADR-800/801).
+
+    Shared by the per-provider config GET/POST and the key DELETE so the
+    contract is symmetric — a POST cannot write a row a GET would 400 on.
+    """
+    if not provider or not re.fullmatch(r"[a-z0-9._-]{1,50}", provider):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid provider identifier"
+        )
+
+
 class ProviderConfigRequest(BaseModel):
     """Per-provider config (#8) — saved without activating the provider."""
     base_url: Optional[str] = None
@@ -725,6 +738,7 @@ async def save_provider_config(
 
     **Authorization:** Requires `extraction_config:write` permission
     """
+    _validate_provider_id(provider)
     from ..lib.ai_extraction_config import save_extraction_config
 
     ok = save_extraction_config({
@@ -759,11 +773,7 @@ async def get_provider_config(
 
     **Authorization:** Requires `extraction_config:read` permission
     """
-    if not provider or not re.fullmatch(r"[a-z0-9._-]{1,50}", provider):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid provider identifier"
-        )
+    _validate_provider_id(provider)
 
     from ..lib.ai_extraction_config import load_provider_config
 
@@ -913,11 +923,7 @@ async def delete_api_key(
     # any provider that has a key (including ones configured via the CLI)
     # must be deletable. A non-configured provider falls through to 404
     # below. Reject only obviously malformed identifiers (ADR-800).
-    if not provider or not re.fullmatch(r"[a-z0-9._-]{1,50}", provider):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid provider identifier"
-        )
+    _validate_provider_id(provider)
 
     try:
         age_client = AGEClient()

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -743,6 +743,45 @@ async def save_provider_config(
     return {"status": "success", "provider": provider}
 
 
+@router.get("/providers/{provider}/config")
+async def get_provider_config(
+    provider: str,
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("extraction_config", "read"))
+):
+    """
+    Read a provider's saved config regardless of whether it is active
+    (#8 — DB-backed per-provider config). Symmetric to the POST: lets the
+    UI pre-populate each provider card (base_url, model, reasoning params)
+    with what is actually persisted, so the database is a two-way source
+    of truth rather than write-only. `config` is null when the provider
+    has no saved row yet.
+
+    **Authorization:** Requires `extraction_config:read` permission
+    """
+    if not provider or not re.fullmatch(r"[a-z0-9._-]{1,50}", provider):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid provider identifier"
+        )
+
+    from ..lib.ai_extraction_config import load_provider_config
+
+    row = load_provider_config(provider)
+    if not row:
+        return {"provider": provider, "config": None}
+    return {
+        "provider": provider,
+        "config": {
+            "base_url": row.get("base_url"),
+            "model_name": row.get("model_name"),
+            "temperature": row.get("temperature"),
+            "max_tokens": row.get("max_tokens"),
+            "active": row.get("active"),
+        },
+    }
+
+
 @router.get("/keys")
 async def list_api_keys(
     current_user: CurrentUser,

--- a/api/app/routes/models.py
+++ b/api/app/routes/models.py
@@ -63,7 +63,7 @@ async def refresh_catalog(request: RefreshRequest):
     from ..lib.ai_providers import get_provider
 
     provider_name = request.provider.lower()
-    if provider_name not in ("openai", "anthropic", "ollama", "openrouter"):
+    if provider_name not in ("openai", "anthropic", "ollama", "openrouter", "llamacpp"):
         raise HTTPException(
             status_code=400,
             detail=f"Unknown provider: {provider_name}",

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -135,6 +135,7 @@ _CLI, web, FUSE, MCP, visualization_
 | [ADR-085](./visualization/ADR-085-document-explorer.md) | Document Explorer with Radial Concept Visualization | Proposed |
 | [ADR-700](./user-interfaces/ADR-700-ontology-explorer.md) | Ontology Explorer | Draft |
 | [ADR-701](./user-interfaces/ADR-701-vocabulary-administration-interface.md) | Vocabulary Administration Interface | Draft |
+| [ADR-702](./user-interfaces/ADR-702-unified-graph-rendering-engine.md) | Unified Graph Rendering Engine | Proposed |
 
 ## AI/Embeddings
 _Providers, extraction, convergence, prompts_
@@ -151,7 +152,8 @@ _Providers, extraction, convergence, prompts_
 | [ADR-058](./ai-embeddings/ADR-058-polarity-axis-triangulation.md) | Polarity Axis Triangulation for Grounding Calculation | Accepted |
 | [ADR-068](./ai-embeddings/ADR-068-source-text-embeddings.md) | Source Text Embeddings for Grounding Truth Retrieval | Accepted |
 | [ADR-070](./ai-embeddings/ADR-070-polarity-axis-analysis.md) | Polarity Axis Analysis for Bidirectional Semantic Dimensions | Accepted |
-| [ADR-800](./ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md) | Dynamic Model Catalog and OpenRouter Support | Draft |
+| [ADR-800](./ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md) | Dynamic Model Catalog and OpenRouter Support | Accepted |
+| [ADR-801](./ai-embeddings/ADR-801-uniform-provider-configuration-contract.md) | Uniform Provider Configuration Contract | Draft |
 
 ## Meta/Process
 _Documentation, workflow, access models, ADR system_

--- a/docs/architecture/ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md
+++ b/docs/architecture/ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md
@@ -1,6 +1,7 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-03-15
+accepted: 2026-05-19
 deciders:
   - aaronsb
   - claude
@@ -229,3 +230,23 @@ Automatically route requests to the cheapest available provider when the same mo
 - Catalog: `GET /api/v1/models` — returns full model list with pricing (no auth required, but rate-limited)
 - Completions: `POST /api/v1/chat/completions` — OpenAI-compatible format
 - Generation stats: `GET /api/v1/generation?id={id}` — token usage and cost for a specific request
+
+### Implementation status (2026-05-19)
+
+All migration-sequence items are complete. The decision is now fully
+implemented; status moved Draft → Accepted.
+
+- Items 1–7 (schema, seed, `OpenRouterProvider`, `fetch_model_catalog`,
+  `configure.py models`, `/admin/models/catalog`, cost estimator) were
+  delivered earlier.
+- Item 8 (web UI) is closed by this change: `SystemTab` no longer hardcodes
+  provider/model lists — it derives them from `/admin/models/catalog` and
+  `/admin/keys`, with per-provider cards that unify API-key management and
+  the active extraction selection.
+- A residual gap is closed alongside item 8: `API_KEY_PROVIDERS` omitted
+  `openrouter`, so `POST/GET/DELETE /admin/keys` rejected or hid OpenRouter
+  keys even though the provider was fully implemented. `openrouter` is now
+  in `API_KEY_PROVIDERS` and `EXTRACTION_PROVIDERS`, with format/validation
+  branches in `admin.py` and `api_key_validator.py` (authenticated
+  `/api/v1/key` check). `GET /admin/keys` now enumerates the union of known
+  and actually-configured providers rather than the constant alone.

--- a/docs/architecture/ai-embeddings/ADR-801-uniform-provider-configuration-contract.md
+++ b/docs/architecture/ai-embeddings/ADR-801-uniform-provider-configuration-contract.md
@@ -1,0 +1,157 @@
+---
+status: Draft
+date: 2026-05-19
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-800
+  - ADR-041
+  - ADR-042
+  - ADR-049
+---
+
+# ADR-801: Uniform Provider Configuration Contract
+
+## Context
+
+ADR-800 specified the dynamic model catalog and OpenRouter support — *what
+models exist* is no longer hardcoded. It deliberately left open *how an
+operator configures and selects a provider*: the per-provider connectivity,
+reasoning controls, and persistence model were unknown and could not be
+designed on paper. We chose to **experiment first and write this ADR from
+the findings** rather than guess the contract up front. This ADR records the
+contract that the experiment converged on; it extends ADR-800 rather than
+modifying it (ADR-800 is Accepted — its decision history is preserved).
+
+The experiment surfaced concrete failures that drive the decisions below:
+
+- Provider configuration was effectively a single global "active config"
+  row. Saving provider B's settings meant losing provider A's. The UI was
+  hardcoded to an openai/anthropic pair and could not show an
+  operator-configured provider (e.g. OpenRouter) at all.
+- Activating a provider, or saving one field, **nulled the rest of that
+  provider's row** (`exclude_none=True` upstream → missing field → `NULL`
+  written). This is the bug class that made a configured local endpoint
+  silently revert to `localhost:8080`.
+- A containerised API cannot reach a local inference server on host
+  loopback: the host's INPUT firewall drops bridge-network traffic. The
+  provider was unreachable until the topology changed.
+- The "no hardcoded models" intent of ADR-800 had **regressed in places**:
+  `AnthropicProvider` returned a static Claude-3 list; `OpenAIProvider`
+  allowlisted a few name fragments. Both hid newer models.
+
+## Decision
+
+A reasoning provider is defined by a **uniform contract of four surfaces**.
+Every connector implements all four; the UI and routes are provider-agnostic.
+
+### 1. Four uniform surfaces
+
+Every provider exposes, by the same interface:
+
+1. **Validate** — model-agnostic connectivity/auth (`validate_provider_key`),
+   never dependent on a specific model id, never raising.
+2. **Enumerate** — `fetch_model_catalog()` lists models from the provider's
+   own API. Enumeration *is* the connectivity test.
+3. **Reasoning controls** — temperature and max-output-tokens, with sane KG
+   defaults, persisted per provider.
+4. **Persisted per-provider config** — base_url / model / reasoning params
+   stored in the database.
+
+The UI renders one card per provider from `/admin/providers` metadata
+(`requires_key`, `is_local`). Field visibility is data-driven (key row vs.
+endpoint row) — **never a provider-specific code branch**. Adding a provider
+is a connector + a metadata row, not UI surgery.
+
+### 2. Per-provider config is decoupled from the active pointer
+
+`kg_api.ai_extraction_config` holds **one row per provider**
+(`UNIQUE(provider)`). `active` is a single live-flag identifying the
+provider used for extraction — it is *not* coupled to provider identity or
+to whether a provider may be configured. A provider can be fully configured
+and saved while another remains active. The schema constraint is the
+decision.
+
+### 3. Partial-save preservation is a persistence-layer invariant
+
+`save_extraction_config` upserts `ON CONFLICT (provider)` and **COALESCEs
+every optional field against the stored value**. An omitted field is left
+alone, never nulled. This invariant lives at the persistence layer, not
+threaded through each caller.
+
+> **Principle (send-only-what-changed):** Any endpoint or caller may persist
+> a partial provider config. Absent fields retain their stored value;
+> brand-new rows fall to column defaults. Callers must not be required to
+> re-send the whole row to avoid data loss.
+
+`model_name` is special-cased — `COALESCE(NULLIF(EXCLUDED.model_name,''),
+stored)` — so the empty-string new-row sentinel never overwrites a real
+model.
+
+### 4. Local inference servers join the API's docker network
+
+A local inference server (llama.cpp, Ollama) is reached **by docker-network
+service name**, exactly as the API reaches Postgres/Garage — not via host
+loopback. Host-loopback is rejected: the host firewall drops bridge→host
+traffic, so loopback is unreliable by construction, not by misconfiguration.
+The persisted `base_url` therefore holds a service-name URL
+(e.g. `http://kg-llamacpp:8080/v1`). Hardware passthrough and bring-up of
+that container is environment-specific operational knowledge and lives in
+the operator way, not here.
+
+### Reaffirmation, not new decision
+
+The Anthropic SDK-enumeration and OpenAI allowlist→denylist fixes restore
+ADR-800's existing "no hardcoded model lists" decision where it had
+regressed. They are recorded as confirmation of ADR-800, not as new
+architecture: enumerate via the provider SDK/API and exclude only *known*
+non-extraction families, so new model generations appear with no code
+change.
+
+## Consequences
+
+### Positive
+
+- The database is a **two-way source of truth**: a `GET` mirrors the `POST`,
+  so every provider card pre-populates from what is actually persisted
+  rather than from defaults. (This is a consequence of decisions 2 + 3, not
+  a separate decision.)
+- Adding a provider is connector + metadata only — no UI or route changes.
+- The partial-save invariant makes whole classes of "save wiped my config"
+  bugs structurally impossible for present and future callers.
+- New model generations surface automatically (decision-reaffirmation).
+
+### Negative
+
+- The persistence layer carries non-obvious COALESCE/NULLIF logic; the
+  send-only-what-changed principle must be understood before adding columns
+  (a column added without a COALESCE branch reintroduces the bug class).
+- Local-provider use requires the inference server to be on the API's docker
+  network — a host-installed server is not directly usable without joining
+  it.
+
+### Neutral
+
+- `vllm` remains an `EXTRACTION_PROVIDERS` placeholder with no connector; it
+  is omitted from `/admin/providers` until one exists (every card maps to a
+  working surface).
+- Reasoning controls are temperature + max_tokens only. A provider-specific
+  context-length (num_ctx) knob was deliberately excluded: no column exists,
+  and it is a no-op for cloud providers. Adding it later is a schema +
+  contract change, scoped separately.
+
+## Alternatives Considered
+
+- **Thread every field through every caller** (instead of COALESCE at the
+  persistence layer). Rejected: it only fixes the one caller you remember;
+  the bug class returns with the next partial-save endpoint.
+- **Mutate ADR-800 to add this contract.** Rejected: ADR-800 is Accepted;
+  overwriting it destroys the decision-history friction. ADR-801 extends it.
+- **Host-loopback for local providers with a firewall rule.** Rejected:
+  fragile and host-specific; the docker-network pattern is how every other
+  service dependency already works.
+- **Per-provider-shaped UI cards** (distinct cloud vs. local components).
+  Rejected: divergent code paths drift; one metadata-driven card shape is
+  the contract's UI expression.
+</content>

--- a/schema/migrations/060_remove_ollama_catalog_seeds.sql
+++ b/schema/migrations/060_remove_ollama_catalog_seeds.sql
@@ -1,0 +1,20 @@
+-- Migration 060: Remove hardcoded Ollama catalog seeds (ADR-800)
+--
+-- Ollama is a local provider that can interrogate itself via /api/tags
+-- (OllamaProvider.fetch_model_catalog). Seeding hardcoded Ollama models in
+-- migration 059 was the same hardcoding anti-pattern ADR-800 set out to
+-- remove: it shows aspirational models that may not be installed locally.
+--
+-- After this migration the Ollama catalog is empty until an operator runs a
+-- catalog Refresh, which discovers the models actually present on the
+-- Ollama server. OpenAI/Anthropic seeds are intentionally kept (Anthropic
+-- has no catalog API; OpenAI pricing is hardcoded), per ADR-800.
+
+DELETE FROM kg_api.provider_model_catalog
+WHERE provider = 'ollama';
+
+-- ===========================================================================
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (60, 'remove_ollama_catalog_seeds')
+ON CONFLICT (version) DO NOTHING;

--- a/schema/migrations/061_llamacpp_provider.sql
+++ b/schema/migrations/061_llamacpp_provider.sql
@@ -1,0 +1,19 @@
+-- Migration 061: Allow llama.cpp as an extraction provider
+--
+-- llama.cpp is a local OpenAI-compatible inference server. Adding it to the
+-- ai_extraction_config provider check constraint lets operators set it as the
+-- active extraction provider. Catalog/keys/UI are already provider-agnostic
+-- (ADR-800); this only widens the allowed-provider constraint.
+
+ALTER TABLE kg_api.ai_extraction_config
+    DROP CONSTRAINT IF EXISTS ai_extraction_config_provider_check;
+
+ALTER TABLE kg_api.ai_extraction_config
+    ADD CONSTRAINT ai_extraction_config_provider_check
+    CHECK (provider IN ('openai', 'anthropic', 'ollama', 'openrouter', 'llamacpp'));
+
+-- ===========================================================================
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (61, 'llamacpp_provider')
+ON CONFLICT (version) DO NOTHING;

--- a/schema/migrations/062_per_provider_config.sql
+++ b/schema/migrations/062_per_provider_config.sql
@@ -1,0 +1,25 @@
+-- Migration 062: ai_extraction_config becomes one row PER PROVIDER (ADR-800 / #8)
+--
+-- The table was used as a single "active config" (insert-new + deactivate-old).
+-- For DB-backed per-provider configuration (base_url, model, reasoning params
+-- persisted per provider, decoupled from which one is active) we make
+-- `provider` unique and switch the save path to an upsert. `active` still
+-- marks the single live provider.
+--
+-- Dedupe: keep, per provider, the active row if any, else the newest id.
+
+DELETE FROM kg_api.ai_extraction_config x
+WHERE x.id NOT IN (
+    SELECT DISTINCT ON (provider) id
+    FROM kg_api.ai_extraction_config
+    ORDER BY provider, active DESC, id DESC
+);
+
+ALTER TABLE kg_api.ai_extraction_config
+    ADD CONSTRAINT ai_extraction_config_provider_key UNIQUE (provider);
+
+-- ===========================================================================
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (62, 'per_provider_config')
+ON CONFLICT (version) DO NOTHING;

--- a/tests/api/test_providers_routes.py
+++ b/tests/api/test_providers_routes.py
@@ -158,6 +158,15 @@ class TestProviderConfigRoundTrip:
                               headers=auth_headers_admin)
         assert resp.status_code == 400
 
+    def test_should_reject_malformed_id_on_save_symmetrically(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        # POST must enforce the same id rule as GET — otherwise it writes
+        # a row the symmetric GET would 400 on (review should-fix #1).
+        resp = api_client.post(
+            "/admin/providers/BAD!!/config", headers=auth_headers_admin,
+            json={"model_name": "x"})
+        assert resp.status_code == 400
+
 
 # ===========================================================================
 # GET /admin/keys — AI key providers only

--- a/tests/api/test_providers_routes.py
+++ b/tests/api/test_providers_routes.py
@@ -1,0 +1,177 @@
+"""
+Route tests for the provider configuration contract (ADR-800, task #10).
+
+Locks the HTTP surface the uniform DB-driven provider UI depends on:
+
+- GET  /admin/providers              — canonical card list, no hardcoding
+- POST /admin/providers/{p}/config   — persist without activating
+- GET  /admin/providers/{p}/config   — two-way source of truth round-trip
+- GET  /admin/keys                   — AI key providers only (no garage,
+                                       no local providers)
+
+DB-mutating tests snapshot-restore kg_api.ai_extraction_config so the
+shared dev DB is left untouched.
+"""
+
+import pytest
+
+from api.app.constants import (
+    EXTRACTION_PROVIDERS, API_KEY_PROVIDERS, LOCAL_PROVIDERS,
+)
+
+
+@pytest.fixture(autouse=True)
+def allow_admin_permissions(monkeypatch):
+    """Admin token passes RBAC; mirrors tests/api/test_endpoint_security.py."""
+    def always_admin(user, resource_type, action,
+                      resource_id=None, resource_context=None):
+        return user.role == "admin"
+    monkeypatch.setattr(
+        "api.app.dependencies.auth.check_permission", always_admin)
+
+
+@pytest.fixture
+def restore_extraction_config():
+    from api.app.lib.age_client import AGEClient
+    client = AGEClient()
+    conn = client.pool.getconn()
+    cols = ("provider, model_name, supports_vision, supports_json_mode, "
+            "max_tokens, updated_by, active, base_url, temperature, top_p, "
+            "gpu_layers, num_threads, thinking_mode, max_concurrent_requests, "
+            "max_retries")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT {cols} FROM kg_api.ai_extraction_config")
+            snapshot = cur.fetchall()
+        conn.commit()
+        yield
+    finally:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM kg_api.ai_extraction_config")
+                if snapshot:
+                    ph = "(" + ",".join(["%s"] * 15) + ")"
+                    cur.execute(
+                        f"INSERT INTO kg_api.ai_extraction_config ({cols}) "
+                        f"VALUES {','.join([ph] * len(snapshot))}",
+                        [v for row in snapshot for v in row],
+                    )
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+
+
+# ===========================================================================
+# GET /admin/providers — canonical, derived, never hardcoded
+# ===========================================================================
+
+class TestListProviders:
+    def test_should_require_authentication(self, api_client,
+                                           mock_oauth_validation):
+        assert api_client.get("/admin/providers").status_code == 401
+
+    def test_should_return_one_entry_per_supported_provider(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        resp = api_client.get("/admin/providers", headers=auth_headers_admin)
+        assert resp.status_code == 200
+        names = {p["provider"] for p in resp.json()["providers"]}
+        # Exactly EXTRACTION_PROVIDERS minus the unimplemented placeholder.
+        assert names == set(EXTRACTION_PROVIDERS) - {"vllm"}
+
+    def test_should_flag_local_and_key_providers_correctly(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        by = {p["provider"]: p for p in api_client.get(
+            "/admin/providers", headers=auth_headers_admin).json()["providers"]}
+        assert by["llamacpp"]["is_local"] is True
+        assert by["llamacpp"]["requires_key"] is False
+        assert by["openai"]["requires_key"] is True
+        assert by["openai"]["is_local"] is False
+        for name, meta in by.items():
+            assert meta["requires_key"] == (name in API_KEY_PROVIDERS)
+            assert meta["is_local"] == (name in LOCAL_PROVIDERS)
+
+
+# ===========================================================================
+# /admin/providers/{p}/config — DB is a two-way source of truth
+# ===========================================================================
+
+@pytest.mark.usefixtures("restore_extraction_config")
+class TestProviderConfigRoundTrip:
+    def test_should_round_trip_saved_config(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        save = api_client.post(
+            "/admin/providers/llamacpp/config",
+            headers=auth_headers_admin,
+            json={"base_url": "http://kg-llamacpp:8080/v1",
+                  "model_name": "qwen3", "temperature": 0.2,
+                  "max_tokens": 4096},
+        )
+        assert save.status_code == 200
+
+        got = api_client.get("/admin/providers/llamacpp/config",
+                             headers=auth_headers_admin)
+        assert got.status_code == 200
+        cfg = got.json()["config"]
+        assert cfg["base_url"] == "http://kg-llamacpp:8080/v1"
+        assert cfg["model_name"] == "qwen3"
+        assert cfg["active"] is False  # saved, NOT activated
+
+    def test_should_not_wipe_fields_on_partial_save_through_route(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        api_client.post(
+            "/admin/providers/llamacpp/config", headers=auth_headers_admin,
+            json={"base_url": "http://kg-llamacpp:8080/v1",
+                  "model_name": "qwen3", "max_tokens": 4096})
+        # Partial: only temperature.
+        api_client.post(
+            "/admin/providers/llamacpp/config", headers=auth_headers_admin,
+            json={"temperature": 0.7})
+        cfg = api_client.get("/admin/providers/llamacpp/config",
+                             headers=auth_headers_admin).json()["config"]
+        assert cfg["base_url"] == "http://kg-llamacpp:8080/v1"
+        assert cfg["model_name"] == "qwen3"
+        assert cfg["max_tokens"] == 4096
+        assert float(cfg["temperature"]) == 0.7
+
+    def test_should_return_null_config_for_unconfigured_provider(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        # Guarantee absence (restore_extraction_config snapshots it back).
+        from api.app.lib.age_client import AGEClient
+        client = AGEClient()
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM kg_api.ai_extraction_config "
+                            "WHERE provider='ollama'")
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+
+        resp = api_client.get("/admin/providers/ollama/config",
+                              headers=auth_headers_admin)
+        assert resp.status_code == 200
+        assert resp.json()["config"] is None
+
+    def test_should_reject_malformed_provider_identifier(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        resp = api_client.get("/admin/providers/BAD!!/config",
+                              headers=auth_headers_admin)
+        assert resp.status_code == 400
+
+
+# ===========================================================================
+# GET /admin/keys — AI key providers only
+# ===========================================================================
+
+class TestListApiKeysScope:
+    def test_should_exclude_garage_and_local_providers(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        resp = api_client.get("/admin/keys", headers=auth_headers_admin)
+        assert resp.status_code == 200
+        names = {k["provider"] for k in resp.json()}
+        # garage is a storage bucket key, not a reasoning provider.
+        assert "garage" not in names
+        # local providers are connectivity-tested, not key-bearing.
+        assert names.isdisjoint(set(LOCAL_PROVIDERS))
+        # key-requiring AI providers are present.
+        assert "openai" in names and "anthropic" in names

--- a/tests/unit/lib/test_provider_config.py
+++ b/tests/unit/lib/test_provider_config.py
@@ -1,0 +1,292 @@
+"""
+Unit tests for the provider configuration contract (ADR-800, tasks #8/#10).
+
+Locks the behaviours the uniform DB-driven provider system depends on:
+
+1. validate_provider_key — model-agnostic, never raises, per-provider.
+2. save_extraction_config — per-provider upsert that COALESCEs omitted
+   fields (partial save never wipes the row) and treats `active` as the
+   sole active-pointer control.
+3. get_provider — resolves a non-active provider's own base_url.
+4. fetch_model_catalog — OpenAI/Anthropic enumerate via the SDK and
+   classify by a non-extraction denylist, not a hardcoded allowlist.
+
+validate_provider_key / catalog tests mock the SDKs (no network).
+save/load tests use the real container DB and snapshot-restore the
+ai_extraction_config table so the shared dev DB is left untouched.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from api.app.lib.ai_providers import validate_provider_key, OpenAIProvider, AnthropicProvider
+
+
+# ===========================================================================
+# 1. validate_provider_key — single source of truth, model-agnostic
+# ===========================================================================
+
+class TestValidateProviderKey:
+    def test_should_return_false_when_openai_sdk_rejects_key(self):
+        fake = MagicMock()
+        fake.models.list.side_effect = Exception("401 invalid_api_key")
+        with patch("openai.OpenAI", return_value=fake):
+            ok, msg = validate_provider_key("openai", "sk-bad")
+        assert ok is False
+        assert msg and "Validation error" in msg
+
+    def test_should_return_true_when_openai_sdk_accepts_key(self):
+        with patch("openai.OpenAI", return_value=MagicMock()):
+            ok, msg = validate_provider_key("openai", "sk-good")
+        assert ok is True
+        assert msg is None
+
+    def test_should_return_false_when_anthropic_sdk_rejects_key(self):
+        fake = MagicMock()
+        fake.models.list.side_effect = Exception("authentication_error")
+        with patch("anthropic.Anthropic", return_value=fake):
+            ok, msg = validate_provider_key("anthropic", "sk-ant-bad")
+        assert ok is False
+
+    def test_should_return_true_when_anthropic_models_list_succeeds(self):
+        # Model-agnostic: a bare models.list() call, no hardcoded model id.
+        with patch("anthropic.Anthropic", return_value=MagicMock()):
+            ok, msg = validate_provider_key("anthropic", "sk-ant-good")
+        assert ok is True and msg is None
+
+    def test_should_return_false_when_openrouter_returns_401(self):
+        resp = MagicMock(status_code=401)
+        with patch("requests.get", return_value=resp):
+            ok, msg = validate_provider_key("openrouter", "bad")
+        assert ok is False
+        assert "401" in msg
+
+    def test_should_return_true_when_openrouter_key_authenticates(self):
+        resp = MagicMock(status_code=200)
+        with patch("requests.get", return_value=resp):
+            ok, msg = validate_provider_key("openrouter", "good")
+        assert ok is True and msg is None
+
+    def test_should_connectivity_check_llamacpp_not_require_key(self):
+        with patch(
+            "api.app.lib.ai_providers.LlamaCppProvider.validate_api_key",
+            return_value=True,
+        ):
+            ok, msg = validate_provider_key("llamacpp", "")
+        assert ok is True and msg is None
+
+    def test_should_report_unreachable_llamacpp(self):
+        with patch(
+            "api.app.lib.ai_providers.LlamaCppProvider.validate_api_key",
+            return_value=False,
+        ):
+            ok, msg = validate_provider_key("llamacpp", "")
+        assert ok is False
+        assert "llama.cpp" in msg
+
+    def test_should_return_false_for_unknown_provider_without_raising(self):
+        ok, msg = validate_provider_key("totally-made-up", "x")
+        assert ok is False
+        assert "No validation available" in msg
+
+    def test_should_never_raise_even_on_unexpected_error(self):
+        with patch("openai.OpenAI", side_effect=RuntimeError("boom")):
+            ok, msg = validate_provider_key("openai", "x")
+        assert ok is False  # swallowed, returned as (False, msg)
+
+
+# ===========================================================================
+# 4. fetch_model_catalog — SDK enumeration + denylist classification
+# ===========================================================================
+
+def _model(**kw):
+    m = MagicMock()
+    for k, v in kw.items():
+        setattr(m, k, v)
+    return m
+
+
+class TestOpenAICatalogClassification:
+    """Built via __new__ to isolate fetch_model_catalog from the
+    network-touching constructor — the unit under test is the classifier."""
+
+    def _provider_with_models(self, ids):
+        p = object.__new__(OpenAIProvider)
+        p.client = MagicMock()
+        p.client.models.list.return_value = MagicMock(
+            data=[_model(id=i, created=0) for i in ids]
+        )
+        return p
+
+    def test_should_include_new_chat_families_without_code_change(self):
+        cat = self._provider_with_models(
+            ["gpt-4o", "o1-mini", "o3", "o4-mini", "gpt-5-preview"]
+        ).fetch_model_catalog()
+        ids = {e["model_id"] for e in cat}
+        # o3 / o4 / gpt-5 would have been dropped by the old allowlist.
+        assert {"o3", "o4-mini", "gpt-5-preview"} <= ids
+
+    def test_should_exclude_known_non_extraction_models(self):
+        cat = self._provider_with_models(
+            ["gpt-4o", "whisper-1", "tts-1", "dall-e-3",
+             "omni-moderation-latest", "davinci-002"]
+        ).fetch_model_catalog()
+        ids = {e["model_id"] for e in cat}
+        assert ids == {"gpt-4o"}
+
+    def test_should_categorise_embeddings_separately(self):
+        cat = self._provider_with_models(
+            ["gpt-4o", "text-embedding-3-large"]
+        ).fetch_model_catalog()
+        by_id = {e["model_id"]: e["category"] for e in cat}
+        assert by_id["text-embedding-3-large"] == "embedding"
+        assert by_id["gpt-4o"] == "extraction"
+
+
+class TestAnthropicCatalogIsDynamic:
+    def _provider_with_models(self, models):
+        p = object.__new__(AnthropicProvider)
+        p.client = MagicMock()
+        p.client.models.list.return_value = MagicMock(data=models)
+        return p
+
+    def test_should_enumerate_from_sdk_not_hardcoded_list(self):
+        # The SDK reports a brand-new model; it must appear (no hardcoding).
+        models = [
+            _model(id="claude-opus-4-1-20250805",
+                    display_name="Claude Opus 4.1", created_at="2025-08-05"),
+            _model(id="claude-future-99",
+                    display_name="Claude Future", created_at=""),
+        ]
+        cat = self._provider_with_models(models).fetch_model_catalog()
+        ids = {e["model_id"] for e in cat}
+        assert "claude-opus-4-1-20250805" in ids
+        assert "claude-future-99" in ids  # unknown still surfaces
+
+    def test_should_price_known_family_and_null_unknown(self):
+        models = [
+            _model(id="claude-sonnet-4-20250514",
+                    display_name="Claude Sonnet 4", created_at=""),
+            _model(id="claude-future-99", display_name="x", created_at=""),
+        ]
+        cat = {e["model_id"]: e for e in
+               self._provider_with_models(models).fetch_model_catalog()}
+        assert cat["claude-sonnet-4-20250514"]["price_prompt_per_m"] == 3.00
+        assert cat["claude-future-99"]["price_prompt_per_m"] is None
+
+
+# ===========================================================================
+# 2 & 3. save_extraction_config COALESCE + get_provider base_url resolution
+#        (real container DB; snapshot-restored)
+# ===========================================================================
+
+@pytest.fixture
+def restore_extraction_config():
+    """Snapshot kg_api.ai_extraction_config and restore it verbatim after
+    the test, so DB-mutating contract tests never pollute the dev DB."""
+    from api.app.lib.age_client import AGEClient
+    client = AGEClient()
+    conn = client.pool.getconn()
+    cols = ("provider, model_name, supports_vision, supports_json_mode, "
+            "max_tokens, updated_by, active, base_url, temperature, top_p, "
+            "gpu_layers, num_threads, thinking_mode, max_concurrent_requests, "
+            "max_retries")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT {cols} FROM kg_api.ai_extraction_config")
+            snapshot = cur.fetchall()
+        conn.commit()
+        yield
+    finally:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM kg_api.ai_extraction_config")
+                if snapshot:
+                    ph = "(" + ",".join(["%s"] * 15) + ")"
+                    cur.execute(
+                        f"INSERT INTO kg_api.ai_extraction_config ({cols}) "
+                        f"VALUES {','.join([ph] * len(snapshot))}",
+                        [v for row in snapshot for v in row],
+                    )
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+
+
+@pytest.mark.usefixtures("restore_extraction_config")
+class TestSaveExtractionConfigContract:
+    def test_should_not_wipe_omitted_fields_on_partial_save(self):
+        from api.app.lib.ai_extraction_config import (
+            save_extraction_config, load_provider_config)
+
+        # Full config, NOT active.
+        save_extraction_config({
+            "provider": "llamacpp", "model_name": "qwen3",
+            "base_url": "http://kg-llamacpp:8080/v1",
+            "temperature": 0.1, "max_tokens": 4096, "active": False,
+        })
+        # Partial save: only temperature changes.
+        save_extraction_config({
+            "provider": "llamacpp", "model_name": "",
+            "temperature": 0.5, "active": False,
+        })
+        row = load_provider_config("llamacpp")
+        assert row["base_url"] == "http://kg-llamacpp:8080/v1"  # preserved
+        assert row["model_name"] == "qwen3"                      # preserved
+        assert row["max_tokens"] == 4096                          # preserved
+        assert float(row["temperature"]) == 0.5                   # updated
+
+    def test_should_preserve_base_url_when_activating_model_only(self):
+        from api.app.lib.ai_extraction_config import (
+            save_extraction_config, load_provider_config,
+            load_active_extraction_config)
+
+        save_extraction_config({
+            "provider": "llamacpp", "model_name": "qwen3",
+            "base_url": "http://kg-llamacpp:8080/v1", "active": False,
+        })
+        # Activation path sends only provider+model (the real /admin/
+        # extraction/config behaviour) — base_url must survive.
+        save_extraction_config({
+            "provider": "llamacpp", "model_name": "qwen3", "active": True,
+        })
+        row = load_provider_config("llamacpp")
+        assert row["base_url"] == "http://kg-llamacpp:8080/v1"
+        assert load_active_extraction_config()["provider"] == "llamacpp"
+
+    def test_should_not_change_active_pointer_when_active_false(self):
+        from api.app.lib.ai_extraction_config import (
+            save_extraction_config, load_active_extraction_config)
+
+        save_extraction_config({
+            "provider": "anthropic", "model_name": "claude-x", "active": True,
+        })
+        save_extraction_config({
+            "provider": "llamacpp", "model_name": "qwen3",
+            "base_url": "http://x:1/v1", "active": False,
+        })
+        assert load_active_extraction_config()["provider"] == "anthropic"
+
+    def test_should_keep_one_row_per_provider(self):
+        from api.app.lib.ai_extraction_config import (
+            save_extraction_config, load_provider_config)
+        from api.app.lib.age_client import AGEClient
+
+        for t in (0.1, 0.2, 0.3):
+            save_extraction_config({
+                "provider": "ollama", "model_name": "m",
+                "temperature": t, "active": False,
+            })
+        client = AGEClient()
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM kg_api.ai_extraction_config "
+                    "WHERE provider='ollama'")
+                count = cur.fetchone()[0]
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+        assert count == 1
+        assert float(load_provider_config("ollama")["temperature"]) == 0.3

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1123,7 +1123,13 @@ class APIClient {
     message: string;
     config: any;
   }> {
-    const response = await this.client.post('/admin/extraction/config', config);
+    // The API contract (UpdateExtractionConfigRequest) requires `model_name`,
+    // not `model` — send the contract field to avoid a 422.
+    const { model, ...rest } = config;
+    const response = await this.client.post('/admin/extraction/config', {
+      ...rest,
+      model_name: model,
+    });
     return response.data;
   }
 
@@ -1170,6 +1176,67 @@ class APIClient {
     message: string;
   }> {
     const response = await this.client.delete(`/admin/keys/${provider}`);
+    return response.data;
+  }
+
+  /**
+   * Canonical supported provider list with metadata (ADR-800).
+   * Single source of truth for which provider cards the UI renders.
+   */
+  async getProviders(): Promise<{
+    providers: Array<{
+      provider: string;
+      requires_key: boolean;
+      is_local: boolean;
+    }>;
+  }> {
+    const response = await this.client.get('/admin/providers');
+    return response.data;
+  }
+
+  /**
+   * List provider model catalog entries (ADR-800).
+   *
+   * The catalog is the runtime source of truth for which providers/models
+   * exist — the UI derives provider and model dropdowns from this rather
+   * than hardcoding them.
+   */
+  async getModelCatalog(params?: {
+    provider?: string;
+    category?: string;
+    enabledOnly?: boolean;
+  }): Promise<{
+    models: Array<{
+      id: number;
+      provider: string;
+      model_id: string;
+      display_name: string | null;
+      category: string;
+      enabled: boolean;
+      is_default: boolean;
+      sort_order: number;
+      upstream_provider: string | null;
+    }>;
+    count: number;
+  }> {
+    const query = new URLSearchParams();
+    if (params?.provider) query.append('provider', params.provider);
+    if (params?.category) query.append('category', params.category);
+    if (params?.enabledOnly) query.append('enabled_only', 'true');
+    const qs = query.toString();
+    const response = await this.client.get(`/admin/models/catalog${qs ? `?${qs}` : ''}`);
+    return response.data;
+  }
+
+  /**
+   * Refresh the model catalog for a provider from its upstream API (ADR-800).
+   */
+  async refreshModelCatalog(provider: string): Promise<{
+    provider: string;
+    message: string;
+    upserted: number;
+  }> {
+    const response = await this.client.post('/admin/models/catalog/refresh', { provider });
     return response.data;
   }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1240,6 +1240,45 @@ class APIClient {
     return response.data;
   }
 
+  /**
+   * Read a provider's saved per-provider config (#8), whether or not it is
+   * the active provider. Lets each provider card pre-populate base_url /
+   * model / reasoning params from what is actually persisted in the DB —
+   * the database is the two-way source of truth, not write-only.
+   * `config` is null when the provider has no saved row yet.
+   */
+  async getProviderConfig(provider: string): Promise<{
+    provider: string;
+    config: {
+      base_url: string | null;
+      model_name: string | null;
+      temperature: number | null;
+      max_tokens: number | null;
+      active: boolean | null;
+    } | null;
+  }> {
+    const response = await this.client.get(`/admin/providers/${provider}/config`);
+    return response.data;
+  }
+
+  /**
+   * Persist a provider's config (base_url, model, reasoning params) WITHOUT
+   * activating it (#8). Backend COALESCEs omitted fields against the stored
+   * row, so a partial save never wipes the rest — send only what changed.
+   */
+  async saveProviderConfig(
+    provider: string,
+    config: {
+      base_url?: string;
+      model_name?: string;
+      temperature?: number;
+      max_tokens?: number;
+    }
+  ): Promise<{ status: string; provider: string }> {
+    const response = await this.client.post(`/admin/providers/${provider}/config`, config);
+    return response.data;
+  }
+
   // ============================================================
   // RBAC MANAGEMENT (ADR-074)
   // ============================================================

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -36,6 +36,17 @@ interface SystemTabProps {
   onError: (error: string) => void;
 }
 
+// Sensible default endpoint for local providers (editable in the card —
+// this is a placeholder, not hardcoded behaviour). Docker-network service
+// name for llamacpp (ADR-800 networking finding); ollama's well-known port.
+const LOCAL_DEFAULT_BASE_URL: Record<string, string> = {
+  llamacpp: 'http://kg-llamacpp:8080/v1',
+  ollama: 'http://localhost:11434',
+};
+
+// Sane KG default sampling temperature for extraction reasoning.
+const DEFAULT_TEMPERATURE = '0.1';
+
 export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   // Data states
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null);
@@ -65,6 +76,16 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
     is_local: boolean;
   }>>([]);
   const [refreshingCatalog, setRefreshingCatalog] = useState<string | null>(null);
+  // Per-provider editable draft (#8): base_url / model / reasoning params,
+  // hydrated from each provider's saved DB row so the card round-trips what
+  // is actually persisted. Same shape for every provider — uniform card.
+  const [providerDrafts, setProviderDrafts] = useState<Record<string, {
+    base_url: string;
+    model: string;
+    temperature: string;
+    max_tokens: string;
+  }>>({});
+  const [savingProvider, setSavingProvider] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshingCounters, setRefreshingCounters] = useState(false);
 
@@ -111,6 +132,32 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       setApiKeys(keys);
       setCatalog(modelCatalog);
       setProviders(supportedProviders);
+
+      // Hydrate each provider card's draft from its saved DB row so the
+      // card shows what is actually persisted (two-way source of truth, #8).
+      // Falls back to the local-provider default endpoint / sane temperature
+      // when there is no saved row yet.
+      const names = Array.from(new Set([
+        ...supportedProviders.map(p => p.provider),
+        ...(extraction?.provider ? [extraction.provider] : []),
+      ]));
+      const savedConfigs = await Promise.all(
+        names.map(n =>
+          apiClient.getProviderConfig(n)
+            .then(r => [n, r.config] as const)
+            .catch(() => [n, null] as const)
+        )
+      );
+      const drafts: Record<string, { base_url: string; model: string; temperature: string; max_tokens: string }> = {};
+      for (const [n, cfg] of savedConfigs) {
+        drafts[n] = {
+          base_url: cfg?.base_url ?? LOCAL_DEFAULT_BASE_URL[n] ?? '',
+          model: cfg?.model_name ?? '',
+          temperature: cfg?.temperature != null ? String(cfg.temperature) : DEFAULT_TEMPERATURE,
+          max_tokens: cfg?.max_tokens != null ? String(cfg.max_tokens) : '',
+        };
+      }
+      setProviderDrafts(drafts);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to load system data');
     } finally {
@@ -145,26 +192,6 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       onError(err instanceof Error ? err.message : 'Failed to activate embedding profile');
     } finally {
       setActivatingEmbedding(null);
-    }
-  };
-
-  // Extraction config handler — set the active provider+model directly from
-  // a provider card (no separate form; a key belongs to a provider).
-  const handleSetExtraction = async (provider: string, model: string) => {
-    if (!model) return;
-    setSettingExtraction(provider);
-    try {
-      await apiClient.updateExtractionConfig({
-        provider,
-        model,
-        updated_by: 'web-admin',
-      });
-      const extraction = await apiClient.getExtractionConfig();
-      setExtractionConfig(extraction);
-    } catch (err) {
-      onError(err instanceof Error ? err.message : 'Failed to save extraction config');
-    } finally {
-      setSettingExtraction(null);
     }
   };
 
@@ -230,16 +257,104 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
     [providers]
   );
 
-  const handleRefreshCatalog = async (provider: string) => {
+  // --- Uniform per-provider card handlers (#8) ------------------------------
+  // Every provider — cloud or local — uses the same shape: edit a draft,
+  // then Save / Get models / Set active. Only what each field means differs
+  // (key vs base_url), driven by /admin/providers metadata, not branches.
+
+  const blankDraft = { base_url: '', model: '', temperature: DEFAULT_TEMPERATURE, max_tokens: '' };
+
+  const updateDraft = (
+    provider: string,
+    patch: Partial<{ base_url: string; model: string; temperature: string; max_tokens: string }>
+  ) => {
+    setProviderDrafts(d => ({
+      ...d,
+      [provider]: { ...(d[provider] ?? blankDraft), ...patch },
+    }));
+  };
+
+  // Only send fields the user actually set — the backend COALESCEs omitted
+  // ones against the stored row, so a partial save never wipes the rest.
+  // base_url is only meaningful for local providers.
+  const buildPayload = (provider: string) => {
+    const d = providerDrafts[provider] ?? blankDraft;
+    const isLocal = !!providerMeta.get(provider)?.is_local;
+    const payload: { base_url?: string; model_name?: string; temperature?: number; max_tokens?: number } = {};
+    if (isLocal && d.base_url.trim()) payload.base_url = d.base_url.trim();
+    if (d.model) payload.model_name = d.model;
+    const t = Number(d.temperature);
+    if (d.temperature.trim() !== '' && !Number.isNaN(t)) payload.temperature = t;
+    const mt = Number(d.max_tokens);
+    if (d.max_tokens.trim() !== '' && Number.isInteger(mt) && mt > 0) payload.max_tokens = mt;
+    return payload;
+  };
+
+  // Re-hydrate one provider's draft from its persisted row (normalises what
+  // the server actually stored after a save).
+  const rehydrateDraft = async (provider: string) => {
+    try {
+      const { config } = await apiClient.getProviderConfig(provider);
+      setProviderDrafts(d => ({
+        ...d,
+        [provider]: {
+          base_url: config?.base_url ?? LOCAL_DEFAULT_BASE_URL[provider] ?? '',
+          model: config?.model_name ?? '',
+          temperature: config?.temperature != null ? String(config.temperature) : DEFAULT_TEMPERATURE,
+          max_tokens: config?.max_tokens != null ? String(config.max_tokens) : '',
+        },
+      }));
+    } catch {
+      /* non-fatal — keep the in-memory draft */
+    }
+  };
+
+  const handleSaveProviderConfig = async (provider: string) => {
+    setSavingProvider(provider);
+    try {
+      await apiClient.saveProviderConfig(provider, buildPayload(provider));
+      await rehydrateDraft(provider);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : `Failed to save ${provider} config`);
+    } finally {
+      setSavingProvider(null);
+    }
+  };
+
+  // "Get models" IS the connectivity test: persist the draft first (so the
+  // connector enumerates against the saved base_url for local providers),
+  // then refresh the catalog from the provider's API.
+  const handleGetModels = async (provider: string) => {
     setRefreshingCatalog(provider);
     try {
+      await apiClient.saveProviderConfig(provider, buildPayload(provider));
       await apiClient.refreshModelCatalog(provider);
       const { models } = await apiClient.getModelCatalog();
       setCatalog(models);
+      await rehydrateDraft(provider);
     } catch (err) {
-      onError(err instanceof Error ? err.message : `Failed to refresh ${provider} catalog`);
+      onError(err instanceof Error ? err.message : `Failed to get models for ${provider}`);
     } finally {
       setRefreshingCatalog(null);
+    }
+  };
+
+  // Persist the draft, then flip the active pointer to this provider+model.
+  // COALESCE on the backend means activation preserves the base_url /
+  // reasoning params just saved.
+  const handleActivate = async (provider: string) => {
+    const model = providerDrafts[provider]?.model;
+    if (!model) return;
+    setSettingExtraction(provider);
+    try {
+      await apiClient.saveProviderConfig(provider, buildPayload(provider));
+      await apiClient.updateExtractionConfig({ provider, model, updated_by: 'web-admin' });
+      const extraction = await apiClient.getExtractionConfig();
+      setExtractionConfig(extraction);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : `Failed to set ${provider} active`);
+    } finally {
+      setSettingExtraction(null);
     }
   };
 
@@ -775,15 +890,24 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
               const isActive = extractionConfig?.provider === name;
               const editingKey = apiKeyForm?.provider === name;
               const keyUsable = !requiresKey || (!!keyInfo?.configured && keyInfo?.validation_status === 'valid');
-              // You can always add/edit/save a key, but a provider can only
-              // be made the active extraction provider once it is actually
-              // usable: a valid key (if it needs one) and models present.
-              const activatable = keyUsable && models.length > 0;
-              const activateBlockReason = models.length === 0
-                ? 'No models — refresh the catalog first'
-                : !keyUsable
-                  ? 'Add a valid API key first'
-                  : `Use ${name} for extraction`;
+              const isLocal = !!meta?.is_local;
+              const draft = providerDrafts[name] ?? blankDraft;
+              // Activation is gated until the provider is genuinely usable:
+              // a valid key (if it needs one) AND an explicitly-picked model
+              // that exists in the catalog (i.e. "Get models" succeeded).
+              const modelChosen = !!draft.model && models.includes(draft.model);
+              const activatable = keyUsable && modelChosen;
+              const activateBlockReason = !keyUsable
+                ? 'Add a valid API key first'
+                : models.length === 0
+                  ? 'Get models first (tests connectivity & enumerates)'
+                  : !draft.model
+                    ? 'Pick a model first'
+                    : !models.includes(draft.model)
+                      ? 'Selected model is not in the catalog — Get models'
+                      : isActive
+                        ? `Re-apply ${name} config`
+                        : `Use ${name} for extraction`;
 
               return (
                 <div
@@ -793,35 +917,21 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                   {/* Header: provider + active state */}
                   <div className="flex items-center justify-between mb-3">
                     <span className="font-medium text-foreground capitalize">{name}</span>
-                    {isActive ? (
+                    {isActive && (
                       <span className="flex items-center gap-1 text-status-active text-xs font-medium">
                         <CheckCircle className="w-4 h-4" />
                         Active for extraction
                       </span>
-                    ) : (
-                      <button
-                        onClick={() => handleSetExtraction(name, models[0] ?? '')}
-                        disabled={settingExtraction !== null || !activatable}
-                        title={activateBlockReason}
-                        className="flex items-center gap-1 px-2.5 py-1 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50"
-                      >
-                        {settingExtraction === name ? (
-                          <Loader2 className="w-3 h-3 animate-spin" />
-                        ) : (
-                          <Play className="w-3 h-3" />
-                        )}
-                        Set active
-                      </button>
                     )}
                   </div>
 
-                  {/* Key row */}
+                  {/* Key row — only for providers that require a key */}
+                  {requiresKey && (
+                  <>
                   <div className="flex items-center justify-between gap-3 text-sm mb-3">
                     <div className="flex items-center gap-3 min-w-0">
                       <Key className="w-4 h-4 text-muted-foreground shrink-0" />
-                      {!requiresKey ? (
-                        <span className="text-muted-foreground">Local provider — no API key required</span>
-                      ) : keyInfo?.configured ? (
+                      {keyInfo?.configured ? (
                         <>
                           {keyInfo?.validation_status === 'valid' ? (
                             <span className="flex items-center gap-1 text-status-active">
@@ -842,7 +952,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                         <span className="text-muted-foreground">No key configured</span>
                       )}
                     </div>
-                    {requiresKey && !editingKey && (
+                    {!editingKey && (
                       <div className="flex items-center gap-2 shrink-0">
                         <button
                           onClick={() => setApiKeyForm({ provider: name, key: '' })}
@@ -908,58 +1018,127 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                       </div>
                     </div>
                   )}
+                  </>
+                  )}
 
-                  {/* Models row */}
-                  <div className="flex items-center justify-between gap-3 text-sm">
-                    <span className="text-muted-foreground">
-                      {models.length} extraction model{models.length === 1 ? '' : 's'} in catalog
-                    </span>
-                    <button
-                      onClick={() => handleRefreshCatalog(name)}
-                      disabled={refreshingCatalog !== null}
-                      className="flex items-center gap-1 px-2 py-1 text-xs bg-muted text-muted-foreground rounded hover:bg-muted/80 disabled:opacity-50"
-                      title={`Refresh ${name} model catalog`}
-                    >
-                      {refreshingCatalog === name ? (
-                        <Loader2 className="w-3 h-3 animate-spin" />
-                      ) : (
-                        <RefreshCw className="w-3 h-3" />
-                      )}
-                      Refresh
-                    </button>
+                  {/* Endpoint row — local providers only. Uniform card: this
+                      is the same slot the key occupies for cloud providers. */}
+                  {isLocal && (
+                    <div className="flex items-center gap-3 text-sm mb-3">
+                      <Server className="w-4 h-4 text-muted-foreground shrink-0" />
+                      <label className="text-muted-foreground shrink-0">Endpoint</label>
+                      <input
+                        type="text"
+                        value={draft.base_url}
+                        onChange={(e) => updateDraft(name, { base_url: e.target.value })}
+                        placeholder={LOCAL_DEFAULT_BASE_URL[name] ?? 'http://host:port/v1'}
+                        className="flex-1 px-3 py-1.5 bg-background border border-border rounded text-foreground text-sm font-mono"
+                      />
+                    </div>
+                  )}
+
+                  {/* Model + reasoning controls — identical for every provider */}
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-3">
+                    <div className="sm:col-span-3 flex items-center gap-2">
+                      <label className="text-sm text-muted-foreground shrink-0 w-24">Model</label>
+                      <select
+                        value={draft.model}
+                        onChange={(e) => updateDraft(name, { model: e.target.value })}
+                        className="flex-1 px-3 py-1.5 bg-background border border-border rounded text-foreground text-sm"
+                      >
+                        <option value="">
+                          {models.length === 0 ? 'No models — Get models first' : 'Select a model…'}
+                        </option>
+                        {draft.model && !models.includes(draft.model) && (
+                          <option value={draft.model}>{draft.model} (saved)</option>
+                        )}
+                        {models.map(m => (
+                          <option key={m} value={m}>{m}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <label className="text-sm text-muted-foreground shrink-0 w-24">Temp</label>
+                      <input
+                        type="number"
+                        step="0.1"
+                        min="0"
+                        max="2"
+                        value={draft.temperature}
+                        onChange={(e) => updateDraft(name, { temperature: e.target.value })}
+                        className="w-full px-2 py-1.5 bg-background border border-border rounded text-foreground text-sm"
+                      />
+                    </div>
+                    <div className="flex items-center gap-2 sm:col-span-2">
+                      <label className="text-sm text-muted-foreground shrink-0 w-24">Max tokens</label>
+                      <input
+                        type="number"
+                        min="1"
+                        step="1"
+                        value={draft.max_tokens}
+                        onChange={(e) => updateDraft(name, { max_tokens: e.target.value })}
+                        placeholder="model default"
+                        className="w-full px-2 py-1.5 bg-background border border-border rounded text-foreground text-sm"
+                      />
+                    </div>
                   </div>
 
-                  {/* Active provider: model selector + config detail */}
-                  {isActive && (
-                    <div className="mt-3 pt-3 border-t border-border space-y-2">
-                      <div className="flex items-center gap-2">
-                        <label className="text-sm text-muted-foreground">Extraction model:</label>
-                        <select
-                          value={extractionConfig?.model ?? ''}
-                          onChange={(e) => handleSetExtraction(name, e.target.value)}
-                          disabled={settingExtraction !== null || models.length === 0}
-                          className="flex-1 px-3 py-1.5 bg-background border border-border rounded text-foreground text-sm"
-                        >
-                          {!models.includes(extractionConfig?.model ?? '') && extractionConfig?.model && (
-                            <option value={extractionConfig.model}>{extractionConfig.model} (current)</option>
-                          )}
-                          {models.map(m => (
-                            <option key={m} value={m}>{m}</option>
-                          ))}
-                        </select>
-                        {settingExtraction === name && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />}
-                      </div>
-                      {extractionConfig && (
-                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                          <span>Max tokens: {extractionConfig.max_tokens?.toLocaleString() ?? '—'}</span>
-                          <span>Vision: {extractionConfig.supports_vision ? 'Yes' : 'No'}</span>
-                          <span>JSON mode: {extractionConfig.supports_json_mode ? 'Yes' : 'No'}</span>
-                          {extractionConfig.rate_limit_config && (
-                            <span>
-                              Concurrency: {extractionConfig.rate_limit_config.max_concurrent_requests} / {extractionConfig.rate_limit_config.max_retries} retries
-                            </span>
-                          )}
-                        </div>
+                  {/* Actions — Save / Get models / Set active, side by side.
+                      "Get models" IS the connectivity test (it enumerates).
+                      "Set active" is gated until tested-valid + model picked. */}
+                  <div className="flex items-center justify-between gap-3 pt-3 border-t border-border">
+                    <span className="text-muted-foreground text-xs">
+                      {models.length} model{models.length === 1 ? '' : 's'} in catalog
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleSaveProviderConfig(name)}
+                        disabled={savingProvider !== null}
+                        title="Persist this provider's config without activating it"
+                        className="flex items-center gap-1 px-2.5 py-1 text-xs bg-muted text-muted-foreground rounded hover:bg-muted/80 disabled:opacity-50"
+                      >
+                        {savingProvider === name && <Loader2 className="w-3 h-3 animate-spin" />}
+                        Save
+                      </button>
+                      <button
+                        onClick={() => handleGetModels(name)}
+                        disabled={refreshingCatalog !== null}
+                        title="Save config, test connectivity, and enumerate models"
+                        className="flex items-center gap-1 px-2.5 py-1 text-xs bg-muted text-muted-foreground rounded hover:bg-muted/80 disabled:opacity-50"
+                      >
+                        {refreshingCatalog === name ? (
+                          <Loader2 className="w-3 h-3 animate-spin" />
+                        ) : (
+                          <RefreshCw className="w-3 h-3" />
+                        )}
+                        Get models
+                      </button>
+                      <button
+                        onClick={() => handleActivate(name)}
+                        disabled={settingExtraction !== null || !activatable}
+                        title={activateBlockReason}
+                        className="flex items-center gap-1 px-2.5 py-1 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50"
+                      >
+                        {settingExtraction === name ? (
+                          <Loader2 className="w-3 h-3 animate-spin" />
+                        ) : (
+                          <Play className="w-3 h-3" />
+                        )}
+                        {isActive ? 'Re-apply' : 'Set active'}
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Active provider: persisted capability detail (read-only) */}
+                  {isActive && extractionConfig && (
+                    <div className="mt-3 pt-3 border-t border-border flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                      <span>Max tokens: {extractionConfig.max_tokens?.toLocaleString() ?? '—'}</span>
+                      <span>Vision: {extractionConfig.supports_vision ? 'Yes' : 'No'}</span>
+                      <span>JSON mode: {extractionConfig.supports_json_mode ? 'Yes' : 'No'}</span>
+                      {extractionConfig.rate_limit_config && (
+                        <span>
+                          Concurrency: {extractionConfig.rate_limit_config.max_concurrent_requests} / {extractionConfig.rate_limit_config.max_retries} retries
+                        </span>
                       )}
                     </div>
                   )}

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -23,12 +23,10 @@ import {
   BarChart3,
   Layers,
   Play,
-  Save,
   Trash2,
   TestTube,
   Eye,
   EyeOff,
-  ChevronDown,
 } from 'lucide-react';
 import { apiClient, API_BASE_URL } from '../../api/client';
 import { Section, StatusBadge } from './components';
@@ -50,14 +48,30 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const [embeddingConfigs, setEmbeddingConfigs] = useState<EmbeddingConfig[]>([]);
   const [extractionConfig, setExtractionConfig] = useState<ExtractionConfig | null>(null);
   const [apiKeys, setApiKeys] = useState<ApiKeyInfo[]>([]);
+  const [catalog, setCatalog] = useState<Array<{
+    id: number;
+    provider: string;
+    model_id: string;
+    display_name: string | null;
+    category: string;
+    enabled: boolean;
+    is_default: boolean;
+    sort_order: number;
+    upstream_provider: string | null;
+  }>>([]);
+  const [providers, setProviders] = useState<Array<{
+    provider: string;
+    requires_key: boolean;
+    is_local: boolean;
+  }>>([]);
+  const [refreshingCatalog, setRefreshingCatalog] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshingCounters, setRefreshingCounters] = useState(false);
 
   // Interactive UI states
   const [activatingEmbedding, setActivatingEmbedding] = useState<number | null>(null);
   const [confirmActivate, setConfirmActivate] = useState<number | null>(null);
-  const [savingExtraction, setSavingExtraction] = useState(false);
-  const [extractionForm, setExtractionForm] = useState<{ provider: string; model: string } | null>(null);
+  const [settingExtraction, setSettingExtraction] = useState<string | null>(null);
   const [apiKeyForm, setApiKeyForm] = useState<{ provider: string; key: string } | null>(null);
   const [savingApiKey, setSavingApiKey] = useState(false);
   const [showApiKey, setShowApiKey] = useState<string | null>(null);
@@ -71,7 +85,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const loadData = async () => {
     setLoading(true);
     try {
-      const [status, stats, counters, scheduler, workers, embeddings, extraction, keys, apiInfo, dbEpoch] = await Promise.all([
+      const [status, stats, counters, scheduler, workers, embeddings, extraction, keys, apiInfo, dbEpoch, modelCatalog, supportedProviders] = await Promise.all([
         apiClient.getSystemStatus().catch(() => null),
         apiClient.getDatabaseStats().catch(() => null),
         apiClient.getDatabaseCounters().catch(() => null),
@@ -82,6 +96,8 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
         apiClient.listApiKeys().catch(() => []),
         apiClient.getApiInfo().catch(() => ({ epoch: 0, status: 'error' })),
         apiClient.getDatabaseEpoch().catch(() => 0),
+        apiClient.getModelCatalog().then(r => r.models).catch(() => []),
+        apiClient.getProviders().then(r => r.providers).catch(() => []),
       ]);
       setSystemStatus(status);
       setDbStats(stats);
@@ -93,6 +109,8 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       setEmbeddingConfigs(embeddings);
       setExtractionConfig(extraction);
       setApiKeys(keys);
+      setCatalog(modelCatalog);
+      setProviders(supportedProviders);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to load system data');
     } finally {
@@ -130,24 +148,23 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
     }
   };
 
-  // Extraction config handler
-  const handleSaveExtraction = async () => {
-    if (!extractionForm) return;
-    setSavingExtraction(true);
+  // Extraction config handler — set the active provider+model directly from
+  // a provider card (no separate form; a key belongs to a provider).
+  const handleSetExtraction = async (provider: string, model: string) => {
+    if (!model) return;
+    setSettingExtraction(provider);
     try {
       await apiClient.updateExtractionConfig({
-        provider: extractionForm.provider,
-        model: extractionForm.model,
+        provider,
+        model,
         updated_by: 'web-admin',
       });
-      // Reload extraction config
       const extraction = await apiClient.getExtractionConfig();
       setExtractionConfig(extraction);
-      setExtractionForm(null);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to save extraction config');
     } finally {
-      setSavingExtraction(false);
+      setSettingExtraction(null);
     }
   };
 
@@ -182,16 +199,49 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
     }
   };
 
-  // Provider/model options
-  const extractionProviders = [
-    { provider: 'openai', models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo'] },
-    { provider: 'anthropic', models: ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022', 'claude-3-haiku-20240307'] },
-    { provider: 'ollama', models: ['mistral', 'llama3.2', 'qwen2.5'] },
-    { provider: 'openrouter', models: ['(placeholder - not yet implemented)'] },
-    { provider: 'llama.cpp', models: ['(placeholder - not yet implemented)'] },
-  ];
+  // Provider/model options are derived from the runtime model catalog and the
+  // configured-keys list — never hardcoded (ADR-800). Operators populate the
+  // catalog via "Refresh" (or the CLI), and the UI reflects whatever is there.
+  const extractionProviders = React.useMemo(() => {
+    const byProvider = new Map<string, string[]>();
+    for (const m of catalog) {
+      if (m.category !== 'extraction') continue;
+      if (!byProvider.has(m.provider)) byProvider.set(m.provider, []);
+      byProvider.get(m.provider)!.push(m.model_id);
+    }
+    return Array.from(byProvider.entries()).map(([provider, models]) => ({ provider, models }));
+  }, [catalog]);
 
-  const apiKeyProviders = ['openai', 'anthropic', 'openrouter'];
+
+  // The canonical /admin/providers list drives which cards render — one per
+  // supported provider, local providers included even with an empty catalog
+  // so they can be enumerated/activated. Fall back to the active provider so
+  // a card always shows for whatever is currently in use.
+  const providerNames = React.useMemo(
+    () => Array.from(new Set([
+      ...providers.map(p => p.provider),
+      ...(extractionConfig?.provider ? [extractionConfig.provider] : []),
+    ])).sort(),
+    [providers, extractionConfig]
+  );
+
+  const providerMeta = React.useMemo(
+    () => new Map(providers.map(p => [p.provider, p])),
+    [providers]
+  );
+
+  const handleRefreshCatalog = async (provider: string) => {
+    setRefreshingCatalog(provider);
+    try {
+      await apiClient.refreshModelCatalog(provider);
+      const { models } = await apiClient.getModelCatalog();
+      setCatalog(models);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : `Failed to refresh ${provider} catalog`);
+    } finally {
+      setRefreshingCatalog(null);
+    }
+  };
 
   if (loading) {
     return (
@@ -694,293 +744,229 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
         )}
       </Section>
 
-      {/* Extraction Config Section */}
+      {/* AI Providers Section — unified per-provider cards (key + models +
+          active extraction selection). A key belongs to a provider, so key
+          management lives on the provider card rather than a separate section. */}
       <Section
-        title="AI Extraction"
+        title="AI Providers"
         icon={<BrainCircuit className="w-5 h-5" />}
       >
         <p className="text-sm text-muted-foreground mb-4">
-          LLM provider for concept extraction from documents.
+          One card per provider. Each card holds its API key (encrypted at rest,
+          validated on save), its catalog models, and whether it is the active
+          provider for concept extraction. Provider and model options are
+          derived from the model catalog — nothing is hardcoded.
         </p>
 
-        {/* Edit Form */}
-        {extractionForm ? (
-          <div className="p-4 bg-muted/50 rounded-lg border border-border mb-4">
-            <div className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm text-muted-foreground mb-1">Provider</label>
-                  <select
-                    value={extractionForm.provider}
-                    onChange={(e) => {
-                      const provider = e.target.value;
-                      const models = extractionProviders.find(p => p.provider === provider)?.models || [];
-                      setExtractionForm({ provider, model: models[0] || '' });
-                    }}
-                    className="w-full px-3 py-2 bg-background border border-border rounded text-foreground text-sm"
-                  >
-                    {extractionProviders.map(p => (
-                      <option key={p.provider} value={p.provider}>
-                        {p.provider}
-                        {(p.provider === 'openrouter' || p.provider === 'llama.cpp') && ' (placeholder)'}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-sm text-muted-foreground mb-1">Model</label>
-                  <select
-                    value={extractionForm.model}
-                    onChange={(e) => setExtractionForm({ ...extractionForm, model: e.target.value })}
-                    className="w-full px-3 py-2 bg-background border border-border rounded text-foreground text-sm"
-                    disabled={extractionForm.provider === 'openrouter' || extractionForm.provider === 'llama.cpp'}
-                  >
-                    {extractionProviders.find(p => p.provider === extractionForm.provider)?.models.map(m => (
-                      <option key={m} value={m}>{m}</option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-              {(extractionForm.provider === 'openrouter' || extractionForm.provider === 'llama.cpp') && (
-                <p className="text-xs text-status-warning">
-                  {extractionForm.provider} support is not yet implemented. This is a placeholder for future development.
-                </p>
-              )}
-              <div className="flex justify-end gap-2">
-                <button
-                  onClick={() => setExtractionForm(null)}
-                  className="px-3 py-1.5 text-sm bg-muted text-muted-foreground rounded hover:bg-muted/80"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSaveExtraction}
-                  disabled={savingExtraction || extractionForm.provider === 'openrouter' || extractionForm.provider === 'llama.cpp'}
-                  className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50"
-                >
-                  {savingExtraction ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                  ) : (
-                    <Save className="w-4 h-4" />
-                  )}
-                  Save
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : extractionConfig ? (
-          <div className="p-4 bg-muted/50 rounded-lg border border-border">
-            <div className="flex items-start justify-between">
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm flex-1">
-                <div>
-                  <span className="text-muted-foreground">Provider:</span>
-                  <span className="ml-2 font-medium text-foreground capitalize">{extractionConfig.provider}</span>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Model:</span>
-                  <span className="ml-2 font-mono text-foreground">{extractionConfig.model}</span>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Max Tokens:</span>
-                  <span className="ml-2 text-foreground">{extractionConfig.max_tokens?.toLocaleString()}</span>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Vision:</span>
-                  <span className={`ml-2 ${extractionConfig.supports_vision ? 'text-status-active' : 'text-muted-foreground'}`}>
-                    {extractionConfig.supports_vision ? 'Yes' : 'No'}
-                  </span>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">JSON Mode:</span>
-                  <span className={`ml-2 ${extractionConfig.supports_json_mode ? 'text-status-active' : 'text-muted-foreground'}`}>
-                    {extractionConfig.supports_json_mode ? 'Yes' : 'No'}
-                  </span>
-                </div>
-                {extractionConfig.rate_limit_config && (
-                  <div>
-                    <span className="text-muted-foreground">Concurrency:</span>
-                    <span className="ml-2 text-foreground">
-                      {extractionConfig.rate_limit_config.max_concurrent_requests} / {extractionConfig.rate_limit_config.max_retries} retries
-                    </span>
-                  </div>
-                )}
-              </div>
-              <button
-                onClick={() => setExtractionForm({
-                  provider: extractionConfig.provider,
-                  model: extractionConfig.model,
-                })}
-                className="ml-4 p-2 text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
-                title="Edit extraction config"
-              >
-                <ChevronDown className="w-4 h-4" />
-              </button>
-            </div>
-          </div>
-        ) : (
-          <div className="p-4 bg-muted/50 rounded-lg border border-border">
-            <p className="text-muted-foreground text-center py-2">
-              No extraction configuration found.
-            </p>
-            <div className="flex justify-center mt-2">
-              <button
-                onClick={() => setExtractionForm({ provider: 'openai', model: 'gpt-4o' })}
-                className="px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded hover:bg-primary/80"
-              >
-                Configure
-              </button>
-            </div>
-          </div>
-        )}
-      </Section>
-
-      {/* API Keys Section */}
-      <Section
-        title="API Keys"
-        icon={<Key className="w-5 h-5" />}
-      >
-        <p className="text-sm text-muted-foreground mb-4">
-          API keys for AI providers (encrypted at rest). Keys are validated on save.
-        </p>
-
-        {/* Add Key Form */}
-        {apiKeyForm ? (
-          <div className="p-4 bg-muted/50 rounded-lg border border-border mb-4">
-            <div className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div>
-                  <label className="block text-sm text-muted-foreground mb-1">Provider</label>
-                  <select
-                    value={apiKeyForm.provider}
-                    onChange={(e) => setApiKeyForm({ ...apiKeyForm, provider: e.target.value })}
-                    className="w-full px-3 py-2 bg-background border border-border rounded text-foreground text-sm"
-                  >
-                    {apiKeyProviders.map(p => (
-                      <option key={p} value={p}>{p}</option>
-                    ))}
-                  </select>
-                </div>
-                <div className="md:col-span-2">
-                  <label className="block text-sm text-muted-foreground mb-1">API Key</label>
-                  <div className="relative">
-                    <input
-                      type={showApiKey === 'form' ? 'text' : 'password'}
-                      value={apiKeyForm.key}
-                      onChange={(e) => setApiKeyForm({ ...apiKeyForm, key: e.target.value })}
-                      placeholder="sk-..."
-                      className="w-full px-3 py-2 pr-10 bg-background border border-border rounded text-foreground text-sm font-mono"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowApiKey(showApiKey === 'form' ? null : 'form')}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
-                    >
-                      {showApiKey === 'form' ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                    </button>
-                  </div>
-                </div>
-              </div>
-              <div className="flex justify-end gap-2">
-                <button
-                  onClick={() => setApiKeyForm(null)}
-                  className="px-3 py-1.5 text-sm bg-muted text-muted-foreground rounded hover:bg-muted/80"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSaveApiKey}
-                  disabled={savingApiKey || !apiKeyForm.key}
-                  className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50"
-                >
-                  {savingApiKey ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                  ) : (
-                    <>
-                      <TestTube className="w-4 h-4" />
-                      Test & Save
-                    </>
-                  )}
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="mb-4">
-            <button
-              onClick={() => setApiKeyForm({ provider: 'openai', key: '' })}
-              className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded hover:bg-primary/80"
-            >
-              <Key className="w-4 h-4" />
-              Add API Key
-            </button>
-          </div>
-        )}
-
-        {/* Existing Keys */}
-        {apiKeys.length > 0 ? (
-          <div className="space-y-2">
-            {apiKeys.map((key) => (
-              <div
-                key={key.provider}
-                className="flex items-center justify-between p-3 bg-muted/50 rounded-lg border border-border"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="font-medium text-foreground capitalize w-24">
-                    {key.provider}
-                  </span>
-                  {key.configured ? (
-                    <>
-                      {key.validation_status === 'valid' ? (
-                        <span className="flex items-center gap-1 text-status-active text-sm">
-                          <CheckCircle className="w-4 h-4" />
-                          Valid
-                        </span>
-                      ) : (
-                        <span className="flex items-center gap-1 text-status-warning text-sm">
-                          <AlertCircle className="w-4 h-4" />
-                          {key.validation_status ?? 'Unknown'}
-                        </span>
-                      )}
-                      {key.masked_key && (
-                        <span className="text-xs text-muted-foreground font-mono">
-                          {key.masked_key}
-                        </span>
-                      )}
-                    </>
-                  ) : (
-                    <span className="text-muted-foreground text-sm">
-                      Not configured
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  {key.last_validated_at && (
-                    <span className="text-xs text-muted-foreground">
-                      {new Date(key.last_validated_at).toLocaleDateString()}
-                    </span>
-                  )}
-                  {key.configured && (
-                    <button
-                      onClick={() => handleDeleteApiKey(key.provider)}
-                      disabled={deletingApiKey === key.provider}
-                      className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded transition-colors disabled:opacity-50"
-                      title="Delete API key"
-                    >
-                      {deletingApiKey === key.provider ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        <Trash2 className="w-4 h-4" />
-                      )}
-                    </button>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
+        {providerNames.length === 0 ? (
           <p className="text-muted-foreground text-center py-4">
-            No API keys configured.
+            No providers configured yet. Add an API key via the CLI, or once a
+            cloud provider key is set its models appear here after a refresh.
           </p>
+        ) : (
+          <div className="space-y-3">
+            {providerNames.map((name) => {
+              const keyInfo = apiKeys.find(k => k.provider === name);
+              const meta = providerMeta.get(name);
+              // Authoritative from /admin/providers; fall back to key presence
+              // only if metadata is somehow missing (e.g. active legacy provider).
+              const requiresKey = meta?.requires_key ?? (keyInfo !== undefined);
+              const models = extractionProviders.find(p => p.provider === name)?.models ?? [];
+              const isActive = extractionConfig?.provider === name;
+              const editingKey = apiKeyForm?.provider === name;
+              const keyUsable = !requiresKey || (!!keyInfo?.configured && keyInfo?.validation_status === 'valid');
+              // You can always add/edit/save a key, but a provider can only
+              // be made the active extraction provider once it is actually
+              // usable: a valid key (if it needs one) and models present.
+              const activatable = keyUsable && models.length > 0;
+              const activateBlockReason = models.length === 0
+                ? 'No models — refresh the catalog first'
+                : !keyUsable
+                  ? 'Add a valid API key first'
+                  : `Use ${name} for extraction`;
+
+              return (
+                <div
+                  key={name}
+                  className={`p-4 rounded-lg border ${isActive ? 'border-status-active bg-status-active/5' : 'border-border bg-muted/50'}`}
+                >
+                  {/* Header: provider + active state */}
+                  <div className="flex items-center justify-between mb-3">
+                    <span className="font-medium text-foreground capitalize">{name}</span>
+                    {isActive ? (
+                      <span className="flex items-center gap-1 text-status-active text-xs font-medium">
+                        <CheckCircle className="w-4 h-4" />
+                        Active for extraction
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => handleSetExtraction(name, models[0] ?? '')}
+                        disabled={settingExtraction !== null || !activatable}
+                        title={activateBlockReason}
+                        className="flex items-center gap-1 px-2.5 py-1 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50"
+                      >
+                        {settingExtraction === name ? (
+                          <Loader2 className="w-3 h-3 animate-spin" />
+                        ) : (
+                          <Play className="w-3 h-3" />
+                        )}
+                        Set active
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Key row */}
+                  <div className="flex items-center justify-between gap-3 text-sm mb-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Key className="w-4 h-4 text-muted-foreground shrink-0" />
+                      {!requiresKey ? (
+                        <span className="text-muted-foreground">Local provider — no API key required</span>
+                      ) : keyInfo?.configured ? (
+                        <>
+                          {keyInfo?.validation_status === 'valid' ? (
+                            <span className="flex items-center gap-1 text-status-active">
+                              <CheckCircle className="w-4 h-4" /> Valid
+                            </span>
+                          ) : (
+                            <span className="flex items-center gap-1 text-status-warning">
+                              <AlertCircle className="w-4 h-4" /> {keyInfo?.validation_status ?? 'Unknown'}
+                            </span>
+                          )}
+                          {keyInfo?.masked_key && (
+                            <span className="text-xs text-muted-foreground font-mono truncate">
+                              {keyInfo?.masked_key}
+                            </span>
+                          )}
+                        </>
+                      ) : (
+                        <span className="text-muted-foreground">No key configured</span>
+                      )}
+                    </div>
+                    {requiresKey && !editingKey && (
+                      <div className="flex items-center gap-2 shrink-0">
+                        <button
+                          onClick={() => setApiKeyForm({ provider: name, key: '' })}
+                          className="px-2 py-1 text-xs bg-muted text-muted-foreground rounded hover:bg-muted/80"
+                        >
+                          {keyInfo?.configured ? 'Replace key' : 'Add key'}
+                        </button>
+                        {keyInfo?.configured && (
+                          <button
+                            onClick={() => handleDeleteApiKey(name)}
+                            disabled={deletingApiKey === name}
+                            className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded disabled:opacity-50"
+                            title="Delete API key"
+                          >
+                            {deletingApiKey === name ? (
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="w-4 h-4" />
+                            )}
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Inline key form for this provider */}
+                  {editingKey && (
+                    <div className="mb-3 p-3 bg-background rounded border border-border space-y-3">
+                      <div className="relative">
+                        <input
+                          type={showApiKey === name ? 'text' : 'password'}
+                          value={apiKeyForm!.key}
+                          onChange={(e) => setApiKeyForm({ provider: name, key: e.target.value })}
+                          placeholder="sk-..."
+                          className="w-full px-3 py-2 pr-10 bg-background border border-border rounded text-foreground text-sm font-mono"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowApiKey(showApiKey === name ? null : name)}
+                          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
+                        >
+                          {showApiKey === name ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                      </div>
+                      <div className="flex justify-end gap-2">
+                        <button
+                          onClick={() => setApiKeyForm(null)}
+                          className="px-3 py-1.5 text-sm bg-muted text-muted-foreground rounded hover:bg-muted/80"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          onClick={handleSaveApiKey}
+                          disabled={savingApiKey || !apiKeyForm!.key}
+                          className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded hover:bg-primary/80 disabled:opacity-50"
+                        >
+                          {savingApiKey ? (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                          ) : (
+                            <><TestTube className="w-4 h-4" /> Test &amp; Save</>
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Models row */}
+                  <div className="flex items-center justify-between gap-3 text-sm">
+                    <span className="text-muted-foreground">
+                      {models.length} extraction model{models.length === 1 ? '' : 's'} in catalog
+                    </span>
+                    <button
+                      onClick={() => handleRefreshCatalog(name)}
+                      disabled={refreshingCatalog !== null}
+                      className="flex items-center gap-1 px-2 py-1 text-xs bg-muted text-muted-foreground rounded hover:bg-muted/80 disabled:opacity-50"
+                      title={`Refresh ${name} model catalog`}
+                    >
+                      {refreshingCatalog === name ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : (
+                        <RefreshCw className="w-3 h-3" />
+                      )}
+                      Refresh
+                    </button>
+                  </div>
+
+                  {/* Active provider: model selector + config detail */}
+                  {isActive && (
+                    <div className="mt-3 pt-3 border-t border-border space-y-2">
+                      <div className="flex items-center gap-2">
+                        <label className="text-sm text-muted-foreground">Extraction model:</label>
+                        <select
+                          value={extractionConfig?.model ?? ''}
+                          onChange={(e) => handleSetExtraction(name, e.target.value)}
+                          disabled={settingExtraction !== null || models.length === 0}
+                          className="flex-1 px-3 py-1.5 bg-background border border-border rounded text-foreground text-sm"
+                        >
+                          {!models.includes(extractionConfig?.model ?? '') && extractionConfig?.model && (
+                            <option value={extractionConfig.model}>{extractionConfig.model} (current)</option>
+                          )}
+                          {models.map(m => (
+                            <option key={m} value={m}>{m}</option>
+                          ))}
+                        </select>
+                        {settingExtraction === name && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />}
+                      </div>
+                      {extractionConfig && (
+                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                          <span>Max tokens: {extractionConfig.max_tokens?.toLocaleString() ?? '—'}</span>
+                          <span>Vision: {extractionConfig.supports_vision ? 'Yes' : 'No'}</span>
+                          <span>JSON mode: {extractionConfig.supports_json_mode ? 'Yes' : 'No'}</span>
+                          {extractionConfig.rate_limit_config && (
+                            <span>
+                              Concurrency: {extractionConfig.rate_limit_config.max_concurrent_requests} / {extractionConfig.rate_limit_config.max_retries} retries
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         )}
       </Section>
     </>

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -995,6 +995,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                           value={apiKeyForm!.key}
                           onChange={(e) => setApiKeyForm({ provider: name, key: e.target.value })}
                           placeholder="sk-..."
+                          autoComplete="new-password"
                           className="w-full px-3 py-2 pr-10 bg-background border border-border rounded text-foreground text-sm font-mono"
                         />
                         <button
@@ -1040,6 +1041,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                         value={draft.base_url}
                         onChange={(e) => updateDraft(name, { base_url: e.target.value })}
                         placeholder={LOCAL_DEFAULT_BASE_URL[name] ?? 'http://host:port/v1'}
+                        autoComplete="off"
                         className="flex-1 px-3 py-1.5 bg-background border border-border rounded text-foreground text-sm font-mono"
                       />
                     </div>
@@ -1074,6 +1076,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                         max="2"
                         value={draft.temperature}
                         onChange={(e) => updateDraft(name, { temperature: e.target.value })}
+                        autoComplete="off"
                         className="w-full px-2 py-1.5 bg-background border border-border rounded text-foreground text-sm"
                       />
                     </div>
@@ -1086,6 +1089,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                         value={draft.max_tokens}
                         onChange={(e) => updateDraft(name, { max_tokens: e.target.value })}
                         placeholder="model default"
+                        autoComplete="off"
                         className="w-full px-2 py-1.5 bg-background border border-border rounded text-foreground text-sm"
                       />
                     </div>

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -314,6 +314,10 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
     try {
       await apiClient.saveProviderConfig(provider, buildPayload(provider));
       await rehydrateDraft(provider);
+      // Keep the active provider's read-only detail line in sync — it reads
+      // from extractionConfig, which the save may have just changed.
+      const extraction = await apiClient.getExtractionConfig();
+      setExtractionConfig(extraction);
     } catch (err) {
       onError(err instanceof Error ? err.message : `Failed to save ${provider} config`);
     } finally {
@@ -332,6 +336,10 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       const { models } = await apiClient.getModelCatalog();
       setCatalog(models);
       await rehydrateDraft(provider);
+      // Active provider's detail line reads extractionConfig — refresh it in
+      // case the refreshed catalog changed what its active model resolves to.
+      const extraction = await apiClient.getExtractionConfig();
+      setExtractionConfig(extraction);
     } catch (err) {
       onError(err instanceof Error ? err.message : `Failed to get models for ${provider}`);
     } finally {


### PR DESCRIPTION
## Summary

Makes the KG provider system **uniform, DB-driven, and non-hardcoded** (ADR-800 → ADR-801). Originated from "setting the Anthropic key in the web UI doesn't save"; the real gap was a hardcoded openai/anthropic UI over a single-global-config model. This PR establishes a uniform provider configuration contract.

## What changed

- **Uniform per-provider card** (`SystemTab.tsx`): one card shape for every provider, cloud and local. Rows are gated by `/admin/providers` metadata (`requires_key` vs `is_local`) — no per-provider code branches. Save / Get models / Set active side-by-side; "Get models" *is* the connectivity test; "Set active" gated on a picked catalog model.
- **Partial-save preservation at the persistence layer** (`save_extraction_config`): `ON CONFLICT(provider)` COALESCEs every omitted field against the stored row, with `COALESCE(NULLIF(EXCLUDED.model_name,''),stored)`. Structurally kills the "activate/partial-save wipes base_url/model" bug class for all callers, present and future.
- **Two-way DB source of truth**: new `GET /admin/providers/{provider}/config` symmetric to the POST; cards pre-populate from what is actually persisted. Shared `_validate_provider_id` so GET/POST/DELETE enforce the same id rule.
- **No hardcoded model lists** (reaffirms ADR-800): `AnthropicProvider.fetch_model_catalog` now SDK-enumerated (was a static Claude-3 list); `OpenAIProvider` inverted from a name allowlist to a non-extraction denylist so new families (o3/o4/gpt-5) appear with no code change. OpenRouter confirmed already fully dynamic.
- **ADR-801** (Draft): the uniform contract's four decisions, written from the experiment per the explicit experiment-first method. Extends ADR-800, does not mutate it.
- **Operator way**: local-inference-provider docker-network pattern, AMD Vulkan/GID notes, the kg-api no-hot-reload + migrate gotchas (ADR-128 routing — ops knowledge → way, not the ADR).
- Web autofill highlight-bleed fix.

## Verification

- 28 new contract tests (`tests/unit/lib/test_provider_config.py`, `tests/api/test_providers_routes.py`); provider/config suite **62 passed**, endpoint-security regression green.
- `tsc --noEmit` clean; `adr lint` 0/0.
- Live, user-verified: llama.cpp Get models → Set active end-to-end; Anthropic Claude 4 + OpenAI correct models after key add; uniform card "very usable".

## Code review

Internal review: **nothing blocking**. Should-fix #1 (asymmetric provider-id validation) fixed in this PR with a test. Follow-ups (not blocking): extract `<ProviderCard>` from the 1167-line `SystemTab.tsx` (SRP); document/guard unused `base_url` for cloud providers; optional loopback-base_url soft-warning for local providers.

## Merge

Requested strategy: **merge commit** (preserve the #8→#12 progression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
