### PR TITLE
fix(query-facade): promote execute_raw patterns to typed methods (#355)

### DIFF
--- a/api/app/launchers/vocab_consolidation.py
+++ b/api/app/launchers/vocab_consolidation.py
@@ -51,26 +51,14 @@ class VocabConsolidationLauncher(JobLauncher):
         try:
             client = AGEClient()
 
-            # Query vocabulary statistics using facade
-            # Complex aggregation requires execute_raw() but with namespace safety (ADR-048)
-            query = """
-                MATCH (v:VocabType)
-                RETURN
-                    COUNT(v) AS total_types,
-                    SUM(CASE WHEN v.is_active = true THEN 1 ELSE 0 END) AS active_types,
-                    SUM(CASE WHEN v.is_active = false THEN 1 ELSE 0 END) AS inactive_types
-            """
+            stats = client.facade.get_vocab_type_stats()
+            total_types = stats["total_types"]
+            active_types = stats["active_types"]
+            inactive_types = stats["inactive_types"]
 
-            results = client.facade.execute_raw(query, namespace="vocabulary")
-
-            if not results:
+            if total_types == 0:
                 logger.warning("VocabConsolidationLauncher: No vocabulary stats found")
                 return False
-
-            row = results[0]
-            total_types = int(row.get('total_types', 0))
-            active_types = int(row.get('active_types', 0))
-            inactive_types = int(row.get('inactive_types', 0))
 
             logger.debug(
                 f"VocabConsolidationLauncher stats: "

--- a/api/app/lib/polarity_axis.py
+++ b/api/app/lib/polarity_axis.py
@@ -216,13 +216,18 @@ def discover_candidate_concepts(
     validate_concept_id(positive_pole_id)
     validate_concept_id(negative_pole_id)
 
-    # Find concepts connected to either pole within max_hops
-    # Filter for concepts with embeddings (required for projection)
-    # Using facade.execute_raw for variable-length path (ADR-048 namespace safety)
-    # Format pole IDs as Cypher list manually (json.dumps uses double quotes which Cypher rejects)
-    # Note: IDs are validated above, safe to use in f-string
-    # Performance optimization: Limit per-pole results to avoid expensive DISTINCT on large sets
-    # Safety: 10 second timeout to prevent database spiral on highly connected graphs
+    # Find concepts connected to either pole within max_hops, filtered for
+    # concepts with embeddings (required for projection).
+    #
+    # This stays on facade.execute_raw rather than a typed match_concepts call
+    # because Cypher's variable-length pattern `[*1..N]` does not accept a bound
+    # parameter for N — the hop count must be inlined into the query text. A
+    # typed method that took `max_hops` would still have to string-substitute
+    # it, defeating the safety promise. The pole IDs are inlined the same way
+    # (validate_concept_id above is the safety boundary). The audit log still
+    # records the namespace, so the escape hatch shows up in QueryAuditLog.
+    # Safety: 10s statement timeout below prevents database spiral on highly
+    # connected graphs.
     pole_ids_cypher = "[" + ", ".join(f"'{pid}'" for pid in [positive_pole_id, negative_pole_id]) + "]"
 
     # Set query timeout to prevent runaway queries (PostgreSQL SQL, not Cypher)

--- a/api/app/lib/query_facade.py
+++ b/api/app/lib/query_facade.py
@@ -107,26 +107,21 @@ class GraphQueryFacade:
         where: Optional[str] = None,
         params: Optional[Dict] = None,
         limit: Optional[int] = None,
-        return_clause: str = "c"
+        return_clause: str = "c",
+        order_by: Optional[str] = None
     ) -> List[Dict]:
         """
         Match concept nodes with explicit :Concept label.
 
         Args:
-            where: Optional WHERE clause (without WHERE keyword)
+            where: Optional WHERE clause (without the WHERE keyword)
             params: Query parameters
             limit: Optional result limit
-            return_clause: What to return (default: "c")
+            return_clause: What to return (default: "c" — full node)
+            order_by: Optional ORDER BY clause (without the ORDER BY keyword)
 
         Returns:
-            List of result dictionaries
-
-        Example:
-            # Find concepts by label pattern
-            concepts = facade.match_concepts(
-                where="c.label =~ '(?i).*recursive.*'",
-                limit=10
-            )
+            List of result dictionaries (keyed by RETURN-clause column names)
         """
         query = "MATCH (c:Concept)"
 
@@ -134,6 +129,9 @@ class GraphQueryFacade:
             query += f" WHERE {where}"
 
         query += f" RETURN {return_clause}"
+
+        if order_by:
+            query += f" ORDER BY {order_by}"
 
         if limit:
             query += f" LIMIT {limit}"
@@ -250,14 +248,11 @@ class GraphQueryFacade:
         Count concept nodes (namespace-safe).
 
         Args:
-            where: Optional WHERE clause
+            where: Optional WHERE clause (without the WHERE keyword)
             params: Query parameters
 
         Returns:
             Count of matching concepts
-
-        Example:
-            total_concepts = facade.count_concepts()
         """
         query = "MATCH (c:Concept)"
 
@@ -279,31 +274,32 @@ class GraphQueryFacade:
         self,
         where: Optional[str] = None,
         params: Optional[Dict] = None,
-        limit: Optional[int] = None
+        limit: Optional[int] = None,
+        return_clause: str = "v",
+        order_by: Optional[str] = None
     ) -> List[Dict]:
         """
         Match vocabulary type nodes with explicit :VocabType label.
 
         Args:
-            where: Optional WHERE clause
+            where: Optional WHERE clause (without the WHERE keyword)
             params: Query parameters
             limit: Optional result limit
+            return_clause: What to return (default: "v" — full node)
+            order_by: Optional ORDER BY clause (without the ORDER BY keyword)
 
         Returns:
-            List of vocabulary type dictionaries
-
-        Example:
-            # Find active vocabulary types in causation category
-            types = facade.match_vocab_types(
-                where="v.is_active = true AND v.category = 'causation'"
-            )
+            List of vocabulary type dictionaries (keyed by RETURN-clause column names)
         """
         query = "MATCH (v:VocabType)"
 
         if where:
             query += f" WHERE {where}"
 
-        query += " RETURN v"
+        query += f" RETURN {return_clause}"
+
+        if order_by:
+            query += f" ORDER BY {order_by}"
 
         if limit:
             query += f" LIMIT {limit}"
@@ -314,27 +310,36 @@ class GraphQueryFacade:
     def match_vocab_categories(
         self,
         where: Optional[str] = None,
-        params: Optional[Dict] = None
+        params: Optional[Dict] = None,
+        limit: Optional[int] = None,
+        return_clause: str = "c",
+        order_by: Optional[str] = None
     ) -> List[Dict]:
         """
-        Match vocabulary category nodes.
+        Match vocabulary category nodes with explicit :VocabCategory label.
 
         Args:
-            where: Optional WHERE clause
+            where: Optional WHERE clause (without the WHERE keyword)
             params: Query parameters
+            limit: Optional result limit
+            return_clause: What to return (default: "c" — full node)
+            order_by: Optional ORDER BY clause (without the ORDER BY keyword)
 
         Returns:
-            List of category dictionaries
-
-        Example:
-            categories = facade.match_vocab_categories()
+            List of category dictionaries (keyed by RETURN-clause column names)
         """
         query = "MATCH (c:VocabCategory)"
 
         if where:
             query += f" WHERE {where}"
 
-        query += " RETURN c"
+        query += f" RETURN {return_clause}"
+
+        if order_by:
+            query += f" ORDER BY {order_by}"
+
+        if limit:
+            query += f" LIMIT {limit}"
 
         self.audit.log_query(query, namespace="vocabulary", params=params)
         return self.db._execute_cypher(query, params)
@@ -388,16 +393,11 @@ class GraphQueryFacade:
         Count vocabulary type nodes (namespace-safe).
 
         Args:
-            where: Optional WHERE clause
+            where: Optional WHERE clause (without the WHERE keyword)
             params: Query parameters
 
         Returns:
-            Count of vocabulary types
-
-        Example:
-            active_types = facade.count_vocab_types(
-                where="v.is_active = true"
-            )
+            Count of matching vocabulary types
         """
         query = "MATCH (v:VocabType)"
 
@@ -411,6 +411,34 @@ class GraphQueryFacade:
 
         return result.get("node_count", 0) if result else 0
 
+    def get_vocab_type_stats(self) -> Dict[str, int]:
+        """
+        Aggregate vocabulary-type counts in a single namespace-safe query.
+
+        Returns:
+            Dict with keys ``total_types``, ``active_types``, ``inactive_types``.
+            Missing values default to 0.
+        """
+        query = """
+            MATCH (v:VocabType)
+            RETURN
+                count(v) as total_types,
+                sum(CASE WHEN v.is_active = true THEN 1 ELSE 0 END) as active_types,
+                sum(CASE WHEN v.is_active = false THEN 1 ELSE 0 END) as inactive_types
+        """
+
+        self.audit.log_query(query, namespace="vocabulary", params=None)
+        result = self.db._execute_cypher(query, None, fetch_one=True)
+
+        if not result:
+            return {"total_types": 0, "active_types": 0, "inactive_types": 0}
+
+        return {
+            "total_types": int(result.get("total_types") or 0),
+            "active_types": int(result.get("active_types") or 0),
+            "inactive_types": int(result.get("inactive_types") or 0),
+        }
+
     # -------------------------------------------------------------------------
     # SOURCE & INSTANCE NAMESPACE
     # -------------------------------------------------------------------------
@@ -419,25 +447,32 @@ class GraphQueryFacade:
         self,
         where: Optional[str] = None,
         params: Optional[Dict] = None,
-        limit: Optional[int] = None
+        limit: Optional[int] = None,
+        return_clause: str = "s",
+        order_by: Optional[str] = None
     ) -> List[Dict]:
         """
         Match source nodes with explicit :Source label.
 
         Args:
-            where: Optional WHERE clause
+            where: Optional WHERE clause (without the WHERE keyword)
             params: Query parameters
             limit: Optional result limit
+            return_clause: What to return (default: "s" — full node)
+            order_by: Optional ORDER BY clause (without the ORDER BY keyword)
 
         Returns:
-            List of source dictionaries
+            List of source dictionaries (keyed by RETURN-clause column names)
         """
         query = "MATCH (s:Source)"
 
         if where:
             query += f" WHERE {where}"
 
-        query += " RETURN s"
+        query += f" RETURN {return_clause}"
+
+        if order_by:
+            query += f" ORDER BY {order_by}"
 
         if limit:
             query += f" LIMIT {limit}"
@@ -445,29 +480,96 @@ class GraphQueryFacade:
         self.audit.log_query(query, namespace="concept", params=params)
         return self.db._execute_cypher(query, params)
 
+    def count_sources(
+        self,
+        where: Optional[str] = None,
+        params: Optional[Dict] = None
+    ) -> int:
+        """
+        Count source nodes (namespace-safe).
+
+        Args:
+            where: Optional WHERE clause (without the WHERE keyword)
+            params: Query parameters
+
+        Returns:
+            Count of matching sources
+        """
+        query = "MATCH (s:Source)"
+
+        if where:
+            query += f" WHERE {where}"
+
+        query += " RETURN count(s) as node_count"
+
+        self.audit.log_query(query, namespace="concept", params=params)
+        result = self.db._execute_cypher(query, params, fetch_one=True)
+
+        return result.get("node_count", 0) if result else 0
+
+    def update_source_properties(
+        self,
+        source_id: str,
+        properties: Dict[str, Any]
+    ) -> Optional[str]:
+        """
+        Set properties on a Source node, returning its source_id on success.
+
+        Args:
+            source_id: Source ID to update
+            properties: Mapping of property name → value to SET on the node
+
+        Returns:
+            source_id if the node existed and was updated; None if no match
+        """
+        if not properties:
+            return source_id
+
+        set_clauses = ", ".join(f"s.{key} = ${key}" for key in properties.keys())
+        query = (
+            "MATCH (s:Source {source_id: $source_id}) "
+            f"SET {set_clauses} "
+            "RETURN s.source_id as source_id"
+        )
+
+        merged_params: Dict[str, Any] = {"source_id": source_id}
+        merged_params.update(properties)
+
+        self.audit.log_query(query, namespace="concept", params=merged_params)
+        result = self.db._execute_cypher(query, merged_params, fetch_one=True)
+
+        return result.get("source_id") if result else None
+
     def match_instances(
         self,
         where: Optional[str] = None,
         params: Optional[Dict] = None,
-        limit: Optional[int] = None
+        limit: Optional[int] = None,
+        return_clause: str = "i",
+        order_by: Optional[str] = None
     ) -> List[Dict]:
         """
         Match instance nodes with explicit :Instance label.
 
         Args:
-            where: Optional WHERE clause
+            where: Optional WHERE clause (without the WHERE keyword)
             params: Query parameters
             limit: Optional result limit
+            return_clause: What to return (default: "i" — full node)
+            order_by: Optional ORDER BY clause (without the ORDER BY keyword)
 
         Returns:
-            List of instance dictionaries
+            List of instance dictionaries (keyed by RETURN-clause column names)
         """
         query = "MATCH (i:Instance)"
 
         if where:
             query += f" WHERE {where}"
 
-        query += " RETURN i"
+        query += f" RETURN {return_clause}"
+
+        if order_by:
+            query += f" ORDER BY {order_by}"
 
         if limit:
             query += f" LIMIT {limit}"

--- a/api/app/workers/source_embedding_worker.py
+++ b/api/app/workers/source_embedding_worker.py
@@ -27,6 +27,13 @@ from api.app.lib.age_client import AGEClient
 
 logger = logging.getLogger(__name__)
 
+# Source columns selected by the regeneration paths. Aliased so the facade
+# return-clause keys match the dict access in `_collect_target_sources`.
+_REGEN_SOURCE_RETURN_CLAUSE = (
+    "s.source_id as source_id, s.full_text as full_text, "
+    "s.document as document, s.paragraph as paragraph"
+)
+
 
 def run_source_embedding_worker(
     job_data: Dict[str, Any],
@@ -152,17 +159,20 @@ def run_source_embedding_worker(
 
         # Fetch Source node from AGE to get full_text
         with AGEClient() as age_client:
-            # Use facade for namespace-safe query (ADR-048)
-            result_set = age_client.facade.execute_raw("""
-                MATCH (s:Source {source_id: $source_id})
-                RETURN s.source_id, s.full_text, s.document, s.paragraph
-            """, params={"source_id": source_id}, namespace="source_embedding")
+            result_set = age_client.facade.match_sources(
+                where="s.source_id = $source_id",
+                params={"source_id": source_id},
+                return_clause=(
+                    "s.source_id as source_id, s.full_text as full_text, "
+                    "s.document as document, s.paragraph as paragraph"
+                ),
+            )
 
             if not result_set:
                 raise ValueError(f"Source not found: {source_id}")
 
             source_data = result_set[0]
-            source_text = source_data[1]  # full_text
+            source_text = source_data["full_text"]
 
             if not source_text:
                 raise ValueError(f"Source {source_id} has no full_text")
@@ -380,15 +390,10 @@ def generate_source_embeddings(
 
         # Step 6: Update Source.content_hash in AGE graph
         with AGEClient() as age_client:
-            # Use facade for namespace-safe query (ADR-048)
-            age_client.facade.execute_raw("""
-                MATCH (s:Source {source_id: $source_id})
-                SET s.content_hash = $content_hash
-                RETURN s.source_id
-            """, params={
-                "source_id": source_id,
-                "content_hash": source_hash
-            }, namespace="source_embedding")
+            age_client.facade.update_source_properties(
+                source_id,
+                {"content_hash": source_hash},
+            )
             logger.debug(f"Updated Source.content_hash in AGE: {source_hash[:16]}...")
 
         # Return success result
@@ -478,47 +483,34 @@ async def get_embedding_status(ontology: Optional[str] = None) -> Dict[str, Any]
     # 1. Concept Embeddings
     # ====================================================================
     with AGEClient() as age_client:
-        # Count total concepts
-        cypher = "MATCH (c:Concept)"
-        params = {}
+        ontology_params = {"ontology": ontology} if ontology else None
 
+        total_concepts = age_client.facade.count_concepts(
+            where="c.ontology = $ontology" if ontology else None,
+            params=ontology_params,
+        )
+
+        embedded_where = "c.embedding IS NOT NULL"
         if ontology:
-            cypher += " WHERE c.ontology = $ontology"
-            params["ontology"] = ontology
+            embedded_where += " AND c.ontology = $ontology"
 
-        cypher += " RETURN count(c) as total"
+        concepts_with_embeddings = age_client.facade.count_concepts(
+            where=embedded_where,
+            params=ontology_params,
+        )
 
-        result = age_client.facade.execute_raw(cypher, params=params if params else None, namespace="embedding_status")
-        total_concepts = result[0]["total"] if result else 0
-
-        # Count concepts WITH embeddings
-        cypher = "MATCH (c:Concept) WHERE c.embedding IS NOT NULL"
-
-        if ontology:
-            cypher += " AND c.ontology = $ontology"
-
-        cypher += " RETURN count(c) as with_embeddings"
-
-        result = age_client.facade.execute_raw(cypher, params=params if params else None, namespace="embedding_status")
-        concepts_with_embeddings = result[0]["with_embeddings"] if result else 0
-
-        # Check for incompatible embeddings (dimension mismatch)
-        # Note: AGE stores embeddings as arrays without metadata, so we check dimension by size
+        # Check for incompatible embeddings (dimension mismatch).
+        # AGE stores embeddings as arrays without metadata, so dimension is checked by size.
         incompatible_concepts = 0
         if active_dims and concepts_with_embeddings > 0:
-            # Fetch all concepts with embeddings and check their dimensions
-            cypher = "MATCH (c:Concept) WHERE c.embedding IS NOT NULL"
+            embedding_rows = age_client.facade.match_concepts(
+                where=embedded_where,
+                params=ontology_params,
+                return_clause="c.concept_id as concept_id, size(c.embedding) as dim",
+            )
 
-            if ontology:
-                cypher += " AND c.ontology = $ontology"
-
-            cypher += " RETURN c.concept_id, size(c.embedding) as dim"
-
-            result = age_client.facade.execute_raw(cypher, params=params if params else None, namespace="embedding_status")
-
-            for row in result:
-                embedding_dim = row["dim"]
-                if embedding_dim != active_dims:
+            for row in embedding_rows:
+                if row["dim"] != active_dims:
                     incompatible_concepts += 1
 
             logger.debug(
@@ -538,29 +530,20 @@ async def get_embedding_status(ontology: Optional[str] = None) -> Dict[str, Any]
     # 2. Source Embeddings (with hash verification)
     # ====================================================================
     with AGEClient() as age_client:
-        # Count total sources
-        cypher = "MATCH (s:Source)"
-        params = {}
+        ontology_where = "s.document = $ontology" if ontology else None
+        ontology_params = {"ontology": ontology} if ontology else None
 
-        if ontology:
-            cypher += " WHERE s.document = $ontology"
-            params["ontology"] = ontology
+        total_sources = age_client.facade.count_sources(
+            where=ontology_where,
+            params=ontology_params,
+        )
 
-        cypher += " RETURN count(s) as total"
-
-        result = age_client.facade.execute_raw(cypher, params=params if params else None, namespace="embedding_status")
-        total_sources = result[0]["total"] if result else 0
-
-        # Get all sources with their content_hash
-        cypher = "MATCH (s:Source)"
-
-        if ontology:
-            cypher += " WHERE s.document = $ontology"
-
-        cypher += " RETURN s.source_id as source_id, s.content_hash as content_hash"
-
-        result = age_client.facade.execute_raw(cypher, params=params if params else None, namespace="embedding_status")
-        sources_map = {row["source_id"]: row["content_hash"] for row in result}  # {source_id: content_hash}
+        source_rows = age_client.facade.match_sources(
+            where=ontology_where,
+            params=ontology_params,
+            return_clause="s.source_id as source_id, s.content_hash as content_hash",
+        )
+        sources_map = {row["source_id"]: row["content_hash"] for row in source_rows}
 
     # Check which sources have embeddings in PostgreSQL
     conn = psycopg2.connect(
@@ -862,33 +845,24 @@ async def regenerate_source_embeddings(
                     "errors": []
                 }
 
-            # Build Cypher query for sources WITH incompatible embeddings
-            cypher_where = "WHERE s.source_id IN $incompatible_ids"
+            where_clause = "s.source_id IN $incompatible_ids"
             params = {"incompatible_ids": list(incompatible_source_ids)}
 
             if ontology:
-                cypher_where += " AND s.document = $ontology"
+                where_clause += " AND s.document = $ontology"
                 params["ontology"] = ontology
 
-            cypher = f"""
-                MATCH (s:Source)
-                {cypher_where}
-                RETURN s.source_id, s.full_text, s.document, s.paragraph
-                ORDER BY s.document, s.paragraph
-            """
-
-            if limit:
-                cypher += f" LIMIT {limit}"
-
-            results = age_client.facade.execute_raw(
-                cypher,
+            results = age_client.facade.match_sources(
+                where=where_clause,
                 params=params,
-                namespace="source_embedding_regeneration"
+                return_clause=_REGEN_SOURCE_RETURN_CLAUSE,
+                order_by="s.document, s.paragraph",
+                limit=limit,
             )
 
         elif only_missing:
-            # Find sources WITHOUT any source_embeddings entries
-            # Use PostgreSQL to check which source_ids are missing from source_embeddings
+            # Find sources WITHOUT any source_embeddings entries.
+            # Use PostgreSQL to check which source_ids are missing from source_embeddings.
             conn = psycopg2.connect(
                 host=os.getenv("POSTGRES_HOST", "localhost"),
                 port=int(os.getenv("POSTGRES_PORT", 5432)),
@@ -899,7 +873,6 @@ async def regenerate_source_embeddings(
 
             try:
                 with conn.cursor() as cursor:
-                    # Get all source_ids that have embeddings
                     cursor.execute("""
                         SELECT DISTINCT source_id
                         FROM kg_api.source_embeddings
@@ -908,51 +881,28 @@ async def regenerate_source_embeddings(
             finally:
                 conn.close()
 
-            # Build Cypher query for sources WITHOUT embeddings
-            cypher_where = "WHERE NOT s.source_id IN $embedded_ids"
+            where_clause = "NOT s.source_id IN $embedded_ids"
             params = {"embedded_ids": list(embedded_source_ids)}
 
             if ontology:
-                cypher_where += " AND s.document = $ontology"
+                where_clause += " AND s.document = $ontology"
                 params["ontology"] = ontology
 
-            cypher = f"""
-                MATCH (s:Source)
-                {cypher_where}
-                RETURN s.source_id, s.full_text, s.document, s.paragraph
-                ORDER BY s.document, s.paragraph
-            """
-
-            if limit:
-                cypher += f" LIMIT {limit}"
-
-            results = age_client.facade.execute_raw(
-                cypher,
+            results = age_client.facade.match_sources(
+                where=where_clause,
                 params=params,
-                namespace="source_embedding_regeneration"
+                return_clause=_REGEN_SOURCE_RETURN_CLAUSE,
+                order_by="s.document, s.paragraph",
+                limit=limit,
             )
 
         else:
-            # Get ALL sources (or filtered by ontology)
-            cypher = "MATCH (s:Source)"
-            params = {}
-
-            if ontology:
-                cypher += " WHERE s.document = $ontology"
-                params["ontology"] = ontology
-
-            cypher += """
-                RETURN s.source_id, s.full_text, s.document, s.paragraph
-                ORDER BY s.document, s.paragraph
-            """
-
-            if limit:
-                cypher += f" LIMIT {limit}"
-
-            results = age_client.facade.execute_raw(
-                cypher,
-                params=params if params else None,
-                namespace="source_embedding_regeneration"
+            results = age_client.facade.match_sources(
+                where="s.document = $ontology" if ontology else None,
+                params={"ontology": ontology} if ontology else None,
+                return_clause=_REGEN_SOURCE_RETURN_CLAUSE,
+                order_by="s.document, s.paragraph",
+                limit=limit,
             )
 
         # Extract source data

--- a/tests/test_query_facade.py
+++ b/tests/test_query_facade.py
@@ -236,6 +236,79 @@ class TestGraphQueryFacade:
         assert 'MATCH (s:Source)' in query
         assert "WHERE s.document = 'test.md'" in query
 
+    def test_match_sources_with_return_and_order(self, facade, mock_age_client):
+        """match_sources composes return_clause + order_by + limit in correct order."""
+        facade.match_sources(
+            where="s.document = $ontology",
+            params={"ontology": "kg"},
+            return_clause="s.source_id as source_id, s.full_text as full_text",
+            order_by="s.document, s.paragraph",
+            limit=25,
+        )
+
+        query = mock_age_client._execute_cypher.call_args[0][0]
+        assert 'MATCH (s:Source)' in query
+        assert 'WHERE s.document = $ontology' in query
+        assert 'RETURN s.source_id as source_id, s.full_text as full_text' in query
+        assert 'ORDER BY s.document, s.paragraph' in query
+        assert 'LIMIT 25' in query
+        # ORDER BY precedes LIMIT
+        assert query.index('ORDER BY') < query.index('LIMIT')
+
+    def test_count_sources(self, facade, mock_age_client):
+        """count_sources returns scalar node_count."""
+        mock_age_client._execute_cypher.return_value = {'node_count': 712}
+
+        count = facade.count_sources(where="s.document = $ontology",
+                                     params={"ontology": "kg"})
+
+        assert count == 712
+        query = mock_age_client._execute_cypher.call_args[0][0]
+        assert 'MATCH (s:Source)' in query
+        assert 'WHERE s.document = $ontology' in query
+        assert 'count(s) as node_count' in query
+
+    def test_count_sources_empty_result(self, facade, mock_age_client):
+        """count_sources returns 0 when the query yields no row."""
+        mock_age_client._execute_cypher.return_value = None
+        assert facade.count_sources() == 0
+
+    def test_update_source_properties_builds_set_clause(self, facade, mock_age_client):
+        """update_source_properties emits a SET clause with one assignment per property
+        and merges source_id into the parameter map."""
+        mock_age_client._execute_cypher.return_value = {'source_id': 'src_abc'}
+
+        returned = facade.update_source_properties(
+            'src_abc',
+            {"content_hash": "deadbeef", "embedding_model": "nomic"},
+        )
+
+        assert returned == 'src_abc'
+        call_args = mock_age_client._execute_cypher.call_args
+        query = call_args[0][0]
+        merged_params = call_args[0][1]
+
+        assert 'MATCH (s:Source {source_id: $source_id})' in query
+        assert 's.content_hash = $content_hash' in query
+        assert 's.embedding_model = $embedding_model' in query
+        assert merged_params == {
+            "source_id": "src_abc",
+            "content_hash": "deadbeef",
+            "embedding_model": "nomic",
+        }
+        assert call_args[1].get('fetch_one') is True
+
+    def test_update_source_properties_returns_none_when_missing(self, facade, mock_age_client):
+        """When the MATCH returns nothing, update_source_properties returns None."""
+        mock_age_client._execute_cypher.return_value = None
+        assert facade.update_source_properties('missing', {"x": 1}) is None
+
+    def test_update_source_properties_noop_on_empty_props(self, facade, mock_age_client):
+        """An empty properties dict short-circuits without touching the database."""
+        result = facade.update_source_properties('src_abc', {})
+        assert result == 'src_abc'
+        mock_age_client._execute_cypher.assert_not_called()
+
     def test_match_instances(self, facade, mock_age_client):
         """Test matching instance nodes."""
         facade.match_instances(limit=50)
@@ -244,6 +317,63 @@ class TestGraphQueryFacade:
         query = call_args[0][0]
         assert 'MATCH (i:Instance)' in query
         assert 'LIMIT 50' in query
+
+    def test_match_instances_with_return_and_order(self, facade, mock_age_client):
+        """match_instances supports return_clause + order_by for DSL parity."""
+        facade.match_instances(
+            where="i.confidence > 0.5",
+            return_clause="i.instance_id as id, i.confidence as conf",
+            order_by="i.confidence DESC",
+            limit=10,
+        )
+
+        query = mock_age_client._execute_cypher.call_args[0][0]
+        assert 'MATCH (i:Instance)' in query
+        assert 'WHERE i.confidence > 0.5' in query
+        assert 'RETURN i.instance_id as id, i.confidence as conf' in query
+        assert 'ORDER BY i.confidence DESC' in query
+        assert 'LIMIT 10' in query
+
+    def test_match_vocab_types_with_return_and_order(self, facade, mock_age_client):
+        """match_vocab_types supports return_clause + order_by for DSL parity."""
+        facade.match_vocab_types(
+            return_clause="v.name as name, v.usage_count as usage",
+            order_by="v.usage_count DESC",
+            limit=5,
+        )
+
+        query = mock_age_client._execute_cypher.call_args[0][0]
+        assert 'MATCH (v:VocabType)' in query
+        assert 'RETURN v.name as name, v.usage_count as usage' in query
+        assert 'ORDER BY v.usage_count DESC' in query
+        assert 'LIMIT 5' in query
+
+    def test_get_vocab_type_stats_returns_aggregate_dict(self, facade, mock_age_client):
+        """get_vocab_type_stats collapses the active/inactive aggregation into a dict."""
+        mock_age_client._execute_cypher.return_value = {
+            'total_types': 118,
+            'active_types': 95,
+            'inactive_types': 23,
+        }
+
+        stats = facade.get_vocab_type_stats()
+
+        assert stats == {'total_types': 118, 'active_types': 95, 'inactive_types': 23}
+        call_args = mock_age_client._execute_cypher.call_args
+        query = call_args[0][0]
+        assert 'MATCH (v:VocabType)' in query
+        assert 'count(v) as total_types' in query
+        assert 'CASE WHEN v.is_active = true' in query
+        assert call_args[1].get('fetch_one') is True
+
+    def test_get_vocab_type_stats_handles_empty(self, facade, mock_age_client):
+        """get_vocab_type_stats returns zeros when AGE returns no row."""
+        mock_age_client._execute_cypher.return_value = None
+        assert facade.get_vocab_type_stats() == {
+            'total_types': 0,
+            'active_types': 0,
+            'inactive_types': 0,
+        }
 
     # =========================================================================
     # Statistics Methods

--- a/tests/unit/workers/test_worker_query_safety.py
+++ b/tests/unit/workers/test_worker_query_safety.py
@@ -1,0 +1,113 @@
+"""
+Regression guard: workers must not reach past the GraphQueryFacade for graph
+queries.
+
+The GraphQueryFacade (ADR-048) is the namespace-safe entry point for all
+Cypher executed against Apache AGE. Workers that reach for the raw escape
+hatch (`facade.execute_raw(...)`) or bypass the facade entirely
+(`age_client._execute_cypher(...)`) lose audit trail, namespace safety, and
+the typed DSL surface that the facade is meant to enforce. See PR #413
+(closes #355) for the migration that drove this guard.
+
+Scope: only Cypher escape hatches are checked. Raw psycopg2 access to
+``kg_api.*`` relational tables (job queue, proposals, artifact metadata,
+embedding storage) is out of scope — the facade is a *graph* DSL, not an
+ORM, and relational reads/writes against the kg_api schema have no facade
+equivalent.
+
+Allowlist policy: any new entry must come with a documented reason inline,
+and ideally a path back to the facade (or an ADR explaining why it stays
+raw). The bar to add an exception is the same as the bar to introduce a
+new `execute_raw` call — high.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+
+
+WORKERS_DIR = Path(__file__).resolve().parents[3] / "api" / "app" / "workers"
+
+# Files whose direct ``_execute_cypher`` usage is intentional and not
+# migratable. Each entry must explain why.
+EXECUTE_CYPHER_ALLOWLIST: Dict[str, str] = {
+    "restore_worker.py": (
+        "Privileged dataset-authority worker. _clear_database issues "
+        "DETACH DELETE against Concept/Source/Instance labels as part of a "
+        "full-restore teardown. No parameter substitution, no user input — "
+        "a facade method would not add safety, and restore needs full "
+        "authority over the graph."
+    ),
+}
+
+
+def _iter_worker_files() -> List[Path]:
+    """Yield every worker .py file (skipping __init__) in lexical order."""
+    return sorted(
+        p for p in WORKERS_DIR.glob("*.py")
+        if p.name != "__init__.py"
+    )
+
+
+def _find_pattern(path: Path, pattern: str) -> List[Tuple[int, str]]:
+    """Return ``(line_number, line)`` pairs where ``pattern`` appears verbatim."""
+    matches: List[Tuple[int, str]] = []
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        if pattern in line:
+            matches.append((lineno, line.rstrip()))
+    return matches
+
+
+# Build parametrize IDs from the file basename so a failure points at the
+# exact worker.
+_WORKER_PARAMS = [pytest.param(p, id=p.name) for p in _iter_worker_files()]
+
+
+@pytest.mark.parametrize("worker_path", _WORKER_PARAMS)
+def test_worker_does_not_use_facade_execute_raw(worker_path: Path) -> None:
+    """No worker may call ``facade.execute_raw(...)`` — the raw escape hatch
+    logs a WARNING on every invocation and bypasses the typed DSL.
+
+    To extend the facade with a new shape, add a typed method to
+    ``GraphQueryFacade`` and route the worker through it. See PR #413 for
+    examples (``count_sources``, ``update_source_properties``,
+    ``get_vocab_type_stats``).
+    """
+    matches = _find_pattern(worker_path, "facade.execute_raw(")
+    assert not matches, (
+        f"{worker_path.name} contains {len(matches)} facade.execute_raw "
+        f"call(s) — promote to a typed GraphQueryFacade method instead.\n"
+        + "\n".join(f"  L{lineno}: {line}" for lineno, line in matches)
+    )
+
+
+@pytest.mark.parametrize("worker_path", _WORKER_PARAMS)
+def test_worker_does_not_call_execute_cypher_directly(worker_path: Path) -> None:
+    """No worker may call ``age_client._execute_cypher(...)`` — that bypasses
+    the facade audit log and namespace safety entirely.
+
+    The single allowed exception is ``restore_worker.py`` (see
+    ``EXECUTE_CYPHER_ALLOWLIST`` for the rationale). Adding a new exception
+    requires the same care as adding a new ``execute_raw`` call.
+    """
+    matches = _find_pattern(worker_path, "._execute_cypher(")
+
+    if worker_path.name in EXECUTE_CYPHER_ALLOWLIST:
+        # Allowlisted: confirm the file still uses it (otherwise the entry
+        # is stale and should be removed) but don't fail.
+        assert matches, (
+            f"{worker_path.name} is in EXECUTE_CYPHER_ALLOWLIST but no "
+            "_execute_cypher calls remain — remove the allowlist entry."
+        )
+        return
+
+    assert not matches, (
+        f"{worker_path.name} bypasses the facade with {len(matches)} "
+        f"_execute_cypher call(s). Either route through GraphQueryFacade or, "
+        f"if this worker has a defensible reason to bypass it, add an entry "
+        f"to EXECUTE_CYPHER_ALLOWLIST with the rationale.\n"
+        + "\n".join(f"  L{lineno}: {line}" for lineno, line in matches)
+    )


### PR DESCRIPTION
Closes #355.

## Why

`GraphQueryFacade` (ADR-048) exposes a typed `match_* / count_*` DSL, but several hot-path callers reached for the `execute_raw` escape hatch for shapes the DSL didn't yet cover. Every escape-hatch call logs a WARNING — so a standard ingest cycle produced hundreds of false alarms and muddied the signal when something genuinely raw appeared.

## What changed in the facade

DSL widened so the real call sites fit. All `match_*` methods now share the same signature: `(where, params, limit, return_clause, order_by)`. Query construction follows the same order (MATCH → WHERE → RETURN → ORDER BY → LIMIT). Docstrings standardized to describe `where` / `order_by` as \"without the keyword\".

| Method | Change |
|---|---|
| `match_concepts` | `+ order_by` (already had `return_clause`) |
| `match_sources` | `+ return_clause, order_by` |
| `match_vocab_types` | `+ return_clause, order_by` |
| `match_vocab_categories` | `+ limit, return_clause, order_by` |
| `match_instances` | `+ return_clause, order_by` |
| `count_sources` | **new** |
| `update_source_properties(source_id, props)` | **new** — first typed mutation primitive; SET clause derived from the property map |
| `get_vocab_type_stats()` | **new** — collapses the active/inactive aggregation |

`find_vocabulary_synonyms` and `match_concept_relationships` stay as-is — they're DSL *consumers* with task-specific signatures, not primitives.

## Callers migrated

- `workers/source_embedding_worker.py` — all 10 escape-hatch sites moved to typed methods. Also fixes a latent bug where the synchronous fetch path indexed the AGE result positionally (`source_data[1]`) on what was actually a dict from `RealDictCursor`; switched to `source_data[\"full_text\"]`.
- `launchers/vocab_consolidation.py` — uses `get_vocab_type_stats()`.

## Left raw (intentionally)

- `lib/polarity_axis.py:discover_candidate_concepts` — Cypher's variable-length pattern `[*1..N]` does **not** accept a bound parameter for the hop count; any typed wrapper would still have to string-substitute. Comment rewritten to explain why instead of just noting \"namespace safety.\" Pole IDs are validated by `validate_concept_id` above.
- `routes/database.py` admin raw-query endpoint — intentional raw surface per #355.

## Test plan

- [x] 9 new unit tests covering: return-clause + order-by composition for `match_sources` and parity peers; `count_sources` (with and without WHERE, empty-result fallback); `update_source_properties` (SET-clause construction, empty-props short-circuit, missing-match → None); `get_vocab_type_stats` (aggregate dict + empty case).
- [x] `tests/test_query_facade.py` — 46 passed, 1 skipped (integration, needs real DB).
- [x] Full `tests/unit/` — 482 passed in ephemeral kg-api container. One unrelated error (`test_provider_config.py` needs `POSTGRES_PASSWORD` env var, pre-existing).
- [x] Docstring coverage on touched files: `query_facade.py` 22/23 (the missing one is pre-existing `QueryAuditLog.__init__`); the three caller files 4/4 + 10/10 + 4/4.
- [ ] Post-merge: confirm the next ingest cycle no longer prints `[QueryFacade] Using escape hatch ...` warnings.