### PR TITLE
fix(annealing): make the cycle idempotent — stop re-proposing queued/done work

### DIFF
--- a/api/app/services/annealing_manager.py
+++ b/api/app/services/annealing_manager.py
@@ -10,7 +10,7 @@ by the annealing worker. In hitl mode, proposals wait for human review.
 
 import logging
 from datetime import datetime, timezone
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Set, Tuple
 
 from api.app.lib.ontology_scorer import OntologyScorer
 from api.app.lib.annealing_evaluator import (
@@ -144,6 +144,29 @@ class AnnealingManager:
                 },
             }
 
+        # 5b. Idempotency guard: the cycle is graph-driven and re-derives
+        # candidates every run. Without this it re-proposes work already in the
+        # queue, piling up duplicates (the original 'duplicate demotion batch').
+        # Skip candidates that already have an open proposal — pending /
+        # approved / executing. Terminal proposals do not block re-proposal, so
+        # the cycle still self-heals when an ontology is later deleted.
+        open_promotions, open_demotions = self._get_open_proposal_targets()
+        if open_promotions or open_demotions:
+            before = (len(demotion_candidates), len(promotion_candidates))
+            demotion_candidates = [
+                c for c in demotion_candidates
+                if c.get("ontology") not in open_demotions
+            ]
+            promotion_candidates = [
+                c for c in promotion_candidates
+                if c.get("concept_id") not in open_promotions
+            ]
+            logger.info(
+                f"Queue dedup: demotion {before[0]}→{len(demotion_candidates)}, "
+                f"promotion {before[1]}→{len(promotion_candidates)} "
+                f"(skipped candidates with open proposals)"
+            )
+
         # 6. Evaluate and store proposals
         proposal_ids = []
         remaining = max_proposals
@@ -226,6 +249,9 @@ class AnnealingManager:
         existing_ontology_names = {
             s["ontology"].lower() for s in all_scores
         }
+        # Concepts that already anchor an ontology have been promoted already —
+        # exclude them so the graph-driven cycle does not keep re-proposing them.
+        anchored_concept_ids = self._get_anchored_concept_ids()
 
         for scores in all_scores:
             name = scores.get("ontology", "")
@@ -237,6 +263,10 @@ class AnnealingManager:
             for concept in ranking:
                 degree = concept.get("degree", 0)
                 if degree < min_degree:
+                    continue
+
+                # Skip concepts that already anchor an ontology
+                if concept.get("concept_id") in anchored_concept_ids:
                     continue
 
                 # Skip if a concept with this label is already an ontology
@@ -255,6 +285,63 @@ class AnnealingManager:
         # Sort by degree descending (strongest first)
         candidates.sort(key=lambda c: c.get("degree", 0), reverse=True)
         return candidates
+
+    def _get_open_proposal_targets(self) -> Tuple[Set[str], Set[str]]:
+        """Targets that already have an open (non-terminal) proposal.
+
+        The annealing cycle is graph-driven — it re-derives candidates from the
+        graph every run. Without this guard it re-proposes work already queued,
+        piling up duplicates. 'Open' means pending / approved / executing;
+        terminal proposals (executed / failed / rejected / expired) do not
+        block re-proposal, so the cycle still self-heals if an ontology is
+        later deleted.
+
+        Returns:
+            (open_promotion_anchor_ids, open_demotion_ontology_names)
+        """
+        open_promotions: Set[str] = set()
+        open_demotions: Set[str] = set()
+        try:
+            conn = self.client.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("""
+                        SELECT proposal_type, ontology_name, anchor_concept_id
+                        FROM kg_api.annealing_proposals
+                        WHERE status IN ('pending', 'approved', 'executing')
+                    """)
+                    rows = cur.fetchall()
+                conn.commit()
+            finally:
+                self.client.pool.putconn(conn)
+            for proposal_type, ontology_name, anchor_concept_id in rows:
+                if proposal_type == "promotion" and anchor_concept_id:
+                    open_promotions.add(anchor_concept_id)
+                elif proposal_type == "demotion" and ontology_name:
+                    open_demotions.add(ontology_name)
+        except Exception as e:
+            logger.error(f"Failed to read open proposals for dedup: {e}")
+        return open_promotions, open_demotions
+
+    def _get_anchored_concept_ids(self) -> Set[str]:
+        """Concept IDs that already anchor an ontology (have an ANCHORED_BY edge).
+
+        Such concepts have already been promoted; the graph-driven cycle would
+        otherwise keep re-proposing them for promotion. Deleting an ontology
+        removes its ANCHORED_BY edge, making the concept eligible again — so the
+        cycle self-heals.
+        """
+        try:
+            rows = self.client._execute_cypher(
+                "MATCH (:Ontology)-[:ANCHORED_BY]->(c:Concept) "
+                "RETURN c.concept_id AS concept_id"
+            )
+            return {
+                r["concept_id"] for r in (rows or []) if r.get("concept_id")
+            }
+        except Exception as e:
+            logger.error(f"Failed to read anchored concepts: {e}")
+            return set()
 
     # =========================================================================
     # LLM Evaluation + Proposal Storage

--- a/tests/unit/services/test_annealing_manager.py
+++ b/tests/unit/services/test_annealing_manager.py
@@ -24,10 +24,14 @@ def mock_client():
     # Default: ecological snapshot needs real dict from get_ontology_stats
     client.get_ontology_stats.return_value = {"concept_count": 10}
 
-    # Default: connection pool mock for _store_proposal
+    # Default: no anchored concepts / no open proposals (queue-dedup guards)
+    client._execute_cypher.return_value = []
+
+    # Default: connection pool mock for _store_proposal / _get_open_proposal_targets
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = (1,)
+    mock_cursor.fetchall.return_value = []
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     client.pool = MagicMock()
@@ -355,6 +359,82 @@ class TestStoreProposal:
         assert reviewed_by is None
         assert reviewed_at is None
         assert reviewer_notes is None
