### PR TITLE
fix(annealing): repair promotion source assignment + autonomous approval

### DIFF
--- a/api/app/lib/age_client/ontology_edges.py
+++ b/api/app/lib/age_client/ontology_edges.py
@@ -97,7 +97,15 @@ class OntologyEdgesMixin:
 
         Used during promotion execution to find which sources to reassign.
         Follows any edge type between the anchor concept and its neighbor concepts,
-        then finds sources of those neighbors scoped to the given ontology.
+        then finds sources of those neighbors scoped to the given ontology — plus
+        the anchor's own sources.
+
+        Implemented as two fixed-length queries unioned in Python. The previous
+        single-query form combined a bound variable with an aggregate in one
+        WITH (`neighbor_sources + collect(...)`), which Apache AGE rejects
+        ("must be either part of an explicitly listed key or used inside an
+        aggregate function") — the error was swallowed and every promotion
+        silently reassigned zero sources.
 
         Args:
             concept_id: The anchor concept ID
@@ -106,21 +114,29 @@ class OntologyEdgesMixin:
         Returns:
             List of source_id strings
         """
-        query = """
+        # Anchor's own sources scoped to the ontology
+        anchor_query = """
+        MATCH (anchor:Concept {concept_id: $cid})-->(s:Source)-[:SCOPED_BY]->(o:Ontology {name: $ontology})
+        RETURN DISTINCT s.source_id as source_id
+        """
+        # Sources of the anchor's first-order concept neighbors
+        neighbor_query = """
         MATCH (anchor:Concept {concept_id: $cid})-[]-(neighbor:Concept)
         MATCH (neighbor)-->(s:Source)-[:SCOPED_BY]->(o:Ontology {name: $ontology})
-        WITH collect(DISTINCT s.source_id) as neighbor_sources
-        OPTIONAL MATCH (anchor2:Concept {concept_id: $cid})-->(s2:Source)-[:SCOPED_BY]->(o2:Ontology {name: $ontology})
-        WITH neighbor_sources + collect(DISTINCT s2.source_id) as all_sources
-        UNWIND all_sources as sid
-        RETURN DISTINCT sid as source_id
+        RETURN DISTINCT s.source_id as source_id
         """
+        params = {"cid": concept_id, "ontology": ontology_name}
+        source_ids: List[str] = []
+        seen = set()
         try:
-            rows = self._execute_cypher(
-                query,
-                params={"cid": concept_id, "ontology": ontology_name},
-            )
-            return [row["source_id"] for row in (rows or []) if row.get("source_id")]
+            for query in (anchor_query, neighbor_query):
+                rows = self._execute_cypher(query, params=params)
+                for row in (rows or []):
+                    sid = row.get("source_id")
+                    if sid and sid not in seen:
+                        seen.add(sid)
+                        source_ids.append(sid)
+            return source_ids
         except Exception as e:
             logger.error(
                 f"Failed to get first-order source IDs for "

--- a/api/app/services/annealing_manager.py
+++ b/api/app/services/annealing_manager.py
@@ -31,10 +31,20 @@ class AnnealingManager:
     human review endpoint (hitl mode).
     """
 
-    def __init__(self, age_client, scorer: OntologyScorer, ai_provider=None):
+    def __init__(
+        self,
+        age_client,
+        scorer: OntologyScorer,
+        ai_provider=None,
+        automation_level: str = "autonomous",
+    ):
         self.client = age_client
         self.scorer = scorer
         self.ai_provider = ai_provider
+        # In autonomous mode proposals are stored already 'approved' so there
+        # is no human-raceable 'pending' window — the annealing worker only
+        # dispatches their execution jobs. In hitl mode they are born 'pending'.
+        self.automation_level = automation_level
 
     async def run_annealing_cycle(
         self,
@@ -383,6 +393,14 @@ class AnnealingManager:
         suggested_description: Optional[str] = None,
     ) -> Optional[int]:
         """Store a proposal in the annealing_proposals table. Returns proposal ID."""
+        # Autonomous mode: born 'approved' (no human-raceable pending window).
+        # hitl mode: born 'pending', awaiting human review.
+        autonomous = self.automation_level == "autonomous"
+        status = "approved" if autonomous else "pending"
+        reviewed_by = "annealing_worker" if autonomous else None
+        reviewed_at = datetime.now(timezone.utc) if autonomous else None
+        reviewer_notes = "auto-approved (autonomous mode)" if autonomous else None
+
         try:
             conn = self.client.pool.getconn()
             try:
@@ -392,21 +410,24 @@ class AnnealingManager:
                         (proposal_type, ontology_name, anchor_concept_id,
                          target_ontology, reasoning, mass_score, coherence_score,
                          protection_score, created_at_epoch,
-                         suggested_name, suggested_description)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                         suggested_name, suggested_description,
+                         status, reviewed_by, reviewed_at, reviewer_notes)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                                %s, %s, %s, %s)
                         RETURNING id
                     """, (
                         proposal_type, ontology_name, anchor_concept_id,
                         target_ontology, reasoning, mass_score, coherence_score,
                         protection_score, epoch,
                         suggested_name, suggested_description,
+                        status, reviewed_by, reviewed_at, reviewer_notes,
                     ))
                     row = cur.fetchone()
                     conn.commit()
                     proposal_id = row[0] if row else None
                     logger.info(
                         f"Stored {proposal_type} proposal #{proposal_id} "
-                        f"for '{ontology_name}'"
+                        f"for '{ontology_name}' (status={status})"
                     )
                     return proposal_id
             finally:

--- a/api/app/workers/annealing_worker.py
+++ b/api/app/workers/annealing_worker.py
@@ -11,7 +11,6 @@ human review via the API.
 
 import asyncio
 import logging
-from datetime import datetime, timezone
 from typing import Dict, Any, List
 
 from api.app.lib.age_client import AGEClient
@@ -49,6 +48,7 @@ def run_annealing_worker(
     derive_edges = job_data.get("derive_edges", True)
     overlap_threshold = job_data.get("overlap_threshold", 0.1)
     specializes_threshold = job_data.get("specializes_threshold", 0.3)
+    automation_level = job_data.get("automation_level", "autonomous")
 
     logger.info(
         f"Annealing worker starting (job {job_id}): "
@@ -72,7 +72,12 @@ def run_annealing_worker(
             ai_provider = None
             logger.info("No AI provider available — using score-based decisions")
 
-        manager = AnnealingManager(age_client, scorer, ai_provider=ai_provider)
+        manager = AnnealingManager(
+            age_client,
+            scorer,
+            ai_provider=ai_provider,
+            automation_level=automation_level,
+        )
 
         job_queue.update_job(job_id, {
             "progress": {"stage": "scoring", "percent": 10}
@@ -93,8 +98,9 @@ def run_annealing_worker(
             specializes_threshold=specializes_threshold,
         ))
 
-        # Auto-approve and dispatch proposals in autonomous mode
-        automation_level = job_data.get("automation_level", "autonomous")
+        # Autonomous mode: the manager already stored proposals as 'approved'
+        # (no human-raceable pending window) — dispatch their execution jobs.
+        # hitl proposals stay 'pending' for human review via the API.
         proposal_ids = result.get("proposal_ids", [])
 
         if automation_level == "autonomous" and not dry_run and proposal_ids:
@@ -106,13 +112,13 @@ def run_annealing_worker(
             job_queue.update_job(job_id, {
                 "progress": {"stage": "executing_proposals", "percent": 90}
             })
-            dispatched = _auto_approve_and_dispatch(
+            dispatched = _dispatch_approved_proposals(
                 proposal_ids, age_client, job_queue
             )
             result["auto_dispatched"] = dispatched
             logger.info(
                 f"Autonomous mode: dispatched {dispatched} of "
-                f"{len(proposal_ids)} proposals for execution"
+                f"{len(proposal_ids)} approved proposals for execution"
             )
         elif proposal_ids:
             logger.info(
@@ -141,15 +147,20 @@ def run_annealing_worker(
             age_client.close()
 
 
-def _auto_approve_and_dispatch(
+def _dispatch_approved_proposals(
     proposal_ids: List[int],
     age_client: AGEClient,
     job_queue,
 ) -> int:
-    """Auto-approve pending proposals and dispatch execution jobs.
+    """Dispatch execution jobs for auto-approved annealing proposals.
 
-    Follows the same execution path as the human review endpoint:
-    mark approved → enqueue proposal_execution job → dispatch async.
+    In autonomous mode the annealing manager stores proposals already
+    'approved' — there is no pending→approved transition to make here. This
+    enqueues one proposal_execution job per proposal, the same job the human
+    review endpoint dispatches on approval.
+
+    Guarded on status == 'approved' so a re-run cannot double-dispatch a
+    proposal that is already executing or executed.
 
     Returns the number of proposals dispatched.
     """
@@ -158,27 +169,22 @@ def _auto_approve_and_dispatch(
     try:
         for proposal_id in proposal_ids:
             try:
-                # Atomic approve — only if still pending (prevents double-dispatch)
                 with conn.cursor() as cur:
-                    cur.execute("""
-                        UPDATE kg_api.annealing_proposals
-                        SET status = 'approved',
-                            reviewed_by = 'annealing_worker',
-                            reviewed_at = %s,
-                            reviewer_notes = 'auto-approved (autonomous mode)'
-                        WHERE id = %s AND status = 'pending'
-                        RETURNING id
-                    """, (datetime.now(timezone.utc), proposal_id))
+                    cur.execute(
+                        "SELECT status FROM kg_api.annealing_proposals WHERE id = %s",
+                        (proposal_id,),
+                    )
                     row = cur.fetchone()
-                conn.commit()
+                conn.commit()  # close the read txn before returning conn to pool
 
-                if not row:
+                if not row or row[0] != "approved":
                     logger.warning(
-                        f"Proposal {proposal_id} not pending — skipping auto-approve"
+                        f"Proposal {proposal_id} not in 'approved' state "
+                        f"({row[0] if row else 'missing'}) — skipping dispatch"
                     )
                     continue
 
-                # Dispatch execution job
+                # Dispatch execution job (same job as the human review endpoint)
                 exec_job_id = job_queue.enqueue(
                     job_type="proposal_execution",
                     job_data={
@@ -194,12 +200,12 @@ def _auto_approve_and_dispatch(
                 dispatched += 1
 
                 logger.info(
-                    f"Auto-approved proposal {proposal_id}, "
-                    f"enqueued execution job {exec_job_id}"
+                    f"Dispatched execution job {exec_job_id} for "
+                    f"approved proposal {proposal_id}"
                 )
             except Exception as e:
                 logger.error(
-                    f"Failed to auto-approve/dispatch proposal {proposal_id}: {e}",
+                    f"Failed to dispatch proposal {proposal_id}: {e}",
                     exc_info=True,
                 )
     finally:

--- a/tests/unit/services/test_annealing_manager.py
+++ b/tests/unit/services/test_annealing_manager.py
@@ -302,6 +302,60 @@ class TestStoreProposal:
 
         assert proposal_id is None
 
+    def test_autonomous_mode_stores_proposal_approved(self, mock_client, mock_scorer):
+        """In autonomous mode a proposal is born 'approved' — no pending window."""
+        manager = AnnealingManager(
+            mock_client, mock_scorer, ai_provider=None,
+            automation_level="autonomous",
+        )
+
+        manager._store_proposal(
+            proposal_type="promotion",
+            ontology_name="big-domain",
+            reasoning="natural nucleus",
+            epoch=20,
+            anchor_concept_id="c_abc123",
+        )
+
+        cursor = (
+            mock_client.pool.getconn.return_value
+            .cursor.return_value.__enter__.return_value
+        )
+        # INSERT params end with (status, reviewed_by, reviewed_at, reviewer_notes)
+        status, reviewed_by, reviewed_at, reviewer_notes = (
+            cursor.execute.call_args[0][1][-4:]
+        )
+        assert status == "approved"
+        assert reviewed_by == "annealing_worker"
+        assert reviewed_at is not None
+        assert "auto-approved" in reviewer_notes
+
+    def test_hitl_mode_stores_proposal_pending(self, mock_client, mock_scorer):
+        """In hitl mode a proposal is born 'pending', awaiting human review."""
+        manager = AnnealingManager(
+            mock_client, mock_scorer, ai_provider=None,
+            automation_level="hitl",
+        )
+
+        manager._store_proposal(
+            proposal_type="demotion",
+            ontology_name="weak-domain",
+            reasoning="too small",
+            epoch=20,
+        )
+
+        cursor = (
+            mock_client.pool.getconn.return_value
+            .cursor.return_value.__enter__.return_value
+        )
+        status, reviewed_by, reviewed_at, reviewer_notes = (
+            cursor.execute.call_args[0][1][-4:]
+        )
+        assert status == "pending"
+        assert reviewed_by is None
+        assert reviewed_at is None
+        assert reviewer_notes is None
+
 
 # ==========================================================================
 # ADR-200 Phase 5: Edge Derivation Integration


### PR DESCRIPTION
## Summary

Goal: get annealing proposals to behave **as advertised**, in their most basic golden-path mode. An investigation of the annealing agent surfaced three issues — two are real defects (fixed here), one is correct behaviour as-is.

## Issue 1 — promotions created empty ontologies 🔴 fixed

`get_first_order_source_ids()` ran a Cypher query that combined a bound variable with an aggregate in a single `WITH`:

```cypher
WITH neighbor_sources + collect(DISTINCT s2.source_id) as all_sources
```

Legal in Neo4j; **rejected by Apache AGE** — `"neighbor_sources" must be either part of an explicitly listed key or used inside an aggregate function`. The `try/except` swallowed it, the function returned `[]`, and **every `execute_promotion()` reassigned zero sources** — creating Ontology nodes with no concepts.

Runtime logs confirmed it fired for all four recent promotions:
```
ERROR get_first_order_source_ids ... Failed ... "neighbor_sources" must be ...
```
And the graph proved the effect: all 7 Source nodes still `SCOPED_BY primordial`, the 4 promoted ontologies empty.

**Fix:** split into two fixed-length queries (the anchor's own sources + its neighbors' sources), unioned in Python. Verified against the live graph — a known anchor now returns 4 primordial-scoped sources where the old query threw.

## Issue 2 — autonomous mode still had a raceable "pending" window 🟠 fixed

Auto-approval ran as a **post-cycle batch** ~30s after proposals were written (each proposal needs an LLM evaluation). During that window proposals sat `pending` in the UI and a human could approve one first — observed in the logs: one proposal executed `triggered_by=admin`, the rest `triggered_by=annealing_worker`, plus a `Proposal N not pending — skipping auto-approve` warning.

**Fix:** in autonomous mode the manager now stores proposals **already `approved`** (`reviewed_by=annealing_worker`) — there is no pending window to race. The worker's post-cycle step is dispatch-only (`_dispatch_approved_proposals`), guarded on `status='approved'` so a re-run can't double-dispatch. The proposal still passes through the same `approved` → `proposal_execution` job lifecycle the manual review endpoint uses. **hitl mode is unchanged** — proposals are born `pending` for human review.

## Issue 3 — failed demotions ("Ontology no longer exists") 🟡 no change, by design

When a proposal targets an ontology that was already removed (by a sibling proposal or manual edits), `execute_demotion()` fails gracefully with a clear error and `status=failed`. That is **correct** — a real reviewer would not approve a proposal against a missing target, and with autonomous approval working there is no drift to reconcile. No state-reconciliation layer added.

## Changes

- `api/app/lib/age_client/ontology_edges.py` — AGE-safe two-query rewrite of `get_first_order_source_ids`
- `api/app/services/annealing_manager.py` — `automation_level` param; `_store_proposal` born-approved in autonomous mode
- `api/app/workers/annealing_worker.py` — pass `automation_level` to the manager; `_auto_approve_and_dispatch` → dispatch-only `_dispatch_approved_proposals`
- `tests/unit/services/test_annealing_manager.py` — born-approved / born-pending tests

## Verification

- **465 unit tests pass** (incl. 2 new).
- Issue 1's fixed query run directly against the live AGE graph — returns sources where the old form errored.
- Backend-only — the web admin tab reflects worker/DB state, no UI change needed.

End-to-end (trigger a real annealing cycle and watch a promotion populate an ontology) is worth doing post-merge — it mutates the graph, so left for an explicit run.
