### PR TITLE
ADR-203: Graph epoch event log (addresses #187)

### DIFF
--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -28,6 +28,44 @@ logger = logging.getLogger(__name__)
 class IngestionMixin:
     """Source, Concept, and Instance node CRUD with graph linking."""
 
+    def record_epoch(
+        self,
+        kind: str,
+        actor: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[int]:
+        """
+        Record a new graph-mutation epoch event and return its event_id.
+
+        ADR-203: Call at the start of an ingestion job (or other unit of
+        graph mutation) so the returned id can tag nodes created during
+        that unit of work. `kind` discriminates whether wall-clock is
+        semantically meaningful for the rows attributable to this event.
+
+        Returns None on failure — callers must treat that as "epoch
+        tagging disabled for this run" rather than fatal.
+        """
+        try:
+            conn = self.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT kg_api.record_graph_epoch(%s::text, %s::text, %s::jsonb)",
+                        (
+                            kind,
+                            str(actor) if actor is not None else None,
+                            json.dumps(metadata or {}),
+                        ),
+                    )
+                    row = cur.fetchone()
+                    return row[0] if row else None
+            finally:
+                conn.commit()
+                self.pool.putconn(conn)
+        except Exception as e:
+            logger.warning(f"record_epoch failed (kind={kind}): {e}")
+            return None
+
     def create_source_node(
         self,
         source_id: str,
@@ -262,7 +300,8 @@ class IngestionMixin:
     def create_instance_node(
         self,
         instance_id: str,
-        quote: str
+        quote: str,
+        created_at_event_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Create an Instance node in the graph.
@@ -270,6 +309,10 @@ class IngestionMixin:
         Args:
             instance_id: Unique identifier for the instance
             quote: Exact quote from the source text
+            created_at_event_id: ADR-203 graph_epochs event_id tagging this Instance
+                with the mutation event that produced it. None when epoch recording
+                failed or for legacy callers; downstream queries treat NULL as
+                pre-epoch cohort.
 
         Returns:
             Dictionary with created node properties
@@ -277,21 +320,37 @@ class IngestionMixin:
         Raises:
             Exception: If node creation fails
         """
-        query = """
-        CREATE (i:Instance {
-            instance_id: $instance_id,
-            quote: $quote
-        })
-        RETURN i
-        """
+        if created_at_event_id is not None:
+            query = """
+            CREATE (i:Instance {
+                instance_id: $instance_id,
+                quote: $quote,
+                created_at_event_id: $created_at_event_id
+            })
+            RETURN i
+            """
+            params = {
+                "instance_id": instance_id,
+                "quote": quote,
+                "created_at_event_id": created_at_event_id,
+            }
+        else:
+            query = """
+            CREATE (i:Instance {
+                instance_id: $instance_id,
+                quote: $quote
+            })
+            RETURN i
+            """
+            params = {
+                "instance_id": instance_id,
+                "quote": quote,
+            }
 
         try:
             results = self._execute_cypher(
                 query,
-                params={
-                    "instance_id": instance_id,
-                    "quote": quote
-                },
+                params=params,
                 fetch_one=True
             )
             if results:

--- a/api/app/lib/ingestion.py
+++ b/api/app/lib/ingestion.py
@@ -179,7 +179,9 @@ def process_chunk(
     text_embedding: Optional[List[float]] = None,
     # ADR-081: Source document lifecycle
     garage_key: Optional[str] = None,
-    content_hash: Optional[str] = None
+    content_hash: Optional[str] = None,
+    # ADR-203: Graph epoch event_id tagging Instances created during this job
+    event_id: Optional[int] = None,
 ) -> List[str]:
     """
     Process a single chunk: create source, extract concepts, create graph nodes.
@@ -463,7 +465,11 @@ def process_chunk(
             else:
                 # Create new instance
                 instance_id = f"{source_id}_inst_{uuid.uuid4().hex[:8]}"
-                age_client.create_instance_node(instance_id=instance_id, quote=quote)
+                age_client.create_instance_node(
+                    instance_id=instance_id,
+                    quote=quote,
+                    created_at_event_id=event_id,  # ADR-203
+                )
                 stats.instances_created += 1
 
             # Link instance to concept and source

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -337,6 +337,26 @@ def run_ingestion_worker(
             logger.warning(f"Failed to ensure Ontology node for '{ontology}': {e}")
             # Non-fatal: s.document on Source nodes still works without Ontology node
 
+        # ADR-203: Record this ingestion as a graph epoch event so every
+        # Instance created during the run carries a stable event_id. On resume,
+        # a fresh event is recorded with resume metadata — honest record that
+        # the work spanned multiple sessions.
+        epoch_metadata = {
+            "job_id": job_id,
+            "ontology": ontology,
+        }
+        if is_resuming:
+            epoch_metadata["resumed_from_chunk"] = resume_from_chunk
+        event_id = age_client.record_epoch(
+            kind="ingestion",
+            actor=job_data.get("user_id") or job_data.get("username"),
+            metadata=epoch_metadata,
+        )
+        if event_id is not None:
+            logger.info(f"📍 Recorded graph epoch event_id={event_id} for this ingestion")
+        else:
+            logger.warning("⚠️  record_epoch returned None — Instances will be untagged")
+
         # Get existing concepts for context
         existing_concepts, has_empty_warnings = age_client.get_document_concepts(
             document_name=ontology,
@@ -389,7 +409,9 @@ def run_ingestion_worker(
                 text_embedding=None,  # Will be generated during concept extraction
                 # ADR-081: Pass source document storage metadata
                 garage_key=job_data.get("source_garage_key"),
-                content_hash=job_data.get("source_content_hash")
+                content_hash=job_data.get("source_content_hash"),
+                # ADR-203: Tag Instances created during this chunk with the job's epoch
+                event_id=event_id,
             )
 
             # Update progress with detailed stats AND save resume checkpoint

--- a/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
+++ b/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
@@ -67,7 +67,7 @@ CREATE INDEX idx_graph_epochs_kind        ON kg_api.graph_epochs(kind, occurred_
 
 A new `graph_epochs` row is recorded **once per logical unit of graph mutation**:
 
-- `kind='ingestion'` — one row per ingestion job, recorded at job *start*, so the assigned `event_id` is available to tag every Instance created during that job.
+- `kind='ingestion'` — one row per ingestion job *invocation*, recorded at job *start*, so the assigned `event_id` is available to tag every Instance created during that invocation. A resumed job records a fresh `event_id` with `metadata.resumed_from_chunk` indicating the split — this honestly preserves "the work spanned multiple sessions" rather than papering over it.
 - `kind='breathing'` — one row per ontology-breathing pass (cross-ref ADR-200).
 - `kind='edit'` — one row per explicit manual mutation.
 - `kind='reasoning'` — one row per agent reasoning session that mutates the graph.
@@ -97,7 +97,7 @@ In scope:
 - The `graph_epochs` table and its insertion contract.
 - Instance-level `created_at_event_id` tagging.
 - Recording an `ingestion` epoch at job start.
-- Test coverage proving re-evidenced Concepts have Instances spanning distinct event_ids.
+- Verification proving re-evidenced Concepts have Instances spanning distinct event_ids (manual end-to-end test via the `kg` CLI on landing; automated coverage deferred to a follow-up).
 
 Out of scope (deferred to follow-up issues):
 - API endpoints for re-evidence timeline queries.

--- a/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
+++ b/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
@@ -1,0 +1,153 @@
+---
+status: Draft
+date: 2026-05-19
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-079
+  - ADR-200
+  - ADR-202
+---
+
+# ADR-203: Graph Epoch Event Log
+
+## Context
+
+The graph already carries a notion of "epoch" — `graph_metrics.graph_change_counter`, introduced by ADR-079 (migration 033). On every ingestion, concepts are tagged with `created_at_epoch` and `last_seen_epoch` (see `api/app/lib/age_client/ingestion.py:168-169`), and the counter is refreshed via `refresh_graph_metrics()`.
+
+That counter is **a composite checksum**, not an event sequence:
+
+```sql
+graph_change_counter = count(concepts) + count(edges) + count(sources) + ...
+```
+
+Two consequences fall out of that definition:
+
+1. **Values are not unique over time.** Delete a concept and add one — the counter is unchanged. Two distinct graph states can produce the same counter value. So `counter_value → wall_clock_time` is not a function: it cannot be a join key.
+2. **There is no wall-clock anywhere.** Concept and Instance nodes do not record when they were created in real time; the system only knows "counter value at write."
+
+Issue #187 originally framed this as "no temporal ordering capability for concept evolution." The original proposal — `PRECEDED_BY` / `EVOLVED_INTO` relationship types inferred from ordering — conflates two things that should remain distinct:
+
+- **Logical time**: monotonic ordering of mutations to the graph. Always meaningful, including for activity that has no useful wall-clock (agent reasoning, ontology breathing, manual restructuring).
+- **Wall-clock time**: when an event physically happened. Always present in absolute terms, but **semantically meaningful only for some kinds of events** — primarily external-corpus ingestion. An agent creating 200 concepts during a reasoning loop at 15:03 UTC doesn't make those concepts "from 15:03" in any useful sense.
+
+The system needs both, treated as orthogonal dimensions. It also needs the data structure that lets the per-concept *re-evidence stream* be walked honestly — without inventing causal edges the data cannot justify.
+
+### The re-evidence stream is the actual payoff
+
+A `:Concept` already accumulates `:Instance` nodes via `EVIDENCED_BY` — one Instance per chunk that re-evidenced it. That stream **is** the concept's lifetime: born at the first Instance, grown by every subsequent one, dormant when none arrive for a long stretch.
+
+Today the stream cannot be ordered chronologically. Instances carry no epoch tag (constructor at `api/app/lib/age_client/ingestion.py:281`). Tagging them closes the loop: a single ordered walk over a Concept's Instances yields its re-evidence history — count, sequence, and time deltas where wall-clock is meaningful — without the LLM having to assert causal relationships.
+
+## Decision
+
+Introduce a dedicated **epoch event log** alongside the existing change counter, and tag `:Instance` nodes with a foreign key into it.
+
+### 1. New table: `kg_api.graph_epochs`
+
+```sql
+CREATE TABLE kg_api.graph_epochs (
+    event_id     BIGSERIAL PRIMARY KEY,
+    occurred_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    kind         TEXT NOT NULL,         -- 'ingestion' | 'reasoning' | 'breathing' | 'edit'
+    actor        TEXT,                  -- user_id, agent session id, system component
+    counter_after BIGINT,               -- graph_change_counter snapshot post-event (cross-ref)
+    metadata     JSONB DEFAULT '{}'::jsonb
+);
+CREATE INDEX idx_graph_epochs_occurred_at ON kg_api.graph_epochs(occurred_at);
+CREATE INDEX idx_graph_epochs_kind        ON kg_api.graph_epochs(kind, occurred_at);
+```
+
+`event_id` is the logical-time axis (monotonic, unique). `occurred_at` is the wall-clock axis (always recorded, but interpret semantically per `kind`). `kind` is the discriminator that tells downstream queries whether wall-clock means anything for this row.
+
+`TIMESTAMPTZ` aligns with the UTC invariant from ADR-202.
+
+### 2. Event granularity: one epoch per job
+
+A new `graph_epochs` row is recorded **once per logical unit of graph mutation**:
+
+- `kind='ingestion'` — one row per ingestion job, recorded at job *start*, so the assigned `event_id` is available to tag every Instance created during that job.
+- `kind='breathing'` — one row per ontology-breathing pass (cross-ref ADR-200).
+- `kind='edit'` — one row per explicit manual mutation.
+- `kind='reasoning'` — one row per agent reasoning session that mutates the graph.
+
+Per-chunk is too granular and explodes the row count without semantic value. Per-session is too coarse and loses the ability to attribute Instances to a specific ingestion. Per-job is the natural transaction boundary the system already operates on.
+
+### 3. Instance tagging
+
+`:Instance` nodes gain a `created_at_event_id` property at creation time (`age_client/ingestion.py:281`). The ingestion flow obtains the event_id at job start (Decision §2) and threads it through to Instance creation. Existing Instances carry no event_id — see Migration below.
+
+### 4. Coexistence with `graph_change_counter`
+
+The existing `graph_change_counter` (ADR-079) is **retained, unchanged**. Its purpose is composite cache-invalidation; it remains a count checksum. `graph_epochs.event_id` is the new monotonic event sequence with different semantics. The two coexist:
+
+- ADR-079 counter → "has any part of the graph changed since I cached?"
+- ADR-203 event_id → "what discrete mutation event introduced this data?"
+
+They are not unified, because their semantics are different. The ADR records this explicitly so future readers do not attempt to reconcile them.
+
+### 5. Concept-level epoch fields
+
+`:Concept.created_at_epoch` and `last_seen_epoch` (count-snapshot values, written by current ingestion code) are **left in place as legacy**. They retain their ADR-079 cache-invalidation semantics. They are *not* renamed or migrated. If a future ADR wants to add `created_at_event_id` / `last_evidenced_event_id` to Concepts directly, that is a separate scope; the present ADR derives concept lifetime from the Instance chain.
+
+### 6. Scope of this ADR
+
+In scope:
+- The `graph_epochs` table and its insertion contract.
+- Instance-level `created_at_event_id` tagging.
+- Recording an `ingestion` epoch at job start.
+- Test coverage proving re-evidenced Concepts have Instances spanning distinct event_ids.
+
+Out of scope (deferred to follow-up issues):
+- API endpoints for re-evidence timeline queries.
+- Web UI for time-travel / epoch picker.
+- Analytics queries (anchor / hot / stale / acceleration signals).
+- Concept-level event_id columns.
+- Backfilling event_ids onto historical Instances.
+- Wiring up `kind='breathing'` / `'reasoning'` / `'edit'` events. These will land as those subsystems independently grow event awareness.
+
+## Consequences
+
+### Positive
+
+- **Honest logical/wall-clock separation.** Two dimensions, queryable independently, no false-causality edges.
+- **Re-evidence stream becomes walkable.** `MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance) ORDER BY i.created_at_event_id` is the concept-lifetime query.
+- **Foundation for drift / freshness signals** — Freshness Way explicitly notes its blindness to content-level drift; epoch-tagged Instances close part of that gap (concepts not re-touched in N events become a derivable signal).
+- **Forensic floor.** Every mutation now has a recorded actor and wall-clock, which is independently useful even when wall-clock isn't semantically primary.
+
+### Negative
+
+- **Insertion-timing contract change.** Ingestion must record its epoch *before* creating Instances, not as a post-hoc effect of `refresh_graph_metrics()`. Code paths need to be audited.
+- **Slight write overhead** — one extra row per ingestion job. Negligible relative to the work the job does.
+- **Two epoch concepts coexist.** Cognitive load on contributors until the distinction is internalized. Mitigated by explicit naming (`graph_change_counter` vs `graph_epochs.event_id`) and this ADR.
+
+### Neutral
+
+- Existing Instances will carry `NULL` for `created_at_event_id`. Queries that require event ordering must either exclude them or treat them as a single "pre-epoch" cohort. Backfill is possible (from each Instance's Source's ingestion job timestamp) but explicitly deferred.
+
+## Alternatives Considered
+
+### A. Promote `created_at_epoch` to TIMESTAMPTZ on every node
+
+Stamp the wall-clock directly onto Concept and Instance properties — no event table.
+
+**Rejected.** Forces wall-clock onto every node, including ones created during agent reasoning or breathing where wall-clock is semantically noise. Conflates the two dimensions the design is trying to separate. Also makes it impossible to attribute multiple Instances to "the same ingestion job" without inventing a separate grouping mechanism.
+
+### B. Reuse `graph_change_counter` as the event_id
+
+Tie a timestamp table to existing counter values.
+
+**Rejected.** The counter is a count checksum, not monotonic — values can recur (delete+add). The mapping `counter_value → wall_clock` is not a function, so it cannot serve as a join key.
+
+### C. PRECEDED_BY / EVOLVED_INTO relationship vocabulary (original #187)
+
+Infer causal relationships between concepts from ordering and re-evidence patterns.
+
+**Rejected.** Requires either ordering-based shallow inference (which is misleading — order ≠ causation, and re-ingesting older content inverts the apparent order) or LLM judgment about evolution (which is expensive, brittle, and asserts facts into the graph the data can't honestly support). The Instance-stream design supersedes this: evolution narratives are *derived* from honest accumulation, not asserted.
+
+### D. Per-chunk event granularity
+
+Record a `graph_epochs` row for every chunk processed.
+
+**Rejected.** Explodes row count without semantic value. The job is the natural transaction boundary; finer granularity is recoverable from `Instance.created_at_event_id` joined to source/chunk metadata if anyone ever needs it.

--- a/schema/migrations/063_graph_epoch_events.sql
+++ b/schema/migrations/063_graph_epoch_events.sql
@@ -1,0 +1,71 @@
+-- Migration 063: Graph epoch event log (ADR-203)
+--
+-- Introduces a monotonic event sequence for graph mutations, distinct from
+-- the count-checksum `graph_change_counter` (ADR-079). Each row represents
+-- one logical mutation event (default granularity: one per ingestion job).
+-- Instance nodes will gain `created_at_event_id` referencing this table,
+-- enabling honest re-evidence-stream queries per concept.
+--
+-- Semantics:
+--   event_id     - logical-time axis (monotonic, unique)
+--   occurred_at  - wall-clock axis (always present, semantically meaningful
+--                  only for kinds where it is — see `kind`)
+--   kind         - discriminator for whether wall-clock has meaning
+--                  ('ingestion'/'edit' = yes; 'reasoning'/'breathing' = forensic only)
+--   actor        - user id, agent session id, system component
+--   counter_after- snapshot of graph_change_counter post-event (cross-ref to ADR-079)
+
+CREATE TABLE IF NOT EXISTS kg_api.graph_epochs (
+    event_id      BIGSERIAL PRIMARY KEY,
+    occurred_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    kind          TEXT NOT NULL CHECK (kind IN ('ingestion', 'reasoning', 'breathing', 'edit')),
+    actor         TEXT,
+    counter_after BIGINT,
+    metadata      JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_epochs_occurred_at
+    ON kg_api.graph_epochs(occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_graph_epochs_kind
+    ON kg_api.graph_epochs(kind, occurred_at);
+
+COMMENT ON TABLE kg_api.graph_epochs IS
+    'ADR-203: Monotonic event log of graph mutations. Distinct from graph_change_counter (ADR-079) which is a composite cache-invalidation checksum.';
+
+COMMENT ON COLUMN kg_api.graph_epochs.event_id IS
+    'Monotonic logical-time id. Foreign-keyed by Instance.created_at_event_id.';
+
+COMMENT ON COLUMN kg_api.graph_epochs.kind IS
+    'ingestion | reasoning | breathing | edit. Determines whether occurred_at is semantically meaningful for the rows attributable to this event.';
+
+-- Helper: record a new epoch event and return its event_id.
+-- Called at the *start* of an ingestion job (or other mutation) so the
+-- returned event_id can tag every node created during that unit of work.
+CREATE OR REPLACE FUNCTION kg_api.record_graph_epoch(
+    p_kind     TEXT,
+    p_actor    TEXT DEFAULT NULL,
+    p_metadata JSONB DEFAULT '{}'::jsonb
+) RETURNS BIGINT AS $$
+DECLARE
+    v_event_id BIGINT;
+    v_counter  BIGINT;
+BEGIN
+    SELECT counter INTO v_counter
+    FROM public.graph_metrics
+    WHERE metric_name = 'graph_change_counter';
+
+    INSERT INTO kg_api.graph_epochs (kind, actor, counter_after, metadata)
+    VALUES (p_kind, p_actor, v_counter, p_metadata)
+    RETURNING event_id INTO v_event_id;
+
+    RETURN v_event_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION kg_api.record_graph_epoch IS
+    'ADR-203: Record a new graph-mutation event and return its event_id. Call at the start of an ingestion job (or other mutation transaction) so the returned id can tag nodes created during the unit of work.';
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (63, 'graph_epoch_events')
+ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Summary

Introduces `kg_api.graph_epochs` — a monotonic event log of graph mutations, distinct from the count-checksum `graph_change_counter` (ADR-079) — and tags every new `:Instance` with `created_at_event_id`.

The data unlock is that a concept's lifetime is now a single ordered walk over its `EVIDENCED_BY` chain: re-evidence count, sequence, and time deltas (where wall-clock is semantically meaningful) become derivable signals without inventing causal edges.

## Design Highlights

- **Two orthogonal dimensions.** `event_id` is logical time (monotonic, always meaningful). `occurred_at` is wall-clock (always recorded, semantically primary only for `kind IN ('ingestion','edit')` — `'reasoning'`/`'breathing'` rows treat it as forensic).
- **One epoch per job invocation.** Resumed ingestions record a *fresh* event with `metadata.resumed_from_chunk` — honest about session boundaries instead of pretending continuity.
- **Coexists with ADR-079.** `graph_change_counter` retains its cache-invalidation semantics; the two are not unified, because their semantics differ.
- **Defensive.** `record_epoch` returns `None` on failure; ingestion still completes with `NULL` event_id (documented "pre-epoch" cohort).

## Relationship to #187

**Addresses #187 with narrowed scope** — not "Closes." The original issue proposed `PRECEDED_BY` / `EVOLVED_INTO` relationship vocabulary. ADR-203 §Alternatives §C explicitly rejects those: inferring causal edges from ordering is misleading, and asserting them via LLM is brittle. The honest design preserves the evidence stream and lets queries derive evolution narratives — supersedes the original ask.

I'll close #187 after merge with a comment pointing readers to ADR-203 §C for the reframing rationale.

## Note on #193

The original investigation of oldest open issues also covered #193 (web auto-refresh on projection job completion). It is intentionally **not** addressed here — different concern, different surface area. Parked, not forgotten.

## Out of Scope (deliberate)

Deferred to follow-up issues per advisor guidance to keep this PR narrow:

- API endpoints for re-evidence timeline queries
- Web UI for time-travel / epoch picker
- Analytics queries (anchor / hot / stale / acceleration)
- Concept-level event_id columns (lifetime is derived from Instance chain)
- Backfill of historical Instances
- Wiring `kind='breathing'`/`'reasoning'`/`'edit'` events

## Verification

Manual end-to-end via `kg` CLI: ingested four short documents with overlapping content into a test ontology. After fixing a Postgres function-dispatch bug (actor passed as int → must cast to text), two `graph_epochs` rows recorded, and re-evidenced concepts (Whiskers, Domestic Cat, Night Vision) carry Instances spanning both event_ids with non-zero wall-clock delta. Test ontology cleaned up; epoch rows correctly retained as forensic record.

Unit suite: 455 pass (one pre-existing unrelated failure in `test_program_executor.py` confirmed independent of these changes — fails on `main` identically). Route tests: 413 pass, 14 skipped.

## Test plan

- [ ] Reviewer reads ADR-203 — particularly §Alternatives — to validate the count-checksum-vs-event-sequence framing
- [ ] Migration 063 applies cleanly to a stable platform install
- [ ] Two consecutive `kg ingest text` calls into a fresh ontology produce two `graph_epochs` rows with distinct `event_id` and `occurred_at`
- [ ] At least one re-evidenced Concept has Instances joining to both event_ids
- [ ] Existing ingestion behavior unchanged when `record_epoch` returns `None` (NULL event_id is non-fatal)