### PR TITLE
ADR-203 exposure: epoch event log + concept lifetime via MCP/CLI

### DIFF
--- a/api/app/lib/age_client/__init__.py
+++ b/api/app/lib/age_client/__init__.py
@@ -42,6 +42,10 @@ class AGEClient(
     - OntologyScoringMixin: Ontology scoring, analytics, and annealing mutations
     - OntologyEdgesMixin: Inter-ontology edges and proposal execution primitives
     - VocabularyMixin: Relationship type config, CRUD, sync, merge, embeddings
+
+    Facades attached lazily via properties on QueryMixin:
+    - client.graph   → GraphFacade (topology + graph_accel)
+    - client.epochs  → EpochFacade (ADR-203 epoch event log read-side)
     """
     pass
 

--- a/api/app/lib/age_client/base.py
+++ b/api/app/lib/age_client/base.py
@@ -92,6 +92,9 @@ class BaseMixin:
         # Lazy-loaded graph facade for accelerated traversal (ADR-201)
         self._graph_facade = None
 
+        # Lazy-loaded epoch facade for ADR-203 event log reads
+        self._epoch_facade = None
+
     def _setup_age(self, conn):
         """Load AGE extension and set search path."""
         with conn.cursor() as cur:

--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -43,7 +43,22 @@ class IngestionMixin:
         semantically meaningful for the rows attributable to this event.
 
         Returns None on failure — callers must treat that as "epoch
-        tagging disabled for this run" rather than fatal.
+        tagging disabled for this run" rather than fatal. The downstream
+        behavior is that Instances created during the run carry no
+        `created_at_event_id` property, indistinguishable in-graph from
+        pre-ADR-203 Instances and rolled into the lifetime response's
+        `pre_epoch_count`.
+
+        Observability: failures are logged at ERROR (not WARNING) so they
+        surface in operator dashboards rather than getting filtered. Any
+        non-zero rate of these in a post-ADR-203 install indicates a
+        schema / permission / connectivity problem with `kg_api.graph_epochs`
+        and should be investigated — silent failure here is acceptable
+        for a single ingestion job, but a steady-state failure rate
+        slowly grows an indistinguishable "failure cohort" that pollutes
+        the pre-ADR-203 reading.
+
+        Grep target: `record_epoch failed`.
         """
         try:
             conn = self.pool.getconn()
@@ -63,7 +78,13 @@ class IngestionMixin:
                 conn.commit()
                 self.pool.putconn(conn)
         except Exception as e:
-            logger.warning(f"record_epoch failed (kind={kind}): {e}")
+            # ERROR (not WARNING) — see docstring. Any non-zero rate of
+            # this in a healthy install indicates a real problem.
+            logger.error(
+                "record_epoch failed (kind=%s, actor=%s): %s",
+                kind, actor, e,
+                exc_info=True,
+            )
             return None
 
     def create_source_node(

--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -28,6 +28,44 @@ logger = logging.getLogger(__name__)
 class IngestionMixin:
     """Source, Concept, and Instance node CRUD with graph linking."""
 
+    def record_epoch(
+        self,
+        kind: str,
+        actor: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[int]:
+        """
+        Record a new graph-mutation epoch event and return its event_id.
+
+        ADR-203: Call at the start of an ingestion job (or other unit of
+        graph mutation) so the returned id can tag nodes created during
+        that unit of work. `kind` discriminates whether wall-clock is
+        semantically meaningful for the rows attributable to this event.
+
+        Returns None on failure — callers must treat that as "epoch
+        tagging disabled for this run" rather than fatal.
+        """
+        try:
+            conn = self.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT kg_api.record_graph_epoch(%s::text, %s::text, %s::jsonb)",
+                        (
+                            kind,
+                            str(actor) if actor is not None else None,
+                            json.dumps(metadata or {}),
+                        ),
+                    )
+                    row = cur.fetchone()
+                    return row[0] if row else None
+            finally:
+                conn.commit()
+                self.pool.putconn(conn)
+        except Exception as e:
+            logger.warning(f"record_epoch failed (kind={kind}): {e}")
+            return None
+
     def create_source_node(
         self,
         source_id: str,
@@ -262,7 +300,8 @@ class IngestionMixin:
     def create_instance_node(
         self,
         instance_id: str,
-        quote: str
+        quote: str,
+        created_at_event_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Create an Instance node in the graph.
@@ -270,6 +309,10 @@ class IngestionMixin:
         Args:
             instance_id: Unique identifier for the instance
             quote: Exact quote from the source text
+            created_at_event_id: ADR-203 graph_epochs event_id tagging this Instance
+                with the mutation event that produced it. None when epoch recording
+                failed or for legacy callers; downstream queries treat NULL as
+                pre-epoch cohort.
 
         Returns:
             Dictionary with created node properties
@@ -277,21 +320,37 @@ class IngestionMixin:
         Raises:
             Exception: If node creation fails
         """
-        query = """
-        CREATE (i:Instance {
-            instance_id: $instance_id,
-            quote: $quote
-        })
-        RETURN i
-        """
+        if created_at_event_id is not None:
+            query = """
+            CREATE (i:Instance {
+                instance_id: $instance_id,
+                quote: $quote,
+                created_at_event_id: $created_at_event_id
+            })
+            RETURN i
+            """
+            params = {
+                "instance_id": instance_id,
+                "quote": quote,
+                "created_at_event_id": created_at_event_id,
+            }
+        else:
+            query = """
+            CREATE (i:Instance {
+                instance_id: $instance_id,
+                quote: $quote
+            })
+            RETURN i
+            """
+            params = {
+                "instance_id": instance_id,
+                "quote": quote,
+            }
 
         try:
             results = self._execute_cypher(
                 query,
-                params={
-                    "instance_id": instance_id,
-                    "quote": quote
-                },
+                params=params,
                 fetch_one=True
             )
             if results:

--- a/api/app/lib/age_client/query.py
+++ b/api/app/lib/age_client/query.py
@@ -1120,3 +1120,22 @@ class QueryMixin:
             self._graph_facade = GraphFacade(self)
 
         return self._graph_facade
+
+    @property
+    def epochs(self):
+        """
+        Get the epoch event log facade (ADR-203).
+
+        Lazy-loads EpochFacade on first access. Provides per-concept
+        re-evidence stream queries and paginated event log access. The
+        write path (`record_epoch`) lives on IngestionMixin; this property
+        is the read-side surface.
+
+        Returns:
+            EpochFacade instance
+        """
+        if self._epoch_facade is None:
+            from api.app.lib.epoch_facade import EpochFacade
+            self._epoch_facade = EpochFacade(self)
+
+        return self._epoch_facade

--- a/api/app/lib/epoch_facade.py
+++ b/api/app/lib/epoch_facade.py
@@ -8,7 +8,11 @@ route handlers never need an `execute_raw` escape hatch.
 
 Two-phase pattern for per-concept lifetime:
   Phase 1: Cypher (via client._execute_cypher) to walk EVIDENCED_BY
-  Phase 2: SQL (via client.pool) to hydrate event metadata in one shot
+           with ORDER BY / SKIP / LIMIT pushed into the graph engine.
+  Phase 2: SQL (via client.pool, RealDictCursor) to hydrate event
+           metadata in one round-trip and pick up the
+           `semantic_wallclock` discriminator from migration 064's
+           graph_epoch_kinds lookup table.
 
 Analytics signals (anchor / hot / stale / acceleration) are derivable
 from the primitives here but are deliberately not part of this surface;
@@ -17,9 +21,18 @@ nodes after the underlying data has been exercised in practice.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+from psycopg2 import extras
 
 logger = logging.getLogger(__name__)
+
+# Defaults / hard caps for lifetime pagination.
+# A concept's re-evidence chain is unbounded in principle, so the route
+# must impose a ceiling — see code review #2 (PR #382).
+LIFETIME_DEFAULT_LIMIT = 200
+LIFETIME_MAX_LIMIT = 1000
 
 
 class EpochFacade:
@@ -36,7 +49,12 @@ class EpochFacade:
     # Per-concept re-evidence stream
     # -------------------------------------------------------------------------
 
-    def get_concept_lifetime(self, concept_id: str) -> Optional[Dict[str, Any]]:
+    def get_concept_lifetime(
+        self,
+        concept_id: str,
+        limit: int = LIFETIME_DEFAULT_LIMIT,
+        offset: int = 0,
+    ) -> Optional[Dict[str, Any]]:
         """
         Return the ordered re-evidence stream for a single Concept.
 
@@ -53,19 +71,29 @@ class EpochFacade:
                         "occurred_at": str | None,  # ISO-8601 UTC
                         "kind": str | None,
                         "actor": str | None,
+                        "semantic_wallclock": bool | None,
                     },
                     ...
                 ],
-                "total_instances": int,
-                "distinct_epochs": int,
-                "pre_epoch_count": int,  # NULL-event_id cohort
+                "total_instances": int,      # Full chain size (independent of paging)
+                "returned_instances": int,   # len(instances) for this page
+                "distinct_epochs": int,      # In returned page only
+                "pre_epoch_count": int,      # In returned page only
+                "limit": int,
+                "offset": int,
+                "has_more": bool,
             }
 
         Returns None if the concept does not exist.
 
-        Instances are ordered by event_id ascending (NULL last — the
-        "pre-epoch cohort" trails the chronologically-tagged stream).
+        Instances are ordered by `i.created_at_event_id ASC NULLS LAST` in
+        Cypher, then `i.instance_id ASC` as a deterministic tiebreaker —
+        the pre-epoch (NULL event_id) cohort trails the chronologically
+        tagged stream.
         """
+        limit = max(1, min(int(limit), LIFETIME_MAX_LIMIT))
+        offset = max(0, int(offset))
+
         label_row = self._client._execute_cypher(
             """
             MATCH (c:Concept {concept_id: $concept_id})
@@ -78,33 +106,63 @@ class EpochFacade:
             return None
         label = label_row.get("label")
 
+        # Total count for paging metadata. Independent of limit/offset so
+        # callers always know the true chain size. count(DISTINCT i)
+        # defends against duplicate :EVIDENCED_BY edges; the unioned
+        # number is what corresponds to the deduplicated page query.
+        total_row = self._client._execute_cypher(
+            """
+            MATCH (c:Concept {concept_id: $concept_id})-[:EVIDENCED_BY]->(i:Instance)
+            RETURN count(DISTINCT i) AS total
+            """,
+            params={"concept_id": concept_id},
+            fetch_one=True,
+        )
+        total_instances = int(total_row.get("total", 0)) if total_row else 0
+
+        # Page query. Fetch limit+1 to set has_more without a second count.
+        # Sort is in Cypher to avoid materializing the whole chain in Python.
+        # RETURN DISTINCT defends against duplicate :FROM_SOURCE or
+        # :EVIDENCED_BY edges in the graph (visible on installs with
+        # broken/retried ingests) — without it the join fans out and
+        # corrupts both the page contents and the has_more reckoning.
         instance_rows = self._client._execute_cypher(
             """
             MATCH (c:Concept {concept_id: $concept_id})-[:EVIDENCED_BY]->(i:Instance)
             OPTIONAL MATCH (i)-[:FROM_SOURCE]->(s:Source)
-            RETURN
+            RETURN DISTINCT
                 i.instance_id AS instance_id,
                 i.quote AS quote,
                 s.source_id AS source_id,
                 i.created_at_event_id AS event_id
+            ORDER BY i.created_at_event_id, i.instance_id
+            SKIP $offset
+            LIMIT $page_size
             """,
-            params={"concept_id": concept_id},
+            params={
+                "concept_id": concept_id,
+                "offset": offset,
+                "page_size": limit + 1,
+            },
             fetch_one=False,
         ) or []
 
+        has_more = len(instance_rows) > limit
+        page_rows = instance_rows[:limit]
+
         event_ids: List[int] = sorted({
-            row["event_id"] for row in instance_rows
+            row["event_id"] for row in page_rows
             if isinstance(row.get("event_id"), int)
         })
         epoch_lookup = self._hydrate_epochs(event_ids)
 
         instances: List[Dict[str, Any]] = []
         pre_epoch = 0
-        for row in instance_rows:
+        for row in page_rows:
             eid = row.get("event_id")
             if not isinstance(eid, int):
                 pre_epoch += 1
-                eid_val = None
+                eid_val: Optional[int] = None
             else:
                 eid_val = eid
             meta = epoch_lookup.get(eid_val, {}) if eid_val is not None else {}
@@ -116,23 +174,20 @@ class EpochFacade:
                 "occurred_at": meta.get("occurred_at"),
                 "kind": meta.get("kind"),
                 "actor": meta.get("actor"),
+                "semantic_wallclock": meta.get("semantic_wallclock"),
             })
