### PR TITLE
test(program-executor): update mocks for dispatch_cypher 3-arg signature

### DIFF
--- a/tests/unit/test_program_executor.py
+++ b/tests/unit/test_program_executor.py
@@ -76,7 +76,7 @@ class TestSequentialExecution:
 
         call_count = [0]
 
-        def mock_dispatch(ctx, op):
+        def mock_dispatch(ctx, op, w=None):
             call_count[0] += 1
             return WorkingGraph(
                 nodes=[_node(f"n{call_count[0]}")],
@@ -105,7 +105,7 @@ class TestSequentialExecution:
         ]
         idx = [0]
 
-        def mock_dispatch(ctx, op):
+        def mock_dispatch(ctx, op, w=None):
             r = results[idx[0]]
             idx[0] += 1
             return r
@@ -134,7 +134,7 @@ class TestAssertAbort:
         ]
         idx = [0]
 
-        def mock_dispatch(ctx, op):
+        def mock_dispatch(ctx, op, w=None):
             r = results[idx[0]]
             idx[0] += 1
             return r
@@ -157,7 +157,7 @@ class TestAssertAbort:
             _cypher_stmt('!'),
         ])
 
-        def mock_dispatch(ctx, op):
+        def mock_dispatch(ctx, op, w=None):
             return WorkingGraph(nodes=[_node("a")], links=[])
 
         client = MagicMock()
@@ -189,7 +189,7 @@ class TestConditionalBranching:
 
         call_count = [0]
 
-        def mock_dispatch(ctx, op):
+        def mock_dispatch(ctx, op, w=None):
             call_count[0] += 1
             return WorkingGraph(nodes=[_node(f"n{call_count[0]}")], links=[])
 
@@ -217,7 +217,7 @@ class TestConditionalBranching:
             ),
         ])
 
-        def mock_dispatch(ctx, op):
+        def mock_dispatch(ctx, op, w=None):
             return WorkingGraph(nodes=[_node("from_else")], links=[])
 
         client = MagicMock()
@@ -239,7 +239,7 @@ class TestStepLog:
             _api_stmt('?'),
         ])
 
-        def mock_cypher(ctx, op):
+        def mock_cypher(ctx, op, w=None):
             return WorkingGraph(nodes=[_node("a")], links=[])
 
         def mock_api(ctx, op):
@@ -281,7 +281,7 @@ class TestErrorHandling:
 
         call_count = [0]
 
-        def mock_dispatch(ctx, op):
+        def mock_dispatch(ctx, op, w=None):
             call_count[0] += 1
             if call_count[0] == 2:
                 raise RuntimeError("Connection lost")


### PR DESCRIPTION
## Summary
- `dispatch_cypher(ctx, op, w)` gained an optional `w` parameter for `\$W_IDS` binding (seed-then-expand pattern), but the unit-test mocks still accepted only `(ctx, op)`.
- The executor passes `w` positionally via `asyncio.to_thread(dispatch_cypher, ctx, op, w)`, so every `side_effect` raised `TypeError: ... takes 2 positional arguments but 3 were given`.
- Added `w=None` to each mock to match the production signature. Behaviour-equivalent — none of the existing test logic depended on inspecting `w`.

## Test plan
- [x] `pytest tests/unit/test_program_executor.py` — 8 passed (was 8 failed)
- [x] `pytest tests/unit/ tests/test_mock_provider.py` — 473 passed, 0 failed (was 465/8)