### PR TITLE
fix(publish): explicit handoff when npm publish needs interactive 2FA

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,6 +23,19 @@
 #   --dry-run              Preview without making changes
 #   --skip-build           Skip build step
 #
+# npm authentication (the `cli` command):
+#   A token from `npm login` STILL requires interactive browser 2FA to
+#   publish. That works in a real terminal but fails with EOTP when this
+#   script runs through a pipe — CI, `| tee`, or a coding agent — because
+#   there is no TTY for the browser handoff.
+#
+#   To publish non-interactively, create a classic *Automation* token
+#   (npmjs.com -> Access Tokens -> Generate New Token -> Classic Token ->
+#   Automation). Automation tokens bypass 2FA. Put it in ~/.npmrc:
+#       //registry.npmjs.org/:_authToken=npm_xxxxxxxxxxxxxxxxxxxx
+#
+#   Without an Automation token, run the publish yourself in a terminal:
+#       cd cli && npm publish --access public
 # ============================================================================
 
 set -e
@@ -772,8 +785,28 @@ cmd_cli() {
     echo ""
     if [ "$DRY_RUN" = "false" ]; then
         echo -e "${BLUE}→ Publishing to npm...${NC}"
-        npm publish --access public
-        echo -e "${GREEN}✓ Published @aaronsb/kg-cli@$CLI_VERSION${NC}"
+        # A plain `npm login` token needs interactive browser 2FA to
+        # publish — impossible without a TTY. Flag it up front so a
+        # non-interactive run (CI / agent) fails loud, not cryptic.
+        if [ ! -t 0 ]; then
+            echo -e "${DIM}  non-interactive shell: this needs an Automation token in${NC}"
+            echo -e "${DIM}  ~/.npmrc, or it will fail — a normal npm-login token cannot${NC}"
+            echo -e "${DIM}  clear browser 2FA here. See this script's header.${NC}"
+        fi
+        # `if` guards the call so set -e doesn't abort before the hint.
+        if npm publish --access public; then
+            echo -e "${GREEN}✓ Published @aaronsb/kg-cli@$CLI_VERSION${NC}"
+        else
+            echo ""
+            echo -e "${RED}✗ npm publish failed.${NC}"
+            echo -e "${YELLOW}If this was a 2FA / EOTP error, npm needs a human:${NC} a"
+            echo -e "  normal \`npm login\` token cannot publish from a script. Either —"
+            echo -e "    1. Run it yourself in a real terminal:"
+            echo -e "         ${BOLD}cd $PROJECT_ROOT/cli && npm publish --access public${NC}"
+            echo -e "    2. Or add a classic ${BOLD}Automation${NC} token to ~/.npmrc to"
+            echo -e "       publish unattended — see this script's header."
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
## What

`./scripts/publish.sh cli` ran `npm publish` bare. A token from `npm login` still requires interactive browser 2FA to publish, so the call dies with a cryptic `EOTP` whenever the script runs without a TTY — CI, a piped invocation, or a coding agent. The **v0.12.0 release hit exactly this**.

## Changes

- **Guard the `npm publish` call with `if`** so `set -e` doesn't abort before the diagnostics can print.
- **On failure, print an explicit, actionable handoff** — run it yourself in a real terminal, or configure a classic Automation token.
- **Up-front non-TTY warning** so a non-interactive run fails loud, not cryptic.
- **Header docs** for the Automation-token setup (`~/.npmrc`).

## Why this approach

Per discussion: the chosen workflow is "no browser popup, but I still run the publish myself." A classic npm **Automation** token (the only token type that reliably bypasses 2FA — granular tokens default to still requiring it) in `~/.npmrc` makes `./scripts/publish.sh cli` non-interactive; without one, the script now hands off clearly instead of failing opaquely.

## Testing

- `bash -n scripts/publish.sh` — syntax clean.
- No behaviour change on a successful publish (the `if`/`then` path is identical to the old bare call + success echo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)