-
-        instances.sort(
-            key=lambda i: (
-                i["event_id"] is None,
-                i["event_id"] or 0,
-                i.get("instance_id") or "",
-            )
-        )
 
         return {
             "concept_id": concept_id,
             "label": label,
             "instances": instances,
-            "total_instances": len(instances),
+            "total_instances": total_instances,
+            "returned_instances": len(instances),
             "distinct_epochs": len(event_ids),
             "pre_epoch_count": pre_epoch,
+            "limit": limit,
+            "offset": offset,
+            "has_more": has_more,
         }
 
     # -------------------------------------------------------------------------
@@ -142,27 +197,30 @@ class EpochFacade:
     def list_epochs(
         self,
         kind: Optional[str] = None,
-        since: Optional[str] = None,
-        until: Optional[str] = None,
+        since: Optional[Union[datetime, str]] = None,
+        until: Optional[Union[datetime, str]] = None,
         actor: Optional[str] = None,
         cursor: Optional[int] = None,
         limit: int = 50,
     ) -> Dict[str, Any]:
         """
-        Cursor-paginated read of kg_api.graph_epochs.
+        Cursor-paginated read of kg_api.graph_epochs, joined to
+        graph_epoch_kinds so callers receive `semantic_wallclock` per row.
 
         Cursor semantics: `cursor` is the *last* event_id from the previous
         page. The next page returns events with `event_id < cursor` in
         descending order. The response's `next_cursor` is the smallest
         event_id in the returned page (None if no more pages).
 
-        Filters apply in addition to the cursor. Wall-clock filters
-        (`since`/`until`) apply regardless of `kind`; callers wanting
-        "ingestion history within window" should pass both.
+        Cursor (rather than limit/offset) is used here intentionally:
+        event_id is monotonic, and cursor pagination is stable under
+        concurrent inserts. Limit/offset is the project default for
+        non-monotonic lists; this endpoint diverges for that specific
+        reason.
 
         Returns:
             {
-                "events": [ ... ],
+                "events": [ ... ],         # each row has semantic_wallclock
                 "next_cursor": int | None,
                 "limit": int,
             }
@@ -173,28 +231,36 @@ class EpochFacade:
         params: Dict[str, Any] = {"limit": limit}
 
         if kind is not None:
-            clauses.append("kind = %(kind)s")
+            clauses.append("e.kind = %(kind)s")
             params["kind"] = kind
         if since is not None:
-            clauses.append("occurred_at >= %(since)s")
+            clauses.append("e.occurred_at >= %(since)s")
             params["since"] = since
         if until is not None:
-            clauses.append("occurred_at <= %(until)s")
+            clauses.append("e.occurred_at <= %(until)s")
             params["until"] = until
         if actor is not None:
-            clauses.append("actor = %(actor)s")
+            clauses.append("e.actor = %(actor)s")
             params["actor"] = actor
         if cursor is not None:
-            clauses.append("event_id < %(cursor)s")
+            clauses.append("e.event_id < %(cursor)s")
             params["cursor"] = int(cursor)
 
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
 
         sql = f"""
-            SELECT event_id, occurred_at, kind, actor, counter_after, metadata
-            FROM kg_api.graph_epochs
+            SELECT
+                e.event_id,
+                e.occurred_at,
+                e.kind,
+                e.actor,
+                e.counter_after,
+                e.metadata,
+                k.semantic_wallclock
+            FROM kg_api.graph_epochs e
+            LEFT JOIN kg_api.graph_epoch_kinds k ON k.kind = e.kind
             {where}
-            ORDER BY event_id DESC
+            ORDER BY e.event_id DESC
             LIMIT %(limit)s
         """
 
@@ -202,12 +268,15 @@ class EpochFacade:
 
         events = [
             {
-                "event_id": row[0],
-                "occurred_at": row[1].isoformat() if row[1] else None,
-                "kind": row[2],
-                "actor": row[3],
-                "counter_after": row[4],
-                "metadata": row[5] or {},
+                "event_id": row["event_id"],
+                "occurred_at": (
+                    row["occurred_at"].isoformat() if row["occurred_at"] else None
+                ),
+                "kind": row["kind"],
+                "actor": row["actor"],
+                "counter_after": row["counter_after"],
+                "metadata": row["metadata"] or {},
+                "semantic_wallclock": row["semantic_wallclock"],
             }
             for row in rows
         ]
@@ -219,19 +288,33 @@ class EpochFacade:
     # -------------------------------------------------------------------------
 
     def _hydrate_epochs(self, event_ids: List[int]) -> Dict[int, Dict[str, Any]]:
-        """Batch-fetch epoch metadata for a list of event_ids."""
+        """Batch-fetch epoch metadata for a list of event_ids, joining the
+        kinds lookup so callers get `semantic_wallclock` without a second
+        round-trip."""
         if not event_ids:
             return {}
         rows = self._execute_sql(
-            "SELECT event_id, occurred_at, kind, actor "
-            "FROM kg_api.graph_epochs WHERE event_id = ANY(%(ids)s)",
+            """
+            SELECT
+                e.event_id,
+                e.occurred_at,
+                e.kind,
+                e.actor,
+                k.semantic_wallclock
+            FROM kg_api.graph_epochs e
+            LEFT JOIN kg_api.graph_epoch_kinds k ON k.kind = e.kind
+            WHERE e.event_id = ANY(%(ids)s)
+            """,
             {"ids": event_ids},
         )
         return {
-            row[0]: {
-                "occurred_at": row[1].isoformat() if row[1] else None,
-                "kind": row[2],
-                "actor": row[3],
+            row["event_id"]: {
+                "occurred_at": (
+                    row["occurred_at"].isoformat() if row["occurred_at"] else None
+                ),
+                "kind": row["kind"],
+                "actor": row["actor"],
+                "semantic_wallclock": row["semantic_wallclock"],
             }
             for row in rows
         }
@@ -240,11 +323,16 @@ class EpochFacade:
         self,
         query: str,
         params: Optional[Dict[str, Any]] = None,
-    ) -> List[tuple]:
-        """Run parameterized SQL via the AGEClient's connection pool."""
+    ) -> List[Dict[str, Any]]:
+        """Run parameterized SQL via the AGEClient's connection pool.
+
+        Returns dict-shaped rows (RealDictCursor) so consumers index by
+        column name and stay robust under SELECT-column reordering — the
+        idiom used by GraphFacade._execute_sql.
+        """
         conn = self._client.pool.getconn()
         try:
-            with conn.cursor() as cur:
+            with conn.cursor(cursor_factory=extras.RealDictCursor) as cur:
                 cur.execute(query, params or {})
                 return cur.fetchall()
         finally:

--- a/api/app/lib/epoch_facade.py
+++ b/api/app/lib/epoch_facade.py
@@ -1,0 +1,252 @@
+"""
+EpochFacade — read-side surface for the ADR-203 graph epoch event log.
+
+Mirrors the construction style of GraphFacade and GraphQueryFacade:
+attached lazily as a property on AGEClient (`client.epochs`), takes the
+client in its constructor, and exposes typed, parameterized methods so
+route handlers never need an `execute_raw` escape hatch.
+
+Two-phase pattern for per-concept lifetime:
+  Phase 1: Cypher (via client._execute_cypher) to walk EVIDENCED_BY
+  Phase 2: SQL (via client.pool) to hydrate event metadata in one shot
+
+Analytics signals (anchor / hot / stale / acceleration) are derivable
+from the primitives here but are deliberately not part of this surface;
+they will land as either follow-up facade methods or composable program
+nodes after the underlying data has been exercised in practice.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class EpochFacade:
+    """ADR-203 epoch event log read surface."""
+
+    def __init__(self, client):
+        """
+        Args:
+            client: AGEClient instance (provides _execute_cypher and pool)
+        """
+        self._client = client
+
+    # -------------------------------------------------------------------------
+    # Per-concept re-evidence stream
+    # -------------------------------------------------------------------------
+
+    def get_concept_lifetime(self, concept_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Return the ordered re-evidence stream for a single Concept.
+
+        Output shape:
+            {
+                "concept_id": str,
+                "label": str | None,
+                "instances": [
+                    {
+                        "instance_id": str,
+                        "quote": str,
+                        "source_id": str | None,
+                        "event_id": int | None,
+                        "occurred_at": str | None,  # ISO-8601 UTC
+                        "kind": str | None,
+                        "actor": str | None,
+                    },
+                    ...
+                ],
+                "total_instances": int,
+                "distinct_epochs": int,
+                "pre_epoch_count": int,  # NULL-event_id cohort
+            }
+
+        Returns None if the concept does not exist.
+
+        Instances are ordered by event_id ascending (NULL last — the
+        "pre-epoch cohort" trails the chronologically-tagged stream).
+        """
+        label_row = self._client._execute_cypher(
+            """
+            MATCH (c:Concept {concept_id: $concept_id})
+            RETURN c.label AS label
+            """,
+            params={"concept_id": concept_id},
+            fetch_one=True,
+        )
+        if not label_row:
+            return None
+        label = label_row.get("label")
+
+        instance_rows = self._client._execute_cypher(
+            """
+            MATCH (c:Concept {concept_id: $concept_id})-[:EVIDENCED_BY]->(i:Instance)
+            OPTIONAL MATCH (i)-[:FROM_SOURCE]->(s:Source)
+            RETURN
+                i.instance_id AS instance_id,
+                i.quote AS quote,
+                s.source_id AS source_id,
+                i.created_at_event_id AS event_id
+            """,
+            params={"concept_id": concept_id},
+            fetch_one=False,
+        ) or []
+
+        event_ids: List[int] = sorted({
+            row["event_id"] for row in instance_rows
+            if isinstance(row.get("event_id"), int)
+        })
+        epoch_lookup = self._hydrate_epochs(event_ids)
+
+        instances: List[Dict[str, Any]] = []
+        pre_epoch = 0
+        for row in instance_rows:
+            eid = row.get("event_id")
+            if not isinstance(eid, int):
+                pre_epoch += 1
+                eid_val = None
+            else:
+                eid_val = eid
+            meta = epoch_lookup.get(eid_val, {}) if eid_val is not None else {}
+            instances.append({
+                "instance_id": row.get("instance_id"),
+                "quote": row.get("quote"),
+                "source_id": row.get("source_id"),
+                "event_id": eid_val,
+                "occurred_at": meta.get("occurred_at"),
+                "kind": meta.get("kind"),
+                "actor": meta.get("actor"),
+            })
+
+        instances.sort(
+            key=lambda i: (
+                i["event_id"] is None,
+                i["event_id"] or 0,
+                i.get("instance_id") or "",
+            )
+        )
+
+        return {
+            "concept_id": concept_id,
+            "label": label,
+            "instances": instances,
+            "total_instances": len(instances),
+            "distinct_epochs": len(event_ids),
+            "pre_epoch_count": pre_epoch,
+        }
+
+    # -------------------------------------------------------------------------
+    # Event log pagination
+    # -------------------------------------------------------------------------
+
+    def list_epochs(
+        self,
+        kind: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        actor: Optional[str] = None,
+        cursor: Optional[int] = None,
+        limit: int = 50,
+    ) -> Dict[str, Any]:
+        """
+        Cursor-paginated read of kg_api.graph_epochs.
+
+        Cursor semantics: `cursor` is the *last* event_id from the previous
+        page. The next page returns events with `event_id < cursor` in
+        descending order. The response's `next_cursor` is the smallest
+        event_id in the returned page (None if no more pages).
+
+        Filters apply in addition to the cursor. Wall-clock filters
+        (`since`/`until`) apply regardless of `kind`; callers wanting
+        "ingestion history within window" should pass both.
+
+        Returns:
+            {
+                "events": [ ... ],
+                "next_cursor": int | None,
+                "limit": int,
+            }
+        """
+        limit = max(1, min(int(limit), 500))
+
+        clauses: List[str] = []
+        params: Dict[str, Any] = {"limit": limit}
+
+        if kind is not None:
+            clauses.append("kind = %(kind)s")
+            params["kind"] = kind
+        if since is not None:
+            clauses.append("occurred_at >= %(since)s")
+            params["since"] = since
+        if until is not None:
+            clauses.append("occurred_at <= %(until)s")
+            params["until"] = until
+        if actor is not None:
+            clauses.append("actor = %(actor)s")
+            params["actor"] = actor
+        if cursor is not None:
+            clauses.append("event_id < %(cursor)s")
+            params["cursor"] = int(cursor)
+
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+
+        sql = f"""
+            SELECT event_id, occurred_at, kind, actor, counter_after, metadata
+            FROM kg_api.graph_epochs
+            {where}
+            ORDER BY event_id DESC
+            LIMIT %(limit)s
+        """
+
+        rows = self._execute_sql(sql, params)
+
+        events = [
+            {
+                "event_id": row[0],
+                "occurred_at": row[1].isoformat() if row[1] else None,
+                "kind": row[2],
+                "actor": row[3],
+                "counter_after": row[4],
+                "metadata": row[5] or {},
+            }
+            for row in rows
+        ]
+        next_cursor = events[-1]["event_id"] if len(events) == limit else None
+        return {"events": events, "next_cursor": next_cursor, "limit": limit}
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _hydrate_epochs(self, event_ids: List[int]) -> Dict[int, Dict[str, Any]]:
+        """Batch-fetch epoch metadata for a list of event_ids."""
+        if not event_ids:
+            return {}
+        rows = self._execute_sql(
+            "SELECT event_id, occurred_at, kind, actor "
+            "FROM kg_api.graph_epochs WHERE event_id = ANY(%(ids)s)",
+            {"ids": event_ids},
+        )
+        return {
+            row[0]: {
+                "occurred_at": row[1].isoformat() if row[1] else None,
+                "kind": row[2],
+                "actor": row[3],
+            }
+            for row in rows
+        }
+
+    def _execute_sql(
+        self,
+        query: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> List[tuple]:
+        """Run parameterized SQL via the AGEClient's connection pool."""
+        conn = self._client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, params or {})
+                return cur.fetchall()
+        finally:
+            conn.commit()
+            self._client.pool.putconn(conn)

