### PR TITLE
fix(api): cost estimate uses active extraction config (closes #406)

### DIFF
--- a/api/app/services/job_analysis.py
+++ b/api/app/services/job_analysis.py
@@ -340,8 +340,19 @@ class JobAnalyzer:
         min_words = job_data.get("min_words", 800)
         max_words = job_data.get("max_words", 1500)
 
-        # Get models from job_data or environment
-        extraction_model = job_data.get("extraction_model") or os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-4o")
+        # Get models: prefer per-job override, then the DB-backed active
+        # extraction config (same source the actual extraction code path
+        # uses), then env-var, then a hard-coded last-resort default.
+        # Without the active-config lookup, the cost-estimate label would
+        # show 'gpt-4o' even when extraction is actually running against
+        # a different configured provider (closes #406).
+        from api.app.lib.ai_extraction_config import load_active_extraction_config
+        active_extraction = load_active_extraction_config() or {}
+        extraction_model = (
+            job_data.get("extraction_model")
+            or active_extraction.get("model_name")
+            or os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-4o")
+        )
         embedding_model = job_data.get("embedding_model") or os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
 
         # Analyze file


### PR DESCRIPTION
Closes #406.

## Summary

`api/app/services/job_analysis.py` hardcoded `"gpt-4o"` as the final fallback for the cost-estimate model label. When neither `job_data.extraction_model` nor the `OPENAI_EXTRACTION_MODEL` env var was set, the estimate panel rendered "Extraction (gpt-4o)" regardless of the actually configured provider — even though the same panel's Total row used the configured provider's pricing (Anthropic Sonnet etc.). Misleading side-by-side discrepancy.

Fix: consult `load_active_extraction_config()` (the same DB-backed helper the real extraction code path uses) as the middle layer of the fallback chain. Env-var and hard-coded defaults remain as last-resort fallbacks.

## Test plan

- [x] Live verification: submitted an ingest with `--no-approve` against a fresh dev env configured for Claude Sonnet. Cost estimate now shows `Extraction (claude-sonnet-4-6)` (was `Extraction (gpt-4o)` before the fix).
- [x] `pytest tests/unit/` — 469 pass

## Files

- `api/app/services/job_analysis.py` — fallback chain now consults `load_active_extraction_config()`