+
+
+@pytest.mark.unit
+class TestQueueDedup:
+    """Tests for the idempotency guards that stop the cycle re-proposing work."""
+
+    def test_get_open_proposal_targets_parses_rows(self, manager, mock_client):
+        """Open proposals split into promotion-anchor and demotion-ontology sets."""
+        cursor = (
+            mock_client.pool.getconn.return_value
+            .cursor.return_value.__enter__.return_value
+        )
+        cursor.fetchall.return_value = [
+            ("promotion", "primordial", "concept-1"),
+            ("promotion", "primordial", "concept-2"),
+            ("demotion", "weak-domain", None),
+        ]
+
+        open_promotions, open_demotions = manager._get_open_proposal_targets()
+
+        assert open_promotions == {"concept-1", "concept-2"}
+        assert open_demotions == {"weak-domain"}
+
+    def test_get_anchored_concept_ids_parses_rows(self, manager, mock_client):
+        """Anchored concept IDs are collected from ANCHORED_BY edges."""
+        mock_client._execute_cypher.return_value = [
+            {"concept_id": "anchor-1"},
+            {"concept_id": "anchor-2"},
+        ]
+
+        assert manager._get_anchored_concept_ids() == {"anchor-1", "anchor-2"}
+
+    def test_promotion_candidates_exclude_anchored_concepts(self, manager, mock_client):
+        """A concept that already anchors an ontology is not a promotion candidate."""
+        # c1 already anchors an ontology
+        mock_client._execute_cypher.return_value = [{"concept_id": "c1"}]
+        mock_client.get_concept_degree_ranking.return_value = [
+            {"concept_id": "c1", "label": "Already Promoted", "degree": 40, "description": ""},
+            {"concept_id": "c2", "label": "Fresh Concept", "degree": 30, "description": ""},
+        ]
+
+        result = manager._find_promotion_candidates(
+            [{"ontology": "primordial"}], min_degree=10
+        )
+
+        assert [c["concept_id"] for c in result] == ["c2"]
+
+    @pytest.mark.asyncio
+    async def test_cycle_skips_candidates_with_open_proposals(self, mock_client, mock_scorer):
+        """run_annealing_cycle skips candidates that already have an open proposal."""
+        manager = AnnealingManager(mock_client, mock_scorer, ai_provider=None)
+        mock_scorer.score_all_ontologies.return_value = [
+            {"ontology": "weak-a", "protection_score": 0.01},
+            {"ontology": "weak-b", "protection_score": 0.02},
+        ]
+        mock_scorer.recompute_all_centroids.return_value = 0
+        mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}
+        mock_client.get_concept_degree_ranking.return_value = []
+
+        # 'weak-a' already has an open demotion proposal in the queue
+        manager._get_open_proposal_targets = MagicMock(
+            return_value=(set(), {"weak-a"})
+        )
+
+        evaluated = []
+
+        async def fake_eval(candidate, epoch):
+            evaluated.append(candidate["ontology"])
+            return None
+
+        manager._evaluate_and_store_demotion = fake_eval
+
+        await manager.run_annealing_cycle(demotion_threshold=0.15)
+
+        assert "weak-a" not in evaluated  # deduped — already has an open proposal
+        assert "weak-b" in evaluated      # still evaluated
 
 
 # ==========================================================================


### PR DESCRIPTION
## Summary

The annealing cycle is **graph-driven** — every run it re-derives candidates from the current graph and **never consults the proposal queue**. So it re-proposes work that is already pending or already done:

- the original **"duplicate demotion batch"** (proposals 1–4 then 5–8, same epoch — the later batch failed "Ontology no longer exists"), and
- **re-promotion of concepts that already anchor an ontology** (observed: a fresh cycle re-proposed "Felinology & Domestic Cat Studies" etc.).

Repeated cycles — a corpus load, the 6-hour cron — pile up duplicate proposals that then collide on "already exists" or fail. This makes the system misbehave under exactly the conditions a larger-corpus test creates.

## Fix — two idempotency guards

Both are graph/queue-aware, so the cycle still **self-heals**: delete an ontology and its concept/work becomes eligible to be re-proposed.

**1. Queue guard** (`run_annealing_cycle`) — skip candidates that already have an **open** proposal (`pending` / `approved` / `executing`). Terminal proposals (`executed` / `failed` / `rejected` / `expired`) do **not** block re-proposal. New helper `_get_open_proposal_targets()`.

**2. Anchored guard** (`_find_promotion_candidates`) — skip concepts that already anchor an ontology (`ANCHORED_BY` edge). Deleting the ontology removes the edge → the concept becomes eligible again. New helper `_get_anchored_concept_ids()`.

Demotion needs only guard 1 — a dissolved ontology leaves the graph, so the graph-driven scan never re-finds it.

## Changes

- `api/app/services/annealing_manager.py` — both guards + the two helpers
- `tests/unit/services/test_annealing_manager.py` — 4 tests (`TestQueueDedup`) + fixture defaults for the new queries

## Verification

- **29 annealing-manager unit tests pass** (4 new): open-proposal parsing, anchored-concept parsing, anchored exclusion in candidate-finding, and a cycle-level test that a candidate with an open proposal is skipped.
- The new `ANCHORED_BY` Cypher was run against the live AGE graph — returns the 4 anchored concepts, no error.

## Context

This is the third and final defect from the annealing investigation, after #393 (promotion source assignment + autonomous born-approved). It's the root of the "duplicate demotion batch" flagged in that investigation. Pairs naturally with the still-open proposal-archival follow-up — a queue that no longer accumulates re-derived duplicates is much easier to keep clean.