--- a/api/app/lib/ingestion.py
+++ b/api/app/lib/ingestion.py
@@ -179,7 +179,9 @@ def process_chunk(
     text_embedding: Optional[List[float]] = None,
     # ADR-081: Source document lifecycle
     garage_key: Optional[str] = None,
-    content_hash: Optional[str] = None
+    content_hash: Optional[str] = None,
+    # ADR-203: Graph epoch event_id tagging Instances created during this job
+    event_id: Optional[int] = None,
 ) -> List[str]:
     """
     Process a single chunk: create source, extract concepts, create graph nodes.
@@ -463,7 +465,11 @@ def process_chunk(
             else:
                 # Create new instance
                 instance_id = f"{source_id}_inst_{uuid.uuid4().hex[:8]}"
-                age_client.create_instance_node(instance_id=instance_id, quote=quote)
+                age_client.create_instance_node(
+                    instance_id=instance_id,
+                    quote=quote,
+                    created_at_event_id=event_id,  # ADR-203
+                )
                 stats.instances_created += 1
 
             # Link instance to concept and source

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -31,7 +31,7 @@ from .services.scheduled_jobs_manager import JobScheduler as ScheduledJobsManage
 from .services.worker_registry import register_all_workers, get_all_job_types, validate_lane_uniqueness
 from .services.lane_manager import LaneManager
 from .launchers import CategoryRefreshLauncher, VocabConsolidationLauncher, EpistemicRemeasurementLauncher, ProjectionLauncher, ArtifactCleanupLauncher, AnnealingLauncher
-from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, oauth, sources, projection, artifacts, grants, query_definitions, documents, concepts, edges, graph, storage_admin, programs, admin_workers, models
+from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, oauth, sources, projection, artifacts, grants, query_definitions, documents, concepts, edges, graph, storage_admin, programs, admin_workers, models, epochs
 from .services.embedding_worker import get_embedding_worker
 from .lib.age_client import AGEClient
 from .lib.ai_providers import get_provider
@@ -430,6 +430,7 @@ app.include_router(programs.router)  # ADR-500: Program notarization
 app.include_router(documents.router)  # ADR-084: Document content retrieval
 app.include_router(documents.query_router)  # ADR-084: Document search
 app.include_router(concepts.router)  # ADR-089: Deterministic concept CRUD
+app.include_router(epochs.router)  # ADR-203: Graph epoch event log read surface
 app.include_router(edges.router)  # ADR-089: Deterministic edge CRUD
 app.include_router(graph.router)  # ADR-089: Batch graph operations
 app.include_router(storage_admin.router)  # Storage diagnostics

--- a/api/app/routes/concepts.py
+++ b/api/app/routes/concepts.py
@@ -287,6 +287,17 @@ async def delete_concept(
 )
 async def get_concept_lifetime(
     concept_id: str,
+    limit: int = Query(
+        200,
+        ge=1,
+        le=1000,
+        description="Maximum Instances to return in this page (default 200, hard cap 1000).",
+    ),
+    offset: int = Query(
+        0,
+        ge=0,
+        description="Number of Instances to skip — anchor concepts can have thousands; paginate to keep payloads bounded.",
+    ),
     current_user: UserInDB = Depends(require_permission("graph", "read"))
 ):
     """
