### PR TITLE
refactor(adr-203): rename graph_epochs kind 'breathing' to 'annealing'

### DIFF
--- a/api/app/routes/epochs.py
+++ b/api/app/routes/epochs.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/epochs", tags=["epochs"])
 async def list_epochs(
     kind: Optional[str] = Query(
         None,
-        description="Filter to a specific event kind (ingestion, reasoning, breathing, edit)",
+        description="Filter to a specific event kind (ingestion, reasoning, annealing, edit)",
     ),
     since: Optional[datetime] = Query(
         None,

--- a/cli/src/mcp-server.ts
+++ b/cli/src/mcp-server.ts
@@ -1352,11 +1352,11 @@ Read the program/syntax resource for the complete language reference with more e
         name: 'epoch',
         description: `Read the graph epoch event log (ADR-203).
 
-Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology breathing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
+Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology annealing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
 
 Two dimensions matter:
   - event_id (logical time): always meaningful — strictly ordered, even for events whose wall-clock is forensic.
-  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'breathing'.
+  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'annealing'.
 
 Cursor-paginated. Pass the previous response's next_cursor as cursor to walk further back.
 
@@ -1366,7 +1366,7 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
           properties: {
             kind: {
               type: 'string',
-              enum: ['ingestion', 'reasoning', 'breathing', 'edit'],
+              enum: ['ingestion', 'reasoning', 'annealing', 'edit'],
               description: 'Filter to a specific event kind. Omit for all kinds.',
             },
             since: {

--- a/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
+++ b/docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md
@@ -29,7 +29,7 @@ Two consequences fall out of that definition:
 
 Issue #187 originally framed this as "no temporal ordering capability for concept evolution." The original proposal — `PRECEDED_BY` / `EVOLVED_INTO` relationship types inferred from ordering — conflates two things that should remain distinct:
 
-- **Logical time**: monotonic ordering of mutations to the graph. Always meaningful, including for activity that has no useful wall-clock (agent reasoning, ontology breathing, manual restructuring).
+- **Logical time**: monotonic ordering of mutations to the graph. Always meaningful, including for activity that has no useful wall-clock (agent reasoning, ontology annealing, manual restructuring).
 - **Wall-clock time**: when an event physically happened. Always present in absolute terms, but **semantically meaningful only for some kinds of events** — primarily external-corpus ingestion. An agent creating 200 concepts during a reasoning loop at 15:03 UTC doesn't make those concepts "from 15:03" in any useful sense.
 
 The system needs both, treated as orthogonal dimensions. It also needs the data structure that lets the per-concept *re-evidence stream* be walked honestly — without inventing causal edges the data cannot justify.
@@ -50,7 +50,7 @@ Introduce a dedicated **epoch event log** alongside the existing change counter,
 CREATE TABLE kg_api.graph_epochs (
     event_id     BIGSERIAL PRIMARY KEY,
     occurred_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    kind         TEXT NOT NULL,         -- 'ingestion' | 'reasoning' | 'breathing' | 'edit'
+    kind         TEXT NOT NULL,         -- 'ingestion' | 'reasoning' | 'annealing' | 'edit'
     actor        TEXT,                  -- user_id, agent session id, system component
     counter_after BIGINT,               -- graph_change_counter snapshot post-event (cross-ref)
     metadata     JSONB DEFAULT '{}'::jsonb
@@ -68,7 +68,7 @@ CREATE INDEX idx_graph_epochs_kind        ON kg_api.graph_epochs(kind, occurred_
 A new `graph_epochs` row is recorded **once per logical unit of graph mutation**:
 
 - `kind='ingestion'` — one row per ingestion job *invocation*, recorded at job *start*, so the assigned `event_id` is available to tag every Instance created during that invocation. A resumed job records a fresh `event_id` with `metadata.resumed_from_chunk` indicating the split — this honestly preserves "the work spanned multiple sessions" rather than papering over it.
-- `kind='breathing'` — one row per ontology-breathing pass (cross-ref ADR-200).
+- `kind='annealing'` — one row per ontology annealing pass (cross-ref ADR-200).
 - `kind='edit'` — one row per explicit manual mutation.
 - `kind='reasoning'` — one row per agent reasoning session that mutates the graph.
 
@@ -105,7 +105,7 @@ Out of scope (deferred to follow-up issues):
 - Analytics queries (anchor / hot / stale / acceleration signals).
 - Concept-level event_id columns.
 - Backfilling event_ids onto historical Instances.
-- Wiring up `kind='breathing'` / `'reasoning'` / `'edit'` events. These will land as those subsystems independently grow event awareness.
+- Wiring up `kind='annealing'` / `'reasoning'` / `'edit'` events. These will land as those subsystems independently grow event awareness.
 
 ## Consequences
 
@@ -132,7 +132,7 @@ Out of scope (deferred to follow-up issues):
 
 Stamp the wall-clock directly onto Concept and Instance properties — no event table.
 
-**Rejected.** Forces wall-clock onto every node, including ones created during agent reasoning or breathing where wall-clock is semantically noise. Conflates the two dimensions the design is trying to separate. Also makes it impossible to attribute multiple Instances to "the same ingestion job" without inventing a separate grouping mechanism.
+**Rejected.** Forces wall-clock onto every node, including ones created during agent reasoning or annealing where wall-clock is semantically noise. Conflates the two dimensions the design is trying to separate. Also makes it impossible to attribute multiple Instances to "the same ingestion job" without inventing a separate grouping mechanism.
 
 ### B. Reuse `graph_change_counter` as the event_id
 

--- a/docs/reference/mcp/README.md
+++ b/docs/reference/mcp/README.md
@@ -530,11 +530,11 @@ Read the program/syntax resource for the complete language reference with more e
 
 Read the graph epoch event log (ADR-203).
 
-Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology breathing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
+Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology annealing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
 
 Two dimensions matter:
   - event_id (logical time): always meaningful — strictly ordered, even for events whose wall-clock is forensic.
-  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'breathing'.
+  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'annealing'.
 
 Cursor-paginated. Pass the previous response's next_cursor as cursor to walk further back.
 
@@ -543,7 +543,7 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
 **Parameters:**
 
 - `kind` (`string`) - Filter to a specific event kind. Omit for all kinds.
-  - Allowed values: `ingestion`, `reasoning`, `breathing`, `edit`
+  - Allowed values: `ingestion`, `reasoning`, `annealing`, `edit`
 - `since` (`string`) - ISO-8601 lower bound on occurred_at. The API parses with FastAPI's datetime parser; tolerant of common forms (with or without "Z", offsets accepted).
 - `until` (`string`) - ISO-8601 upper bound on occurred_at. Same parsing semantics as `since`.
 - `actor` (`string`) - Filter by exact actor string (user id, agent session id, system component)

--- a/docs/reference/mcp/tools/epoch.md
+++ b/docs/reference/mcp/tools/epoch.md
@@ -6,11 +6,11 @@
 
 Read the graph epoch event log (ADR-203).
 
-Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology breathing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
+Every mutation to the knowledge graph (ingestion job, agent reasoning, ontology annealing, manual edit) records a monotonic event with a wall-clock timestamp. This tool exposes that log so you can ask "when did the system come to know X?" or "what arrived in the graph during this window?" — without inventing causal edges between concepts.
 
 Two dimensions matter:
   - event_id (logical time): always meaningful — strictly ordered, even for events whose wall-clock is forensic.
-  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'breathing'.
+  - occurred_at (wall-clock): semantically meaningful for kinds like 'ingestion' / 'edit'; treat as forensic-only for 'reasoning' / 'annealing'.
 
 Cursor-paginated. Pass the previous response's next_cursor as cursor to walk further back.
 
@@ -19,7 +19,7 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
 **Parameters:**
 
 - `kind` (`string`) - Filter to a specific event kind. Omit for all kinds.
-  - Allowed values: `ingestion`, `reasoning`, `breathing`, `edit`
+  - Allowed values: `ingestion`, `reasoning`, `annealing`, `edit`
 - `since` (`string`) - ISO-8601 lower bound on occurred_at. The API parses with FastAPI's datetime parser; tolerant of common forms (with or without "Z", offsets accepted).
 - `until` (`string`) - ISO-8601 upper bound on occurred_at. Same parsing semantics as `since`.
 - `actor` (`string`) - Filter by exact actor string (user id, agent session id, system component)

--- a/schema/migrations/063_graph_epoch_events.sql
+++ b/schema/migrations/063_graph_epoch_events.sql
@@ -11,14 +11,14 @@
 --   occurred_at  - wall-clock axis (always present, semantically meaningful
 --                  only for kinds where it is — see `kind`)
 --   kind         - discriminator for whether wall-clock has meaning
---                  ('ingestion'/'edit' = yes; 'reasoning'/'breathing' = forensic only)
+--                  ('ingestion'/'edit' = yes; 'reasoning'/'annealing' = forensic only)
 --   actor        - user id, agent session id, system component
 --   counter_after- snapshot of graph_change_counter post-event (cross-ref to ADR-079)
 
 CREATE TABLE IF NOT EXISTS kg_api.graph_epochs (
     event_id      BIGSERIAL PRIMARY KEY,
     occurred_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    kind          TEXT NOT NULL CHECK (kind IN ('ingestion', 'reasoning', 'breathing', 'edit')),
+    kind          TEXT NOT NULL CHECK (kind IN ('ingestion', 'reasoning', 'annealing', 'edit')),
     actor         TEXT,
     counter_after BIGINT,
     metadata      JSONB NOT NULL DEFAULT '{}'::jsonb
@@ -37,7 +37,7 @@ COMMENT ON COLUMN kg_api.graph_epochs.event_id IS
     'Monotonic logical-time id. Foreign-keyed by Instance.created_at_event_id.';
 
 COMMENT ON COLUMN kg_api.graph_epochs.kind IS
-    'ingestion | reasoning | breathing | edit. Determines whether occurred_at is semantically meaningful for the rows attributable to this event.';
+    'ingestion | reasoning | annealing | edit. Determines whether occurred_at is semantically meaningful for the rows attributable to this event.';
 
 -- Helper: record a new epoch event and return its event_id.
 -- Called at the *start* of an ingestion job (or other mutation) so the

--- a/schema/migrations/064_graph_epoch_kinds_lookup.sql
+++ b/schema/migrations/064_graph_epoch_kinds_lookup.sql
@@ -1,7 +1,7 @@
 -- Migration 064: Replace graph_epochs.kind CHECK constraint with a lookup table.
 --
 -- ADR-203 §Decision §1 introduced graph_epochs.kind with a hard-coded
--- CHECK constraint (`kind IN ('ingestion','reasoning','breathing','edit')`).
+-- CHECK constraint (`kind IN ('ingestion','reasoning','annealing','edit')`).
 -- The constraint was also duplicated, in spirit, by the formatter's
 -- `KINDS_WITH_WALLCLOCK` set in cli/src/mcp/formatters/epoch.ts — both
 -- need to stay in sync as the system grows new event kinds.
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS kg_api.graph_epoch_kinds (
 );
 
 COMMENT ON TABLE kg_api.graph_epoch_kinds IS
-    'ADR-203: Discriminator for graph_epochs.kind. semantic_wallclock distinguishes events whose occurred_at is semantically primary (ingestion, edit) from those where it is forensic-only (reasoning, breathing).';
+    'ADR-203: Discriminator for graph_epochs.kind. semantic_wallclock distinguishes events whose occurred_at is semantically primary (ingestion, edit) from those where it is forensic-only (reasoning, annealing).';
 
 COMMENT ON COLUMN kg_api.graph_epoch_kinds.semantic_wallclock IS
     'When TRUE, occurred_at is the meaningful timestamp for downstream consumers. When FALSE, occurred_at is recorded for audit/forensics but should not drive time-based queries on the resulting graph state.';
@@ -36,7 +36,7 @@ INSERT INTO kg_api.graph_epoch_kinds (kind, semantic_wallclock, description) VAL
     ('ingestion',  TRUE,  'External corpus arrived via the ingestion pipeline.'),
     ('edit',       TRUE,  'Explicit manual mutation by an operator.'),
     ('reasoning',  FALSE, 'Agent-driven reasoning session mutated the graph internally.'),
-    ('breathing',  FALSE, 'Ontology annealing / breathing pass mutated the graph internally.')
+    ('annealing',  FALSE, 'Ontology annealing pass mutated the graph internally.')
 ON CONFLICT (kind) DO NOTHING;
 
 -- Drop the closed-set CHECK constraint added by migration 063.


### PR DESCRIPTION
## Summary

PR #254 renamed *breathing → annealing* across the codebase in v0.8.1, but recent ADR-203 work reintroduced **'breathing'** as a `graph_epochs.kind` enum value, with matching references in the API route, MCP server, and docs. The lookup-table seed (migration 064) literally read *"Ontology annealing / breathing pass"* — the author noticed the conflict and shipped both names anyway.

This PR purges the term. Zero `breathing` references remain in source, schema, or docs.

## Why amend 063/064 in place

Convention says don't modify shipped migrations. These were merged in PR #382, the `graph_epochs` table didn't exist in any developer DB I could verify, and the user explicitly chose in-place edit over adding a 065 rename migration. A standalone install that has already applied 063/064 needs to drop+rerun (no production rows to lose).

## Changes

- `schema/migrations/063_graph_epoch_events.sql` — CHECK constraint + comments
- `schema/migrations/064_graph_epoch_kinds_lookup.sql` — lookup row + table comment
- `api/app/routes/epochs.py` — `kind` filter description
- `cli/src/mcp-server.ts` — MCP tool description + enum
- `docs/architecture/database-schema/ADR-203-graph-epoch-event-log.md` — 5 occurrences
- `docs/reference/mcp/README.md`, `docs/reference/mcp/tools/epoch.md` — generated docs

Also retitled open issues #386 / #251 / #250 and updated bodies of #241 / #249 / #250 / #251 / #384 / #386 to match.

## Test plan

- [x] `grep -rEni "breath(e|ing|es|ed)?"` over the tree returns only an unrelated *deep breath* in ADR-038 dialog.
- [x] `cd cli && npm run build` — clean.
- [x] No epoch-specific tests exist yet (#383 tracks adding coverage); broader unit suite unaffected.