### PR TITLE
feat(vision): catalog-driven vision model selection (reaffirms ADR-801)

### DIFF
--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -540,6 +540,11 @@ class OpenAIProvider(AIProvider):
                     "context_length": None,
                     # Vision-capable families: 4o, gpt-4-turbo, the o-series
                     # reasoning models (o1/o3/o4 accept image input), gpt-5.
+                    # Known maintenance point: the o-series prefix list is a
+                    # bounded-staleness heuristic (a future o5/alias not
+                    # literally prefixed needs adding) — same accepted
+                    # ADR-800/801 trade-off; a missed flag degrades to the
+                    # warned literal, not a hard failure.
                     "supports_vision": (
                         "4o" in mid or "gpt-4-turbo" in mid
                         or mid.startswith(("o1", "o3", "o4"))

--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -538,7 +538,13 @@ class OpenAIProvider(AIProvider):
                     "display_name": mid,
                     "category": category,
                     "context_length": None,
-                    "supports_vision": "4o" in mid or "gpt-4-turbo" in mid,
+                    # Vision-capable families: 4o, gpt-4-turbo, the o-series
+                    # reasoning models (o1/o3/o4 accept image input), gpt-5.
+                    "supports_vision": (
+                        "4o" in mid or "gpt-4-turbo" in mid
+                        or mid.startswith(("o1", "o3", "o4"))
+                        or "gpt-5" in mid
+                    ),
                     "supports_json_mode": not is_embedding and "o1" not in mid,
                     "supports_tool_use": not is_embedding and "o1" not in mid,
                     "supports_streaming": True,

--- a/api/app/lib/vision_providers.py
+++ b/api/app/lib/vision_providers.py
@@ -39,6 +39,11 @@ def _catalog_vision_models(provider: str) -> list[dict]:
 
     Empty list when the catalog is unavailable or has no vision model for
     the provider (e.g. its 'Get models' has not been run yet).
+
+    A pooled checkout + one indexed SELECT per call. Callers are the
+    image-ingestion provider construction and the admin enumeration path
+    — NOT a per-image hot loop; memoization would only add catalog-change
+    invalidation complexity for no measured benefit at this frequency.
     """
     try:
         from .model_catalog import list_catalog
@@ -52,6 +57,14 @@ def _catalog_vision_models(provider: str) -> list[dict]:
         finally:
             client.pool.putconn(conn)
     except Exception:
+        # Deliberate degradation: a catalog/DB failure must fall through to
+        # env/literal, never break image ingestion (see _resolve_vision_model
+        # and test_catalog_lookup_swallows_db_errors_and_returns_empty). Log
+        # at debug so a *persistent* failure is diagnosable — the warned
+        # literal fallback is the user-visible signal.
+        logger.debug(
+            f"Vision catalog lookup failed for '{provider}'; "
+            f"degrading to env/literal", exc_info=True)
         return []
 
 

--- a/api/app/lib/vision_providers.py
+++ b/api/app/lib/vision_providers.py
@@ -27,6 +27,64 @@ from io import BytesIO
 logger = logging.getLogger(__name__)
 
 
+# --- Catalog-driven vision model selection (ADR-801) -----------------------
+# Vision provider/model selection must come from the dynamic model catalog's
+# per-model supports_vision flag, not hardcoded lists — the same "no
+# hardcoded models" decision ADR-801 applies to extraction, applied here
+# where it had regressed. Resolution order: explicit param → catalog →
+# VISION_MODEL env (bootstrap) → hardcoded literal (last resort, warned).
+
+def _catalog_vision_models(provider: str) -> list[dict]:
+    """Enabled, vision-capable catalog rows for a provider, by sort_order.
+
+    Empty list when the catalog is unavailable or has no vision model for
+    the provider (e.g. its 'Get models' has not been run yet).
+    """
+    try:
+        from .model_catalog import list_catalog
+        from .age_client import AGEClient
+
+        client = AGEClient()
+        conn = client.pool.getconn()
+        try:
+            rows = list_catalog(conn, provider=provider, enabled_only=True)
+            return [r for r in rows if r.get("supports_vision")]
+        finally:
+            client.pool.putconn(conn)
+    except Exception:
+        return []
+
+
+def _catalog_vision_model_ids(provider: str) -> list[str]:
+    """Vision-capable model ids for a provider from the catalog."""
+    return [r["model_id"] for r in _catalog_vision_models(provider)]
+
+
+def _resolve_vision_model(provider: str, model: Optional[str], literal: str) -> str:
+    """Resolve the vision model: param → catalog → env → literal (warned).
+
+    The hardcoded literal is kept only as a last resort so deployments
+    whose vision catalog has not been refreshed yet still work; the
+    warning surfaces the gap without breaking them.
+    """
+    if model:
+        return model
+    rows = _catalog_vision_models(provider)
+    if rows:
+        for r in rows:
+            if r.get("is_default"):
+                return r["model_id"]
+        return rows[0]["model_id"]
+    env = os.getenv("VISION_MODEL")
+    if env:
+        return env
+    logger.warning(
+        f"No catalog vision model for '{provider}'; falling back to "
+        f"'{literal}'. Populate it via the provider's 'Get models' (ADR-801)."
+    )
+    return literal
+
+
 # Literal description prompt (validated in research, Nov 2025)
 # See docs/research/vision-testing/FINDINGS.md
 LITERAL_DESCRIPTION_PROMPT = """
@@ -193,7 +251,7 @@ class OpenAIVisionProvider(VisionProvider):
         logger.info(f"OpenAI Vision client configured with max_retries={max_retries}")
 
         # Configurable model with default
-        self.model = model or os.getenv("VISION_MODEL", "gpt-4o")
+        self.model = _resolve_vision_model("openai", model, "gpt-4o")
 
     def describe_image(self, image_bytes: bytes, prompt: Optional[str] = None) -> Dict[str, Any]:
         """
@@ -287,7 +345,7 @@ class OpenAIVisionProvider(VisionProvider):
 
     def list_available_models(self) -> list[str]:
         """List available vision models"""
-        return ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"]
+        return _catalog_vision_model_ids("openai") or ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"]
 
 
 class AnthropicVisionProvider(VisionProvider):
@@ -329,7 +387,7 @@ class AnthropicVisionProvider(VisionProvider):
         logger.info(f"Anthropic Vision client configured with max_retries={max_retries}")
 
         # Configurable model with default
-        self.model = model or os.getenv("VISION_MODEL", "claude-3-5-sonnet-20241022")
+        self.model = _resolve_vision_model("anthropic", model, "claude-3-5-sonnet-20241022")
 
     def describe_image(self, image_bytes: bytes, prompt: Optional[str] = None) -> Dict[str, Any]:
         """
@@ -427,7 +485,7 @@ class AnthropicVisionProvider(VisionProvider):
 
     def list_available_models(self) -> list[str]:
         """List available vision models"""
-        return [
+        return _catalog_vision_model_ids("anthropic") or [
             "claude-3-5-sonnet-20241022",
             "claude-3-opus-20240229",
             "claude-3-sonnet-20240229",
@@ -463,7 +521,7 @@ class OllamaVisionProvider(VisionProvider):
             model: Vision model name (defaults to VISION_MODEL env or granite-vision-3.3:2b)
         """
         self.base_url = base_url or os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
-        self.model = model or os.getenv("VISION_MODEL", "granite-vision-3.3:2b")
+        self.model = _resolve_vision_model("ollama", model, "granite-vision-3.3:2b")
 
         logger.warning(
             f"Using Ollama Vision ({self.model}). Research shows inconsistent quality. "
@@ -549,7 +607,11 @@ class OllamaVisionProvider(VisionProvider):
             return False
 
     def list_available_models(self) -> list[str]:
-        """List available vision models from Ollama"""
+        """List vision models from the catalog (ADR-801); live Ollama query
+        as fallback when the catalog has no vision rows for ollama yet."""
+        catalog = _catalog_vision_model_ids("ollama")
+        if catalog:
+            return catalog
         import requests
         try:
             response = requests.get(f"{self.base_url}/api/tags", timeout=5.0)

--- a/tests/unit/lib/test_vision_provider_catalog.py
+++ b/tests/unit/lib/test_vision_provider_catalog.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for catalog-driven vision model selection (ADR-801, task #13).
+
+Vision provider/model selection must come from the dynamic catalog's
+per-model supports_vision flag, not hardcoded lists — the same decision
+ADR-801 applies to extraction, applied to the vision path where it had
+regressed. The catalog boundary is mocked (no DB/network).
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from api.app.lib import vision_providers as vp
+from api.app.lib.ai_providers import OpenAIProvider
+
+
+# ===========================================================================
+# _resolve_vision_model — param → catalog → env → literal (warned)
+# ===========================================================================
+
+class TestResolveVisionModel:
+    def test_should_prefer_explicit_param_over_everything(self):
+        assert vp._resolve_vision_model("anthropic", "my-model", "lit") == "my-model"
+
+    def test_should_use_catalog_is_default_when_no_param(self):
+        rows = [{"model_id": "a", "is_default": False},
+                {"model_id": "b", "is_default": True}]
+        with patch.object(vp, "_catalog_vision_models", return_value=rows):
+            assert vp._resolve_vision_model("openai", None, "lit") == "b"
+
+    def test_should_use_first_catalog_row_when_no_default(self):
+        rows = [{"model_id": "first", "is_default": False},
+                {"model_id": "second", "is_default": False}]
+        with patch.object(vp, "_catalog_vision_models", return_value=rows):
+            assert vp._resolve_vision_model("openai", None, "lit") == "first"
+
+    def test_should_fall_back_to_env_when_catalog_empty(self, monkeypatch):
+        monkeypatch.setenv("VISION_MODEL", "env-model")
+        with patch.object(vp, "_catalog_vision_models", return_value=[]):
+            assert vp._resolve_vision_model("ollama", None, "lit") == "env-model"
+
+    def test_should_fall_back_to_literal_and_warn_when_nothing_else(
+            self, monkeypatch, caplog):
+        monkeypatch.delenv("VISION_MODEL", raising=False)
+        with patch.object(vp, "_catalog_vision_models", return_value=[]):
+            with caplog.at_level("WARNING"):
+                got = vp._resolve_vision_model("ollama", None, "granite:2b")
+        assert got == "granite:2b"
+        assert any("No catalog vision model for 'ollama'" in r.message
+                   for r in caplog.records)
+
+    def test_catalog_lookup_swallows_db_errors_and_returns_empty(
+            self, monkeypatch):
+        # The helper is the guard: any catalog/DB failure → [] (never raises),
+        # so resolution degrades to env/literal rather than erroring.
+        monkeypatch.delenv("VISION_MODEL", raising=False)
+        with patch("api.app.lib.model_catalog.list_catalog",
+                   side_effect=Exception("db down")):
+            assert vp._catalog_vision_models("openai") == []
+            assert vp._resolve_vision_model("openai", None, "gpt-4o") == "gpt-4o"
+
+
+# ===========================================================================
+# list_available_models — catalog-first, hardcoded fallback
+# ===========================================================================
+
+class TestListAvailableModelsCatalogFirst:
+    def test_openai_should_return_catalog_vision_ids_when_present(self):
+        p = object.__new__(vp.OpenAIVisionProvider)
+        with patch.object(vp, "_catalog_vision_model_ids",
+                          return_value=["gpt-4o", "o3"]):
+            assert p.list_available_models() == ["gpt-4o", "o3"]
+
+    def test_openai_should_fall_back_to_hardcoded_when_catalog_empty(self):
+        p = object.__new__(vp.OpenAIVisionProvider)
+        with patch.object(vp, "_catalog_vision_model_ids", return_value=[]):
+            assert "gpt-4o" in p.list_available_models()
+
+    def test_anthropic_should_prefer_catalog(self):
+        p = object.__new__(vp.AnthropicVisionProvider)
+        with patch.object(vp, "_catalog_vision_model_ids",
+                          return_value=["claude-sonnet-4-20250514"]):
+            assert p.list_available_models() == ["claude-sonnet-4-20250514"]
+
+
+# ===========================================================================
+# OpenAI catalog vision heuristic — reasoning families are vision-capable
+# ===========================================================================
+
+class TestOpenAIVisionHeuristic:
+    def _catalog(self, ids):
+        p = object.__new__(OpenAIProvider)
+        p.client = MagicMock()
+        p.client.models.list.return_value = MagicMock(
+            data=[MagicMock(id=i, created=0) for i in ids])
+        return {e["model_id"]: e for e in p.fetch_model_catalog()}
+
+    def test_should_flag_o_series_and_gpt5_vision_capable(self):
+        cat = self._catalog(["gpt-4o", "o1", "o3-mini", "o4", "gpt-5-preview",
+                              "gpt-3.5-turbo"])
+        assert cat["gpt-4o"]["supports_vision"] is True
+        assert cat["o1"]["supports_vision"] is True       # was missed before
+        assert cat["o3-mini"]["supports_vision"] is True
+        assert cat["o4"]["supports_vision"] is True
+        assert cat["gpt-5-preview"]["supports_vision"] is True
+        # gpt-3.5 is genuinely not vision-capable.
+        assert cat["gpt-3.5-turbo"]["supports_vision"] is False


### PR DESCRIPTION
## Summary

Extends the ADR-801 uniform-provider-contract principle into the **vision path**: vision provider/model selection is now driven by the dynamic model catalog's per-model `supports_vision` flag instead of hardcoded lists and defaults.

Originated from "we should support vision — for models that support it." Investigation found `supports_vision` was tracked in `provider_model_catalog` but **inert**: `vision_providers.py` used hardcoded per-provider model defaults (`gpt-4o`, `claude-3-5-sonnet-20241022`, `granite-vision-3.3:2b`) and hardcoded `list_available_models()` — the exact drift ADR-801 removed from extraction, regressed in the vision path.

## What changed

- `vision_providers.py`: `_resolve_vision_model()` resolves **param → catalog (`is_default` or first `supports_vision` row) → `VISION_MODEL` env → hardcoded literal** (last resort, logged as a warning so an un-refreshed catalog is visible without breaking the deployment). All three providers' `__init__` and `list_available_models()` are catalog-first; Ollama keeps its live `/api/tags` query as fallback.
- `ai_providers.py`: OpenAI catalog vision heuristic widened — `o1`/`o3`/`o4` reasoning models and `gpt-5` accept image input but were incorrectly flagged `supports_vision=False`.

## Scope (deliberate)

`vision_providers.py` only. The `ingestion_worker` hardcoded `"openai"` *provider* default and the vision-vs-extraction parallel-hierarchy question are separable design decisions — filed as **#378** and **#379**, not bundled. No new ADR / no ADR-801 mutation — this is reaffirmation, like the Anthropic-SDK and OpenAI-denylist fixes.

## Verification

- 10 new contract tests (`tests/unit/lib/test_vision_provider_catalog.py`); provider/route + vision suites = **38 passed**, no regression.
- Functional: Anthropic vision now resolves `claude-sonnet-4-20250514` from the live catalog (was hardcoded Claude-3.5); explicit param wins; empty-catalog Ollama → literal + warning.

## Merge

Requested strategy: **merge commit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