@@ -294,16 +305,22 @@ async def get_concept_lifetime(
 
     Walks `(:Concept)-[:EVIDENCED_BY]->(:Instance)` and joins each Instance
     to its `graph_epochs` event row, so the returned chain carries
-    `event_id`, `occurred_at`, `kind`, and `actor` per Instance.
+    `event_id`, `occurred_at`, `kind`, `actor`, and `semantic_wallclock`
+    per Instance.
 
     Instances created before ADR-203 carry `NULL` event_id and are surfaced
-    as a `pre_epoch_count`; they appear at the tail of the chain.
+    as `pre_epoch_count`; they appear at the tail of the chain. The chain
+    is paginated because anchor concepts can have thousands of Instances —
+    the response carries `total_instances` (full chain size), `limit`,
+    `offset`, and `has_more` so callers can walk further pages.
 
     Requires `graph:read` permission.
     """
     age_client = get_age_client()
     try:
-        result = age_client.epochs.get_concept_lifetime(concept_id)
+        result = age_client.epochs.get_concept_lifetime(
+            concept_id, limit=limit, offset=offset
+        )
     except Exception as e:
         logger.error(f"get_concept_lifetime({concept_id}) failed: {e}")
         raise HTTPException(

--- a/api/app/routes/concepts.py
+++ b/api/app/routes/concepts.py
@@ -281,6 +281,44 @@ async def delete_concept(
         )
 
 
+@router.get(
+    "/{concept_id}/lifetime",
+    summary="Get concept re-evidence timeline (ADR-203)",
+)
+async def get_concept_lifetime(
+    concept_id: str,
+    current_user: UserInDB = Depends(require_permission("graph", "read"))
+):
+    """
+    Return the ordered re-evidence stream for a single concept.
+
+    Walks `(:Concept)-[:EVIDENCED_BY]->(:Instance)` and joins each Instance
+    to its `graph_epochs` event row, so the returned chain carries
+    `event_id`, `occurred_at`, `kind`, and `actor` per Instance.
+
+    Instances created before ADR-203 carry `NULL` event_id and are surfaced
+    as a `pre_epoch_count`; they appear at the tail of the chain.
+
+    Requires `graph:read` permission.
+    """
+    age_client = get_age_client()
+    try:
+        result = age_client.epochs.get_concept_lifetime(concept_id)
+    except Exception as e:
+        logger.error(f"get_concept_lifetime({concept_id}) failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to get concept lifetime",
+        )
+
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Concept not found: {concept_id}",
+        )
+    return result
+
+
 @router.post(
     "/{concept_id}/evidence",
     response_model=EvidenceResponse,

--- a/api/app/routes/epochs.py
+++ b/api/app/routes/epochs.py
@@ -1,0 +1,83 @@
+"""
+Epoch Routes (ADR-203)
+
+Read-only endpoints for the graph epoch event log. Pairs with the
+concept-lifetime endpoint in routes/concepts.py — both delegate to
+EpochFacade (`age_client.epochs`).
+"""
+
+from typing import Optional
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from ..models.auth import UserInDB
+from ..dependencies.auth import require_permission
+from .database import get_age_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/epochs", tags=["epochs"])
+
+
+@router.get(
+    "",
+    summary="List graph epoch events (ADR-203)",
+)
+async def list_epochs(
+    kind: Optional[str] = Query(
+        None,
+        description="Filter to a specific event kind (ingestion, reasoning, breathing, edit)",
+    ),
+    since: Optional[str] = Query(
+        None,
+        description="ISO-8601 lower bound on occurred_at (UTC)",
+    ),
+    until: Optional[str] = Query(
+        None,
+        description="ISO-8601 upper bound on occurred_at (UTC)",
+    ),
+    actor: Optional[str] = Query(
+        None,
+        description="Filter by exact actor string",
+    ),
+    cursor: Optional[int] = Query(
+        None,
+        description="Pagination cursor — return events with event_id < cursor",
+    ),
+    limit: int = Query(50, ge=1, le=500, description="Max events per page"),
+    current_user: UserInDB = Depends(require_permission("graph", "read")),
+):
+    """
+    Cursor-paginated read of `kg_api.graph_epochs`.
+
+    Events are returned most-recent-first. To page back through history,
+    pass the previous response's `next_cursor` as `cursor`. When the
+    response's `next_cursor` is null, no further pages exist for the
+    current filter set.
+
+    Filter semantics:
+      - `kind` matches exact (no wildcards). Honest about the discriminator
+        in ADR-203 §Decision: only some kinds make wall-clock semantically
+        meaningful.
+      - `since`/`until` apply to `occurred_at` regardless of `kind`.
+      - `actor` matches exact.
+
+    Requires `graph:read` permission.
+    """
+    age_client = get_age_client()
+    try:
+        return age_client.epochs.list_epochs(
+            kind=kind,
+            since=since,
+            until=until,
+            actor=actor,
+            cursor=cursor,
+            limit=limit,
+        )
+    except Exception as e:
+        logger.error(f"list_epochs failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list epochs",
+        )

--- a/api/app/routes/epochs.py
+++ b/api/app/routes/epochs.py
@@ -6,6 +6,7 @@ concept-lifetime endpoint in routes/concepts.py — both delegate to
 EpochFacade (`age_client.epochs`).
 """
 
+from datetime import datetime
 from typing import Optional
 import logging
 
@@ -29,13 +30,13 @@ async def list_epochs(
         None,
         description="Filter to a specific event kind (ingestion, reasoning, breathing, edit)",
     ),
-    since: Optional[str] = Query(
+    since: Optional[datetime] = Query(
         None,
-        description="ISO-8601 lower bound on occurred_at (UTC)",
+        description="ISO-8601 lower bound on occurred_at (UTC). FastAPI parses; malformed input → 422.",
     ),
-    until: Optional[str] = Query(
+    until: Optional[datetime] = Query(
         None,
-        description="ISO-8601 upper bound on occurred_at (UTC)",
+        description="ISO-8601 upper bound on occurred_at (UTC). FastAPI parses; malformed input → 422.",
     ),
     actor: Optional[str] = Query(
         None,
@@ -51,6 +52,13 @@ async def list_epochs(
     """
     Cursor-paginated read of `kg_api.graph_epochs`.
 
+    Cursor pagination (rather than the project's usual limit/offset) is
+    used here because `event_id` is strictly monotonic. Cursors are stable
+    under concurrent inserts — a new ingestion landing mid-pagination
+    cannot shift items between pages. For non-monotonic lists, the
+    project default of limit/offset remains correct; this endpoint
+    diverges for that specific reason.
+
     Events are returned most-recent-first. To page back through history,
     pass the previous response's `next_cursor` as `cursor`. When the
     response's `next_cursor` is null, no further pages exist for the
@@ -59,7 +67,8 @@ async def list_epochs(
     Filter semantics:
       - `kind` matches exact (no wildcards). Honest about the discriminator
         in ADR-203 §Decision: only some kinds make wall-clock semantically
-        meaningful.
+        meaningful; each event row carries `semantic_wallclock` so callers
+        can reason about that without duplicating the table.
       - `since`/`until` apply to `occurred_at` regardless of `kind`.
       - `actor` matches exact.
 

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -337,6 +337,26 @@ def run_ingestion_worker(
             logger.warning(f"Failed to ensure Ontology node for '{ontology}': {e}")
             # Non-fatal: s.document on Source nodes still works without Ontology node
 
+        # ADR-203: Record this ingestion as a graph epoch event so every
+        # Instance created during the run carries a stable event_id. On resume,
+        # a fresh event is recorded with resume metadata — honest record that
+        # the work spanned multiple sessions.
+        epoch_metadata = {
+            "job_id": job_id,
+            "ontology": ontology,
+        }
+        if is_resuming:
+            epoch_metadata["resumed_from_chunk"] = resume_from_chunk
+        event_id = age_client.record_epoch(
+            kind="ingestion",
+            actor=job_data.get("user_id") or job_data.get("username"),
+            metadata=epoch_metadata,
+        )
+        if event_id is not None:
+            logger.info(f"📍 Recorded graph epoch event_id={event_id} for this ingestion")
+        else:
+            logger.warning("⚠️  record_epoch returned None — Instances will be untagged")
+
         # Get existing concepts for context
         existing_concepts, has_empty_warnings = age_client.get_document_concepts(
             document_name=ontology,
@@ -389,7 +409,9 @@ def run_ingestion_worker(
                 text_embedding=None,  # Will be generated during concept extraction
                 # ADR-081: Pass source document storage metadata
                 garage_key=job_data.get("source_garage_key"),
-                content_hash=job_data.get("source_content_hash")
+                content_hash=job_data.get("source_content_hash"),
+                # ADR-203: Tag Instances created during this chunk with the job's epoch
+                event_id=event_id,
             )
 
             # Update progress with detailed stats AND save resume checkpoint

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -73,6 +73,9 @@ import {
   BatchCreateRequest,
   BatchCreateResponse,
   EvidenceResponse,
+  // ADR-203: Graph epoch event log
+  ConceptLifetimeResponse,
+  EpochListResponse,
 } from '../types';
 
 export class KnowledgeGraphClient {
@@ -794,6 +797,37 @@ export class KnowledgeGraphClient {
   async deleteConcept(conceptId: string, cascade?: boolean): Promise<void> {
     const params = cascade ? { cascade: true } : {};
     await this.client.delete(`/concepts/${encodeURIComponent(conceptId)}`, { params });
+  }
+
+  // ========== Epoch Lifetime / Event Log (ADR-203) ==========
+
+  /**
+   * Get the re-evidence stream for a concept, joined to graph_epochs.
+   * Each Instance carries event_id + occurred_at + kind + actor; pre-ADR-203
+   * Instances are tallied separately as pre_epoch_count.
+   */
+  async getConceptLifetime(conceptId: string): Promise<ConceptLifetimeResponse> {
+    const response = await this.client.get(
+      `/concepts/${encodeURIComponent(conceptId)}/lifetime`
+    );
+    return response.data;
+  }
+
+  /**
+   * Paginated read of the graph epoch event log (ADR-203).
+   * Cursor is the previous response's next_cursor (returns events with
+   * event_id < cursor in descending order).
+   */
+  async listEpochs(params?: {
+    kind?: string;
+    since?: string;
+    until?: string;
+    actor?: string;
+    cursor?: number;
+    limit?: number;
+  }): Promise<EpochListResponse> {
+    const response = await this.client.get('/epochs', { params });
+    return response.data;
   }
 
   // ========== Edge CRUD Methods (ADR-089) ==========

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -803,12 +803,21 @@ export class KnowledgeGraphClient {
 
   /**
    * Get the re-evidence stream for a concept, joined to graph_epochs.
-   * Each Instance carries event_id + occurred_at + kind + actor; pre-ADR-203
-   * Instances are tallied separately as pre_epoch_count.
+   * Each Instance carries event_id + occurred_at + kind + actor +
+   * semantic_wallclock; pre-ADR-203 Instances are tallied as
+   * pre_epoch_count.
+   *
+   * Paginated: anchor concepts can have thousands of Instances.
+   * `total_instances` in the response reflects the full chain size
+   * independent of paging.
    */
-  async getConceptLifetime(conceptId: string): Promise<ConceptLifetimeResponse> {
+  async getConceptLifetime(
+    conceptId: string,
+    params?: { limit?: number; offset?: number }
+  ): Promise<ConceptLifetimeResponse> {
     const response = await this.client.get(
-      `/concepts/${encodeURIComponent(conceptId)}/lifetime`
+      `/concepts/${encodeURIComponent(conceptId)}/lifetime`,
+      { params }
     );
     return response.data;
   }

--- a/cli/src/mcp-server.ts
+++ b/cli/src/mcp-server.ts
@@ -63,6 +63,9 @@ import {
   formatAnnealingCycleResult,
   formatSessionContext,
   formatSessionIngest,
+  // ADR-203: Graph epoch event log
+  formatConceptLifetime,
+  formatEpochList,
 } from './mcp/formatters/index.js';
 import {
   GraphOperationExecutor,
@@ -442,8 +445,8 @@ For multi-step workflows (search → connect → expand → filter), compose the
           properties: {
             action: {
               type: 'string',
-              enum: ['details', 'related', 'connect', 'add_evidence'],
-              description: 'Operation: "details" (get ALL evidence), "related" (explore neighborhood), "connect" (find paths), "add_evidence" (attach evidence text to a concept)',
+              enum: ['details', 'related', 'connect', 'add_evidence', 'lifetime'],
+              description: 'Operation: "details" (get ALL evidence), "related" (explore neighborhood), "connect" (find paths), "add_evidence" (attach evidence text to a concept), "lifetime" (ADR-203 re-evidence stream — ordered Instance chain with graph_epochs metadata, showing when the system came to know this concept)',
             },
             // For details, related, and add_evidence
             concept_id: {
@@ -1335,6 +1338,52 @@ Read the program/syntax resource for the complete language reference with more e
           required: ['text'],
         },
       },
+      // ADR-203: Graph epoch event log
+      {
+        name: 'epoch',
+        description: `Read the graph epoch event log (ADR-203).
+
+Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology breathing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
+
+Two dimensions matter:
+  - event_id (logical time): always meaningful — strictly ordered, even for events whose wall-clock is forensic.
+  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'breathing'.
+
+Cursor-paginated. Pass the previous response's next_cursor as cursor to walk further back.
+
+For the per-concept re-evidence stream (which Concepts were touched in which epochs), use the concept tool's 'lifetime' action instead.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            kind: {
+              type: 'string',
+              enum: ['ingestion', 'reasoning', 'breathing', 'edit'],
+              description: 'Filter to a specific event kind. Omit for all kinds.',
+            },
+            since: {
+              type: 'string',
+              description: 'ISO-8601 lower bound on occurred_at (UTC, e.g., "2026-05-01T00:00:00Z")',
+            },
+            until: {
+              type: 'string',
+              description: 'ISO-8601 upper bound on occurred_at (UTC)',
+            },
+            actor: {
+              type: 'string',
+              description: 'Filter by exact actor string (user id, agent session id, system component)',
+            },
+            cursor: {
+              type: 'number',
+              description: 'Pagination cursor — returns events with event_id < cursor. Omit for the first page.',
+            },
+            limit: {
+              type: 'number',
+              description: 'Max events per page (1-500, default 50)',
+              default: 50,
+            },
+          },
+        },
+      },
     ],
   };
 });
@@ -1730,6 +1779,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
             return {
               content: [{ type: 'text', text: `Evidence added to concept ${result.concept_id}\n\nInstance: ${result.instance_id}\nSource: ${result.source_id}\nText: ${result.evidence_text}` }],
+            };
+          }
+
+          case 'lifetime': {
+            const conceptId = toolArgs.concept_id as string;
+            if (!conceptId) {
+              throw new Error('concept_id is required for lifetime');
+            }
+            const result = await client.getConceptLifetime(conceptId);
+            return {
+              content: [{ type: 'text', text: formatConceptLifetime(result) }],
             };
           }
 
@@ -3132,6 +3192,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         return {
           content: [{ type: 'text', text: formatSessionIngest(result) }],
+        };
+      }
+
+      // ADR-203: Graph epoch event log
+      case 'epoch': {
+        const result = await client.listEpochs({
+          kind: toolArgs.kind as string | undefined,
+          since: toolArgs.since as string | undefined,
+          until: toolArgs.until as string | undefined,
+          actor: toolArgs.actor as string | undefined,
+          cursor: toolArgs.cursor as number | undefined,
+          limit: toolArgs.limit as number | undefined,
+        });
+        return {
+          content: [{ type: 'text', text: formatEpochList(result) }],
         };
       }
 

--- a/cli/src/mcp-server.ts
+++ b/cli/src/mcp-server.ts
@@ -532,6 +532,15 @@ For multi-step workflows (search → connect → expand → filter), compose the
               description: 'Similarity threshold for semantic mode (default: 0.5). Lower values find broader matches. The API enforces backend safety limits.',
               default: 0.5,
             },
+            // ADR-203: pagination for the lifetime action — anchor concepts can have thousands of Instances.
+            lifetime_limit: {
+              type: 'number',
+              description: 'For action=lifetime: max Instances per page (default 200, hard cap 1000).',
+            },
+            lifetime_offset: {
+              type: 'number',
+              description: 'For action=lifetime: number of Instances to skip. Use with has_more in the response to walk further pages.',
+            },
           },
           required: ['action'],
         },
@@ -1362,11 +1371,13 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
             },
             since: {
               type: 'string',
-              description: 'ISO-8601 lower bound on occurred_at (UTC, e.g., "2026-05-01T00:00:00Z")',
+              format: 'date-time',
+              description: 'ISO-8601 lower bound on occurred_at. The API parses with FastAPI\'s datetime parser; tolerant of common forms (with or without "Z", offsets accepted).',
             },
             until: {
               type: 'string',
-              description: 'ISO-8601 upper bound on occurred_at (UTC)',
+              format: 'date-time',
+              description: 'ISO-8601 upper bound on occurred_at. Same parsing semantics as `since`.',
             },
             actor: {
               type: 'string',
@@ -1787,7 +1798,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             if (!conceptId) {
               throw new Error('concept_id is required for lifetime');
             }
-            const result = await client.getConceptLifetime(conceptId);
+            const result = await client.getConceptLifetime(conceptId, {
+              limit: toolArgs.lifetime_limit as number | undefined,
+              offset: toolArgs.lifetime_offset as number | undefined,
+            });
             return {
               content: [{ type: 'text', text: formatConceptLifetime(result) }],
             };

--- a/cli/src/mcp/formatters/epoch.ts
+++ b/cli/src/mcp/formatters/epoch.ts
@@ -3,16 +3,20 @@
  *
  * Renders responses as compact markdown for token-efficient consumption
  * by agents. Visualizes the two-dimension model: logical-time ordering
- * via event_id, wall-clock time via occurred_at, kind as the
- * discriminator for whether wall-clock is semantically primary.
+ * via event_id, wall-clock via occurred_at, and the per-kind
+ * `semantic_wallclock` flag (sourced from the API, originally from the
+ * graph_epoch_kinds lookup table) as the discriminator for whether
+ * wall-clock is semantically primary.
+ *
+ * Previously this formatter hardcoded a `KINDS_WITH_WALLCLOCK` set —
+ * removed in the migration-064 round so kinds and their semantics live
+ * in one place (the database).
  */
 
 import type {
   ConceptLifetimeResponse,
   EpochListResponse,
 } from '../../types/index.js';
-
-const KINDS_WITH_WALLCLOCK = new Set(['ingestion', 'edit']);
 
 function formatTime(iso: string | null): string {
   if (!iso) return '—';
@@ -23,6 +27,13 @@ function formatTime(iso: string | null): string {
 function truncateQuote(quote: string, max = 120): string {
   if (quote.length <= max) return quote;
   return quote.slice(0, max - 1).trimEnd() + '…';
+}
+
+function forensicSuffix(semanticWallclock: boolean | null | undefined): string {
+  // null = no epoch row joined (e.g. pre-ADR-203 Instance). Treat as
+  // "no statement" and omit the suffix entirely.
+  if (semanticWallclock === null || semanticWallclock === undefined) return '';
+  return semanticWallclock ? '' : ' _(forensic)_';
 }
 
 /**
@@ -37,16 +48,24 @@ export function formatConceptLifetime(result: ConceptLifetimeResponse): string {
   lines.push(`# Concept Lifetime — ${result.label ?? '(unlabeled)'}`);
   lines.push('');
   lines.push(`Concept ID: \`${result.concept_id}\``);
-  lines.push(
-    `Total Instances: ${result.total_instances} · Distinct Epochs: ${result.distinct_epochs}` +
-      (result.pre_epoch_count > 0
-        ? ` · Pre-epoch cohort: ${result.pre_epoch_count}`
-        : '')
-  );
+  const summary = [
+    `Total Instances (full chain): ${result.total_instances}`,
+    `Returned this page: ${result.returned_instances}`,
+    `Distinct Epochs (page): ${result.distinct_epochs}`,
+  ];
+  if (result.pre_epoch_count > 0) {
+    summary.push(`Pre-epoch cohort (page): ${result.pre_epoch_count}`);
+  }
+  lines.push(summary.join(' · '));
+  lines.push(`Page: limit=${result.limit}, offset=${result.offset}${result.has_more ? ' — `has_more=true`' : ''}`);
   lines.push('');
 
-  if (result.total_instances === 0) {
-    lines.push('_No Instances recorded for this concept._');
+  if (result.returned_instances === 0) {
+    if (result.total_instances === 0) {
+      lines.push('_No Instances recorded for this concept._');
+    } else {
+      lines.push('_Offset is past the end of the chain — try a smaller offset._');
+    }
     return lines.join('\n');
   }
 
@@ -67,14 +86,14 @@ export function formatConceptLifetime(result: ConceptLifetimeResponse): string {
     const bucket = groups.get(key)!;
     if (key === null) {
       lines.push(`## Pre-epoch cohort (${bucket.length} instance${bucket.length === 1 ? '' : 's'})`);
-      lines.push('_Created before ADR-203 — no event metadata available._');
+      lines.push('_Created before ADR-203 (or `record_epoch` failed) — no event metadata available._');
     } else {
       const head = bucket[0];
       const kind = head.kind ?? '?';
       const wallclock = formatTime(head.occurred_at);
-      const wallclockMeaning = KINDS_WITH_WALLCLOCK.has(kind) ? '' : ' _(forensic)_';
+      const suffix = forensicSuffix(head.semantic_wallclock);
       lines.push(
-        `## Epoch ${key} · \`${kind}\` · ${wallclock}${wallclockMeaning}` +
+        `## Epoch ${key} · \`${kind}\` · ${wallclock}${suffix}` +
           (head.actor ? ` · actor: ${head.actor}` : '')
       );
     }
@@ -85,11 +104,21 @@ export function formatConceptLifetime(result: ConceptLifetimeResponse): string {
     lines.push('');
   }
 
+  if (result.has_more) {
+    lines.push(`---`);
+    lines.push(`Next page: pass \`lifetime_offset=${result.offset + result.returned_instances}\` to continue.`);
+  }
+
   return lines.join('\n').trimEnd();
 }
 
 /**
  * Epoch event log page — most-recent-first, with next_cursor hint.
+ *
+ * Each row's `_forensic_` suffix is driven by `semantic_wallclock` from
+ * the API (originally from kg_api.graph_epoch_kinds), not by a local
+ * hardcoded set — adding a new kind only requires inserting a row in
+ * the lookup table.
  */
 export function formatEpochList(result: EpochListResponse): string {
   const lines: string[] = [];
@@ -103,11 +132,11 @@ export function formatEpochList(result: EpochListResponse): string {
 
   for (const ev of result.events) {
     const wallclock = formatTime(ev.occurred_at);
-    const wallclockMeaning = KINDS_WITH_WALLCLOCK.has(ev.kind) ? '' : ' _(forensic)_';
+    const suffix = forensicSuffix(ev.semantic_wallclock);
     const actor = ev.actor ? ` · actor: ${ev.actor}` : '';
     const counter = ev.counter_after !== null ? ` · counter: ${ev.counter_after}` : '';
     lines.push(
-      `- **${ev.event_id}** \`${ev.kind}\` · ${wallclock}${wallclockMeaning}${actor}${counter}`
+      `- **${ev.event_id}** \`${ev.kind}\` · ${wallclock}${suffix}${actor}${counter}`
     );
     const metaKeys = Object.keys(ev.metadata || {});
     if (metaKeys.length > 0) {

--- a/cli/src/mcp/formatters/epoch.ts
+++ b/cli/src/mcp/formatters/epoch.ts
@@ -1,0 +1,132 @@
+/**
+ * MCP formatters for the graph epoch event log (ADR-203).
+ *
+ * Renders responses as compact markdown for token-efficient consumption
+ * by agents. Visualizes the two-dimension model: logical-time ordering
+ * via event_id, wall-clock time via occurred_at, kind as the
+ * discriminator for whether wall-clock is semantically primary.
+ */
+
+import type {
+  ConceptLifetimeResponse,
+  EpochListResponse,
+} from '../../types/index.js';
+
+const KINDS_WITH_WALLCLOCK = new Set(['ingestion', 'edit']);
+
+function formatTime(iso: string | null): string {
+  if (!iso) return '—';
+  // Strip milliseconds for compactness, keep timezone
+  return iso.replace(/\.\d+/, '');
+}
+
+function truncateQuote(quote: string, max = 120): string {
+  if (quote.length <= max) return quote;
+  return quote.slice(0, max - 1).trimEnd() + '…';
+}
+
+/**
+ * Concept re-evidence stream — grouped by epoch for readability.
+ *
+ * Each epoch block shows kind + wall-clock context + every Instance
+ * attached to that epoch. Pre-epoch (NULL event_id) Instances are
+ * listed last as a known cohort, honest about their lack of metadata.
+ */
+export function formatConceptLifetime(result: ConceptLifetimeResponse): string {
+  const lines: string[] = [];
+  lines.push(`# Concept Lifetime — ${result.label ?? '(unlabeled)'}`);
+  lines.push('');
+  lines.push(`Concept ID: \`${result.concept_id}\``);
+  lines.push(
+    `Total Instances: ${result.total_instances} · Distinct Epochs: ${result.distinct_epochs}` +
+      (result.pre_epoch_count > 0
+        ? ` · Pre-epoch cohort: ${result.pre_epoch_count}`
+        : '')
+  );
+  lines.push('');
+
+  if (result.total_instances === 0) {
+    lines.push('_No Instances recorded for this concept._');
+    return lines.join('\n');
+  }
+
+  // Group by event_id (null → pre-epoch bucket, listed last).
+  const groups = new Map<number | null, typeof result.instances>();
+  for (const inst of result.instances) {
+    const key = inst.event_id;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(inst);
+  }
+
+  const orderedKeys: (number | null)[] = [
+    ...[...groups.keys()].filter((k): k is number => k !== null).sort((a, b) => a - b),
+    ...(groups.has(null) ? [null] : []),
+  ];
+
+  for (const key of orderedKeys) {
+    const bucket = groups.get(key)!;
+    if (key === null) {
+      lines.push(`## Pre-epoch cohort (${bucket.length} instance${bucket.length === 1 ? '' : 's'})`);
+      lines.push('_Created before ADR-203 — no event metadata available._');
+    } else {
+      const head = bucket[0];
+      const kind = head.kind ?? '?';
+      const wallclock = formatTime(head.occurred_at);
+      const wallclockMeaning = KINDS_WITH_WALLCLOCK.has(kind) ? '' : ' _(forensic)_';
+      lines.push(
+        `## Epoch ${key} · \`${kind}\` · ${wallclock}${wallclockMeaning}` +
+          (head.actor ? ` · actor: ${head.actor}` : '')
+      );
+    }
+    for (const inst of bucket) {
+      const source = inst.source_id ? ` → ${inst.source_id}` : '';
+      lines.push(`- "${truncateQuote(inst.quote)}"${source}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+/**
+ * Epoch event log page — most-recent-first, with next_cursor hint.
+ */
+export function formatEpochList(result: EpochListResponse): string {
+  const lines: string[] = [];
+  lines.push(`# Graph Epochs (page of ${result.events.length}, limit ${result.limit})`);
+  lines.push('');
+
+  if (result.events.length === 0) {
+    lines.push('_No events match the current filter._');
+    return lines.join('\n');
+  }
+
+  for (const ev of result.events) {
+    const wallclock = formatTime(ev.occurred_at);
+    const wallclockMeaning = KINDS_WITH_WALLCLOCK.has(ev.kind) ? '' : ' _(forensic)_';
+    const actor = ev.actor ? ` · actor: ${ev.actor}` : '';
+    const counter = ev.counter_after !== null ? ` · counter: ${ev.counter_after}` : '';
+    lines.push(
+      `- **${ev.event_id}** \`${ev.kind}\` · ${wallclock}${wallclockMeaning}${actor}${counter}`
+    );
+    const metaKeys = Object.keys(ev.metadata || {});
+    if (metaKeys.length > 0) {
+      const metaPairs = metaKeys
+        .slice(0, 5)
+        .map((k) => `${k}=${JSON.stringify((ev.metadata as any)[k])}`)
+        .join(' · ');
+      lines.push(`  _${metaPairs}_`);
+    }
+  }
+  lines.push('');
+
+  if (result.next_cursor !== null) {
+    lines.push(`---`);
+    lines.push(`Next page: pass \`cursor=${result.next_cursor}\` to continue.`);
+  } else {
+    lines.push(`---`);
+    lines.push(`_No further pages for current filter._`);
+  }
+
+  return lines.join('\n');
+}

--- a/cli/src/mcp/formatters/index.ts
+++ b/cli/src/mcp/formatters/index.ts
@@ -71,6 +71,9 @@ export {
 // Session context formatters
 export { formatSessionContext, formatSessionIngest } from './session.js';
 
+// Graph epoch event log formatters (ADR-203)
+export { formatConceptLifetime, formatEpochList } from './epoch.js';
+
 // Ontology formatters (ADR-200)
 export {
   formatOntologyList,

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1101,6 +1101,62 @@ export interface ConceptListCRUDResponse {
   limit: number;
 }
 
+// ========== Graph Epoch Event Log (ADR-203) ==========
+
+/**
+ * A single Instance in a concept's re-evidence stream, joined to its
+ * graph_epochs event. event_id is null for pre-ADR-203 Instances —
+ * those are surfaced separately as pre_epoch_count on the parent.
+ */
+export interface ConceptLifetimeInstance {
+  instance_id: string;
+  quote: string;
+  source_id: string | null;
+  event_id: number | null;
+  occurred_at: string | null;  // ISO-8601 UTC
+  kind: string | null;
+  actor: string | null;
+}
+
+/**
+ * Ordered re-evidence stream for a single Concept (ADR-203).
+ * Instances are sorted by event_id ascending; pre-epoch cohort trails.
+ */
+export interface ConceptLifetimeResponse {
+  concept_id: string;
+  label: string | null;
+  instances: ConceptLifetimeInstance[];
+  total_instances: number;
+  distinct_epochs: number;
+  pre_epoch_count: number;
+}
+
+/**
+ * One row of the graph epoch event log.
+ *
+ * `occurred_at` is always present (wall-clock), but semantically
+ * meaningful primarily for `kind` values where it isn't forensic
+ * (typically 'ingestion' / 'edit').
+ */
+export interface EpochEvent {
+  event_id: number;
+  occurred_at: string;
+  kind: 'ingestion' | 'reasoning' | 'breathing' | 'edit' | string;
+  actor: string | null;
+  counter_after: number | null;
+  metadata: Record<string, any>;
+}
+
+/**
+ * Cursor-paginated event log response. `next_cursor` is null when
+ * no further pages exist for the current filter set.
+ */
+export interface EpochListResponse {
+  events: EpochEvent[];
+  next_cursor: number | null;
+  limit: number;
+}
+
 // ========== Edge CRUD Types (ADR-089) ==========
 
 /**

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1107,6 +1107,10 @@ export interface ConceptListCRUDResponse {
  * A single Instance in a concept's re-evidence stream, joined to its
  * graph_epochs event. event_id is null for pre-ADR-203 Instances —
  * those are surfaced separately as pre_epoch_count on the parent.
+ *
+ * `semantic_wallclock` mirrors graph_epoch_kinds.semantic_wallclock for
+ * this Instance's epoch (or null when no epoch). When false, treat
+ * `occurred_at` as forensic-only.
  */
 export interface ConceptLifetimeInstance {
   instance_id: string;
@@ -1116,35 +1120,49 @@ export interface ConceptLifetimeInstance {
   occurred_at: string | null;  // ISO-8601 UTC
   kind: string | null;
   actor: string | null;
+  semantic_wallclock: boolean | null;
 }
 
 /**
  * Ordered re-evidence stream for a single Concept (ADR-203).
- * Instances are sorted by event_id ascending; pre-epoch cohort trails.
+ *
+ * Paginated: anchor concepts can have thousands of Instances, so the
+ * response carries `total_instances` (full chain size), the current
+ * page in `instances`, plus `limit`/`offset`/`has_more` for paging.
+ * `distinct_epochs` and `pre_epoch_count` are scoped to the returned
+ * page; callers that need global counts should walk all pages or rely
+ * on `total_instances` alone.
  */
 export interface ConceptLifetimeResponse {
   concept_id: string;
   label: string | null;
   instances: ConceptLifetimeInstance[];
   total_instances: number;
+  returned_instances: number;
   distinct_epochs: number;
   pre_epoch_count: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
 }
 
 /**
  * One row of the graph epoch event log.
  *
- * `occurred_at` is always present (wall-clock), but semantically
- * meaningful primarily for `kind` values where it isn't forensic
- * (typically 'ingestion' / 'edit').
+ * `occurred_at` is always present (wall-clock). `semantic_wallclock`
+ * (from kg_api.graph_epoch_kinds) is the authoritative discriminator
+ * for whether the timestamp is semantically primary or forensic-only.
+ * Migration 064 made this a per-kind row in the database, replacing the
+ * formerly duplicated TS-side hardcoded set.
  */
 export interface EpochEvent {
   event_id: number;
   occurred_at: string;
-  kind: 'ingestion' | 'reasoning' | 'breathing' | 'edit' | string;
+  kind: string;
   actor: string | null;
   counter_after: number | null;
   metadata: Record<string, any>;
+  semantic_wallclock: boolean | null;
 }
 
 /**

--- a/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
+++ b/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
@@ -67,7 +67,7 @@ CREATE INDEX idx_graph_epochs_kind        ON kg_api.graph_epochs(kind, occurred_
 
 A new `graph_epochs` row is recorded **once per logical unit of graph mutation**:
 
-- `kind='ingestion'` — one row per ingestion job, recorded at job *start*, so the assigned `event_id` is available to tag every Instance created during that job.
+- `kind='ingestion'` — one row per ingestion job *invocation*, recorded at job *start*, so the assigned `event_id` is available to tag every Instance created during that invocation. A resumed job records a fresh `event_id` with `metadata.resumed_from_chunk` indicating the split — this honestly preserves "the work spanned multiple sessions" rather than papering over it.
 - `kind='breathing'` — one row per ontology-breathing pass (cross-ref ADR-200).
 - `kind='edit'` — one row per explicit manual mutation.
 - `kind='reasoning'` — one row per agent reasoning session that mutates the graph.
@@ -97,7 +97,7 @@ In scope:
 - The `graph_epochs` table and its insertion contract.
 - Instance-level `created_at_event_id` tagging.
 - Recording an `ingestion` epoch at job start.
-- Test coverage proving re-evidenced Concepts have Instances spanning distinct event_ids.
+- Verification proving re-evidenced Concepts have Instances spanning distinct event_ids (manual end-to-end test via the `kg` CLI on landing; automated coverage deferred to a follow-up).
 
 Out of scope (deferred to follow-up issues):
 - API endpoints for re-evidence timeline queries.

--- a/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
+++ b/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
@@ -1,0 +1,153 @@
+---
+status: Draft
+date: 2026-05-19
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-079
+  - ADR-200
+  - ADR-202
+---
+
+# ADR-203: Graph Epoch Event Log
+
+## Context
+
+The graph already carries a notion of "epoch" — `graph_metrics.graph_change_counter`, introduced by ADR-079 (migration 033). On every ingestion, concepts are tagged with `created_at_epoch` and `last_seen_epoch` (see `api/app/lib/age_client/ingestion.py:168-169`), and the counter is refreshed via `refresh_graph_metrics()`.
+
+That counter is **a composite checksum**, not an event sequence:
+
+```sql
+graph_change_counter = count(concepts) + count(edges) + count(sources) + ...
+```
+
+Two consequences fall out of that definition:
+
+1. **Values are not unique over time.** Delete a concept and add one — the counter is unchanged. Two distinct graph states can produce the same counter value. So `counter_value → wall_clock_time` is not a function: it cannot be a join key.
+2. **There is no wall-clock anywhere.** Concept and Instance nodes do not record when they were created in real time; the system only knows "counter value at write."
+
+Issue #187 originally framed this as "no temporal ordering capability for concept evolution." The original proposal — `PRECEDED_BY` / `EVOLVED_INTO` relationship types inferred from ordering — conflates two things that should remain distinct:
+
+- **Logical time**: monotonic ordering of mutations to the graph. Always meaningful, including for activity that has no useful wall-clock (agent reasoning, ontology breathing, manual restructuring).
+- **Wall-clock time**: when an event physically happened. Always present in absolute terms, but **semantically meaningful only for some kinds of events** — primarily external-corpus ingestion. An agent creating 200 concepts during a reasoning loop at 15:03 UTC doesn't make those concepts "from 15:03" in any useful sense.
+
+The system needs both, treated as orthogonal dimensions. It also needs the data structure that lets the per-concept *re-evidence stream* be walked honestly — without inventing causal edges the data cannot justify.
+
+### The re-evidence stream is the actual payoff
+
+A `:Concept` already accumulates `:Instance` nodes via `EVIDENCED_BY` — one Instance per chunk that re-evidenced it. That stream **is** the concept's lifetime: born at the first Instance, grown by every subsequent one, dormant when none arrive for a long stretch.
+
+Today the stream cannot be ordered chronologically. Instances carry no epoch tag (constructor at `api/app/lib/age_client/ingestion.py:281`). Tagging them closes the loop: a single ordered walk over a Concept's Instances yields its re-evidence history — count, sequence, and time deltas where wall-clock is meaningful — without the LLM having to assert causal relationships.
+
+## Decision
+
+Introduce a dedicated **epoch event log** alongside the existing change counter, and tag `:Instance` nodes with a foreign key into it.
+
+### 1. New table: `kg_api.graph_epochs`
+
+```sql
+CREATE TABLE kg_api.graph_epochs (
+    event_id     BIGSERIAL PRIMARY KEY,
+    occurred_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    kind         TEXT NOT NULL,         -- 'ingestion' | 'reasoning' | 'breathing' | 'edit'
+    actor        TEXT,                  -- user_id, agent session id, system component
+    counter_after BIGINT,               -- graph_change_counter snapshot post-event (cross-ref)
+    metadata     JSONB DEFAULT '{}'::jsonb
+);
+CREATE INDEX idx_graph_epochs_occurred_at ON kg_api.graph_epochs(occurred_at);
+CREATE INDEX idx_graph_epochs_kind        ON kg_api.graph_epochs(kind, occurred_at);
+```
+
+`event_id` is the logical-time axis (monotonic, unique). `occurred_at` is the wall-clock axis (always recorded, but interpret semantically per `kind`). `kind` is the discriminator that tells downstream queries whether wall-clock means anything for this row.
+
+`TIMESTAMPTZ` aligns with the UTC invariant from ADR-202.
+
+### 2. Event granularity: one epoch per job
+
+A new `graph_epochs` row is recorded **once per logical unit of graph mutation**:
+
+- `kind='ingestion'` — one row per ingestion job, recorded at job *start*, so the assigned `event_id` is available to tag every Instance created during that job.
+- `kind='breathing'` — one row per ontology-breathing pass (cross-ref ADR-200).
+- `kind='edit'` — one row per explicit manual mutation.
+- `kind='reasoning'` — one row per agent reasoning session that mutates the graph.
+
+Per-chunk is too granular and explodes the row count without semantic value. Per-session is too coarse and loses the ability to attribute Instances to a specific ingestion. Per-job is the natural transaction boundary the system already operates on.
+
+### 3. Instance tagging
+
+`:Instance` nodes gain a `created_at_event_id` property at creation time (`age_client/ingestion.py:281`). The ingestion flow obtains the event_id at job start (Decision §2) and threads it through to Instance creation. Existing Instances carry no event_id — see Migration below.
+
+### 4. Coexistence with `graph_change_counter`
+
+The existing `graph_change_counter` (ADR-079) is **retained, unchanged**. Its purpose is composite cache-invalidation; it remains a count checksum. `graph_epochs.event_id` is the new monotonic event sequence with different semantics. The two coexist:
+
+- ADR-079 counter → "has any part of the graph changed since I cached?"
+- ADR-203 event_id → "what discrete mutation event introduced this data?"
+
+They are not unified, because their semantics are different. The ADR records this explicitly so future readers do not attempt to reconcile them.
+
+### 5. Concept-level epoch fields
+
+`:Concept.created_at_epoch` and `last_seen_epoch` (count-snapshot values, written by current ingestion code) are **left in place as legacy**. They retain their ADR-079 cache-invalidation semantics. They are *not* renamed or migrated. If a future ADR wants to add `created_at_event_id` / `last_evidenced_event_id` to Concepts directly, that is a separate scope; the present ADR derives concept lifetime from the Instance chain.
+
+### 6. Scope of this ADR
+
+In scope:
+- The `graph_epochs` table and its insertion contract.
+- Instance-level `created_at_event_id` tagging.
+- Recording an `ingestion` epoch at job start.
+- Test coverage proving re-evidenced Concepts have Instances spanning distinct event_ids.
+
+Out of scope (deferred to follow-up issues):
+- API endpoints for re-evidence timeline queries.
+- Web UI for time-travel / epoch picker.
+- Analytics queries (anchor / hot / stale / acceleration signals).
+- Concept-level event_id columns.
+- Backfilling event_ids onto historical Instances.
+- Wiring up `kind='breathing'` / `'reasoning'` / `'edit'` events. These will land as those subsystems independently grow event awareness.
+
+## Consequences
+
+### Positive
+
+- **Honest logical/wall-clock separation.** Two dimensions, queryable independently, no false-causality edges.
+- **Re-evidence stream becomes walkable.** `MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance) ORDER BY i.created_at_event_id` is the concept-lifetime query.
+- **Foundation for drift / freshness signals** — Freshness Way explicitly notes its blindness to content-level drift; epoch-tagged Instances close part of that gap (concepts not re-touched in N events become a derivable signal).
+- **Forensic floor.** Every mutation now has a recorded actor and wall-clock, which is independently useful even when wall-clock isn't semantically primary.
+
+### Negative
+
+- **Insertion-timing contract change.** Ingestion must record its epoch *before* creating Instances, not as a post-hoc effect of `refresh_graph_metrics()`. Code paths need to be audited.
+- **Slight write overhead** — one extra row per ingestion job. Negligible relative to the work the job does.
+- **Two epoch concepts coexist.** Cognitive load on contributors until the distinction is internalized. Mitigated by explicit naming (`graph_change_counter` vs `graph_epochs.event_id`) and this ADR.
+
+### Neutral
+
+- Existing Instances will carry `NULL` for `created_at_event_id`. Queries that require event ordering must either exclude them or treat them as a single "pre-epoch" cohort. Backfill is possible (from each Instance's Source's ingestion job timestamp) but explicitly deferred.
+
+## Alternatives Considered
+
+### A. Promote `created_at_epoch` to TIMESTAMPTZ on every node
+
+Stamp the wall-clock directly onto Concept and Instance properties — no event table.
+
+**Rejected.** Forces wall-clock onto every node, including ones created during agent reasoning or breathing where wall-clock is semantically noise. Conflates the two dimensions the design is trying to separate. Also makes it impossible to attribute multiple Instances to "the same ingestion job" without inventing a separate grouping mechanism.
+
+### B. Reuse `graph_change_counter` as the event_id
+
+Tie a timestamp table to existing counter values.
+
+**Rejected.** The counter is a count checksum, not monotonic — values can recur (delete+add). The mapping `counter_value → wall_clock` is not a function, so it cannot serve as a join key.
+
+### C. PRECEDED_BY / EVOLVED_INTO relationship vocabulary (original #187)
+
+Infer causal relationships between concepts from ordering and re-evidence patterns.
+
+**Rejected.** Requires either ordering-based shallow inference (which is misleading — order ≠ causation, and re-ingesting older content inverts the apparent order) or LLM judgment about evolution (which is expensive, brittle, and asserts facts into the graph the data can't honestly support). The Instance-stream design supersedes this: evolution narratives are *derived* from honest accumulation, not asserted.
+
+### D. Per-chunk event granularity
+
+Record a `graph_epochs` row for every chunk processed.
+
+**Rejected.** Explodes row count without semantic value. The job is the natural transaction boundary; finer granularity is recoverable from `Instance.created_at_event_id` joined to source/chunk metadata if anyone ever needs it.

--- a/docs/reference/mcp/README.md
+++ b/docs/reference/mcp/README.md
@@ -122,6 +122,8 @@ For multi-step workflows (search → connect → expand → filter), compose the
   - Default: `5`
 - `threshold` (`number`) - Similarity threshold for semantic mode (default: 0.5). Lower values find broader matches. The API enforces backend safety limits.
   - Default: `0.5`
+- `lifetime_limit` (`number`) - For action=lifetime: max Instances per page (default 200, hard cap 1000).
+- `lifetime_offset` (`number`) - For action=lifetime: number of Instances to skip. Use with has_more in the response to walk further pages.
 
 ---
 
@@ -542,8 +544,8 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
 
 - `kind` (`string`) - Filter to a specific event kind. Omit for all kinds.
   - Allowed values: `ingestion`, `reasoning`, `breathing`, `edit`
-- `since` (`string`) - ISO-8601 lower bound on occurred_at (UTC, e.g., "2026-05-01T00:00:00Z")
-- `until` (`string`) - ISO-8601 upper bound on occurred_at (UTC)
+- `since` (`string`) - ISO-8601 lower bound on occurred_at. The API parses with FastAPI's datetime parser; tolerant of common forms (with or without "Z", offsets accepted).
+- `until` (`string`) - ISO-8601 upper bound on occurred_at. Same parsing semantics as `since`.
 - `actor` (`string`) - Filter by exact actor string (user id, agent session id, system component)
 - `cursor` (`number`) - Pagination cursor — returns events with event_id < cursor. Omit for the first page.
 - `limit` (`number`) - Max events per page (1-500, default 50)

--- a/docs/reference/mcp/README.md
+++ b/docs/reference/mcp/README.md
@@ -3,7 +3,7 @@
 > **Auto-Generated Documentation**
 > 
 > Generated from MCP server tool schemas.
-> Last updated: 2026-03-26
+> Last updated: 2026-05-19
 
 ---
 
@@ -28,6 +28,7 @@ These tools enable semantic search, concept exploration, and graph traversal dir
 - [`document`](#document) - Work with documents: list all, show content, or get concepts (ADR-084).
 - [`graph`](#graph) - Create, edit, delete, and list concepts and edges in the knowledge graph (ADR-089).
 - [`program`](#program) - Compose and execute GraphProgram queries against the knowledge graph (ADR-500).
+- [`epoch`](#epoch) - Read the graph epoch event log (ADR-203).
 
 ---
 
@@ -93,8 +94,8 @@ For multi-step workflows (search → connect → expand → filter), compose the
 
 **Parameters:**
 
-- `action` (`string`) **(required)** - Operation: "details" (get ALL evidence), "related" (explore neighborhood), "connect" (find paths), "add_evidence" (attach evidence text to a concept)
-  - Allowed values: `details`, `related`, `connect`, `add_evidence`
+- `action` (`string`) **(required)** - Operation: "details" (get ALL evidence), "related" (explore neighborhood), "connect" (find paths), "add_evidence" (attach evidence text to a concept), "lifetime" (ADR-203 re-evidence stream — ordered Instance chain with graph_epochs metadata, showing when the system came to know this concept)
+  - Allowed values: `details`, `related`, `connect`, `add_evidence`, `lifetime`
 - `concept_id` (`string`) - Concept ID (required for details, related, add_evidence)
 - `evidence_text` (`string`) - Evidence/rationale text to attach to a concept (required for add_evidence, min 10 chars)
 - `include_grounding` (`boolean`) - Include grounding_strength (default: true)
@@ -520,5 +521,32 @@ Read the program/syntax resource for the complete language reference with more e
 - `search` (`string`) - Search text for list action (matches name and description)
 - `limit` (`number`) - Max results for list action (default: 20)
 - `deck` (`array`) - Array of program entries for chain action (max 10). Each entry needs program_id or program.
+
+---
+
+### epoch
+
+Read the graph epoch event log (ADR-203).
+
+Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology breathing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
+
+Two dimensions matter:
+  - event_id (logical time): always meaningful — strictly ordered, even for events whose wall-clock is forensic.
+  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'breathing'.
+
+Cursor-paginated. Pass the previous response's next_cursor as cursor to walk further back.
+
+For the per-concept re-evidence stream (which Concepts were touched in which epochs), use the concept tool's 'lifetime' action instead.
+
+**Parameters:**
+
+- `kind` (`string`) - Filter to a specific event kind. Omit for all kinds.
+  - Allowed values: `ingestion`, `reasoning`, `breathing`, `edit`
+- `since` (`string`) - ISO-8601 lower bound on occurred_at (UTC, e.g., "2026-05-01T00:00:00Z")
+- `until` (`string`) - ISO-8601 upper bound on occurred_at (UTC)
+- `actor` (`string`) - Filter by exact actor string (user id, agent session id, system component)
+- `cursor` (`number`) - Pagination cursor — returns events with event_id < cursor. Omit for the first page.
+- `limit` (`number`) - Max events per page (1-500, default 50)
+  - Default: `50`
 
 ---

--- a/docs/reference/mcp/tools/concept.md
+++ b/docs/reference/mcp/tools/concept.md
@@ -14,8 +14,8 @@ For multi-step workflows (search → connect → expand → filter), compose the
 
 **Parameters:**
 
-- `action` (`string`) **(required)** - Operation: "details" (get ALL evidence), "related" (explore neighborhood), "connect" (find paths), "add_evidence" (attach evidence text to a concept)
-  - Allowed values: `details`, `related`, `connect`, `add_evidence`
+- `action` (`string`) **(required)** - Operation: "details" (get ALL evidence), "related" (explore neighborhood), "connect" (find paths), "add_evidence" (attach evidence text to a concept), "lifetime" (ADR-203 re-evidence stream — ordered Instance chain with graph_epochs metadata, showing when the system came to know this concept)
+  - Allowed values: `details`, `related`, `connect`, `add_evidence`, `lifetime`
 - `concept_id` (`string`) - Concept ID (required for details, related, add_evidence)
 - `evidence_text` (`string`) - Evidence/rationale text to attach to a concept (required for add_evidence, min 10 chars)
 - `include_grounding` (`boolean`) - Include grounding_strength (default: true)

--- a/docs/reference/mcp/tools/concept.md
+++ b/docs/reference/mcp/tools/concept.md
@@ -42,5 +42,7 @@ For multi-step workflows (search → connect → expand → filter), compose the
   - Default: `5`
 - `threshold` (`number`) - Similarity threshold for semantic mode (default: 0.5). Lower values find broader matches. The API enforces backend safety limits.
   - Default: `0.5`
+- `lifetime_limit` (`number`) - For action=lifetime: max Instances per page (default 200, hard cap 1000).
+- `lifetime_offset` (`number`) - For action=lifetime: number of Instances to skip. Use with has_more in the response to walk further pages.
 
 ---

--- a/docs/reference/mcp/tools/epoch.md
+++ b/docs/reference/mcp/tools/epoch.md
@@ -20,8 +20,8 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
 
 - `kind` (`string`) - Filter to a specific event kind. Omit for all kinds.
   - Allowed values: `ingestion`, `reasoning`, `breathing`, `edit`
-- `since` (`string`) - ISO-8601 lower bound on occurred_at (UTC, e.g., "2026-05-01T00:00:00Z")
-- `until` (`string`) - ISO-8601 upper bound on occurred_at (UTC)
+- `since` (`string`) - ISO-8601 lower bound on occurred_at. The API parses with FastAPI's datetime parser; tolerant of common forms (with or without "Z", offsets accepted).
+- `until` (`string`) - ISO-8601 upper bound on occurred_at. Same parsing semantics as `since`.
 - `actor` (`string`) - Filter by exact actor string (user id, agent session id, system component)
 - `cursor` (`number`) - Pagination cursor — returns events with event_id < cursor. Omit for the first page.
 - `limit` (`number`) - Max events per page (1-500, default 50)

--- a/docs/reference/mcp/tools/epoch.md
+++ b/docs/reference/mcp/tools/epoch.md
@@ -1,0 +1,30 @@
+# epoch
+
+> Auto-generated from MCP tool schema
+
+### epoch
+
+Read the graph epoch event log (ADR-203).
+
+Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology breathing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
+
+Two dimensions matter:
+  - event_id (logical time): always meaningful — strictly ordered, even for events whose wall-clock is forensic.
+  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'breathing'.
+
+Cursor-paginated. Pass the previous response's next_cursor as cursor to walk further back.
+
+For the per-concept re-evidence stream (which Concepts were touched in which epochs), use the concept tool's 'lifetime' action instead.
+
+**Parameters:**
+
+- `kind` (`string`) - Filter to a specific event kind. Omit for all kinds.
+  - Allowed values: `ingestion`, `reasoning`, `breathing`, `edit`
+- `since` (`string`) - ISO-8601 lower bound on occurred_at (UTC, e.g., "2026-05-01T00:00:00Z")
+- `until` (`string`) - ISO-8601 upper bound on occurred_at (UTC)
+- `actor` (`string`) - Filter by exact actor string (user id, agent session id, system component)
+- `cursor` (`number`) - Pagination cursor — returns events with event_id < cursor. Omit for the first page.
+- `limit` (`number`) - Max events per page (1-500, default 50)
+  - Default: `50`
+
+---

--- a/schema/migrations/063_graph_epoch_events.sql
+++ b/schema/migrations/063_graph_epoch_events.sql
@@ -1,0 +1,71 @@
+-- Migration 063: Graph epoch event log (ADR-203)
+--
+-- Introduces a monotonic event sequence for graph mutations, distinct from
+-- the count-checksum `graph_change_counter` (ADR-079). Each row represents
+-- one logical mutation event (default granularity: one per ingestion job).
+-- Instance nodes will gain `created_at_event_id` referencing this table,
+-- enabling honest re-evidence-stream queries per concept.
+--
+-- Semantics:
+--   event_id     - logical-time axis (monotonic, unique)
+--   occurred_at  - wall-clock axis (always present, semantically meaningful
+--                  only for kinds where it is — see `kind`)
+--   kind         - discriminator for whether wall-clock has meaning
+--                  ('ingestion'/'edit' = yes; 'reasoning'/'breathing' = forensic only)
+--   actor        - user id, agent session id, system component
+--   counter_after- snapshot of graph_change_counter post-event (cross-ref to ADR-079)
+
+CREATE TABLE IF NOT EXISTS kg_api.graph_epochs (
+    event_id      BIGSERIAL PRIMARY KEY,
+    occurred_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    kind          TEXT NOT NULL CHECK (kind IN ('ingestion', 'reasoning', 'breathing', 'edit')),
+    actor         TEXT,
+    counter_after BIGINT,
+    metadata      JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_graph_epochs_occurred_at
+    ON kg_api.graph_epochs(occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_graph_epochs_kind
+    ON kg_api.graph_epochs(kind, occurred_at);
+
+COMMENT ON TABLE kg_api.graph_epochs IS
+    'ADR-203: Monotonic event log of graph mutations. Distinct from graph_change_counter (ADR-079) which is a composite cache-invalidation checksum.';
+
+COMMENT ON COLUMN kg_api.graph_epochs.event_id IS
+    'Monotonic logical-time id. Foreign-keyed by Instance.created_at_event_id.';
+
+COMMENT ON COLUMN kg_api.graph_epochs.kind IS
+    'ingestion | reasoning | breathing | edit. Determines whether occurred_at is semantically meaningful for the rows attributable to this event.';
+
+-- Helper: record a new epoch event and return its event_id.
+-- Called at the *start* of an ingestion job (or other mutation) so the
+-- returned event_id can tag every node created during that unit of work.
+CREATE OR REPLACE FUNCTION kg_api.record_graph_epoch(
+    p_kind     TEXT,
+    p_actor    TEXT DEFAULT NULL,
+    p_metadata JSONB DEFAULT '{}'::jsonb
+) RETURNS BIGINT AS $$
+DECLARE
+    v_event_id BIGINT;
+    v_counter  BIGINT;
+BEGIN
+    SELECT counter INTO v_counter
+    FROM public.graph_metrics
+    WHERE metric_name = 'graph_change_counter';
+
+    INSERT INTO kg_api.graph_epochs (kind, actor, counter_after, metadata)
+    VALUES (p_kind, p_actor, v_counter, p_metadata)
+    RETURNING event_id INTO v_event_id;
+
+    RETURN v_event_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION kg_api.record_graph_epoch IS
+    'ADR-203: Record a new graph-mutation event and return its event_id. Call at the start of an ingestion job (or other mutation transaction) so the returned id can tag nodes created during the unit of work.';
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (63, 'graph_epoch_events')
+ON CONFLICT (version) DO NOTHING;

--- a/schema/migrations/064_graph_epoch_kinds_lookup.sql
+++ b/schema/migrations/064_graph_epoch_kinds_lookup.sql
@@ -1,0 +1,72 @@
+-- Migration 064: Replace graph_epochs.kind CHECK constraint with a lookup table.
+--
+-- ADR-203 §Decision §1 introduced graph_epochs.kind with a hard-coded
+-- CHECK constraint (`kind IN ('ingestion','reasoning','breathing','edit')`).
+-- The constraint was also duplicated, in spirit, by the formatter's
+-- `KINDS_WITH_WALLCLOCK` set in cli/src/mcp/formatters/epoch.ts — both
+-- need to stay in sync as the system grows new event kinds.
+--
+-- This migration:
+--   1. Adds kg_api.graph_epoch_kinds — one row per kind with a
+--      `semantic_wallclock` flag (the discriminator from ADR-203 §Decision
+--      that says "is occurred_at semantically primary for this kind?").
+--   2. Seeds the four kinds from ADR-203.
+--   3. Drops the closed-set CHECK on graph_epochs.kind.
+--   4. Adds a foreign key from graph_epochs.kind into the lookup table so
+--      invalid kinds are still rejected, but new kinds are added by
+--      INSERT rather than by ALTER CONSTRAINT migration.
+--
+-- The semantic_wallclock flag becomes the single source of truth, exposed
+-- via the lifetime / epochs API responses so the TS formatter stops
+-- duplicating the set.
+
+CREATE TABLE IF NOT EXISTS kg_api.graph_epoch_kinds (
+    kind                TEXT PRIMARY KEY,
+    semantic_wallclock  BOOLEAN NOT NULL,
+    description         TEXT
+);
+
+COMMENT ON TABLE kg_api.graph_epoch_kinds IS
+    'ADR-203: Discriminator for graph_epochs.kind. semantic_wallclock distinguishes events whose occurred_at is semantically primary (ingestion, edit) from those where it is forensic-only (reasoning, breathing).';
+
+COMMENT ON COLUMN kg_api.graph_epoch_kinds.semantic_wallclock IS
+    'When TRUE, occurred_at is the meaningful timestamp for downstream consumers. When FALSE, occurred_at is recorded for audit/forensics but should not drive time-based queries on the resulting graph state.';
+
+INSERT INTO kg_api.graph_epoch_kinds (kind, semantic_wallclock, description) VALUES
+    ('ingestion',  TRUE,  'External corpus arrived via the ingestion pipeline.'),
+    ('edit',       TRUE,  'Explicit manual mutation by an operator.'),
+    ('reasoning',  FALSE, 'Agent-driven reasoning session mutated the graph internally.'),
+    ('breathing',  FALSE, 'Ontology annealing / breathing pass mutated the graph internally.')
+ON CONFLICT (kind) DO NOTHING;
+
+-- Drop the closed-set CHECK constraint added by migration 063.
+-- The constraint name was assigned by Postgres; find it dynamically.
+DO $$
+DECLARE
+    v_constraint_name TEXT;
+BEGIN
+    SELECT conname INTO v_constraint_name
+    FROM pg_constraint
+    WHERE conrelid = 'kg_api.graph_epochs'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%kind = ANY%';
+
+    IF v_constraint_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE kg_api.graph_epochs DROP CONSTRAINT %I',
+            v_constraint_name
+        );
+    END IF;
+END $$;
+
+-- Replace with a foreign key.
+ALTER TABLE kg_api.graph_epochs
+    ADD CONSTRAINT graph_epochs_kind_fkey
+    FOREIGN KEY (kind)
+    REFERENCES kg_api.graph_epoch_kinds (kind)
+    ON UPDATE CASCADE
+    ON DELETE RESTRICT;
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (64, 'graph_epoch_kinds_lookup')
+ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
## Summary

Builds on PR #381 (ADR-203 core). Adds the read surface so agents and the CLI can actually consume the epoch event log and the per-concept re-evidence stream.

**Targets** `adr-203-graph-epoch-events` (PR #381). Merge #381 first; this auto-rebases onto main afterwards.

## What's new

### API
- **`EpochFacade`** (`api/app/lib/epoch_facade.py`) — attached lazily as `client.epochs`, mirrors `GraphFacade`'s two-phase pattern (Cypher property fetch → batch SQL hydration → Python merge). Specifically avoids `QueryFacade.execute_raw` since issue #355 wants that escape hatch reduced.
- **`GET /concepts/{id}/lifetime`** — ordered Instance chain for one concept, joined to `graph_epochs`. 404 on missing concept. Surfaces the pre-ADR-203 `NULL`-event_id cohort as `pre_epoch_count`.
- **`GET /epochs`** — cursor-paginated event log with `kind` / `since` / `until` / `actor` filters. Cursor semantics: pass previous `next_cursor` as `cursor`; null means no more pages.

### CLI / MCP
- `KnowledgeGraphClient.getConceptLifetime()` + `listEpochs()`
- New TypeScript types: `ConceptLifetimeResponse`, `EpochListResponse`, `ConceptLifetimeInstance`, `EpochEvent`
- MCP `concept` tool: new `lifetime` action
- MCP `epoch` tool: cursor-paginated event log with the same filters. Tool description names the logical-vs-wall-clock distinction so agents reading `kind='reasoning'` epochs don't treat the timestamp as semantically primary.
- `formatConceptLifetime` / `formatEpochList`: grouped-by-epoch markdown output, flags `_forensic_` on kinds where wall-clock is not semantically primary.

## Manual verification (post-MCP reload)

- `epoch` tool returned 11 events with correct cursor pagination (`next_cursor=2` for the second page).
- `concept lifetime` for `sha256:88beb_chunk1_96fa7416` ("Test Content") returned 6 Instances grouped across 3 distinct epochs (event_ids 6, 8, 10), each block showing kind + wall-clock + actor.

## Out of scope (follow-ups, intentional)

- **Web UI** — deferred until concrete demand surfaces.
- **Analytics queries** (anchor / hot / stale / acceleration) — derivable from these primitives; will land as facade methods once the data has been exercised in practice.
- **`status` column on `graph_epochs`** — surfaced by today's failed Wikipedia ingest: the epoch row is recorded at job *start*, so a failed job leaves a "ghost" event with no attributable Instances. Honest as forensic record, but future analytics like "epochs with zero Instances" will want a `status` column to discriminate.
- **Backfill of pre-ADR-203 Instances** — explicitly deferred in ADR-203 §6.

## Test plan

- [ ] Reviewer reads `EpochFacade` and confirms the two-phase pattern follows `GraphFacade` idiom (no `execute_raw`)
- [ ] `GET /concepts/{id}/lifetime` returns 404 for an unknown concept, 200 with correct schema for a known one
- [ ] `GET /epochs?limit=N` returns at most N events, `next_cursor` is null on the last page
- [ ] MCP `epoch` and `concept` (lifetime) tools render readably
- [ ] Existing tests still pass (the API restart for this branch did not regress route or unit tests)