### PR TITLE
fix: annealing/ingestion race — layered defense (closes #402)

### DIFF
--- a/api/app/launchers/annealing.py
+++ b/api/app/launchers/annealing.py
@@ -16,7 +16,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# Code defaults — overridden by kg_api.annealing_options rows
+# Code defaults — overridden by kg_api.annealing_options rows.
+# Per-ontology cadence floors (min_ontology_age_epochs, min_ontology_concept_count)
+# are added by migration 065 for #402 Defect C.
 DEFAULTS = {
     "epoch_interval": 5,
     "demotion_threshold": 0.15,
@@ -24,6 +26,8 @@ DEFAULTS = {
     "max_proposals": 5,
     "enabled": True,
     "automation_level": "autonomous",
+    "min_ontology_age_epochs": 3,
+    "min_ontology_concept_count": 5,
 }
 
 
@@ -36,7 +40,13 @@ def _read_options(conn) -> Dict:
             for key, value in cur.fetchall():
                 if key in ("enabled", "derive_edges"):
                     options[key] = value.lower() in ("true", "1", "yes")
-                elif key in ("epoch_interval", "promotion_min_degree", "max_proposals"):
+                elif key in (
+                    "epoch_interval",
+                    "promotion_min_degree",
+                    "max_proposals",
+                    "min_ontology_age_epochs",
+                    "min_ontology_concept_count",
+                ):
                     options[key] = int(value)
                 elif key in ("demotion_threshold", "overlap_threshold", "specializes_threshold"):
                     options[key] = float(value)
@@ -144,6 +154,8 @@ class AnnealingLauncher(JobLauncher):
             "overlap_threshold": options.get("overlap_threshold", 0.1),
             "specializes_threshold": options.get("specializes_threshold", 0.3),
             "automation_level": options.get("automation_level", "autonomous"),
+            "min_ontology_age_epochs": options.get("min_ontology_age_epochs", 3),
+            "min_ontology_concept_count": options.get("min_ontology_concept_count", 5),
             "dry_run": False,
             "triggered_at_epoch": current_epoch,
             "description": f"Annealing cycle at epoch {current_epoch}",

--- a/api/app/routes/ingest.py
+++ b/api/app/routes/ingest.py
@@ -245,6 +245,13 @@ async def ingest_document(
                     content=duplicate_info
                 )
 
+        # #402 Defect B1: Record whether the target ontology existed at submit
+        # time. The worker uses this to distinguish "first ingest, create the
+        # ontology" from "ontology vanished between queue and execution"
+        # (annealing dissolve, manual delete) — silent recreate of a dissolved
+        # ontology would mask operator-visible data loss.
+        existed_at_submit = age_client.get_ontology_node(ontology) is not None
+
         # Prepare job data
         use_filename = filename or file.filename or "uploaded_document"
 
@@ -260,6 +267,7 @@ async def ingest_document(
             "content": base64.b64encode(content).decode('utf-8'),  # Base64 encode for JSON serialization
             "content_hash": content_hash,
             "ontology": ontology,
+            "ontology_existed_at_submit": existed_at_submit,
             "filename": use_filename,
             "user_id": current_user.id,  # Track job owner (user ID from kg_auth.users)
             "username": current_user.username,  # For Garage metadata (FUSE support)
@@ -389,6 +397,9 @@ async def ingest_text(
                     content=duplicate_info
                 )
 
+        # #402 Defect B1: see file-upload endpoint above for rationale.
+        existed_at_submit = age_client.get_ontology_node(ontology) is not None
+
         # Prepare job
         use_filename = filename or "text_input"
 
@@ -396,6 +407,7 @@ async def ingest_text(
             "content": base64.b64encode(content).decode('utf-8'),  # Base64 encode for JSON serialization
             "content_hash": content_hash,
             "ontology": ontology,
+            "ontology_existed_at_submit": existed_at_submit,
             "filename": use_filename,
             "user_id": current_user.id,  # Track job owner (user ID from kg_auth.users)
             "username": current_user.username,  # For Garage metadata (FUSE support)

--- a/api/app/routes/ontology.py
+++ b/api/app/routes/ontology.py
@@ -58,6 +58,91 @@ def get_age_client() -> AGEClient:
     return AGEClient()
 
 
+def _clear_ontology_tombstone(client, ontology_name: str) -> bool:
+    """Remove a tombstone for `ontology_name`, if present.
+
+    Called when an operator explicitly re-creates a previously removed
+    ontology — the recreate is positive operator intent that supersedes
+    the prior removal intent. Without this, the unconditional tombstone
+    check in the ingestion worker would fail every future ingest into
+    the recreated name (#402 PR-404 review, finding #6 / advisor flag).
+
+    Returns True if a tombstone was actually deleted, False if none
+    existed or the lookup failed. Errors are logged but not raised —
+    the create itself should still succeed.
+    """
+    try:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM kg_api.ontology_tombstones WHERE name = %s",
+                    (ontology_name,),
+                )
+                deleted = cur.rowcount > 0
+            conn.commit()
+            if deleted:
+                logger.info(
+                    f"Cleared tombstone for '{ontology_name}' on operator recreate"
+                )
+            return deleted
+        finally:
+            client.pool.putconn(conn)
+    except Exception as e:
+        logger.error(
+            f"Failed to clear tombstone for '{ontology_name}': {e}",
+            exc_info=True,
+        )
+        return False
+
+
+def _record_ontology_tombstone(client, ontology_name: str, removed_by: str, reason: str) -> None:
+    """Record a tombstone for an operator-initiated removal (#402 B2 + PR-404).
+
+    The tombstone is the positive operator-intent signal that distinguishes
+    "deliberately removed by an operator" from "dissolved by background
+    annealing" — the ingestion worker checks for it unconditionally (before
+    reading the graph node) so a tombstone written before the graph delete
+    fails the in-flight ingest with ONTOLOGY_TOMBSTONED_ERROR rather than
+    letting it write orphan content into a graph the operator is removing.
+
+    Annealing's own dissolve_ontology path does NOT call this; that's the
+    asymmetry B2 relies on (annealing dissolve is recoverable via recreate,
+    operator delete/dissolve is not).
+
+    Errors are logged but not raised — the tombstone is defense-in-depth on
+    top of the queue-aware veto (Defect A) and the proposal-executor re-check.
+    """
+    try:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO kg_api.ontology_tombstones
+                        (name, removed_by, reason)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (name) DO UPDATE SET
+                        removed_at = NOW(),
+                        removed_by = EXCLUDED.removed_by,
+                        reason     = EXCLUDED.reason
+                    """,
+                    (ontology_name, removed_by, reason),
+                )
+            conn.commit()
+            logger.info(
+                f"Recorded tombstone for ontology '{ontology_name}' "
+                f"(by={removed_by}, reason={reason})"
+            )
+        finally:
+            client.pool.putconn(conn)
+    except Exception as e:
+        logger.error(
+            f"Failed to record tombstone for '{ontology_name}': {e}",
+            exc_info=True,
+        )
+
+
 @router.post("/", response_model=OntologyNodeResponse, status_code=201)
 async def create_ontology(
     request: OntologyCreateRequest,
@@ -109,6 +194,11 @@ async def create_ontology(
                 status_code=409,
                 detail=f"Ontology '{request.name}' already exists (has source data)"
             )
+
+        # #402 PR-404 review (finding #6 / advisor): operator-initiated
+        # recreate is positive intent that supersedes a prior tombstone.
+        # Clear it so subsequent ingests don't fail TOMBSTONED forever.
+        _clear_ontology_tombstone(client, request.name)
 
         # Get creation epoch
         creation_epoch = client.get_current_epoch()
@@ -1005,6 +1095,13 @@ async def delete_ontology(
 
     Example:
         DELETE /ontology/Test%20Ontology?force=true
+
+    Note (PR-404 review): a tombstone is recorded before any graph
+    mutation. With force=true on a name that never existed, this leaves
+    a tombstone that blocks future ingests into that name until the
+    operator either re-creates the ontology (clears the tombstone) or
+    deletes the row from kg_api.ontology_tombstones directly. The
+    error string operators see explains both recovery paths.
     """
     from ..services.job_queue import get_job_queue
 
@@ -1024,6 +1121,18 @@ async def delete_ontology(
                     status_code=404,
                     detail=f"Ontology '{ontology_name}' not found"
                 )
+
+        # #402 B2 + PR-404 review: write the tombstone *before* any graph
+        # mutation. The worker checks tombstones unconditionally, so any
+        # ingest dequeuing during the delete sees the operator's intent
+        # and fails ONTOLOGY_TOMBSTONED rather than racing into a graph
+        # that's about to be removed.
+        _record_ontology_tombstone(
+            client,
+            ontology_name,
+            removed_by=getattr(current_user, "username", None) or "unknown",
+            reason="operator-initiated delete via API",
+        )
 
         # ADR-057/ADR-081: Clean up ALL Garage objects before deleting sources
         # This includes: images, source documents, and projections
@@ -1142,53 +1251,14 @@ async def delete_ontology(
 
         orphaned_count = orphaned_result['orphaned_count'] if orphaned_result else 0
 
-        # ADR-200: Delete Ontology node and its edges (SCOPED_BY, etc)
+        # ADR-200: Delete Ontology node and its edges (SCOPED_BY, etc).
+        # Tombstone was written upstream so any racing ingest already
+        # fails TOMBSTONED before this commit lands.
         try:
             if client.delete_ontology_node(ontology_name):
                 logger.info(f"Deleted Ontology node for '{ontology_name}'")
         except Exception as e:
             logger.warning(f"Failed to delete Ontology node for '{ontology_name}': {e}")
-
-        # #402 Defect B2: Write a tombstone so any subsequent ingest job
-        # targeting this name is failed loudly instead of silently
-        # recreating it. The tombstone is the positive operator-intent
-        # signal that distinguishes "deliberately removed" from "annealing
-        # dissolved" (which intentionally does NOT write a tombstone, so
-        # operator-intent ingests can still recreate).
-        try:
-            conn = client.pool.getconn()
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        """
-                        INSERT INTO kg_api.ontology_tombstones
-                            (name, removed_by, reason)
-                        VALUES (%s, %s, %s)
-                        ON CONFLICT (name) DO UPDATE SET
-                            removed_at = NOW(),
-                            removed_by = EXCLUDED.removed_by,
-                            reason     = EXCLUDED.reason
-                        """,
-                        (
-                            ontology_name,
-                            getattr(current_user, "username", None) or "unknown",
-                            "operator-initiated delete via API",
-                        ),
-                    )
-                conn.commit()
-                logger.info(
-                    f"Recorded tombstone for ontology '{ontology_name}' "
-                    f"(by={getattr(current_user, 'username', 'unknown')})"
-                )
-            finally:
-                client.pool.putconn(conn)
-        except Exception as e:
-            # Tombstone is defense-in-depth — log loudly but do not abort
-            # the delete that already succeeded above.
-            logger.error(
-                f"Failed to record tombstone for '{ontology_name}': {e}",
-                exc_info=True,
-            )
 
         # Delete job records for this ontology to allow clean re-ingestion
         jobs_deleted = queue.delete_jobs_by_ontology(ontology_name)
@@ -1755,6 +1825,34 @@ async def dissolve_ontology(
     """
     client = get_age_client()
     try:
+        # #402 PR-404 review (finding #1): operator-initiated dissolve is
+        # the same data-loss class as operator-initiated delete — a racing
+        # ingest against the dissolved name would otherwise silently
+        # recreate it. Pre-flight check + tombstone + dissolve, in that
+        # order, so we don't write a tombstone for an ontology that
+        # dissolve_ontology will refuse (pinned/frozen/missing).
+        node = client.get_ontology_node(ontology_name)
+        if not node:
+            raise HTTPException(
+                status_code=404, detail=f"Ontology '{ontology_name}' not found"
+            )
+        lifecycle = node.get("lifecycle_state", "active")
+        if lifecycle in ("pinned", "frozen"):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Ontology '{ontology_name}' is {lifecycle} — cannot dissolve",
+            )
+
+        # Record tombstone *before* the graph mutation. Annealing's
+        # dissolve path does not write a tombstone — that asymmetry is
+        # intentional and preserved.
+        _record_ontology_tombstone(
+            client,
+            ontology_name,
+            removed_by=getattr(current_user, "username", None) or "unknown",
+            reason=f"operator-initiated dissolve via API (absorbed into '{request.target_ontology}')",
+        )
+
         result = client.dissolve_ontology(
             name=ontology_name,
             target_ontology=request.target_ontology,

--- a/api/app/routes/ontology.py
+++ b/api/app/routes/ontology.py
@@ -1336,6 +1336,14 @@ async def rename_ontology(
                 logger.warning(f"Failed to rename Ontology node: {e}")
                 # Non-fatal: Source nodes are already renamed
 
+            # #402 PR-404 review-2 (finding A): operator-initiated rename
+            # establishes an ontology under new_name. Same invariant as
+            # create-clears-tombstone — clear any prior tombstone for the
+            # target name so subsequent ingests don't fail TOMBSTONED. The
+            # delete-then-rename recovery flow would otherwise be broken
+            # by the unconditional tombstone check.
+            _clear_ontology_tombstone(client, request.new_name)
+
             return OntologyRenameResponse(
                 old_name=ontology_name,
                 new_name=request.new_name,
@@ -1853,12 +1861,25 @@ async def dissolve_ontology(
             reason=f"operator-initiated dissolve via API (absorbed into '{request.target_ontology}')",
         )
 
-        result = client.dissolve_ontology(
-            name=ontology_name,
-            target_ontology=request.target_ontology,
-        )
+        try:
+            result = client.dissolve_ontology(
+                name=ontology_name,
+                target_ontology=request.target_ontology,
+            )
+        except Exception:
+            # #402 PR-404 review-2 (finding B): dissolve_ontology has
+            # failure modes beyond our route-level pre-flight (source
+            # listing, partial reassign, lifecycle TOCTOU). On any of
+            # those, the tombstone we just wrote refers to an ontology
+            # that still exists in the graph — clearing it avoids
+            # leaving the operator with a "dissolve failed AND future
+            # ingests fail TOMBSTONED" trap.
+            _clear_ontology_tombstone(client, ontology_name)
+            raise
 
         if not result.get("success"):
+            # Same stale-tombstone hazard on a structured failure result.
+            _clear_ontology_tombstone(client, ontology_name)
             error = result.get("error", "Unknown error")
             if "not found" in error:
                 raise HTTPException(status_code=404, detail=error)

--- a/api/app/routes/ontology.py
+++ b/api/app/routes/ontology.py
@@ -1149,6 +1149,47 @@ async def delete_ontology(
         except Exception as e:
             logger.warning(f"Failed to delete Ontology node for '{ontology_name}': {e}")
 
+        # #402 Defect B2: Write a tombstone so any subsequent ingest job
+        # targeting this name is failed loudly instead of silently
+        # recreating it. The tombstone is the positive operator-intent
+        # signal that distinguishes "deliberately removed" from "annealing
+        # dissolved" (which intentionally does NOT write a tombstone, so
+        # operator-intent ingests can still recreate).
+        try:
+            conn = client.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO kg_api.ontology_tombstones
+                            (name, removed_by, reason)
+                        VALUES (%s, %s, %s)
+                        ON CONFLICT (name) DO UPDATE SET
+                            removed_at = NOW(),
+                            removed_by = EXCLUDED.removed_by,
+                            reason     = EXCLUDED.reason
+                        """,
+                        (
+                            ontology_name,
+                            getattr(current_user, "username", None) or "unknown",
+                            "operator-initiated delete via API",
+                        ),
+                    )
+                conn.commit()
+                logger.info(
+                    f"Recorded tombstone for ontology '{ontology_name}' "
+                    f"(by={getattr(current_user, 'username', 'unknown')})"
+                )
+            finally:
+                client.pool.putconn(conn)
+        except Exception as e:
+            # Tombstone is defense-in-depth — log loudly but do not abort
+            # the delete that already succeeded above.
+            logger.error(
+                f"Failed to record tombstone for '{ontology_name}': {e}",
+                exc_info=True,
+            )
+
         # Delete job records for this ontology to allow clean re-ingestion
         jobs_deleted = queue.delete_jobs_by_ontology(ontology_name)
         if jobs_deleted > 0:

--- a/api/app/services/annealing_manager.py
+++ b/api/app/services/annealing_manager.py
@@ -167,6 +167,39 @@ class AnnealingManager:
                 f"(skipped candidates with open proposals)"
             )
 
+        # 5c. Queue-aware veto (#402, Defect A): annealing must not propose a
+        # mutation against an ontology that still has in-flight ingestion work
+        # queued for it. Without this guard the worker dissolves X, the
+        # ingestion job dequeues with target=X, and the operator-submitted
+        # content silently never lands. Promotions are not vetoed — they create
+        # a new ontology and do not modify the existing one in a way that
+        # invalidates queued ingest jobs against the source ontology.
+        vetoed_inflight: List[Dict[str, Any]] = []
+        if demotion_candidates:
+            candidate_names = {c.get("ontology") for c in demotion_candidates}
+            candidate_names.discard(None)
+            inflight = self._get_inflight_ingestion_targets(candidate_names)
+            if inflight:
+                kept: List[Dict] = []
+                for c in demotion_candidates:
+                    name = c.get("ontology")
+                    blocking = inflight.get(name) if name else None
+                    if blocking:
+                        vetoed_inflight.append({
+                            "ontology": name,
+                            "blocking_job_count": len(blocking),
+                            "blocking_job_ids": blocking,
+                        })
+                        logger.info(
+                            "Annealing veto: skipping demotion candidate "
+                            f"'{name}' — {len(blocking)} in-flight ingestion "
+                            f"job(s) target this ontology "
+                            f"(job_ids={blocking})"
+                        )
+                    else:
+                        kept.append(c)
+                demotion_candidates = kept
+
         # 6. Evaluate and store proposals
         proposal_ids = []
         remaining = max_proposals
@@ -192,7 +225,8 @@ class AnnealingManager:
         logger.info(
             f"Annealing cycle complete: {len(proposal_ids)} proposals, "
             f"{len(all_scores)} scored, {centroids_updated} centroids, "
-            f"{edge_result.get('edges_created', 0)} edges"
+            f"{edge_result.get('edges_created', 0)} edges, "
+            f"{len(vetoed_inflight)} vetoed (in-flight ingestion)"
         )
 
         return {
@@ -205,6 +239,7 @@ class AnnealingManager:
             "edges_created": edge_result.get("edges_created", 0),
             "edges_deleted": edge_result.get("edges_deleted", 0),
             "cycle_epoch": global_epoch,
+            "vetoed_for_inflight_ingestion": vetoed_inflight,
             "dry_run": False,
         }
 
@@ -322,6 +357,73 @@ class AnnealingManager:
         except Exception as e:
             logger.error(f"Failed to read open proposals for dedup: {e}")
         return open_promotions, open_demotions
+
+    # Non-terminal job statuses on kg_api.jobs. An ingestion job in any of
+    # these states still intends to write to its target ontology — annealing
+    # must not dissolve / merge / decompose that ontology out from under it
+    # (#402, Defect A). Terminal statuses (completed / failed / cancelled /
+    # expired) do not block.
+    _NON_TERMINAL_JOB_STATUSES: Tuple[str, ...] = (
+        "pending",
+        "awaiting_approval",
+        "approved",
+        "queued",
+        "running",
+        "processing",
+    )
+
+    # Job types that target an ontology with intent to write. Keep in sync
+    # with WORKER_REGISTRY in api/app/services/worker_registry.py.
+    _INGESTION_JOB_TYPES: Tuple[str, ...] = ("ingestion", "ingest_image")
+
+    def _get_inflight_ingestion_targets(
+        self, ontology_names: Set[str]
+    ) -> Dict[str, List[str]]:
+        """In-flight ingestion jobs grouped by target ontology name.
+
+        Returns a mapping `{ontology_name: [job_id, ...]}` covering only the
+        supplied names — empty for an ontology with no non-terminal ingestion
+        work, omitted entirely if nothing matches. Used by the queue-aware
+        veto in the annealing cycle (#402).
+
+        Reads from kg_api.jobs directly via the AGE client's pool, mirroring
+        how _get_open_proposal_targets reads kg_api.annealing_proposals — the
+        manager stays a self-contained consumer of the shared connection pool.
+        """
+        if not ontology_names:
+            return {}
+        targets: Dict[str, List[str]] = {}
+        try:
+            conn = self.client.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT ontology, job_id
+                        FROM kg_api.jobs
+                        WHERE job_type = ANY(%s)
+                          AND status = ANY(%s)
+                          AND ontology = ANY(%s)
+                        """,
+                        (
+                            list(self._INGESTION_JOB_TYPES),
+                            list(self._NON_TERMINAL_JOB_STATUSES),
+                            list(ontology_names),
+                        ),
+                    )
+                    rows = cur.fetchall()
+                conn.commit()
+            finally:
+                self.client.pool.putconn(conn)
+            for ontology, job_id in rows:
+                if not ontology:
+                    continue
+                targets.setdefault(ontology, []).append(job_id)
+        except Exception as e:
+            logger.error(
+                f"Failed to read in-flight ingestion targets for veto: {e}"
+            )
+        return targets
 
     def _get_anchored_concept_ids(self) -> Set[str]:
         """Concept IDs that already anchor an ontology (have an ANCHORED_BY edge).

--- a/api/app/services/annealing_manager.py
+++ b/api/app/services/annealing_manager.py
@@ -55,6 +55,8 @@ class AnnealingManager:
         derive_edges: bool = True,
         overlap_threshold: float = 0.1,
         specializes_threshold: float = 0.3,
+        min_ontology_age_epochs: int = 3,
+        min_ontology_concept_count: int = 5,
     ) -> Dict[str, Any]:
         """
         Run a full annealing cycle.
@@ -111,13 +113,21 @@ class AnnealingManager:
 
         # 4. Identify demotion candidates
         demotion_candidates = self._find_demotion_candidates(
-            all_scores, demotion_threshold
+            all_scores,
+            demotion_threshold,
+            current_epoch=global_epoch,
+            min_age_epochs=min_ontology_age_epochs,
+            min_concept_count=min_ontology_concept_count,
         )
         logger.info(f"Found {len(demotion_candidates)} demotion candidates")
 
         # 5. Identify promotion candidates
         promotion_candidates = self._find_promotion_candidates(
-            all_scores, promotion_min_degree
+            all_scores,
+            promotion_min_degree,
+            current_epoch=global_epoch,
+            min_age_epochs=min_ontology_age_epochs,
+            min_concept_count=min_ontology_concept_count,
         )
         logger.info(f"Found {len(promotion_candidates)} promotion candidates")
 
@@ -248,9 +258,21 @@ class AnnealingManager:
     # =========================================================================
 
     def _find_demotion_candidates(
-        self, all_scores: List[Dict], threshold: float
+        self,
+        all_scores: List[Dict],
+        threshold: float,
+        current_epoch: int = 0,
+        min_age_epochs: int = 0,
+        min_concept_count: int = 0,
     ) -> List[Dict]:
-        """Find ontologies with protection below threshold, excluding pinned/frozen."""
+        """Find ontologies with protection below threshold, excluding pinned/frozen.
+
+        Per-ontology cadence floors (#402 Defect C) gate eligibility:
+        ontologies younger than min_age_epochs or holding fewer than
+        min_concept_count concepts are skipped — their scores are dominated
+        by per-concept noise rather than ontology structure, so evaluating
+        them wastes LLM calls and widens the ingestion race window.
+        """
         candidates = []
         for scores in all_scores:
             name = scores.get("ontology", "")
@@ -259,12 +281,32 @@ class AnnealingManager:
             if protection >= threshold:
                 continue
 
+            # Activity floor — ontology must have enough mass to be judged.
+            if scores.get("concept_count", 0) < min_concept_count:
+                logger.debug(
+                    f"Skipping demotion candidate '{name}': concept_count "
+                    f"{scores.get('concept_count', 0)} < floor {min_concept_count}"
+                )
+                continue
+
             # Check lifecycle — skip pinned/frozen
             node = self.client.get_ontology_node(name)
             if not node:
                 continue
             lifecycle = node.get("lifecycle_state", "active")
             if lifecycle in ("pinned", "frozen"):
+                continue
+
+            # Age floor — ontology must have existed for ≥ min_age_epochs.
+            # creation_epoch missing on legacy nodes is treated as 0 (oldest),
+            # so the floor never blocks pre-existing ontologies.
+            creation_epoch = node.get("creation_epoch", 0) or 0
+            age = current_epoch - creation_epoch
+            if min_age_epochs > 0 and age < min_age_epochs:
+                logger.debug(
+                    f"Skipping demotion candidate '{name}': age {age} "
+                    f"< floor {min_age_epochs} epochs"
+                )
                 continue
 
             candidates.append({
@@ -277,9 +319,20 @@ class AnnealingManager:
         return candidates
 
     def _find_promotion_candidates(
-        self, all_scores: List[Dict], min_degree: int
+        self,
+        all_scores: List[Dict],
+        min_degree: int,
+        current_epoch: int = 0,
+        min_age_epochs: int = 0,
+        min_concept_count: int = 0,
     ) -> List[Dict]:
-        """Find high-degree concepts that could become ontologies."""
+        """Find high-degree concepts that could become ontologies.
+
+        The cadence floors that gate demotion (#402 Defect C) also gate
+        promotion: a brand-new or near-empty source ontology has not
+        accumulated enough signal for its high-degree concepts to be
+        judged as natural new nuclei.
+        """
         candidates = []
         existing_ontology_names = {
             s["ontology"].lower() for s in all_scores
@@ -290,6 +343,17 @@ class AnnealingManager:
 
         for scores in all_scores:
             name = scores.get("ontology", "")
+
+            # Apply the same activity / age floors as demotion: a sparse or
+            # very young source ontology hasn't earned an evaluation yet.
+            if scores.get("concept_count", 0) < min_concept_count:
+                continue
+            if min_age_epochs > 0:
+                node = self.client.get_ontology_node(name)
+                creation_epoch = (node or {}).get("creation_epoch", 0) or 0
+                if current_epoch - creation_epoch < min_age_epochs:
+                    continue
+
             try:
                 ranking = self.client.get_concept_degree_ranking(name, limit=10)
             except Exception:

--- a/api/app/services/proposal_executor.py
+++ b/api/app/services/proposal_executor.py
@@ -16,9 +16,23 @@ All execution primitives were built in Phases 3a/5. This module is plumbing.
 import json
 import logging
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+# Mirrors AnnealingManager._NON_TERMINAL_JOB_STATUSES and _INGESTION_JOB_TYPES.
+# Kept in sync rather than imported to avoid a circular dep (the manager
+# already imports from this module's execution surface via the worker).
+_NON_TERMINAL_JOB_STATUSES = (
+    "pending",
+    "awaiting_approval",
+    "approved",
+    "queued",
+    "running",
+    "processing",
+)
+_INGESTION_JOB_TYPES = ("ingestion", "ingest_image")
 
 
 class ProposalExecutor:
@@ -169,8 +183,9 @@ class ProposalExecutor:
 
         Steps:
             1. Validate: ontology still exists, not pinned/frozen
-            2. Determine absorption target (cascading fallback)
-            3. dissolve_ontology() → reassign sources + remove node
+            2. Queue-aware veto re-check (#402 PR-404 finding #2)
+            3. Determine absorption target (cascading fallback)
+            4. dissolve_ontology() → reassign sources + remove node
 
         Args:
             proposal: Dict with proposal fields from annealing_proposals table
@@ -200,7 +215,41 @@ class ProposalExecutor:
                 "error": f"Ontology '{ontology_name}' is {lifecycle} — cannot demote",
             }
 
-        # 2. Determine absorption target
+        # 2. Queue-aware veto re-check (#402 PR-404 review, finding #2).
+        # AnnealingManager already vetoes candidates with in-flight ingestion
+        # at proposal *creation*, but in human-approval mode a proposal can
+        # sit for minutes-to-hours between creation and approval. A new
+        # ingest job enqueued in that window would otherwise be silently
+        # dissolved out from under the operator. Re-check now.
+        #
+        # Residual TOCTOU: this SELECT and the dissolve commit below are
+        # not atomic — a job enqueued between them slips through. Closing
+        # that fully needs an advisory lock on the ontology name (taken in
+        # both job-enqueue and dissolve). For now, the ingestion worker's
+        # unconditional tombstone check is the upstream-of-recreate
+        # backstop, and an existed_at_submit=True + missing target raises
+        # ONTOLOGY_VANISHED_MID_FLIGHT_ERROR rather than silently
+        # recreating — operators see the failure either way.
+        inflight = self._inflight_ingestion_jobs(ontology_name)
+        if inflight:
+            logger.warning(
+                f"Demotion execution vetoed for '{ontology_name}' — "
+                f"{len(inflight)} in-flight ingestion job(s) enqueued "
+                f"after proposal creation: {inflight}"
+            )
+            return {
+                "success": False,
+                "retry_later": True,
+                "error": (
+                    f"Demotion of '{ontology_name}' vetoed at execute time: "
+                    f"{len(inflight)} in-flight ingestion job(s) "
+                    f"({', '.join(inflight)}) — proposal will be retried "
+                    f"in a later cycle once the queue clears"
+                ),
+                "vetoed_for_inflight_ingestion": inflight,
+            }
+
+        # 3. Determine absorption target
         proposed_target = proposal.get("target_ontology")
         target = self._determine_absorption_target(ontology_name, proposed_target)
 
@@ -233,7 +282,7 @@ class ProposalExecutor:
                     "error": f"Absorption target '{target}' does not exist",
                 }
 
-        # 3. Dissolve — reassign sources + remove ontology node
+        # 4. Dissolve — reassign sources + remove ontology node
         result = self.client.dissolve_ontology(ontology_name, target)
 
         if not result.get("success"):
@@ -319,6 +368,47 @@ class ProposalExecutor:
 
         # 4. Last resort: primordial pool
         return self._get_primordial_pool_name()
+
+    def _inflight_ingestion_jobs(self, ontology_name: str) -> List[str]:
+        """Job IDs of non-terminal ingestion jobs targeting `ontology_name`.
+
+        Mirrors AnnealingManager._get_inflight_ingestion_targets for a single
+        ontology — used by execute_demotion to re-check the queue veto at
+        execute time (#402 PR-404 review, finding #2).
+
+        Returns an empty list on DB error so a transient failure doesn't
+        block legitimate demotions; the worker's unconditional tombstone
+        check + VANISHED raise remain the downstream backstop.
+        """
+        try:
+            conn = self.client.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT job_id
+                        FROM kg_api.jobs
+                        WHERE job_type = ANY(%s)
+                          AND status = ANY(%s)
+                          AND ontology = %s
+                        """,
+                        (
+                            list(_INGESTION_JOB_TYPES),
+                            list(_NON_TERMINAL_JOB_STATUSES),
+                            ontology_name,
+                        ),
+                    )
+                    rows = cur.fetchall()
+                conn.commit()
+                return [row[0] for row in rows if row and row[0]]
+            finally:
+                self.client.pool.putconn(conn)
+        except Exception as e:
+            logger.error(
+                f"Failed to read in-flight ingestion targets for "
+                f"'{ontology_name}' veto re-check: {e}"
+            )
+            return []
 
     def _get_primordial_pool_name(self) -> str:
         """Read primordial pool name from annealing_options, default 'primordial'."""

--- a/api/app/workers/annealing_worker.py
+++ b/api/app/workers/annealing_worker.py
@@ -49,6 +49,8 @@ def run_annealing_worker(
     overlap_threshold = job_data.get("overlap_threshold", 0.1)
     specializes_threshold = job_data.get("specializes_threshold", 0.3)
     automation_level = job_data.get("automation_level", "autonomous")
+    min_ontology_age_epochs = job_data.get("min_ontology_age_epochs", 3)
+    min_ontology_concept_count = job_data.get("min_ontology_concept_count", 5)
 
     logger.info(
         f"Annealing worker starting (job {job_id}): "
@@ -96,6 +98,8 @@ def run_annealing_worker(
             derive_edges=derive_edges,
             overlap_threshold=overlap_threshold,
             specializes_threshold=specializes_threshold,
+            min_ontology_age_epochs=min_ontology_age_epochs,
+            min_ontology_concept_count=min_ontology_concept_count,
         ))
 
         # Autonomous mode: the manager already stored proposals as 'approved'

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -23,10 +23,14 @@ from api.app.lib.ai_providers import get_provider
 logger = logging.getLogger(__name__)
 
 
-# #402 Defect B1: Distinct error strings so the job-list API can show, and
-# tests / clients can match, the difference between "frozen lifecycle" and
-# "vanished between queue and execution". Defect B2 will add a third
-# distinct string for "operator deliberately removed" (tombstoned).
+# Distinct error strings so the job-list API can show, and tests / clients
+# can match, the three structurally different failure modes (#402 B1 + B2):
+#   * tombstoned    → operator deliberately removed, do not recreate
+#   * frozen        → exists but read-only
+#   * vanished      → missing without a tombstone (recovered via recreate,
+#                     so this string only appears on legacy/pre-B2 jobs
+#                     where ontology_existed_at_submit was True but the
+#                     tombstone path was not checked).
 ONTOLOGY_VANISHED_MID_FLIGHT_ERROR = (
     "target ontology '{name}' was removed between queue and execution "
     "(annealing dissolve, manual delete, or rename without job migration) "
@@ -36,6 +40,54 @@ ONTOLOGY_FROZEN_ERROR = (
     "Ontology '{name}' is frozen (read-only). Job rejected. "
     "Set lifecycle state to 'active' before ingesting."
 )
+ONTOLOGY_TOMBSTONED_ERROR = (
+    "target ontology '{name}' was deliberately removed by an operator "
+    "(tombstone present in kg_api.ontology_tombstones) — ingest job not "
+    "retried. Remove the tombstone explicitly to re-enable this name."
+)
+
+
+def _ontology_tombstone(age_client, name: str):
+    """Return the tombstone row for `name` or None if no tombstone exists.
+
+    The tombstone is the positive operator-intent signal that distinguishes
+    "deliberately removed" from "annealing dissolved" (#402 Defect B2).
+    Read-only — the operator-delete API writes; nothing else does.
+    """
+    try:
+        conn = age_client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT name, removed_at, removed_by, reason "
+                    "FROM kg_api.ontology_tombstones "
+                    "WHERE name = %s",
+                    (name,),
+                )
+                row = cur.fetchone()
+            conn.commit()
+            if not row:
+                return None
+            return {
+                "name": row[0],
+                "removed_at": row[1],
+                "removed_by": row[2],
+                "reason": row[3],
+            }
+        finally:
+            age_client.pool.putconn(conn)
+    except Exception as e:
+        # Tombstone lookup failure should not silently mask the race —
+        # log loudly and treat as "no tombstone" so the recreate path
+        # runs (the worst case is recreating an ontology the operator
+        # tombstoned, which is recoverable; the alternative is to fail
+        # every ingest when the tombstone table is unreachable, which is
+        # worse). Defect A's queue-veto still applies upstream.
+        logger.error(
+            f"Failed to read ontology tombstone for '{name}': {e}",
+            exc_info=True,
+        )
+        return None
 
 
 def _validate_target_ontology(
@@ -43,35 +95,51 @@ def _validate_target_ontology(
     ontology: str,
     existed_at_submit: bool,
     created_by: str = None,
+    job_id: str = None,
 ):
     """Resolve the ingestion target's Ontology node, failing loudly when
-    the operator's intent has been invalidated (#402 Defect B1).
+    the operator's intent has been deliberately countermanded (#402 B1+B2).
 
-    Returns the ontology node dict on success. Raises Exception (which the
-    job-queue exception handler translates to status='failed' with the
-    message stamped on the job's error column) when:
+    Returns the ontology node dict on success. Raises Exception when:
 
-    - The ontology existed at submit time but is gone now → operator-
-      visible data loss if we silently recreate. Uses
-      ONTOLOGY_VANISHED_MID_FLIGHT_ERROR so the failure is distinguishable
-      in logs and the job-list API.
-    - The ontology is frozen → existing ADR-200 Phase 2 behavior.
+    - Tombstone present (operator deliberately removed the ontology) →
+      ONTOLOGY_TOMBSTONED_ERROR. The job-queue exception handler maps
+      this to status='failed' with the message on the job's error column,
+      which the job-list API already surfaces.
+    - Frozen lifecycle → ONTOLOGY_FROZEN_ERROR.
 
-    The first-ever-ingest case (existed_at_submit is False and the node
-    is missing) creates the ontology — that IS the operator's intent.
+    When the ontology is missing and no tombstone is present, the queued
+    ingest is treated as positive operator intent that overrides whatever
+    background reorganization caused the disappearance — the worker
+    recreates the ontology and proceeds, with an auditable log line
+    naming the job and the actor.
     """
     ont_node = age_client.get_ontology_node(ontology)
 
     if ont_node is None:
-        if existed_at_submit:
-            raise Exception(
-                ONTOLOGY_VANISHED_MID_FLIGHT_ERROR.format(name=ontology)
+        tombstone = _ontology_tombstone(age_client, ontology)
+        if tombstone:
+            logger.warning(
+                f"Ingest job blocked by tombstone for '{ontology}' "
+                f"(removed_at={tombstone['removed_at']}, "
+                f"removed_by={tombstone['removed_by']}, "
+                f"reason={tombstone['reason']})"
             )
-        # First-ever ingest: create the ontology, that IS the operator intent.
+            raise Exception(ONTOLOGY_TOMBSTONED_ERROR.format(name=ontology))
+
+        # Operator-intent recreation (#402 Defect B2): a queued ingest is
+        # active operator intent; a missing ontology without a tombstone
+        # means a background process removed it without operator consent,
+        # so honor the ingest by recreating the namespace. Audit-log the
+        # event with job + actor for traceability.
         ont_node = age_client.ensure_ontology_exists(
             ontology, created_by=created_by
         )
-        logger.info(f"Ontology '{ontology}' created on first ingest")
+        logger.info(
+            f"Ontology '{ontology}' (re)created for ingest job "
+            f"job_id={job_id} actor={created_by} "
+            f"existed_at_submit={existed_at_submit}"
+        )
 
     if ont_node.get("lifecycle_state") == "frozen":
         raise Exception(ONTOLOGY_FROZEN_ERROR.format(name=ontology))
@@ -371,6 +439,7 @@ def run_ingestion_worker(
             ontology,
             existed_at_submit=job_data.get("ontology_existed_at_submit", True),
             created_by=job_data.get("username"),
+            job_id=job_id,
         )
 
         # Generate embedding for ontology node if missing (best-effort).

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -23,6 +23,62 @@ from api.app.lib.ai_providers import get_provider
 logger = logging.getLogger(__name__)
 
 
+# #402 Defect B1: Distinct error strings so the job-list API can show, and
+# tests / clients can match, the difference between "frozen lifecycle" and
+# "vanished between queue and execution". Defect B2 will add a third
+# distinct string for "operator deliberately removed" (tombstoned).
+ONTOLOGY_VANISHED_MID_FLIGHT_ERROR = (
+    "target ontology '{name}' was removed between queue and execution "
+    "(annealing dissolve, manual delete, or rename without job migration) "
+    "— job not retried"
+)
+ONTOLOGY_FROZEN_ERROR = (
+    "Ontology '{name}' is frozen (read-only). Job rejected. "
+    "Set lifecycle state to 'active' before ingesting."
+)
+
+
+def _validate_target_ontology(
+    age_client,
+    ontology: str,
+    existed_at_submit: bool,
+    created_by: str = None,
+):
+    """Resolve the ingestion target's Ontology node, failing loudly when
+    the operator's intent has been invalidated (#402 Defect B1).
+
+    Returns the ontology node dict on success. Raises Exception (which the
+    job-queue exception handler translates to status='failed' with the
+    message stamped on the job's error column) when:
+
+    - The ontology existed at submit time but is gone now → operator-
+      visible data loss if we silently recreate. Uses
+      ONTOLOGY_VANISHED_MID_FLIGHT_ERROR so the failure is distinguishable
+      in logs and the job-list API.
+    - The ontology is frozen → existing ADR-200 Phase 2 behavior.
+
+    The first-ever-ingest case (existed_at_submit is False and the node
+    is missing) creates the ontology — that IS the operator's intent.
+    """
+    ont_node = age_client.get_ontology_node(ontology)
+
+    if ont_node is None:
+        if existed_at_submit:
+            raise Exception(
+                ONTOLOGY_VANISHED_MID_FLIGHT_ERROR.format(name=ontology)
+            )
+        # First-ever ingest: create the ontology, that IS the operator intent.
+        ont_node = age_client.ensure_ontology_exists(
+            ontology, created_by=created_by
+        )
+        logger.info(f"Ontology '{ontology}' created on first ingest")
+
+    if ont_node.get("lifecycle_state") == "frozen":
+        raise Exception(ONTOLOGY_FROZEN_ERROR.format(name=ontology))
+
+    return ont_node
+
+
 def run_ingestion_worker(
     job_data: Dict[str, Any],
     job_id: str,
@@ -310,32 +366,27 @@ def run_ingestion_worker(
         # Initialize AGE client
         age_client = AGEClient()
 
-        # ADR-200: Ensure Ontology node exists before creating Source nodes
-        try:
-            ont_node = age_client.ensure_ontology_exists(ontology, created_by=job_data.get("username"))
-            logger.debug(f"Ontology node ensured for '{ontology}'")
+        ont_node = _validate_target_ontology(
+            age_client,
+            ontology,
+            existed_at_submit=job_data.get("ontology_existed_at_submit", True),
+            created_by=job_data.get("username"),
+        )
 
-            # ADR-200 Phase 2: Defense-in-depth — reject if frozen between submission and execution
-            if ont_node and ont_node.get("lifecycle_state") == "frozen":
-                raise Exception(f"Ontology '{ontology}' is frozen (read-only). Job rejected. Set lifecycle state to 'active' before ingesting.")
-
-            # Generate embedding for ontology node if missing
-            if ont_node and not ont_node.get("embedding") and provider:
-                try:
-                    ont_text = ontology
-                    desc = ont_node.get("description")
-                    if desc:
-                        ont_text = f"{ontology}: {desc}"
-                    emb_result = provider.generate_embedding(ont_text)
-                    emb_vector = emb_result if isinstance(emb_result, list) else emb_result.get("embedding", [])
-                    if emb_vector:
-                        age_client.update_ontology_embedding(ontology, emb_vector)
-                        logger.info(f"Generated embedding for Ontology '{ontology}'")
-                except Exception as e:
-                    logger.debug(f"Skipped ontology embedding: {e}")
-        except Exception as e:
-            logger.warning(f"Failed to ensure Ontology node for '{ontology}': {e}")
-            # Non-fatal: s.document on Source nodes still works without Ontology node
+        # Generate embedding for ontology node if missing (best-effort).
+        if not ont_node.get("embedding") and provider:
+            try:
+                ont_text = ontology
+                desc = ont_node.get("description")
+                if desc:
+                    ont_text = f"{ontology}: {desc}"
+                emb_result = provider.generate_embedding(ont_text)
+                emb_vector = emb_result if isinstance(emb_result, list) else emb_result.get("embedding", [])
+                if emb_vector:
+                    age_client.update_ontology_embedding(ontology, emb_vector)
+                    logger.info(f"Generated embedding for Ontology '{ontology}'")
+            except Exception as e:
+                logger.debug(f"Skipped ontology embedding: {e}")
 
         # ADR-203: Record this ingestion as a graph epoch event so every
         # Instance created during the run carries a stable event_id. On resume,

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -27,14 +27,15 @@ logger = logging.getLogger(__name__)
 # can match, the three structurally different failure modes (#402 B1 + B2):
 #   * tombstoned    → operator deliberately removed, do not recreate
 #   * frozen        → exists but read-only
-#   * vanished      → missing without a tombstone (recovered via recreate,
-#                     so this string only appears on legacy/pre-B2 jobs
-#                     where ontology_existed_at_submit was True but the
-#                     tombstone path was not checked).
+#   * vanished      → existed at submit, missing at execute, no tombstone:
+#                     A-veto + executor re-check should make this unreachable
+#                     under normal operation, so reaching it indicates a real
+#                     anomaly worth surfacing rather than silently recreating.
 ONTOLOGY_VANISHED_MID_FLIGHT_ERROR = (
-    "target ontology '{name}' was removed between queue and execution "
-    "(annealing dissolve, manual delete, or rename without job migration) "
-    "— job not retried"
+    "target ontology '{name}' existed at job submit but was missing at "
+    "execute, with no operator tombstone — annealing veto + proposal "
+    "re-check should make this unreachable, so the anomaly is surfaced "
+    "rather than silently recreated. Job not retried."
 )
 ONTOLOGY_FROZEN_ERROR = (
     "Ontology '{name}' is frozen (read-only). Job rejected. "
@@ -51,8 +52,27 @@ def _ontology_tombstone(age_client, name: str):
     """Return the tombstone row for `name` or None if no tombstone exists.
 
     The tombstone is the positive operator-intent signal that distinguishes
-    "deliberately removed" from "annealing dissolved" (#402 Defect B2).
-    Read-only — the operator-delete API writes; nothing else does.
+    "deliberately removed by an operator" from "dissolved by background
+    annealing" (#402 Defect B2). Read-only — the operator-delete and
+    operator-dissolve routes write; the create-ontology route clears;
+    nothing else touches it.
+
+    On DB read failure, returns None (treat as "no tombstone"). Combined
+    with the post-PR-404 layered defense, this fallback is still
+    acceptable:
+
+      * existed_at_submit=True + missing target: the worker raises
+        ONTOLOGY_VANISHED_MID_FLIGHT_ERROR before consulting the
+        tombstone-failed result for recreation — the operator-deleted
+        case still fails loudly, just with a slightly less specific
+        error string than TOMBSTONED.
+      * existed_at_submit=False + missing target: first-ever ingest into
+        a new name, recreate is correct. A residual risk exists if the
+        operator deleted the name *before* the ingest was submitted AND
+        the tombstone-read fails — in that narrow case the worker
+        silently recreates. The alternative (fail every first ingest
+        when the tombstone table is unreachable) is a worse operational
+        hazard.
     """
     try:
         conn = age_client.pool.getconn()
@@ -77,12 +97,6 @@ def _ontology_tombstone(age_client, name: str):
         finally:
             age_client.pool.putconn(conn)
     except Exception as e:
-        # Tombstone lookup failure should not silently mask the race —
-        # log loudly and treat as "no tombstone" so the recreate path
-        # runs (the worst case is recreating an ontology the operator
-        # tombstoned, which is recoverable; the alternative is to fail
-        # every ingest when the tombstone table is unreachable, which is
-        # worse). Defect A's queue-veto still applies upstream.
         logger.error(
             f"Failed to read ontology tombstone for '{name}': {e}",
             exc_info=True,
@@ -103,40 +117,50 @@ def _validate_target_ontology(
     Returns the ontology node dict on success. Raises Exception when:
 
     - Tombstone present (operator deliberately removed the ontology) →
-      ONTOLOGY_TOMBSTONED_ERROR. The job-queue exception handler maps
-      this to status='failed' with the message on the job's error column,
-      which the job-list API already surfaces.
+      ONTOLOGY_TOMBSTONED_ERROR. Checked unconditionally (before reading
+      the graph node) so the operator-delete route can write the tombstone
+      *before* the graph delete; a worker dequeuing in the window where
+      both the node and the tombstone exist still fails loudly instead of
+      writing orphan content into a graph the operator is removing.
     - Frozen lifecycle → ONTOLOGY_FROZEN_ERROR.
+    - Existed at submit + missing at execute + no tombstone →
+      ONTOLOGY_VANISHED_MID_FLIGHT_ERROR. With Defect A's queue veto and
+      the proposal-executor re-check in place, an annealing dissolve of a
+      queued target should not occur; reaching this branch indicates a
+      real anomaly (rename without job migration, manual graph surgery,
+      or a residual race window) that operators should see.
 
-    When the ontology is missing and no tombstone is present, the queued
-    ingest is treated as positive operator intent that overrides whatever
-    background reorganization caused the disappearance — the worker
-    recreates the ontology and proceeds, with an auditable log line
-    naming the job and the actor.
+    When the ontology is missing, no tombstone is present, AND the
+    ontology did NOT exist at submit (first-ever ingest into a new
+    name), the worker creates the ontology and proceeds, with an
+    auditable log line naming the job and the actor.
     """
+    tombstone = _ontology_tombstone(age_client, ontology)
+    if tombstone:
+        logger.warning(
+            f"Ingest job blocked by tombstone for '{ontology}' "
+            f"(removed_at={tombstone['removed_at']}, "
+            f"removed_by={tombstone['removed_by']}, "
+            f"reason={tombstone['reason']})"
+        )
+        raise Exception(ONTOLOGY_TOMBSTONED_ERROR.format(name=ontology))
+
     ont_node = age_client.get_ontology_node(ontology)
 
     if ont_node is None:
-        tombstone = _ontology_tombstone(age_client, ontology)
-        if tombstone:
-            logger.warning(
-                f"Ingest job blocked by tombstone for '{ontology}' "
-                f"(removed_at={tombstone['removed_at']}, "
-                f"removed_by={tombstone['removed_by']}, "
-                f"reason={tombstone['reason']})"
+        if existed_at_submit:
+            raise Exception(
+                ONTOLOGY_VANISHED_MID_FLIGHT_ERROR.format(name=ontology)
             )
-            raise Exception(ONTOLOGY_TOMBSTONED_ERROR.format(name=ontology))
 
-        # Operator-intent recreation (#402 Defect B2): a queued ingest is
-        # active operator intent; a missing ontology without a tombstone
-        # means a background process removed it without operator consent,
-        # so honor the ingest by recreating the namespace. Audit-log the
+        # First-ever ingest into a brand-new name (existed_at_submit=False):
+        # creating the ontology IS the operator's intent. Audit-log the
         # event with job + actor for traceability.
         ont_node = age_client.ensure_ontology_exists(
             ontology, created_by=created_by
         )
         logger.info(
-            f"Ontology '{ontology}' (re)created for ingest job "
+            f"Ontology '{ontology}' created for ingest job "
             f"job_id={job_id} actor={created_by} "
             f"existed_at_submit={existed_at_submit}"
         )

--- a/api/app/workers/proposal_execution_worker.py
+++ b/api/app/workers/proposal_execution_worker.py
@@ -98,6 +98,18 @@ def run_proposal_execution_worker(
                 f"Proposal {proposal_id} ({proposal['proposal_type']}) "
                 f"executed successfully"
             )
+        elif result.get("retry_later"):
+            # #402 PR-404 review (finding #2 / advisor): revert the claim
+            # so the proposal stays available for the next cycle. Without
+            # this, a queue-veto re-check would dead-end an approved
+            # proposal — the operator's approval is consumed by a
+            # transient queue state. Reverting to 'approved' makes the
+            # re-check a soft skip rather than a permanent failure.
+            _update_proposal_status(age_client, proposal_id, "approved")
+            logger.info(
+                f"Proposal {proposal_id} ({proposal['proposal_type']}) "
+                f"deferred: {result.get('error')}"
+            )
         else:
             _update_proposal_status(
                 age_client, proposal_id, "failed",
@@ -112,8 +124,15 @@ def run_proposal_execution_worker(
             "progress": {"stage": "complete", "percent": 100}
         })
 
+        if result.get("success"):
+            return_status = "completed"
+        elif result.get("retry_later"):
+            return_status = "deferred"
+        else:
+            return_status = "failed"
+
         return {
-            "status": "completed" if result.get("success") else "failed",
+            "status": return_status,
             "proposal_id": proposal_id,
             "proposal_type": proposal["proposal_type"],
             **result,

--- a/schema/migrations/065_annealing_cadence_floors.sql
+++ b/schema/migrations/065_annealing_cadence_floors.sql
@@ -1,0 +1,73 @@
+-- Migration 065: Raise annealing cadence floors (#402 Defect C)
+--
+-- The shipping defaults emit annealing cycles too aggressively relative to
+-- typical operator activity. Cycles evaluate brand-new or near-empty
+-- ontologies before they have accumulated enough signal to judge — which
+-- both wastes LLM evaluations and widens the race window with the
+-- ingestion queue (the very race that #402 Defect A blocks).
+--
+-- Two new per-ontology floors gate cycle eligibility:
+--
+-- 1. min_ontology_age_epochs = 3
+--    An ontology must exist for at least three epoch ticks (a tick fires
+--    after each ingestion job's epoch increment) before annealing can
+--    judge it. Three is the smallest floor that survives a single batch:
+--    an ontology created mid-batch is still maturing while remaining jobs
+--    in the batch land, and the worker should not act on it until the
+--    batch is settled.
+--
+-- 2. min_ontology_concept_count = 5
+--    An ontology must hold at least five concepts before annealing can
+--    judge it. Below five, scores like protection and coherence are
+--    dominated by per-concept noise rather than ontology-level structure.
+--    Five is small enough to catch real-but-sparse ontologies while
+--    excluding stubs and partial-ingest snapshots.
+--
+-- These are *new* keys — no existing operator can have tuned them. INSERT
+-- ... ON CONFLICT DO NOTHING leaves operator-tuned values alone (the
+-- pattern already used by 047's seed block); the existing-key floors
+-- (epoch_interval, demotion_threshold, promotion_min_degree, max_proposals)
+-- are intentionally not changed here so this migration does not silently
+-- overwrite operators who have already tuned them.
+
+INSERT INTO kg_api.annealing_options (key, value, description) VALUES
+    ('min_ontology_age_epochs',
+     '3',
+     'Ontology must exist for at least this many epochs before annealing '
+     'evaluates it. Prevents acting on ontologies still settling from '
+     'recent ingestion (#402 Defect C).'),
+    ('min_ontology_concept_count',
+     '5',
+     'Ontology must hold at least this many concepts before annealing '
+     'evaluates it. Below this floor, scores are dominated by per-concept '
+     'noise rather than ontology structure (#402 Defect C).')
+ON CONFLICT (key) DO NOTHING;
+
+-- ============================================================================
+-- Verification
+-- ============================================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT FROM kg_api.annealing_options WHERE key = 'min_ontology_age_epochs'
+    ) THEN
+        RAISE EXCEPTION 'Migration failed: min_ontology_age_epochs not seeded';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT FROM kg_api.annealing_options WHERE key = 'min_ontology_concept_count'
+    ) THEN
+        RAISE EXCEPTION 'Migration failed: min_ontology_concept_count not seeded';
+    END IF;
+
+    RAISE NOTICE 'Migration 065: annealing cadence floors installed';
+END $$;
+
+-- ============================================================================
+-- Record Migration
+-- ============================================================================
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (65, 'annealing_cadence_floors')
+ON CONFLICT (version) DO NOTHING;

--- a/schema/migrations/066_ontology_tombstones.sql
+++ b/schema/migrations/066_ontology_tombstones.sql
@@ -1,0 +1,58 @@
+-- Migration 066: Ontology tombstones (#402 Defect B2)
+--
+-- A queued ingestion is operator intent: if annealing dissolves the target
+-- between queue and execution, recreating the ontology and ingesting under
+-- it is what the operator wanted. But there is one case where recreation
+-- is wrong — when an operator deliberately removed the ontology and does
+-- not want any later job to silently bring it back.
+--
+-- Tombstones make that distinction with a positive signal. An operator-
+-- initiated delete writes a row here; annealing's dissolve_ontology()
+-- path does NOT. The ingestion worker consults the table when its target
+-- is missing:
+--
+--   missing + tombstoned   → fail with the "deliberately removed" string
+--   missing + no tombstone → recreate and proceed (operator intent wins
+--                            over background reorganization)
+--
+-- The tombstone is keyed by name (the same handle operators and ingest
+-- jobs use). An operator who later wants to re-use the name removes the
+-- tombstone explicitly — that is itself a positive signal.
+
+CREATE TABLE IF NOT EXISTS kg_api.ontology_tombstones (
+    name        VARCHAR(200) PRIMARY KEY,
+    removed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    removed_by  VARCHAR(100),
+    reason      TEXT
+);
+
+COMMENT ON TABLE kg_api.ontology_tombstones IS
+    'Positive operator-intent signal that an ontology was deliberately '
+    'removed and must not be silently recreated by a subsequent ingest '
+    '(#402 Defect B2). Operator-initiated delete writes a row; annealing '
+    'dissolution does not.';
+
+-- ============================================================================
+-- Verification
+-- ============================================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_schema = 'kg_api'
+          AND table_name   = 'ontology_tombstones'
+    ) THEN
+        RAISE EXCEPTION 'Migration failed: kg_api.ontology_tombstones not created';
+    END IF;
+
+    RAISE NOTICE 'Migration 066: ontology tombstones installed';
+END $$;
+
+-- ============================================================================
+-- Record Migration
+-- ============================================================================
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (66, 'ontology_tombstones')
+ON CONFLICT (version) DO NOTHING;

--- a/tests/api/test_ontology_routes.py
+++ b/tests/api/test_ontology_routes.py
@@ -949,6 +949,90 @@ class TestDissolveRoute:
             for c in insert_calls
         )
 
+    def test_dissolve_failure_clears_tombstone(
+        self, api_client, auth_headers_admin
+    ):
+        """#402 PR-404 review-2 (finding B): when dissolve_ontology fails
+        after the route-level pre-flight (source listing, partial reassign,
+        lifecycle TOCTOU), the tombstone we wrote points to an ontology
+        that still exists. The route must clear it before raising so the
+        operator doesn't end up with 'dissolve failed AND future ingests
+        fail TOMBSTONED'."""
+        client = mock_age_client(
+            get_ontology_node={'name': 'old-onto', 'lifecycle_state': 'active'}
+        )
+        # Simulate the late-failure mode (source listing died in
+        # dissolve_ontology, returned a structured error).
+        client.dissolve_ontology = MagicMock(return_value={
+            'dissolved_ontology': 'old-onto',
+            'sources_reassigned': 0,
+            'ontology_node_deleted': False,
+            'reassignment_targets': [],
+            'success': False,
+            'error': 'Failed to list sources: connection reset',
+        })
+
+        with patch('api.app.routes.ontology.get_age_client', return_value=client):
+            response = api_client.post(
+                "/ontology/old-onto/dissolve",
+                json={"target_ontology": "target-onto"},
+                headers=auth_headers_admin,
+            )
+
+        assert response.status_code == 500
+        mock_cursor = (
+            client.pool.getconn.return_value.cursor.return_value.__enter__.return_value
+        )
+        # Both INSERT (pre-dissolve) and DELETE (rollback) must have run.
+        insert_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO kg_api.ontology_tombstones" in str(c)
+        ]
+        delete_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "DELETE FROM kg_api.ontology_tombstones" in str(c)
+        ]
+        assert len(insert_calls) >= 1
+        assert len(delete_calls) >= 1, (
+            "dissolve failure must clear the stale tombstone"
+        )
+
+
+@pytest.mark.unit
+class TestRenameOntologyTombstone:
+    """#402 PR-404 review-2 (finding A): rename establishes an ontology
+    under new_name, same invariant as create-clears-tombstone. The
+    delete-then-rename recovery flow would otherwise be broken by the
+    unconditional tombstone check."""
+
+    def test_rename_clears_tombstone_for_new_name(
+        self, api_client, auth_headers_admin
+    ):
+        client = mock_age_client()
+        client.is_ontology_frozen = MagicMock(return_value=False)
+        client.rename_ontology = MagicMock(return_value={'sources_updated': 7})
+        client.rename_ontology_node = MagicMock(return_value=True)
+
+        with patch('api.app.routes.ontology.get_age_client', return_value=client):
+            response = api_client.post(
+                "/ontology/old-name/rename",
+                json={"new_name": "phoenix-name"},
+                headers=auth_headers_admin,
+            )
+
+        assert response.status_code == 200, response.text
+        mock_cursor = (
+            client.pool.getconn.return_value.cursor.return_value.__enter__.return_value
+        )
+        delete_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "DELETE FROM kg_api.ontology_tombstones" in str(c)
+            and "phoenix-name" in str(c)
+        ]
+        assert len(delete_calls) >= 1, (
+            "rename must clear any prior tombstone for new_name"
+        )
+
 
 @pytest.mark.unit
 class TestDeleteOntologyTombstone:

--- a/tests/api/test_ontology_routes.py
+++ b/tests/api/test_ontology_routes.py
@@ -126,6 +126,40 @@ class TestCreateOntologyRoute:
             )
         assert response.status_code == 422
 
+    def test_create_clears_existing_tombstone(self, api_client, auth_headers_admin):
+        """#402 PR-404 finding #6 (advisor): operator-initiated recreate is
+        positive intent that supersedes a prior tombstone. The create route
+        must clear the tombstone so subsequent ingests don't fail
+        TOMBSTONED indefinitely."""
+        client = mock_age_client(
+            create_ontology_node={
+                'ontology_id': 'ont_revived',
+                'name': 'Phoenix Domain',
+                'lifecycle_state': 'active',
+                'creation_epoch': 100,
+            }
+        )
+
+        with patch('api.app.routes.ontology.get_age_client', return_value=client):
+            with patch('api.app.lib.ai_providers.get_provider', return_value=None):
+                response = api_client.post(
+                    "/ontology/",
+                    json={"name": "Phoenix Domain"},
+                    headers=auth_headers_admin,
+                )
+
+        assert response.status_code == 201
+        mock_cursor = (
+            client.pool.getconn.return_value.cursor.return_value.__enter__.return_value
+        )
+        delete_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "DELETE FROM kg_api.ontology_tombstones" in str(c)
+        ]
+        assert len(delete_calls) >= 1, (
+            "operator-initiated create must clear any prior tombstone"
+        )
+
 
 # ==========================================================================
 # GET /ontology/{name}/node — Graph node properties
@@ -810,7 +844,9 @@ class TestDissolveRoute:
 
     def test_dissolve_success(self, api_client, auth_headers_admin):
         """POST dissolve moves sources and removes node."""
-        client = mock_age_client()
+        client = mock_age_client(
+            get_ontology_node={'name': 'old-onto', 'lifecycle_state': 'active'}
+        )
         client.dissolve_ontology = MagicMock(return_value={
             'dissolved_ontology': 'old-onto',
             'sources_reassigned': 5,
@@ -834,15 +870,12 @@ class TestDissolveRoute:
 
     def test_dissolve_pinned_rejected(self, api_client, auth_headers_admin):
         """POST dissolve pinned ontology returns 403."""
-        client = mock_age_client()
-        client.dissolve_ontology = MagicMock(return_value={
-            'dissolved_ontology': 'pinned-onto',
-            'sources_reassigned': 0,
-            'ontology_node_deleted': False,
-            'reassignment_targets': [],
-            'success': False,
-            'error': "Ontology 'pinned-onto' is pinned — cannot dissolve",
-        })
+        # Pre-flight (#402 PR-404 review): pinned check happens in the route
+        # itself now so the tombstone is never written for a refused dissolve.
+        client = mock_age_client(
+            get_ontology_node={'name': 'pinned-onto', 'lifecycle_state': 'pinned'}
+        )
+        client.dissolve_ontology = MagicMock()
 
         with patch('api.app.routes.ontology.get_age_client', return_value=client):
             response = api_client.post(
@@ -852,18 +885,15 @@ class TestDissolveRoute:
             )
 
         assert response.status_code == 403
+        # Critical: dissolve_ontology must NOT be called.
+        client.dissolve_ontology.assert_not_called()
 
     def test_dissolve_not_found(self, api_client, auth_headers_admin):
         """POST dissolve nonexistent ontology returns 404."""
+        # Pre-flight: get_ontology_node returns None (default) → 404 before
+        # any tombstone write or dissolve call.
         client = mock_age_client()
-        client.dissolve_ontology = MagicMock(return_value={
-            'dissolved_ontology': 'ghost',
-            'sources_reassigned': 0,
-            'ontology_node_deleted': False,
-            'reassignment_targets': [],
-            'success': False,
-            'error': "Ontology 'ghost' not found",
-        })
+        client.dissolve_ontology = MagicMock()
 
         with patch('api.app.routes.ontology.get_age_client', return_value=client):
             response = api_client.post(
@@ -873,6 +903,110 @@ class TestDissolveRoute:
             )
 
         assert response.status_code == 404
+        client.dissolve_ontology.assert_not_called()
+
+    def test_dissolve_writes_tombstone_before_graph_mutation(
+        self, api_client, auth_headers_admin
+    ):
+        """#402 PR-404 finding #1: operator-initiated dissolve writes a
+        tombstone so a racing ingest fails TOMBSTONED rather than
+        silently recreating the dissolved name. Tombstone must be
+        recorded *before* dissolve_ontology runs."""
+        client = mock_age_client(
+            get_ontology_node={'name': 'old-onto', 'lifecycle_state': 'active'}
+        )
+        client.dissolve_ontology = MagicMock(return_value={
+            'dissolved_ontology': 'old-onto',
+            'sources_reassigned': 3,
+            'ontology_node_deleted': True,
+            'reassignment_targets': ['target-onto'],
+            'success': True,
+            'error': None,
+        })
+
+        with patch('api.app.routes.ontology.get_age_client', return_value=client):
+            response = api_client.post(
+                "/ontology/old-onto/dissolve",
+                json={"target_ontology": "target-onto"},
+                headers=auth_headers_admin,
+            )
+
+        assert response.status_code == 200
+        # Tombstone INSERT must have been executed on the pool.
+        mock_cursor = (
+            client.pool.getconn.return_value.cursor.return_value.__enter__.return_value
+        )
+        insert_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "INSERT INTO kg_api.ontology_tombstones" in str(c)
+        ]
+        assert len(insert_calls) >= 1, (
+            "operator-initiated dissolve must write a tombstone"
+        )
+        # The tombstone reason should mention dissolve and the target.
+        assert any(
+            "dissolve" in str(c).lower() and "target-onto" in str(c)
+            for c in insert_calls
+        )
+
+
+@pytest.mark.unit
+class TestDeleteOntologyTombstone:
+    """#402 PR-404 finding #4 (advisor-revised): tombstone is written before
+    the graph delete *and* the worker checks tombstones unconditionally —
+    a worker dequeuing during the delete must fail TOMBSTONED rather than
+    write orphan content into a graph the operator is removing."""
+
+    def test_delete_writes_tombstone_before_delete_ontology_node(
+        self, api_client, auth_headers_admin
+    ):
+        """The tombstone INSERT must precede the call to delete_ontology_node
+        on the AGE client. Verified by patching the helper with a side
+        effect that asserts the graph delete has not happened yet."""
+        client = mock_age_client()
+        client.delete_ontology_node = MagicMock(return_value=True)
+        # All Garage cleanup paths are best-effort try/except — defaults are fine.
+
+        order = []
+
+        def record_tombstone(client_arg, name, removed_by, reason):
+            order.append(("tombstone", name))
+            # Critical: delete_ontology_node must not have been called yet.
+            assert client_arg.delete_ontology_node.call_count == 0, (
+                "tombstone must be recorded before delete_ontology_node"
+            )
+
+        def record_delete(name):
+            order.append(("delete_node", name))
+            return True
+
+        client.delete_ontology_node.side_effect = record_delete
+
+        with patch(
+            'api.app.routes.ontology._record_ontology_tombstone',
+            side_effect=record_tombstone,
+        ):
+            with patch(
+                'api.app.routes.ontology.get_age_client', return_value=client
+            ):
+                with patch(
+                    'api.app.services.job_queue.get_job_queue'
+                ) as mock_queue:
+                    mock_queue.return_value.delete_jobs_by_ontology = MagicMock(
+                        return_value=0
+                    )
+                    response = api_client.delete(
+                        "/ontology/doomed-onto?force=true",
+                        headers=auth_headers_admin,
+                    )
+
+        assert response.status_code == 200, response.text
+        # Both events ran, in the right order.
+        assert ("tombstone", "doomed-onto") in order
+        assert ("delete_node", "doomed-onto") in order
+        assert order.index(("tombstone", "doomed-onto")) < order.index(
+            ("delete_node", "doomed-onto")
+        )
 
 
 # ==========================================================================

--- a/tests/unit/services/test_annealing_manager.py
+++ b/tests/unit/services/test_annealing_manager.py
@@ -187,8 +187,8 @@ class TestAnnealingCycleDryRun:
     async def test_dry_run_returns_candidates_without_proposals(self, manager, mock_scorer, mock_client):
         """Dry run returns candidate counts but generates no proposals."""
         mock_scorer.score_all_ontologies.return_value = [
-            {"ontology": "weak", "protection_score": 0.05},
-            {"ontology": "strong", "protection_score": 0.8},
+            {"ontology": "weak", "protection_score": 0.05, "concept_count": 10},
+            {"ontology": "strong", "protection_score": 0.8, "concept_count": 10},
         ]
         mock_scorer.recompute_all_centroids.return_value = 2
         mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}
@@ -206,7 +206,7 @@ class TestAnnealingCycleDryRun:
     async def test_dry_run_includes_candidate_details(self, manager, mock_scorer, mock_client):
         """Dry run includes detailed candidate information."""
         mock_scorer.score_all_ontologies.return_value = [
-            {"ontology": "weak", "protection_score": 0.05},
+            {"ontology": "weak", "protection_score": 0.05, "concept_count": 10},
         ]
         mock_scorer.recompute_all_centroids.return_value = 0
         mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}
@@ -245,7 +245,7 @@ class TestAnnealingCycleFull:
         """Proposals are capped at max_proposals."""
         # 5 demotion candidates but max_proposals=2
         mock_scorer.score_all_ontologies.return_value = [
-            {"ontology": f"weak-{i}", "protection_score": 0.01 * i}
+            {"ontology": f"weak-{i}", "protection_score": 0.01 * i, "concept_count": 10}
             for i in range(5)
         ]
         mock_scorer.recompute_all_centroids.return_value = 0
@@ -411,8 +411,8 @@ class TestQueueDedup:
         """run_annealing_cycle skips candidates that already have an open proposal."""
         manager = AnnealingManager(mock_client, mock_scorer, ai_provider=None)
         mock_scorer.score_all_ontologies.return_value = [
-            {"ontology": "weak-a", "protection_score": 0.01},
-            {"ontology": "weak-b", "protection_score": 0.02},
+            {"ontology": "weak-a", "protection_score": 0.01, "concept_count": 10},
+            {"ontology": "weak-b", "protection_score": 0.02, "concept_count": 10},
         ]
         mock_scorer.recompute_all_centroids.return_value = 0
         mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}
@@ -435,6 +435,117 @@ class TestQueueDedup:
 
         assert "weak-a" not in evaluated  # deduped — already has an open proposal
         assert "weak-b" in evaluated      # still evaluated
+
+
+# ==========================================================================
+# #402 Defect C: Per-ontology cadence floors (age / activity)
+# ==========================================================================
+
+
+@pytest.mark.unit
+class TestCadenceFloors:
+    """An ontology that is brand-new or near-empty must not be evaluated by
+    annealing (#402 Defect C). Its scores are dominated by per-concept noise
+    rather than ontology structure, so judging it wastes LLM calls and
+    widens the ingestion race window (#402 Defect A).
+    """
+
+    def test_demotion_skips_sparse_ontology(self, manager, mock_client):
+        """Ontology with concept_count below the activity floor is skipped."""
+        scores = [
+            {"ontology": "tiny", "protection_score": 0.01, "concept_count": 2},
+            {"ontology": "sized", "protection_score": 0.01, "concept_count": 8},
+        ]
+        mock_client.get_ontology_node.return_value = {
+            "lifecycle_state": "active",
+            "creation_epoch": 0,
+        }
+        mock_client.get_current_epoch.return_value = 100
+
+        result = manager._find_demotion_candidates(
+            scores,
+            threshold=0.15,
+            current_epoch=100,
+            min_age_epochs=0,
+            min_concept_count=5,
+        )
+
+        assert [c["ontology"] for c in result] == ["sized"]
+
+    def test_demotion_skips_too_young_ontology(self, manager, mock_client):
+        """Ontology younger than min_age_epochs is skipped."""
+        scores = [
+            {"ontology": "fresh", "protection_score": 0.01, "concept_count": 50},
+            {"ontology": "settled", "protection_score": 0.01, "concept_count": 50},
+        ]
+
+        def node_for(name):
+            return {
+                "fresh": {"lifecycle_state": "active", "creation_epoch": 99},
+                "settled": {"lifecycle_state": "active", "creation_epoch": 10},
+            }[name]
+
+        mock_client.get_ontology_node.side_effect = node_for
+
+        result = manager._find_demotion_candidates(
+            scores,
+            threshold=0.15,
+            current_epoch=100,  # delta: fresh=1, settled=90
+            min_age_epochs=3,
+            min_concept_count=0,
+        )
+
+        assert [c["ontology"] for c in result] == ["settled"]
+
+    def test_demotion_floors_disabled_when_zero(self, manager, mock_client):
+        """Floors at 0 must not block anything — preserves pre-floor behavior."""
+        scores = [
+            {"ontology": "tiny", "protection_score": 0.01, "concept_count": 1},
+        ]
+        mock_client.get_ontology_node.return_value = {
+            "lifecycle_state": "active",
+            "creation_epoch": 99,
+        }
+
+        result = manager._find_demotion_candidates(
+            scores,
+            threshold=0.15,
+            current_epoch=100,
+            min_age_epochs=0,
+            min_concept_count=0,
+        )
+
+        assert len(result) == 1
+
+    def test_promotion_respects_same_floors(self, manager, mock_client):
+        """Promotion candidates also gated by source-ontology age and activity:
+        high-degree concepts in a brand-new or sparse ontology have not yet
+        earned an evaluation as natural new nuclei.
+        """
+        scores = [
+            {"ontology": "tiny", "concept_count": 2},
+            {"ontology": "sized", "concept_count": 50},
+        ]
+        mock_client.get_ontology_node.return_value = {
+            "lifecycle_state": "active",
+            "creation_epoch": 0,
+        }
+        mock_client.get_concept_degree_ranking.return_value = [
+            {"concept_id": "c1", "label": "Anchor", "degree": 40, "description": ""},
+        ]
+        mock_client._execute_cypher.return_value = []  # no anchored concepts
+
+        result = manager._find_promotion_candidates(
+            scores,
+            min_degree=10,
+            current_epoch=100,
+            min_age_epochs=0,
+            min_concept_count=5,
+        )
+
+        # Only the candidate sourced from 'sized' should survive — 'tiny' is
+        # below the activity floor.
+        assert [c["ontology"] for c in result] == ["sized"]
 
 
 # ==========================================================================
@@ -502,8 +613,8 @@ class TestInflightIngestionVeto:
         """
         manager = AnnealingManager(mock_client, mock_scorer, ai_provider=None)
         mock_scorer.score_all_ontologies.return_value = [
-            {"ontology": "weak-a", "protection_score": 0.01},
-            {"ontology": "weak-b", "protection_score": 0.02},
+            {"ontology": "weak-a", "protection_score": 0.01, "concept_count": 10},
+            {"ontology": "weak-b", "protection_score": 0.02, "concept_count": 10},
         ]
         mock_scorer.recompute_all_centroids.return_value = 0
         mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}
@@ -550,7 +661,7 @@ class TestInflightIngestionVeto:
         """
         manager = AnnealingManager(mock_client, mock_scorer, ai_provider=None)
         mock_scorer.score_all_ontologies.return_value = [
-            {"ontology": "busy-ontology"},
+            {"ontology": "busy-ontology", "concept_count": 50},
         ]
         mock_scorer.recompute_all_centroids.return_value = 0
         mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}

--- a/tests/unit/services/test_annealing_manager.py
+++ b/tests/unit/services/test_annealing_manager.py
@@ -438,6 +438,148 @@ class TestQueueDedup:
 
 
 # ==========================================================================
+# #402 Defect A: Queue-aware veto for in-flight ingestion
+# ==========================================================================
+
+
+@pytest.mark.unit
+class TestInflightIngestionVeto:
+    """An annealing cycle must not demote an ontology that still has
+    in-flight ingestion work queued for it (#402 Defect A). Otherwise the
+    worker dissolves the target, the ingestion job dequeues with a missing
+    target, and the operator-submitted content silently never lands.
+    """
+
+    def test_get_inflight_ingestion_targets_groups_by_ontology(
+        self, manager, mock_client
+    ):
+        """Returned mapping groups non-terminal job ids per ontology name."""
+        cursor = (
+            mock_client.pool.getconn.return_value
+            .cursor.return_value.__enter__.return_value
+        )
+        cursor.fetchall.return_value = [
+            ("weak-a", "job_aaaaaaaaaaaa"),
+            ("weak-a", "job_bbbbbbbbbbbb"),
+            ("weak-b", "job_cccccccccccc"),
+        ]
+
+        targets = manager._get_inflight_ingestion_targets(
+            {"weak-a", "weak-b", "weak-c"}
+        )
+
+        assert targets == {
+            "weak-a": ["job_aaaaaaaaaaaa", "job_bbbbbbbbbbbb"],
+            "weak-b": ["job_cccccccccccc"],
+        }
+
+    def test_get_inflight_ingestion_targets_empty_input_short_circuits(
+        self, manager, mock_client
+    ):
+        """Empty candidate set skips the query entirely."""
+        targets = manager._get_inflight_ingestion_targets(set())
+        assert targets == {}
+        mock_client.pool.getconn.assert_not_called()
+
+    def test_get_inflight_ingestion_targets_swallows_errors(
+        self, manager, mock_client
+    ):
+        """A DB error returns an empty mapping rather than aborting the cycle."""
+        mock_client.pool.getconn.side_effect = Exception("connection refused")
+
+        targets = manager._get_inflight_ingestion_targets({"weak-a"})
+
+        assert targets == {}
+
+    @pytest.mark.asyncio
+    async def test_cycle_vetoes_demotion_with_inflight_ingestion(
+        self, mock_client, mock_scorer, caplog
+    ):
+        """The race: queue a job targeting X, then trigger a cycle that
+        would otherwise demote X. The candidate must be vetoed, no proposal
+        produced, and the veto must be observable in the cycle result and
+        in the log.
+        """
+        manager = AnnealingManager(mock_client, mock_scorer, ai_provider=None)
+        mock_scorer.score_all_ontologies.return_value = [
+            {"ontology": "weak-a", "protection_score": 0.01},
+            {"ontology": "weak-b", "protection_score": 0.02},
+        ]
+        mock_scorer.recompute_all_centroids.return_value = 0
+        mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}
+        mock_client.get_concept_degree_ranking.return_value = []
+
+        # weak-a has an in-flight ingestion job; weak-b does not.
+        manager._get_inflight_ingestion_targets = MagicMock(
+            return_value={"weak-a": ["job_inflight_1"]}
+        )
+
+        evaluated = []
+
+        async def fake_eval(candidate, epoch):
+            evaluated.append(candidate["ontology"])
+            return None
+
+        manager._evaluate_and_store_demotion = fake_eval
+
+        import logging
+        with caplog.at_level(logging.INFO):
+            result = await manager.run_annealing_cycle(demotion_threshold=0.15)
+
+        assert "weak-a" not in evaluated  # vetoed
+        assert "weak-b" in evaluated      # still evaluated
+
+        veto_log = [r for r in result["vetoed_for_inflight_ingestion"]
+                    if r["ontology"] == "weak-a"]
+        assert len(veto_log) == 1
+        assert veto_log[0]["blocking_job_count"] == 1
+        assert veto_log[0]["blocking_job_ids"] == ["job_inflight_1"]
+
+        assert any(
+            "Annealing veto" in rec.message and "weak-a" in rec.message
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_cycle_does_not_veto_promotion_for_inflight_work(
+        self, mock_client, mock_scorer
+    ):
+        """Promotion creates a *new* ontology and does not modify the source
+        ontology in a way that invalidates queued ingest jobs against it. It
+        must not be vetoed by in-flight ingestion against the source.
+        """
+        manager = AnnealingManager(mock_client, mock_scorer, ai_provider=None)
+        mock_scorer.score_all_ontologies.return_value = [
+            {"ontology": "busy-ontology"},
+        ]
+        mock_scorer.recompute_all_centroids.return_value = 0
+        mock_client.get_ontology_node.return_value = {"lifecycle_state": "active"}
+        mock_client.get_concept_degree_ranking.return_value = [
+            {"concept_id": "c1", "label": "PostgreSQL", "degree": 30, "description": ""},
+        ]
+
+        inflight_spy = MagicMock(return_value={"busy-ontology": ["job_x"]})
+        manager._get_inflight_ingestion_targets = inflight_spy
+
+        evaluated = []
+
+        async def fake_promo(candidate, epoch):
+            evaluated.append(candidate["concept_id"])
+            return None
+
+        manager._evaluate_and_store_promotion = fake_promo
+
+        await manager.run_annealing_cycle()
+
+        # Promotion still evaluated despite in-flight work on the source ontology.
+        assert evaluated == ["c1"]
+        # Veto helper was not consulted with the promotion source — only
+        # demotion candidates feed it (there are none in this fixture, so it
+        # was never called).
+        inflight_spy.assert_not_called()
+
+
+# ==========================================================================
 # ADR-200 Phase 5: Edge Derivation Integration
 # ==========================================================================
 

--- a/tests/unit/services/test_proposal_executor.py
+++ b/tests/unit/services/test_proposal_executor.py
@@ -18,10 +18,14 @@ def mock_client():
     """Create a mock AGE client with default behaviors."""
     client = MagicMock()
 
-    # Default pool mock for _get_primordial_pool_name
+    # Default pool mock for _get_primordial_pool_name and
+    # _inflight_ingestion_jobs (PR-404 review, finding #2).
+    # fetchone() → ("primordial",) for the pool-name query.
+    # fetchall() → [] for the in-flight job query (no jobs by default).
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
     mock_cursor.fetchone.return_value = ("primordial",)
+    mock_cursor.fetchall.return_value = []
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     client.pool = MagicMock()
@@ -253,6 +257,36 @@ class TestExecuteDemotion:
 
         assert result["success"] is False
         assert "frozen" in result["error"]
+
+    def test_demotion_vetoed_by_inflight_ingestion(self, executor, mock_client):
+        """#402 PR-404 finding #2: re-check the queue veto at execute time.
+
+        AnnealingManager vetoes at proposal creation. In human-approval
+        mode a proposal can sit between creation and approval; a new
+        ingest enqueued in that window would be silently dissolved out
+        from under the operator. The executor re-checks and refuses."""
+        mock_client.get_ontology_node.return_value = {
+            "name": "weak-ontology",
+            "lifecycle_state": "active",
+        }
+        # Override fetchall to return in-flight job IDs for this test.
+        mock_cursor = (
+            mock_client.pool.getconn.return_value.cursor.return_value.__enter__.return_value
+        )
+        mock_cursor.fetchall.return_value = [("job_late_1",), ("job_late_2",)]
+
+        result = executor.execute_demotion(_demotion_proposal())
+
+        assert result["success"] is False
+        # retry_later signals the worker to revert claim to 'approved' so
+        # the proposal isn't permanently failed by a transient queue state.
+        assert result["retry_later"] is True
+        assert "vetoed at execute time" in result["error"]
+        assert "job_late_1" in result["error"]
+        assert "job_late_2" in result["error"]
+        assert result["vetoed_for_inflight_ingestion"] == ["job_late_1", "job_late_2"]
+        # Critical: dissolve must NOT have been called.
+        mock_client.dissolve_ontology.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/unit/workers/test_ingestion_worker.py
+++ b/tests/unit/workers/test_ingestion_worker.py
@@ -1,8 +1,16 @@
-"""Unit tests for ingestion worker helpers (#402 Defects B1 + B2).
+"""Unit tests for ingestion worker helpers (#402 Defects B1 + B2 + PR-404 review).
 
 Focused on the target-ontology validation step that decides between
-"missing — recreate per operator intent", "missing but tombstoned — fail
-loudly", and "frozen — fail loudly".
+"first-ever ingest — create", "missing after existing — fail with
+VANISHED", "tombstoned — fail with TOMBSTONED", and "frozen — fail
+with FROZEN".
+
+PR-404 review revision: tombstone is now checked *unconditionally*
+(before reading the graph node) so the operator-delete route can write
+the tombstone before the graph delete without a worker dequeue in the
+intermediate window writing orphan content. The recreate branch
+narrowed to existed_at_submit=False (first-ever ingest); existed_at_
+submit=True + missing + no tombstone raises VANISHED as a real anomaly.
 """
 
 import pytest
@@ -63,28 +71,33 @@ class TestValidateTargetOntology:
         assert node["lifecycle_state"] == "active"
         age_client.ensure_ontology_exists.assert_not_called()
 
-    def test_missing_without_tombstone_triggers_recreate(self):
-        """A missing ontology with no tombstone is recreated — operator
-        intent (the queued ingest) overrides background dissolution."""
+    def test_missing_after_existing_raises_vanished(self):
+        """existed_at_submit=True + missing + no tombstone → VANISHED.
+
+        With the annealing veto (A) and proposal-executor re-check in
+        place, an in-flight ingest's target should not be dissolved.
+        Reaching this branch indicates a real anomaly (rename without
+        job migration, manual graph surgery, residual race) that an
+        operator should see rather than have silently recreated."""
         age_client = _make_age_client(tombstone_row=None)
         age_client.get_ontology_node.return_value = None
-        age_client.ensure_ontology_exists.return_value = {
-            "lifecycle_state": "active",
-            "embedding": [],
-        }
 
-        node = _validate_target_ontology(
-            age_client,
-            "dissolved-domain",
-            existed_at_submit=True,
-            created_by="alice",
-            job_id="job_abc",
-        )
+        with pytest.raises(Exception) as exc_info:
+            _validate_target_ontology(
+                age_client,
+                "vanished-domain",
+                existed_at_submit=True,
+                created_by="alice",
+                job_id="job_abc",
+            )
 
-        age_client.ensure_ontology_exists.assert_called_once_with(
-            "dissolved-domain", created_by="alice"
-        )
-        assert node["lifecycle_state"] == "active"
+        msg = str(exc_info.value)
+        assert "vanished-domain" in msg
+        assert "existed at job submit" in msg
+        # Distinct from tombstoned and frozen.
+        assert msg != ONTOLOGY_TOMBSTONED_ERROR.format(name="vanished-domain")
+        assert msg != ONTOLOGY_FROZEN_ERROR.format(name="vanished-domain")
+        age_client.ensure_ontology_exists.assert_not_called()
 
     def test_missing_with_tombstone_raises_distinct_error(self):
         """An operator-tombstoned ontology must not be silently recreated —
@@ -158,11 +171,64 @@ class TestValidateTargetOntology:
         assert "frozen (read-only)" in msg
         assert msg != ONTOLOGY_TOMBSTONED_ERROR.format(name="frozen-domain")
 
-    def test_tombstone_read_failure_falls_back_to_recreate(self):
-        """If the tombstone lookup itself fails (DB unreachable), the worker
-        treats the result as 'no tombstone' and recreates — failing every
-        ingest when the tombstone table is unreachable would be worse.
-        Defect A's queue-veto remains the upstream safety layer."""
+    def test_tombstone_present_with_live_node_still_raises(self):
+        """The unconditional tombstone check covers the window where the
+        operator-delete route has written the tombstone but not yet
+        committed the graph delete: ontology still exists, but operator
+        intent has been recorded. The worker fails TOMBSTONED rather
+        than racing to write into a graph the operator is removing."""
+        age_client = _make_age_client(
+            tombstone_row=(
+                "deleting-domain",
+                "2026-05-22 12:00:00",
+                "alice",
+                "operator-initiated delete via API",
+            )
+        )
+        age_client.get_ontology_node.return_value = {
+            "lifecycle_state": "active",
+            "embedding": [],
+        }
+
+        with pytest.raises(Exception) as exc_info:
+            _validate_target_ontology(
+                age_client,
+                "deleting-domain",
+                existed_at_submit=True,
+            )
+
+        msg = str(exc_info.value)
+        assert "deliberately removed" in msg
+        # Must not have even consulted the graph for lifecycle.
+        age_client.ensure_ontology_exists.assert_not_called()
+
+    def test_tombstone_read_failure_with_existed_at_submit_raises_vanished(self):
+        """If the tombstone lookup itself fails (DB unreachable) AND the
+        ontology was supposed to exist at submit but is missing, the
+        VANISHED path fires — failing loudly is the correct fallback when
+        we cannot positively rule out an operator delete. (Previously the
+        worker silently recreated; that was the over-tolerant behavior
+        the PR-404 review flagged.)"""
+        age_client = _make_age_client(raise_on_tombstone_read=True)
+        age_client.get_ontology_node.return_value = None
+
+        with pytest.raises(Exception) as exc_info:
+            _validate_target_ontology(
+                age_client,
+                "dissolved-domain",
+                existed_at_submit=True,
+                created_by="alice",
+            )
+
+        assert "existed at job submit" in str(exc_info.value)
+        age_client.ensure_ontology_exists.assert_not_called()
+
+    def test_tombstone_read_failure_on_first_ingest_still_creates(self):
+        """existed_at_submit=False is a positive intent signal that the
+        operator is establishing a new namespace. A tombstone-read DB
+        failure on this path falls through to create (the worst case is
+        creating an ontology over a stale tombstone we couldn't read; the
+        operator-recreate flow already needs to handle that case)."""
         age_client = _make_age_client(raise_on_tombstone_read=True)
         age_client.get_ontology_node.return_value = None
         age_client.ensure_ontology_exists.return_value = {
@@ -172,8 +238,8 @@ class TestValidateTargetOntology:
 
         node = _validate_target_ontology(
             age_client,
-            "dissolved-domain",
-            existed_at_submit=True,
+            "fresh-domain",
+            existed_at_submit=False,
             created_by="alice",
         )
 

--- a/tests/unit/workers/test_ingestion_worker.py
+++ b/tests/unit/workers/test_ingestion_worker.py
@@ -1,0 +1,123 @@
+"""Unit tests for ingestion worker helpers (#402 Defect B1).
+
+Focused on the target-ontology validation step that decides between
+"first-ingest, create it" and "vanished mid-flight, fail loudly".
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from api.app.workers.ingestion_worker import (
+    _validate_target_ontology,
+    ONTOLOGY_VANISHED_MID_FLIGHT_ERROR,
+    ONTOLOGY_FROZEN_ERROR,
+)
+
+
+@pytest.mark.unit
+class TestValidateTargetOntology:
+    """Defect B1: when the target ontology disappears between job submit and
+    job execute (annealing dissolved it, an operator deleted it, etc.) the
+    ingestion worker must fail loudly with a structured error rather than
+    silently recreate the ontology and accept the data."""
+
+    def test_existing_ontology_passes_through(self):
+        """A live, active ontology is returned untouched."""
+        age_client = MagicMock()
+        age_client.get_ontology_node.return_value = {
+            "lifecycle_state": "active",
+            "embedding": [],
+        }
+
+        node = _validate_target_ontology(
+            age_client,
+            "my-domain",
+            existed_at_submit=True,
+        )
+
+        assert node["lifecycle_state"] == "active"
+        age_client.ensure_ontology_exists.assert_not_called()
+
+    def test_vanished_after_submit_raises_distinct_error(self):
+        """If the operator targeted an existing ontology and it is gone
+        now, the worker must raise with the 'vanished mid-flight' string."""
+        age_client = MagicMock()
+        age_client.get_ontology_node.return_value = None
+
+        with pytest.raises(Exception) as exc_info:
+            _validate_target_ontology(
+                age_client,
+                "vanished-domain",
+                existed_at_submit=True,
+            )
+
+        msg = str(exc_info.value)
+        assert "vanished-domain" in msg
+        assert "removed between queue and execution" in msg
+        # Must be the distinct string, not the frozen one — Defect B2 will
+        # add a third distinct string for 'deliberately removed'.
+        assert msg != ONTOLOGY_FROZEN_ERROR.format(name="vanished-domain")
+        age_client.ensure_ontology_exists.assert_not_called()
+
+    def test_first_ingest_creates_ontology(self):
+        """If the operator targeted a fresh namespace (existed_at_submit
+        is False) and no node exists, creating it IS the intent — do so."""
+        age_client = MagicMock()
+        age_client.get_ontology_node.return_value = None
+        age_client.ensure_ontology_exists.return_value = {
+            "lifecycle_state": "active",
+            "embedding": [],
+        }
+
+        node = _validate_target_ontology(
+            age_client,
+            "fresh-domain",
+            existed_at_submit=False,
+            created_by="alice",
+        )
+
+        age_client.ensure_ontology_exists.assert_called_once_with(
+            "fresh-domain", created_by="alice"
+        )
+        assert node["lifecycle_state"] == "active"
+
+    def test_frozen_ontology_raises_frozen_error(self):
+        """A frozen ontology fails with the frozen string — distinct from
+        the vanished-mid-flight string so both can be told apart."""
+        age_client = MagicMock()
+        age_client.get_ontology_node.return_value = {
+            "lifecycle_state": "frozen",
+            "embedding": [],
+        }
+
+        with pytest.raises(Exception) as exc_info:
+            _validate_target_ontology(
+                age_client,
+                "frozen-domain",
+                existed_at_submit=True,
+            )
+
+        msg = str(exc_info.value)
+        assert "frozen-domain" in msg
+        assert "frozen (read-only)" in msg
+        assert msg != ONTOLOGY_VANISHED_MID_FLIGHT_ERROR.format(
+            name="frozen-domain"
+        )
+
+    def test_legacy_job_defaults_existed_at_submit_true(self):
+        """A pre-B1 job without the ontology_existed_at_submit key on its
+        job_data must default to the safe behavior (fail on missing) when
+        the worker's job_data.get(..., True) is supplied as the argument."""
+        age_client = MagicMock()
+        age_client.get_ontology_node.return_value = None
+
+        # The worker calls job_data.get('ontology_existed_at_submit', True);
+        # this test exercises the post-get value directly.
+        with pytest.raises(Exception) as exc_info:
+            _validate_target_ontology(
+                age_client,
+                "legacy-domain",
+                existed_at_submit=True,
+            )
+
+        assert "removed between queue and execution" in str(exc_info.value)

--- a/tests/unit/workers/test_ingestion_worker.py
+++ b/tests/unit/workers/test_ingestion_worker.py
@@ -1,7 +1,8 @@
-"""Unit tests for ingestion worker helpers (#402 Defect B1).
+"""Unit tests for ingestion worker helpers (#402 Defects B1 + B2).
 
 Focused on the target-ontology validation step that decides between
-"first-ingest, create it" and "vanished mid-flight, fail loudly".
+"missing — recreate per operator intent", "missing but tombstoned — fail
+loudly", and "frozen — fail loudly".
 """
 
 import pytest
@@ -9,21 +10,45 @@ from unittest.mock import MagicMock
 
 from api.app.workers.ingestion_worker import (
     _validate_target_ontology,
+    _ontology_tombstone,
     ONTOLOGY_VANISHED_MID_FLIGHT_ERROR,
     ONTOLOGY_FROZEN_ERROR,
+    ONTOLOGY_TOMBSTONED_ERROR,
 )
+
+
+def _make_age_client(tombstone_row=None, raise_on_tombstone_read=False):
+    """Build an AGEClient mock with a stub pool that returns the given
+    tombstone row (or None) when the worker queries kg_api.ontology_tombstones.
+    """
+    client = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = tombstone_row
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    if raise_on_tombstone_read:
+        client.pool.getconn.side_effect = Exception("connection refused")
+    else:
+        client.pool.getconn.return_value = conn
+    return client
 
 
 @pytest.mark.unit
 class TestValidateTargetOntology:
-    """Defect B1: when the target ontology disappears between job submit and
-    job execute (annealing dissolved it, an operator deleted it, etc.) the
-    ingestion worker must fail loudly with a structured error rather than
-    silently recreate the ontology and accept the data."""
+    """Defect B1+B2: missing-target handling.
+
+    B1 established the loud-failure infrastructure (distinct error strings,
+    raise propagates to status='failed' with error column populated).
+    B2 narrows the loud-failure trigger to the operator-intent signal: a
+    queued ingest is itself operator intent that overrides a background
+    dissolution, so a missing-without-tombstone target is recreated. Only
+    an explicit operator tombstone blocks recreation.
+    """
 
     def test_existing_ontology_passes_through(self):
         """A live, active ontology is returned untouched."""
-        age_client = MagicMock()
+        age_client = _make_age_client()
         age_client.get_ontology_node.return_value = {
             "lifecycle_state": "active",
             "embedding": [],
@@ -38,31 +63,64 @@ class TestValidateTargetOntology:
         assert node["lifecycle_state"] == "active"
         age_client.ensure_ontology_exists.assert_not_called()
 
-    def test_vanished_after_submit_raises_distinct_error(self):
-        """If the operator targeted an existing ontology and it is gone
-        now, the worker must raise with the 'vanished mid-flight' string."""
-        age_client = MagicMock()
+    def test_missing_without_tombstone_triggers_recreate(self):
+        """A missing ontology with no tombstone is recreated — operator
+        intent (the queued ingest) overrides background dissolution."""
+        age_client = _make_age_client(tombstone_row=None)
+        age_client.get_ontology_node.return_value = None
+        age_client.ensure_ontology_exists.return_value = {
+            "lifecycle_state": "active",
+            "embedding": [],
+        }
+
+        node = _validate_target_ontology(
+            age_client,
+            "dissolved-domain",
+            existed_at_submit=True,
+            created_by="alice",
+            job_id="job_abc",
+        )
+
+        age_client.ensure_ontology_exists.assert_called_once_with(
+            "dissolved-domain", created_by="alice"
+        )
+        assert node["lifecycle_state"] == "active"
+
+    def test_missing_with_tombstone_raises_distinct_error(self):
+        """An operator-tombstoned ontology must not be silently recreated —
+        raise with the 'deliberately removed' string."""
+        age_client = _make_age_client(
+            tombstone_row=(
+                "removed-domain",
+                "2026-05-22 12:00:00",
+                "alice",
+                "operator-initiated delete via API",
+            )
+        )
         age_client.get_ontology_node.return_value = None
 
         with pytest.raises(Exception) as exc_info:
             _validate_target_ontology(
                 age_client,
-                "vanished-domain",
+                "removed-domain",
                 existed_at_submit=True,
             )
 
         msg = str(exc_info.value)
-        assert "vanished-domain" in msg
-        assert "removed between queue and execution" in msg
-        # Must be the distinct string, not the frozen one — Defect B2 will
-        # add a third distinct string for 'deliberately removed'.
-        assert msg != ONTOLOGY_FROZEN_ERROR.format(name="vanished-domain")
+        assert "removed-domain" in msg
+        assert "deliberately removed" in msg
+        # Must be the tombstoned string, not the vanished one — operator
+        # intent of removal is distinct from queue/execute race.
+        assert msg != ONTOLOGY_VANISHED_MID_FLIGHT_ERROR.format(
+            name="removed-domain"
+        )
+        # Must not have tried to recreate.
         age_client.ensure_ontology_exists.assert_not_called()
 
     def test_first_ingest_creates_ontology(self):
-        """If the operator targeted a fresh namespace (existed_at_submit
-        is False) and no node exists, creating it IS the intent — do so."""
-        age_client = MagicMock()
+        """First ingest (no prior node, no tombstone) creates the namespace —
+        that IS the operator's intent."""
+        age_client = _make_age_client(tombstone_row=None)
         age_client.get_ontology_node.return_value = None
         age_client.ensure_ontology_exists.return_value = {
             "lifecycle_state": "active",
@@ -76,15 +134,13 @@ class TestValidateTargetOntology:
             created_by="alice",
         )
 
-        age_client.ensure_ontology_exists.assert_called_once_with(
-            "fresh-domain", created_by="alice"
-        )
+        age_client.ensure_ontology_exists.assert_called_once()
         assert node["lifecycle_state"] == "active"
 
     def test_frozen_ontology_raises_frozen_error(self):
         """A frozen ontology fails with the frozen string — distinct from
-        the vanished-mid-flight string so both can be told apart."""
-        age_client = MagicMock()
+        the tombstoned string so both can be told apart by an operator."""
+        age_client = _make_age_client()
         age_client.get_ontology_node.return_value = {
             "lifecycle_state": "frozen",
             "embedding": [],
@@ -100,24 +156,56 @@ class TestValidateTargetOntology:
         msg = str(exc_info.value)
         assert "frozen-domain" in msg
         assert "frozen (read-only)" in msg
-        assert msg != ONTOLOGY_VANISHED_MID_FLIGHT_ERROR.format(
-            name="frozen-domain"
+        assert msg != ONTOLOGY_TOMBSTONED_ERROR.format(name="frozen-domain")
+
+    def test_tombstone_read_failure_falls_back_to_recreate(self):
+        """If the tombstone lookup itself fails (DB unreachable), the worker
+        treats the result as 'no tombstone' and recreates — failing every
+        ingest when the tombstone table is unreachable would be worse.
+        Defect A's queue-veto remains the upstream safety layer."""
+        age_client = _make_age_client(raise_on_tombstone_read=True)
+        age_client.get_ontology_node.return_value = None
+        age_client.ensure_ontology_exists.return_value = {
+            "lifecycle_state": "active",
+            "embedding": [],
+        }
+
+        node = _validate_target_ontology(
+            age_client,
+            "dissolved-domain",
+            existed_at_submit=True,
+            created_by="alice",
         )
 
-    def test_legacy_job_defaults_existed_at_submit_true(self):
-        """A pre-B1 job without the ontology_existed_at_submit key on its
-        job_data must default to the safe behavior (fail on missing) when
-        the worker's job_data.get(..., True) is supplied as the argument."""
-        age_client = MagicMock()
-        age_client.get_ontology_node.return_value = None
+        age_client.ensure_ontology_exists.assert_called_once()
+        assert node["lifecycle_state"] == "active"
 
-        # The worker calls job_data.get('ontology_existed_at_submit', True);
-        # this test exercises the post-get value directly.
-        with pytest.raises(Exception) as exc_info:
-            _validate_target_ontology(
-                age_client,
-                "legacy-domain",
-                existed_at_submit=True,
+
+@pytest.mark.unit
+class TestOntologyTombstone:
+    """Direct tests of the tombstone lookup helper."""
+
+    def test_returns_row_when_tombstone_exists(self):
+        age_client = _make_age_client(
+            tombstone_row=(
+                "removed-domain",
+                "2026-05-22 12:00:00",
+                "alice",
+                "operator-initiated delete via API",
             )
+        )
 
-        assert "removed between queue and execution" in str(exc_info.value)
+        result = _ontology_tombstone(age_client, "removed-domain")
+
+        assert result is not None
+        assert result["name"] == "removed-domain"
+        assert result["removed_by"] == "alice"
+        assert result["reason"] == "operator-initiated delete via API"
+
+    def test_returns_none_when_no_tombstone(self):
+        age_client = _make_age_client(tombstone_row=None)
+        assert _ontology_tombstone(age_client, "any-name") is None
+
+    def test_returns_none_on_db_error(self):
+        age_client = _make_age_client(raise_on_tombstone_read=True)
+        assert _ontology_tombstone(age_client, "any-name") is None

--- a/tests/unit/workers/test_proposal_execution_worker.py
+++ b/tests/unit/workers/test_proposal_execution_worker.py
@@ -1,0 +1,116 @@
+"""Unit tests for proposal_execution_worker (#402 PR-404 review, finding #2).
+
+The retry_later path is the operational counterpart to the executor's
+queue-veto re-check: when execute_demotion returns
+{success=False, retry_later=True}, the worker must revert the claim to
+'approved' status so the proposal stays alive for the next cycle. Without
+this, an approved proposal that hits a transient queue race is
+permanently failed — the queue veto becomes a footgun.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from api.app.workers.proposal_execution_worker import (
+    run_proposal_execution_worker,
+)
+
+
+def _make_job_queue():
+    queue = MagicMock()
+    queue.is_job_cancelled.return_value = False
+    queue.update_job = MagicMock()
+    return queue
+
+
+@pytest.mark.unit
+class TestRetryLaterPath:
+    """retry_later=True must revert proposal status, not mark it failed."""
+
+    def test_vetoed_demotion_reverts_to_approved(self):
+        """When execute_demotion returns retry_later=True, the worker must
+        call _update_proposal_status with 'approved' (not 'failed')."""
+        with patch(
+            "api.app.workers.proposal_execution_worker.AGEClient"
+        ) as MockClient, patch(
+            "api.app.workers.proposal_execution_worker._load_proposal",
+            return_value={
+                "id": 42,
+                "proposal_type": "demotion",
+                "ontology_name": "weak-onto",
+                "status": "approved",
+            },
+        ), patch(
+            "api.app.workers.proposal_execution_worker._claim_proposal",
+            return_value=True,
+        ), patch(
+            "api.app.workers.proposal_execution_worker._update_proposal_status"
+        ) as mock_update, patch(
+            "api.app.workers.proposal_execution_worker.ProposalExecutor"
+        ) as MockExecutor:
+            MockClient.return_value = MagicMock()
+            MockExecutor.return_value.execute_demotion.return_value = {
+                "success": False,
+                "retry_later": True,
+                "error": "Demotion of 'weak-onto' vetoed at execute time: 1 in-flight ingestion job(s) (job_xyz)",
+                "vetoed_for_inflight_ingestion": ["job_xyz"],
+            }
+
+            result = run_proposal_execution_worker(
+                job_data={"proposal_id": 42, "triggered_by": "test"},
+                job_id="job_worker_1",
+                job_queue=_make_job_queue(),
+            )
+
+        # The proposal must be reverted to 'approved' — NOT 'failed'.
+        update_calls = mock_update.call_args_list
+        assert len(update_calls) == 1, (
+            f"expected exactly one status update, got {len(update_calls)}"
+        )
+        # _update_proposal_status(age_client, proposal_id, status, ...)
+        args, kwargs = update_calls[0]
+        called_status = args[2] if len(args) >= 3 else kwargs.get("status")
+        assert called_status == "approved", (
+            f"retry_later must revert to 'approved', got '{called_status}'"
+        )
+
+        assert result["status"] == "deferred"
+        assert result["retry_later"] is True
+
+    def test_genuine_failure_still_marked_failed(self):
+        """retry_later branch must not swallow real failures — a non-veto
+        failure (e.g. anchor concept gone) is still marked 'failed'."""
+        with patch(
+            "api.app.workers.proposal_execution_worker.AGEClient"
+        ) as MockClient, patch(
+            "api.app.workers.proposal_execution_worker._load_proposal",
+            return_value={
+                "id": 43,
+                "proposal_type": "demotion",
+                "ontology_name": "weak-onto",
+                "status": "approved",
+            },
+        ), patch(
+            "api.app.workers.proposal_execution_worker._claim_proposal",
+            return_value=True,
+        ), patch(
+            "api.app.workers.proposal_execution_worker._update_proposal_status"
+        ) as mock_update, patch(
+            "api.app.workers.proposal_execution_worker.ProposalExecutor"
+        ) as MockExecutor:
+            MockClient.return_value = MagicMock()
+            MockExecutor.return_value.execute_demotion.return_value = {
+                "success": False,
+                "error": "Ontology 'weak-onto' is frozen — cannot demote",
+            }
+
+            result = run_proposal_execution_worker(
+                job_data={"proposal_id": 43, "triggered_by": "test"},
+                job_id="job_worker_2",
+                job_queue=_make_job_queue(),
+            )
+
+        args, kwargs = mock_update.call_args_list[0]
+        called_status = args[2] if len(args) >= 3 else kwargs.get("status")
+        assert called_status == "failed"
+        assert result["status"] == "failed"


### PR DESCRIPTION
Closes #402.

The annealing manager and ingestion queue did not coordinate. When annealing dissolved an ontology that still had ingest jobs queued against it, the worker dequeued with a missing target and silently recreated the ontology under a fresh id — operator saw "submitted," content never landed where they asked.

Four atomic commits, one per defect in #402, layered prevent → shrink → recover; then three follow-up commits responding to the review on this PR.

## Summary

| Layer | Commit | Defect |
|---|---|---|
| Prevent | `4282768f` | **A** — Annealing vetoes demotion candidates with in-flight ingestion. Queue-aware: queries `kg_api.jobs` for non-terminal ingestion jobs against each demotion candidate; vetoes structurally, logs the count + job_ids, counts vetoes in the cycle result. Promotions are not vetoed (they don't modify the source ontology). |
| Shrink window | `99cadd46` | **C** — Per-ontology cadence floors. Migration 065 adds `min_ontology_age_epochs=3` and `min_ontology_concept_count=5`. Both demotion and promotion candidate selection consult them. Migration uses `INSERT … ON CONFLICT DO NOTHING` so operator-tuned rows stay put; existing keys are deliberately not changed. |
| Recover (loud) | `f73737e5` | **B1** — Worker fails loudly on missing target. Both ingest routes stamp `ontology_existed_at_submit` on the job; a new `_validate_target_ontology` helper raises with a structured, distinct error string when the operator's intent has been invalidated. Job-queue exception handler maps to `status='failed'` with the message on the `error` column; the job-list API already surfaces it. |
| Recover (intent) | `7fbe2498` | **B2** — Tombstone-aware idempotent recreate. Migration 066 adds `kg_api.ontology_tombstones`. Operator-delete writes a tombstone; annealing dissolve does not. Worker consults it: missing + tombstoned → fail; missing + no tombstone → recreate with audit log (operator intent overrides background reorganization). |

## Review response (PR-404, 5 findings)

Code review surfaced 5 findings; advisor reconciliation found that finding #4 as written would have introduced a worse bug (orphan content into a graph being deleted) unless paired with a worker-side change, and that finding #2 had a secondary footgun (vetoed-at-execute proposals permanently failed instead of soft-skipped). Three follow-up commits address all 5 plus both advisor flags.

| Commit | Findings addressed |
|---|---|
| `8f6f0586` (worker) | **#3** restore VANISHED raise; **#4** worker checks tombstone *unconditionally* (the precondition for safely reordering tombstone writes upstream); **#5** tombstone-read fallback reassessed — `existed_at_submit=True` + read-failure now falls through to VANISHED, no longer silently recreates |
| `c0cc5f2b` (routes) | **#1** dissolve writes tombstone (same data-loss class as delete); **#4** tombstone is the *first* graph-mutating step of delete; **#6** advisor-flagged — `POST /ontology/` clears any prior tombstone so operator-recreate doesn't leave a "create succeeds, ingest fails forever" trap |
| `2a99e555` (executor) | **#2** `execute_demotion` re-checks the queue veto before calling `dissolve_ontology` (closes the cycle-to-execute gap that's wide in human-approval mode); advisor-flagged footgun — vetoed proposals return `retry_later=True` and the worker reverts status to `'approved'` (soft skip) instead of marking `'failed'` (permanent dead-end) |

A residual TOCTOU exists between the executor's veto SELECT and the dissolve commit — closing it fully needs an advisory lock on the ontology name in both job-enqueue and dissolve. Documented inline; the worker's `existed_at_submit=True` + missing → VANISHED raise is the downstream backstop for that residual window.

## Definition of done

> An operator running a batch ingest concurrent with annealing observes either successful ingestion or a clearly-failed job — never a silent drop.

- A + executor re-check block the common race upstream at two points (proposal creation and proposal execution).
- C shrinks the residual window for ontologies still settling.
- B1 + B2 + worker-unconditional-tombstone turn the surviving cases into observable, structurally distinct failures (vanished / tombstoned / frozen) or honored recreations.
- Dissolve route + create-clear-tombstone close the operator-initiated paths that B2 left exposed.

## Test plan

- [x] `pytest tests/unit/` + `tests/api/test_ingest.py` + `tests/api/test_ontology_routes.py` — 568 pass (full suite passes after review-response commits; new tests cover one observable per finding)
- [x] Migration 065 applied successfully on dev
- [x] Migration 066 applied successfully on dev
- [ ] Manual smoke: queue an ingest job, force an annealing cycle, observe veto log + no proposal for that ontology
- [ ] Manual smoke: delete an ontology via API, attempt re-ingest, observe `status=failed` with tombstone error
- [ ] Manual smoke: approve a demotion proposal, enqueue an ingest for the same ontology, run the execution worker; verify the proposal status reverts to `'approved'` (not `'failed'`) and dissolve did not run

## Files

- `api/app/services/annealing_manager.py` — veto logic + cadence floors
- `api/app/services/proposal_executor.py` — execute-time veto re-check + `retry_later`
- `api/app/launchers/annealing.py`, `api/app/workers/annealing_worker.py` — option plumbing
- `api/app/workers/ingestion_worker.py` — `_validate_target_ontology` (unconditional tombstone check, VANISHED restored) + `_ontology_tombstone`
- `api/app/workers/proposal_execution_worker.py` — retry_later soft-skip
- `api/app/routes/ingest.py` — stamp `ontology_existed_at_submit`
- `api/app/routes/ontology.py` — tombstone helpers (`_record_ontology_tombstone`, `_clear_ontology_tombstone`); delete/dissolve write tombstone before mutation; create clears tombstone
- `schema/migrations/065_annealing_cadence_floors.sql`
- `schema/migrations/066_ontology_tombstones.sql`
- `tests/unit/services/test_annealing_manager.py`, `tests/unit/services/test_proposal_executor.py`, `tests/unit/workers/test_ingestion_worker.py`, `tests/unit/workers/test_proposal_execution_worker.py`, `tests/api/test_ontology_routes.py`
