### PR TITLE
Vocab embedding lifecycle: counter, cold-start, hourly launcher

### DIFF
--- a/api/app/launchers/__init__.py
+++ b/api/app/launchers/__init__.py
@@ -13,6 +13,7 @@ from .base import JobLauncher
 from .category_refresh import CategoryRefreshLauncher
 from .vocab_consolidation import VocabConsolidationLauncher
 from .epistemic_remeasurement import EpistemicRemeasurementLauncher
+from .vocab_embedding import VocabEmbeddingLauncher
 from .projection import ProjectionLauncher
 from .artifact_cleanup import ArtifactCleanupLauncher
 from .annealing import AnnealingLauncher
@@ -22,6 +23,7 @@ __all__ = [
     "CategoryRefreshLauncher",
     "VocabConsolidationLauncher",
     "EpistemicRemeasurementLauncher",
+    "VocabEmbeddingLauncher",
     "ProjectionLauncher",
     "ArtifactCleanupLauncher",
     "AnnealingLauncher",

--- a/api/app/launchers/vocab_embedding.py
+++ b/api/app/launchers/vocab_embedding.py
@@ -80,21 +80,27 @@ class VocabEmbeddingLauncher(JobLauncher):
             conn = client.pool.getconn()
             try:
                 with conn.cursor() as cur:
+                    # Read both counters in one round-trip. Two separate
+                    # SELECTs would be transactionally inconsistent if the
+                    # membership counter advanced between them; the CTE keeps
+                    # the comparison atomic on the read side and saves a
+                    # round-trip on every hourly tick.
                     cur.execute(
-                        "SELECT counter FROM graph_metrics "
-                        "WHERE metric_name = 'vocabulary_change_counter'"
-                    )
-                    row = cur.fetchone()
-                    current_counter = int(row[0]) if row else 0
-
-                    cur.execute(
-                        "SELECT last_processed_vocab_change_counter "
-                        "FROM kg_api.system_initialization_status "
-                        "WHERE component = %s",
+                        """
+                        SELECT
+                            (SELECT counter FROM graph_metrics
+                             WHERE metric_name = 'vocabulary_change_counter')
+                                AS current_counter,
+                            (SELECT last_processed_vocab_change_counter
+                             FROM kg_api.system_initialization_status
+                             WHERE component = %s)
+                                AS last_processed
+                        """,
                         (self.component,)
                     )
                     row = cur.fetchone()
-                    last_processed = int(row[0]) if row else 0
+                    current_counter = int(row[0]) if row and row[0] is not None else 0
+                    last_processed = int(row[1]) if row and row[1] is not None else 0
 
                 if current_counter > last_processed:
                     logger.info(

--- a/api/app/launchers/vocab_embedding.py
+++ b/api/app/launchers/vocab_embedding.py
@@ -1,0 +1,140 @@
+"""
+Vocab Embedding Launcher (migration 069).
+
+Background companion to the cold-start path. Pattern-matches
+EpistemicRemeasurementLauncher: polls hourly, runs when there's vocab
+membership growth that the embedding worker hasn't caught up with yet.
+
+The launcher exists because two earlier paths weren't sufficient on
+their own:
+
+- Cold-start at boot covers the case where the API process restarts
+  after vocab grew. But long-running processes (the common case in
+  production) never re-check.
+
+- The inline `add_edge_type(..., ai_provider=...)` path during LLM
+  extraction covers new types added through ingestion. But it skips on
+  exceptions (silent), and it doesn't cover types added by other paths
+  (migrations, manual SQL).
+
+This launcher is the safety net: if `vocabulary_change_counter` has
+moved past `last_processed_vocab_change_counter` for this component,
+the worker invokes EmbeddingWorker.regenerate_missing_if_vocab_changed
+to fill in any missing embeddings.
+"""
+
+import logging
+from typing import Dict
+
+from .base import JobLauncher
+from api.app.lib.age_client import AGEClient
+
+logger = logging.getLogger(__name__)
+
+
+class VocabEmbeddingLauncher(JobLauncher):
+    """
+    Automatically regenerate missing vocab embeddings when vocabulary
+    membership grows.
+
+    Schedule: Every 1 hour (cron: "0 * * * *")
+    Condition: vocabulary_change_counter > last_processed_vocab_change_counter
+               for the 'builtin_vocabulary_embeddings' component (any delta)
+    Worker: vocab_embedding_worker
+    Pattern: Polling (checks hourly, runs when delta > 0)
+
+    Distinct from EpistemicRemeasurementLauncher: that one also keys on
+    vocabulary_change_counter but reads the *global* delta via
+    mark_measurement_complete / get_counter_delta. We use the
+    *per-component* cursor on system_initialization_status so the two
+    consumers track progress independently and don't reset each other.
+    """
+
+    def __init__(
+        self,
+        job_queue,
+        max_retries: int = 5,
+        component: str = "builtin_vocabulary_embeddings",
+    ):
+        """
+        Args:
+            job_queue: JobQueue instance
+            max_retries: Maximum retry attempts for failed jobs
+            component: which row of system_initialization_status to track
+        """
+        super().__init__(job_queue, max_retries)
+        self.component = component
+
+    def check_conditions(self) -> bool:
+        """
+        Check whether there's vocab membership the embedding worker hasn't
+        caught up with yet.
+
+        Reads the membership counter and the per-component cursor in one
+        round-trip each, computes the delta in Python. Threshold is 1
+        (any new vocab triggers a run) — embedding generation per type
+        is cheap enough that we don't need to batch.
+        """
+        try:
+            client = AGEClient()
+            conn = client.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT counter FROM graph_metrics "
+                        "WHERE metric_name = 'vocabulary_change_counter'"
+                    )
+                    row = cur.fetchone()
+                    current_counter = int(row[0]) if row else 0
+
+                    cur.execute(
+                        "SELECT last_processed_vocab_change_counter "
+                        "FROM kg_api.system_initialization_status "
+                        "WHERE component = %s",
+                        (self.component,)
+                    )
+                    row = cur.fetchone()
+                    last_processed = int(row[0]) if row else 0
+
+                if current_counter > last_processed:
+                    logger.info(
+                        f"✓ VocabEmbeddingLauncher: vocabulary_change_counter "
+                        f"({current_counter}) > last_processed ({last_processed}) "
+                        f"for component={self.component}"
+                    )
+                    return True
+
+                logger.debug(
+                    f"VocabEmbeddingLauncher: counter ({current_counter}) at or "
+                    f"below last_processed ({last_processed}) — no work"
+                )
+                return False
+            finally:
+                client.pool.putconn(conn)
+
+        except Exception as e:
+            # Let exceptions bubble up so the scheduler can retry.
+            logger.error(f"VocabEmbeddingLauncher condition check failed: {e}")
+            raise
+
+    def prepare_job_data(self) -> Dict:
+        """
+        Prepare data for vocab embedding worker.
+
+        The worker reads the membership counter itself (snapshot at start
+        of run) — we don't pass it through job_data because there's a
+        race window between launcher and worker startup, and the worker's
+        snapshot is what gets stored on completion.
+        """
+        return {
+            "operation": "regenerate_missing_vocab_embeddings",
+            "component": self.component,
+            "description": (
+                f"Scheduled vocab embedding regen "
+                f"(component={self.component})"
+            ),
+        }
+
+    def get_job_type(self) -> str:
+        """Return job type for worker registry."""
+        return "vocab_embedding"

--- a/api/app/lib/age_client/grounding.py
+++ b/api/app/lib/age_client/grounding.py
@@ -15,9 +15,11 @@ without touching unrelated query paths.
 ## Two-tier cache (ADR-201 Phase 5f)
 
 Tier 1 — Polarity axis: derived from vocabulary embeddings, shared
-across all concepts. Invalidates when vocabulary_change_counter changes
-(synonym collapse, embedding regeneration). One axis computation
-replaces N identical DB queries.
+across all concepts. Invalidates when
+vocabulary_embedding_generation_counter changes — bumped by any path
+that updates the `embedding` column on relationship_vocabulary rows
+(batch generation, add_edge_type inline path, regen). One axis
+computation replaces N identical DB queries.
 
 Tier 2 — Per-concept grounding: cached against graph generation. Each
 concept's grounding depends only on its own incoming edges (no
@@ -95,12 +97,20 @@ class GroundingMixin:
     - self._execute_cypher (BaseMixin) — Cypher executor
     """
 
-    def _get_vocab_generation(self, cur) -> int:
-        """Read vocabulary_change_counter from graph_metrics (single-row query)."""
+    def _get_vocab_embedding_generation(self, cur) -> int:
+        """Read vocabulary_embedding_generation_counter from graph_metrics.
+
+        Migration 069 introduced this counter as the polarity-axis cache key.
+        Distinct from vocabulary_change_counter: that one tracks row
+        membership (add/remove/categorize), this one tracks embedding
+        contents. The polarity axis is built from embedding vectors, so
+        it's the embedding-generation counter that should drive
+        invalidation — not membership.
+        """
         try:
             cur.execute(
                 "SELECT counter FROM graph_metrics "
-                "WHERE metric_name = 'vocabulary_change_counter'"
+                "WHERE metric_name = 'vocabulary_embedding_generation_counter'"
             )
             row = cur.fetchone()
             return int(row['counter']) if row else 0
@@ -108,19 +118,23 @@ class GroundingMixin:
             return 0
 
     def _get_polarity_axis(self, cur) -> Optional[np.ndarray]:
-        """Get cached polarity axis, recomputing if vocabulary has changed.
+        """Get cached polarity axis, recomputing if vocab embeddings changed.
 
         The polarity axis is derived from vocabulary embeddings for opposing
         relationship pairs (SUPPORTS/CONTRADICTS, etc.). It's shared across
         all concepts — only the per-concept edge projections differ.
 
-        Cached against graph_metrics.vocabulary_change_counter. Invalidates
-        when synonym collapse, embedding regeneration, or any vocabulary
-        mutation bumps the counter via refresh_graph_metrics().
+        Cached against graph_metrics.vocabulary_embedding_generation_counter
+        (migration 069). Invalidates when embeddings are generated or
+        regenerated — including via `kg admin embedding regenerate` and
+        the inline path in age_client/vocabulary.py:add_edge_type. The
+        previous key (vocabulary_change_counter, membership) didn't move
+        on embedding-content changes, requiring a process restart to
+        invalidate after `kg admin embedding regenerate --type vocabulary`.
         """
         global _polarity_axis_cache
 
-        vocab_gen = self._get_vocab_generation(cur)
+        vocab_gen = self._get_vocab_embedding_generation(cur)
 
         with _polarity_axis_cache_lock:
             if _polarity_axis_cache is not None:
@@ -205,8 +219,9 @@ class GroundingMixin:
 
         Tier 1 — Polarity axis (vocabulary-level): derived from
         relationship-type embeddings, shared across every concept. Cached
-        against graph_metrics.vocabulary_change_counter. Invalidates only
-        when vocabulary mutates (synonym collapse, embedding regeneration).
+        against graph_metrics.vocabulary_embedding_generation_counter
+        (migration 069). Invalidates only when embeddings are generated
+        or regenerated — including regen via `kg admin embedding regenerate`.
         One axis computation amortizes across the entire concept space.
 
         Tier 2 — Per-concept grounding: cached against

--- a/api/app/lib/age_client/grounding.py
+++ b/api/app/lib/age_client/grounding.py
@@ -234,8 +234,16 @@ class GroundingMixin:
         Warm-cache short-circuit (#278): if `_grounding_cache_generation`
         is set and `(concept_id, _grounding_cache_generation)` is already
         in the cache, this method returns without acquiring a pool
-        connection. Soundness: we might serve up-to-one-call-stale data
-        right after a graph mutation, but the next miss reseeds.
+        connection. Soundness: the warm path never re-reads the generation,
+        so the staleness window is bounded by the next cold-path call in
+        this process — not by wall-clock time. A workload that repeatedly
+        hits the same hot concepts can keep serving cached values from
+        before a graph mutation until something else takes the cold path
+        and re-reads the generation. This is the intended trade-off for
+        read-heavy steady-state workloads; callers that need linearizable
+        freshness should call `include_grounding=False` to bypass the
+        cache entirely, or rely on cache eviction triggered by other
+        endpoint hits.
 
         Args:
             concept_id: Target concept to calculate grounding for.
@@ -436,10 +444,14 @@ class GroundingMixin:
         # repeatedly (search-then-render, paginated UIs, etc.).
         #
         # Soundness trade-off: skipping the get_graph_generation() probe
-        # means we might serve up-to-one-call-stale data right after the
-        # graph mutates. The next non-warm call reads the new generation
-        # and evicts, so the stale window is bounded by exactly one call
-        # that happens between mutation and the first cache miss. Worth it
+        # means staleness is bounded by the next cold-path call in this
+        # process, NOT by wall-clock time. A workload that keeps hitting
+        # the same warm working set will keep returning pre-mutation values
+        # until something else (a different concept set, an unrelated
+        # endpoint, the API restart) takes the cold path and re-reads the
+        # generation. For the read-heavy steady state this targets that's
+        # the right trade — but callers needing linearizable freshness
+        # should opt out of the cache entirely. Worth it
         # for the read-heavy steady state.
         with _grounding_cache_lock:
             cached_gen = _grounding_cache_generation

--- a/api/app/lib/age_client/vocabulary.py
+++ b/api/app/lib/age_client/vocabulary.py
@@ -421,6 +421,16 @@ class VocabularyMixin:
                             WHERE relationship_type = %s
                         """, (embedding_json, model, relationship_type))
 
+                        # Migration 069: bump embedding-generation counter so the
+                        # polarity-axis cache (GroundingMixin) invalidates on next
+                        # read. The vocabulary_change_counter trigger will also
+                        # advance because of the INSERT above, but that counter is
+                        # for membership changes; the cache keys on this one for
+                        # embedding-content changes specifically.
+                        cur.execute(
+                            "SELECT increment_counter('vocabulary_embedding_generation_counter')"
+                        )
+
                         logger.debug(f"Generated embedding for vocabulary type '{relationship_type}' ({len(embedding)} dims)")
 
                         # ADR-047: Auto-categorize LLM-generated types

--- a/api/app/lib/graph_facade.py
+++ b/api/app/lib/graph_facade.py
@@ -25,9 +25,15 @@ ConfidenceAnalyzer, both backed by the two-tier cache described below.
 ## Two-tier grounding cache
 
 Tier 1 — Polarity axis: derived from vocabulary embeddings, shared
-across all concepts. Cached against `graph_metrics.vocabulary_change_counter`.
-Invalidates when vocabulary mutates (synonym collapse, embedding
-regeneration). One axis computation amortizes across every concept.
+across all concepts. Cached against
+`graph_metrics.vocabulary_embedding_generation_counter` (migration 069).
+Invalidates when embeddings are generated or regenerated — including via
+the inline path in age_client/vocabulary.py:add_edge_type and via
+`kg admin embedding regenerate`. Distinct from
+`vocabulary_change_counter`, which tracks row membership (add/remove/
+categorize) — the polarity axis is built from embedding vectors, so
+membership changes that don't touch embeddings aren't enough to
+invalidate it. One axis computation amortizes across every concept.
 
 Tier 2 — Per-concept grounding: cached against `graph_accel.generation`.
 Each concept's grounding depends only on its own incoming edges (no
@@ -35,7 +41,9 @@ cross-concept dependency), making independent caching safe. Invalidates
 when graph_accel_invalidate() bumps the generation after ingestion,
 edits, or vocabulary merges. A "warm cache" call (all requested
 concepts already cached at the current generation) returns without
-acquiring a pool connection — see #278 Phase 0 short-circuit.
+acquiring a pool connection — see #278 Phase 0 short-circuit. Staleness
+in the warm path is bounded by the next cold-path call in this process,
+not by wall-clock time.
 
 ## Connection architecture
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -30,7 +30,7 @@ from .services.job_scheduler import init_job_scheduler, get_job_scheduler
 from .services.scheduled_jobs_manager import JobScheduler as ScheduledJobsManager
 from .services.worker_registry import register_all_workers, get_all_job_types, validate_lane_uniqueness
 from .services.lane_manager import LaneManager
-from .launchers import CategoryRefreshLauncher, VocabConsolidationLauncher, EpistemicRemeasurementLauncher, ProjectionLauncher, ArtifactCleanupLauncher, AnnealingLauncher
+from .launchers import CategoryRefreshLauncher, VocabConsolidationLauncher, EpistemicRemeasurementLauncher, VocabEmbeddingLauncher, ProjectionLauncher, ArtifactCleanupLauncher, AnnealingLauncher
 from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, oauth, sources, projection, artifacts, grants, query_definitions, documents, concepts, edges, graph, storage_admin, programs, admin_workers, models, epochs
 from .services.embedding_worker import get_embedding_worker
 from .lib.age_client import AGEClient
@@ -350,6 +350,7 @@ async def startup_event():
             'CategoryRefreshLauncher': CategoryRefreshLauncher,
             'VocabConsolidationLauncher': VocabConsolidationLauncher,
             'EpistemicRemeasurementLauncher': EpistemicRemeasurementLauncher,
+            'VocabEmbeddingLauncher': VocabEmbeddingLauncher,  # Migration 069: vocab embedding regen
             'ProjectionLauncher': ProjectionLauncher,  # ADR-078: Embedding projections
             'ArtifactCleanupLauncher': ArtifactCleanupLauncher,  # ADR-083: Artifact cleanup
             'AnnealingLauncher': AnnealingLauncher,  # ADR-200: Ontology annealing cycle

--- a/api/app/services/confidence_analyzer.py
+++ b/api/app/services/confidence_analyzer.py
@@ -253,12 +253,16 @@ class ConfidenceAnalyzer:
         from psycopg2 import extras as pg_extras
 
         # --- Phase 0: warm-cache short-circuit (ADR-201 Phase 5f #278) ---
-        # Mirror of the grounding-batch optimization in grounding.py. If
-        # every requested concept is cached at the last-known generation,
-        # return without acquiring a pool connection. Caveat: grounding_display
-        # is recomputed even on a warm hit because it depends on the caller's
-        # current grounding_map (which can change call-to-call independently
-        # of the graph generation).
+        # Mirror of the grounding-batch optimization in grounding.py — same
+        # staleness bound: bounded by the next cold-path call in this
+        # process, NOT by wall-clock time. See the long comment on
+        # grounding.py:calculate_grounding_strength_batch for the full
+        # rationale; the trade-off applies identically here.
+        #
+        # Caveat specific to confidence: grounding_display is recomputed
+        # even on a warm hit because it depends on the caller's current
+        # grounding_map (which can change call-to-call independently of
+        # the graph generation).
         with _confidence_cache_lock:
             cached_gen = _confidence_cache_generation
             if cached_gen is not None:

--- a/api/app/services/embedding_worker.py
+++ b/api/app/services/embedding_worker.py
@@ -124,33 +124,58 @@ class EmbeddingWorker:
             self._executor = None
             logger.debug(f"☁️  Cloud embedding provider ({self.provider_name}): native concurrency")
 
-    async def initialize_builtin_embeddings(self) -> EmbeddingJobResult:
+    async def regenerate_missing_if_vocab_changed(
+        self,
+        component: str = "builtin_vocabulary_embeddings",
+        job_type: str = "cold_start",
+    ) -> EmbeddingJobResult:
         """
-        Generate embeddings for all builtin vocabulary types without embeddings.
+        Generate embeddings for any vocab types missing them, IF the vocab
+        membership counter has advanced since the last successful run.
 
-        Called during system initialization or after schema migrations.
-        Idempotent - safe to call multiple times.
+        This is the workhorse for both boot-time cold-start (called from
+        main.py with default args) and the hourly VocabEmbeddingLauncher.
+        Both compare `vocabulary_change_counter` against
+        `last_processed_vocab_change_counter` on the named init-status
+        component, run the regen if there's a delta, and update the
+        last-processed value on success.
+
+        Migration 069 replaced the binary `initialized` flag with this
+        counter-delta gate. Pre-069 the binary flag was set to TRUE on
+        first boot regardless of whether any types were actually processed,
+        which permanently blocked re-runs after the vocab table grew. The
+        counter-delta gate naturally re-fires whenever new vocab membership
+        arrives, since the counter advances on each add.
+
+        Args:
+            component: system_initialization_status.component key (default
+                covers builtin types; future components can use the same
+                helper by passing a different key).
+            job_type: embedding_generation_jobs.job_type label for the audit
+                trail. Cold-start at boot uses "cold_start" for backwards
+                compatibility; the launcher uses "vocabulary_update".
 
         Returns:
-            EmbeddingJobResult with processing statistics
-
-        Example:
-            >>> worker = EmbeddingWorker(age_client, ai_provider)
-            >>> result = await worker.initialize_builtin_embeddings()
-            >>> print(f"Initialized {result.processed_count}/{result.target_count} types")
+            EmbeddingJobResult with processing statistics. target_count=0
+            when no work was needed (counter hadn't advanced or all types
+            already embedded).
         """
         job_id = str(uuid4())
         start_time = datetime.now()
 
-        logger.info(f"[{job_id}] Starting cold start: Initializing builtin vocabulary embeddings")
+        # Counter-delta gate. If we've already processed at or beyond the
+        # current vocab counter, there's nothing new to do.
+        current_counter = await self._get_vocab_change_counter()
+        last_processed = await self._get_last_processed_vocab_change(component)
 
-        # Check if already initialized
-        is_initialized = await self._check_initialization_status()
-        if is_initialized:
-            logger.info(f"[{job_id}] Cold start already completed, skipping")
+        if current_counter <= last_processed:
+            logger.info(
+                f"[{job_id}] No vocab changes since last embedding run "
+                f"(counter={current_counter}, last_processed={last_processed}) — skipping"
+            )
             return EmbeddingJobResult(
                 job_id=job_id,
-                job_type="cold_start",
+                job_type=job_type,
                 target_count=0,
                 processed_count=0,
                 failed_count=0,
@@ -159,15 +184,30 @@ class EmbeddingWorker:
                 embedding_provider=self.provider_name
             )
 
-        # Get builtin types missing embeddings
-        target_types = await self._get_builtin_types_missing_embeddings()
+        logger.info(
+            f"[{job_id}] Starting embedding regen: vocab_change_counter "
+            f"advanced from {last_processed} to {current_counter} "
+            f"(component={component})"
+        )
+
+        # Find types that need embeddings. Any active type without an
+        # embedding is in scope — this covers both builtin types (seeded
+        # by migrations) and LLM-discovered types.
+        target_types = await self._get_types_without_embeddings()
 
         if not target_types:
-            logger.info(f"[{job_id}] No builtin types need embeddings")
-            await self._mark_initialization_complete(job_id, 0)
+            logger.info(
+                f"[{job_id}] Counter advanced but no types are missing embeddings — "
+                f"likely a category-only change. Marking last_processed={current_counter}."
+            )
+            # Record the counter value so we don't keep re-checking the same delta.
+            await self._mark_initialization_complete(
+                job_id, count=0, component=component,
+                vocab_change_counter=current_counter
+            )
             return EmbeddingJobResult(
                 job_id=job_id,
-                job_type="cold_start",
+                job_type=job_type,
                 target_count=0,
                 processed_count=0,
                 failed_count=0,
@@ -179,7 +219,7 @@ class EmbeddingWorker:
         # Create job record
         await self._create_job_record(
             job_id=job_id,
-            job_type="cold_start",
+            job_type=job_type,
             target_types=target_types
         )
 
@@ -190,11 +230,17 @@ class EmbeddingWorker:
         result = await self._batch_generate_embeddings(
             job_id=job_id,
             relationship_types=target_types,
-            job_type="cold_start"
+            job_type=job_type
         )
 
-        # Mark initialization as complete
-        await self._mark_initialization_complete(job_id, result.processed_count)
+        # Update last_processed only on this run's counter snapshot — if
+        # new vocab rows arrived mid-run, they'll surface as a delta on
+        # the next call rather than being silently considered "done."
+        await self._mark_initialization_complete(
+            job_id, count=result.processed_count,
+            component=component,
+            vocab_change_counter=current_counter
+        )
 
         # Update job record with final status
         end_time = datetime.now()
@@ -209,11 +255,28 @@ class EmbeddingWorker:
         )
 
         logger.info(
-            f"[{job_id}] Cold start complete: {result.processed_count}/{result.target_count} "
-            f"builtin types initialized in {duration_ms}ms"
+            f"[{job_id}] Embedding regen complete: {result.processed_count}/{result.target_count} "
+            f"types in {duration_ms}ms (component={component}, "
+            f"last_processed_vocab_change_counter now={current_counter})"
         )
 
         return result
+
+    async def initialize_builtin_embeddings(self) -> EmbeddingJobResult:
+        """
+        Boot-time cold-start entry point. Thin wrapper around
+        regenerate_missing_if_vocab_changed for backwards compatibility
+        with main.py's startup sequence.
+
+        Migration 069 changed the semantics: this no longer uses a binary
+        one-shot flag. It re-fires whenever vocab membership has advanced
+        since the last successful embedding run, so a fresh boot after
+        migrations seed new builtin types will pick them up automatically.
+        """
+        return await self.regenerate_missing_if_vocab_changed(
+            component="builtin_vocabulary_embeddings",
+            job_type="cold_start",
+        )
 
     def _generate_embedding_internal(self, text: str) -> Dict[str, Any]:
         """
@@ -796,8 +859,55 @@ class EmbeddingWorker:
             "SELECT increment_counter('vocabulary_embedding_generation_counter')"
         )
 
+    async def _get_vocab_change_counter(self) -> int:
+        """Read current vocabulary_change_counter from graph_metrics.
+
+        Used by regenerate_missing_if_vocab_changed to detect new work
+        since the last successful run. Distinct from
+        vocabulary_embedding_generation_counter (which keys the polarity
+        cache and is bumped by embedding-content changes); this counter
+        moves on row membership changes.
+        """
+        query = """
+            SELECT counter FROM graph_metrics
+            WHERE metric_name = 'vocabulary_change_counter'
+        """
+        try:
+            results = await self.db.execute_query(query)
+            if results and len(results) > 0:
+                return int(results[0]["counter"])
+            return 0
+        except Exception as e:
+            logger.debug(f"Error reading vocabulary_change_counter: {e}")
+            return 0
+
+    async def _get_last_processed_vocab_change(self, component: str) -> int:
+        """Read last_processed_vocab_change_counter for the given component.
+
+        Added by migration 069 to replace the binary `initialized` flag's
+        role as the "have we done embedding work?" gate.
+        """
+        query = """
+            SELECT last_processed_vocab_change_counter
+            FROM kg_api.system_initialization_status
+            WHERE component = %s
+        """
+        try:
+            results = await self.db.execute_query(query, (component,))
+            if results and len(results) > 0:
+                return int(results[0]["last_processed_vocab_change_counter"])
+            return 0
+        except Exception as e:
+            logger.debug(f"Error reading last_processed for {component}: {e}")
+            return 0
+
     async def _check_initialization_status(self) -> bool:
-        """Check if cold start initialization is complete"""
+        """
+        Legacy binary-flag check. Kept for code paths that still need it
+        (e.g., non-embedding components on system_initialization_status).
+        The cold-start path uses regenerate_missing_if_vocab_changed
+        instead — see migration 069.
+        """
         query = """
             SELECT initialized
             FROM kg_api.system_initialization_status
@@ -812,27 +922,53 @@ class EmbeddingWorker:
             logger.debug(f"Error checking initialization status: {e}")
             return False
 
-    async def _mark_initialization_complete(self, job_id: str, count: int) -> None:
-        """Mark cold start initialization as complete"""
+    async def _mark_initialization_complete(
+        self,
+        job_id: str,
+        count: int,
+        component: str = "builtin_vocabulary_embeddings",
+        vocab_change_counter: Optional[int] = None,
+    ) -> None:
+        """
+        Mark embedding work complete for the given component.
+
+        Updates the binary `initialized` flag (kept for non-counter
+        components) AND, when `vocab_change_counter` is provided, updates
+        `last_processed_vocab_change_counter` — the new counter-delta gate.
+
+        Args:
+            job_id: embedding_generation_jobs.job_id for the audit trail.
+            count: how many types were processed in this run.
+            component: which row of system_initialization_status to update.
+            vocab_change_counter: snapshot of vocabulary_change_counter at
+                the start of this run. Stored so the next call's delta
+                check sees "we processed up to N." Pass None to skip the
+                counter update (legacy callers).
+        """
         query = """
             UPDATE kg_api.system_initialization_status
             SET initialized = TRUE,
                 initialized_at = CURRENT_TIMESTAMP,
                 initialization_job_id = %s,
+                last_processed_vocab_change_counter = COALESCE(
+                    %s, last_processed_vocab_change_counter
+                ),
                 metadata = jsonb_build_object(
                     'types_initialized', %s,
                     'provider', %s,
                     'model', %s
                 )
-            WHERE component = 'builtin_vocabulary_embeddings'
+            WHERE component = %s
         """
         await self.db.execute_query(
             query,
             (
                 job_id,
+                vocab_change_counter,
                 count,
                 self.provider_name,
-                self.provider.model_name if hasattr(self.provider, 'model_name') else "unknown"
+                self.provider.model_name if hasattr(self.provider, 'model_name') else "unknown",
+                component,
             )
         )
 

--- a/api/app/services/embedding_worker.py
+++ b/api/app/services/embedding_worker.py
@@ -775,7 +775,11 @@ class EmbeddingWorker:
         model: str,
         provider: str
     ) -> None:
-        """Store embedding in relationship_vocabulary table"""
+        """
+        Store embedding in relationship_vocabulary table and bump the
+        vocabulary_embedding_generation_counter so the polarity-axis cache
+        (GroundingMixin) invalidates on next read (migration 069).
+        """
         query = """
             UPDATE kg_api.relationship_vocabulary
             SET embedding = %s::jsonb,
@@ -785,6 +789,12 @@ class EmbeddingWorker:
         """
         embedding_json = json.dumps(embedding)
         await self.db.execute_query(query, (embedding_json, model, relationship_type))
+        # Bump the embedding-generation counter so any cache keyed against it
+        # picks up the change. Independent of vocabulary_change_counter,
+        # which only moves on row membership changes (add/remove/categorize).
+        await self.db.execute_query(
+            "SELECT increment_counter('vocabulary_embedding_generation_counter')"
+        )
 
     async def _check_initialization_status(self) -> bool:
         """Check if cold start initialization is complete"""

--- a/api/app/services/embedding_worker.py
+++ b/api/app/services/embedding_worker.py
@@ -193,6 +193,18 @@ class EmbeddingWorker:
         # Find types that need embeddings. Any active type without an
         # embedding is in scope — this covers both builtin types (seeded
         # by migrations) and LLM-discovered types.
+        #
+        # Race-window note: a new vocab row can arrive between the counter
+        # snapshot at line 168 and this fetch. That row will land in
+        # target_types AND it will have advanced the counter past our
+        # snapshot. After this run completes, last_processed gets set to
+        # the snapshot value (not the current counter), so the next launcher
+        # tick observes a residual delta of 1 and dispatches another run.
+        # That follow-up run reaches the "no types missing" no-op branch
+        # below (since the row we just processed is now embedded), advances
+        # last_processed to the new counter, and the loop closes. Net cost
+        # of the race: one extra worker dispatch per concurrent vocab add.
+        # Acceptable at hourly cadence.
         target_types = await self._get_types_without_embeddings()
 
         if not target_types:

--- a/api/app/services/worker_registry.py
+++ b/api/app/services/worker_registry.py
@@ -16,6 +16,7 @@ from ..workers.restore_worker import run_restore_worker
 from ..workers.vocab_refresh_worker import run_vocab_refresh_worker
 from ..workers.vocab_consolidate_worker import run_vocab_consolidate_worker
 from ..workers.epistemic_remeasurement_worker import run_epistemic_remeasurement_worker
+from ..workers.vocab_embedding_worker import run_vocab_embedding_worker
 from ..workers.source_embedding_worker import run_source_embedding_worker
 from ..workers.projection_worker import run_projection_worker
 from ..workers.polarity_worker import run_polarity_worker
@@ -41,6 +42,7 @@ WORKER_REGISTRY: dict[str, WorkerEntry] = {
     "projection":              WorkerEntry(run_projection_worker,              "maintenance"),  # ADR-078
     "vocab_refresh":           WorkerEntry(run_vocab_refresh_worker,           "maintenance"),  # ADR-050
     "epistemic_remeasurement": WorkerEntry(run_epistemic_remeasurement_worker, "maintenance"),  # ADR-065
+    "vocab_embedding":         WorkerEntry(run_vocab_embedding_worker,         "maintenance"),  # Migration 069
     "ontology_annealing":      WorkerEntry(run_annealing_worker,              "maintenance"),  # ADR-200
     "proposal_execution":      WorkerEntry(run_proposal_execution_worker,     "maintenance"),  # ADR-200
 

--- a/api/app/workers/vocab_embedding_worker.py
+++ b/api/app/workers/vocab_embedding_worker.py
@@ -1,0 +1,121 @@
+"""
+Vocab Embedding Worker (migration 069).
+
+Background worker triggered by VocabEmbeddingLauncher. Invokes the same
+EmbeddingWorker.regenerate_missing_if_vocab_changed workhorse the
+boot-time cold-start uses — single source of truth for "regenerate
+missing vocab embeddings if vocab membership has advanced."
+
+Pattern-matches vocab_refresh_worker and epistemic_remeasurement_worker.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def run_vocab_embedding_worker(
+    job_data: Dict[str, Any],
+    job_id: str,
+    job_queue
+) -> Dict[str, Any]:
+    """
+    Execute vocab embedding regeneration as a background job.
+
+    Same logic as `kg admin embedding regenerate --type vocabulary` but
+    gated by the membership-counter delta — does nothing if no new vocab
+    has arrived since the last successful run for this component.
+
+    Args:
+        job_data: Job parameters from VocabEmbeddingLauncher.prepare_job_data
+            - operation: "regenerate_missing_vocab_embeddings"
+            - component: system_initialization_status row to track
+              (default: "builtin_vocabulary_embeddings")
+            - description: human-readable job summary
+        job_id: Job ID for progress tracking
+        job_queue: Queue instance for progress updates
+
+    Returns:
+        Result dict mirroring EmbeddingJobResult.to_dict() — target_count,
+        processed_count, failed_count, duration_ms, status.
+
+    Raises:
+        Exception: If embedding generation fails catastrophically. Per-type
+            failures inside the worker are logged but don't raise (matches
+            the chunk-recovery pattern in calculate_grounding_strength_batch).
+    """
+    try:
+        from api.app.services.embedding_worker import get_embedding_worker
+        from api.app.lib.age_client import AGEClient
+        from api.app.lib.ai_providers import get_provider
+
+        component = job_data.get("component", "builtin_vocabulary_embeddings")
+
+        logger.info(f"🔄 Vocab embedding worker started: {job_id} (component={component})")
+
+        job_queue.update_job(job_id, {
+            "status": "processing",
+            "progress": "Vocab embedding worker started"
+        })
+
+        # ADR-100: check for cancellation before starting work
+        if job_queue.is_job_cancelled(job_id):
+            logger.info(f"Vocab embedding job {job_id} cancelled before start")
+            return {"status": "cancelled"}
+
+        # Build embedding worker. get_embedding_worker is the singleton
+        # factory already used by the API startup path; reusing it means
+        # the launcher path and cold-start path share the same instance.
+        age_client = AGEClient()
+        ai_provider = get_provider()
+        embedding_worker = get_embedding_worker(age_client, ai_provider)
+
+        if embedding_worker is None:
+            raise RuntimeError(
+                "EmbeddingWorker not initialized — cannot regen vocab embeddings"
+            )
+
+        # Run the shared workhorse. The counter-delta gate inside this
+        # method is the second line of defense: even if the launcher's
+        # check_conditions returned True but the counter advanced again
+        # between then and now (or another worker raced us to the regen),
+        # the method exits cleanly.
+        result = asyncio.run(
+            embedding_worker.regenerate_missing_if_vocab_changed(
+                component=component,
+                job_type="vocabulary_update",
+            )
+        )
+
+        job_queue.update_job(job_id, {
+            "status": "completed",
+            "progress": (
+                f"Processed {result.processed_count}/{result.target_count} types "
+                f"in {result.duration_ms}ms"
+            ),
+        })
+
+        logger.info(
+            f"✓ Vocab embedding worker complete: {job_id} — "
+            f"{result.processed_count}/{result.target_count} types, "
+            f"{result.failed_count} failed"
+        )
+
+        return {
+            "status": "completed",
+            "component": component,
+            "target_count": result.target_count,
+            "processed_count": result.processed_count,
+            "failed_count": result.failed_count,
+            "duration_ms": result.duration_ms,
+        }
+
+    except Exception as e:
+        logger.error(f"Vocab embedding worker failed: {job_id} — {e}", exc_info=True)
+        job_queue.update_job(job_id, {
+            "status": "failed",
+            "error": str(e),
+        })
+        raise

--- a/schema/migrations/069_vocab_embedding_lifecycle.sql
+++ b/schema/migrations/069_vocab_embedding_lifecycle.sql
@@ -1,0 +1,82 @@
+-- Migration 069: Vocabulary embedding lifecycle (#420 follow-up)
+-- Purpose: Track vocab embedding generation events independently from vocab membership,
+--          and replace the cold-start binary init flag with last-processed-counter semantics.
+-- Date: 2026-05-26
+--
+-- ## Background
+--
+-- The Feb 2 cluster verification (PR #420) exposed two pre-existing lifecycle bugs:
+--
+-- 1. The polarity-axis cache in GroundingMixin keys against
+--    `vocabulary_change_counter` (membership counter). But that counter advances
+--    only when vocab rows are added/removed/categorized — not when their
+--    `embedding` column is updated. After `kg admin embedding regenerate
+--    --type vocabulary`, the cache held a stale (vocab_gen, axis=None) entry
+--    and never invalidated until the API process restarted.
+--
+-- 2. Cold-start uses a binary `initialized` flag on system_initialization_status.
+--    If cold-start ran when the vocab table was empty (count=0), the row was
+--    marked initialized=TRUE forever, and the 48 builtin types seeded by later
+--    migrations never got embeddings on subsequent boots.
+--
+-- ## What this migration adds
+--
+-- - `vocabulary_embedding_generation_counter` row in graph_metrics. Bumped by
+--   code paths that actually change embedding values (batch generation, add_edge_type
+--   inline generation). The polarity-axis cache will key against this in a
+--   follow-up commit, so embedding changes invalidate the cache without needing
+--   a process restart.
+--
+-- - `last_processed_vocab_change_counter` column on
+--   kg_api.system_initialization_status. Stores the value of
+--   `vocabulary_change_counter` at the time embedding work last completed for
+--   this component. Replaces the binary `initialized` flag's role as the
+--   "should I do work?" gate — the cold-start path and the new
+--   VocabEmbeddingLauncher (separate commit) both compare current vs. last
+--   processed instead of checking a one-shot flag.
+--
+-- ## Idempotency
+--
+-- All operations are safe to re-run:
+--   - `INSERT ... ON CONFLICT (metric_name) DO NOTHING` for the counter row
+--   - `ADD COLUMN IF NOT EXISTS` for the new column
+--   - `INSERT ... ON CONFLICT (version) DO NOTHING` for schema_migrations
+--
+-- The migration leaves existing data untouched: the new column defaults to 0,
+-- which by the new semantics means "no embedding work has completed yet" —
+-- which is the correct initial state regardless of what `initialized` says.
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1. Counter for vocabulary embedding generation events
+-- ----------------------------------------------------------------------------
+
+INSERT INTO public.graph_metrics (metric_name, counter, last_measured_counter, notes)
+VALUES (
+    'vocabulary_embedding_generation_counter',
+    0,
+    0,
+    'Increments each time a vocabulary type embedding is generated or regenerated. The polarity-axis cache (GroundingMixin) keys against this counter — bumping it invalidates the cache without requiring a process restart. Distinct from vocabulary_change_counter, which tracks row membership rather than embedding contents.'
+)
+ON CONFLICT (metric_name) DO NOTHING;
+
+-- ----------------------------------------------------------------------------
+-- 2. Last-processed-counter column on initialization status
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE kg_api.system_initialization_status
+    ADD COLUMN IF NOT EXISTS last_processed_vocab_change_counter BIGINT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN kg_api.system_initialization_status.last_processed_vocab_change_counter IS
+'Snapshot of vocabulary_change_counter at the time this initialization component last completed embedding work. The cold-start and VocabEmbeddingLauncher paths compare current counter vs. this value to detect new work since the last successful run. Replaces the binary `initialized` flag for embedding components (the flag stays for non-counter-driven components). Default 0 means "no work has completed yet" — correct initial state.';
+
+-- ----------------------------------------------------------------------------
+-- 3. Migration tracking
+-- ----------------------------------------------------------------------------
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (69, 'vocab_embedding_lifecycle')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/schema/migrations/070_vocab_embedding_scheduled_job.sql
+++ b/schema/migrations/070_vocab_embedding_scheduled_job.sql
@@ -1,0 +1,69 @@
+-- Migration 070: Schedule the VocabEmbeddingLauncher
+-- Companion to migration 069 (vocab embedding lifecycle counters).
+-- Date: 2026-05-26
+--
+-- ## What this adds
+--
+-- The hourly scheduled job that fires VocabEmbeddingLauncher. The launcher
+-- checks vocabulary_change_counter against last_processed_vocab_change_counter
+-- for the 'builtin_vocabulary_embeddings' component and, when the membership
+-- counter has advanced, enqueues a vocab_embedding worker job to regenerate
+-- any missing embeddings.
+--
+-- Pattern-matches migration 026 (epistemic_remeasurement scheduled job) —
+-- same shape, same cron cadence (hourly at minute 0). The two launchers
+-- run independently: epistemic uses get_counter_delta() / mark_measurement_complete()
+-- (global cursor on graph_metrics), this one uses last_processed_vocab_change_counter
+-- (per-component cursor on system_initialization_status). The two consumers
+-- track their progress separately and don't interfere.
+--
+-- ## Idempotency
+--
+-- ON CONFLICT (name) DO UPDATE — re-running this migration refreshes the
+-- launcher_class / schedule_cron / enabled fields without erroring on the
+-- existing row, matching the pattern in 026 / 047 / 048.
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- Schedule vocab embedding launcher
+-- ----------------------------------------------------------------------------
+
+INSERT INTO kg_api.scheduled_jobs (name, launcher_class, schedule_cron, enabled)
+VALUES (
+    'vocab_embedding',
+    'VocabEmbeddingLauncher',
+    '0 * * * *',  -- Every hour at minute 0 (same cadence as epistemic_remeasurement)
+    TRUE
+)
+ON CONFLICT (name) DO UPDATE SET
+    launcher_class = EXCLUDED.launcher_class,
+    schedule_cron = EXCLUDED.schedule_cron,
+    enabled = EXCLUDED.enabled;
+
+-- ----------------------------------------------------------------------------
+-- Verify
+-- ----------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT FROM kg_api.scheduled_jobs
+        WHERE name = 'vocab_embedding'
+          AND launcher_class = 'VocabEmbeddingLauncher'
+    ) THEN
+        RAISE EXCEPTION 'Migration 070 failed: vocab_embedding scheduled job not registered';
+    END IF;
+
+    RAISE NOTICE 'Migration 070: vocab_embedding scheduled job registered';
+END $$;
+
+-- ----------------------------------------------------------------------------
+-- Migration tracking
+-- ----------------------------------------------------------------------------
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (70, 'vocab_embedding_scheduled_job')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/tests/unit/launchers/test_vocab_embedding_launcher.py
+++ b/tests/unit/launchers/test_vocab_embedding_launcher.py
@@ -13,7 +13,8 @@ track progress independently; tests guard against accidentally coupling
 them.
 """
 
-from typing import Any, List, Optional, Tuple
+from contextlib import contextmanager
+from typing import Any, Iterator, List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -38,10 +39,20 @@ class FakeCursor:
 
     def execute(self, sql: str, params: Optional[tuple] = None):
         self.queries.append((sql, params))
-        if "vocabulary_change_counter" in sql:
-            self._next_row = (self.vocab_change_counter,)
+        # Order matters: the combined CTE query mentions both phrases, so
+        # check for the more-specific (per-component cursor) phrase first.
+        # If the launcher ever splits these back into two queries, this
+        # cursor still handles each shape.
+        if (
+            "last_processed_vocab_change_counter" in sql
+            and "vocabulary_change_counter" in sql
+        ):
+            # Combined CTE — return both columns in one row
+            self._next_row = (self.vocab_change_counter, self.last_processed)
         elif "last_processed_vocab_change_counter" in sql:
             self._next_row = (self.last_processed,)
+        elif "vocabulary_change_counter" in sql:
+            self._next_row = (self.vocab_change_counter,)
         else:
             self._next_row = None
 
@@ -68,13 +79,22 @@ class FakePool:
         pass
 
 
-def _build_launcher_with_state(
+@contextmanager
+def _patched_launcher(
     vocab_change_counter: int, last_processed: int
-) -> Tuple[VocabEmbeddingLauncher, FakeCursor]:
+) -> Iterator[Tuple[VocabEmbeddingLauncher, FakeCursor]]:
     """
     Build a VocabEmbeddingLauncher whose check_conditions reads from a
-    scripted FakeCursor. Patches AGEClient inside the launcher module
-    so we don't need a live container.
+    scripted FakeCursor, with AGEClient already patched in the launcher
+    module's namespace. Use as:
+
+        with _patched_launcher(counter=42, last_processed=10) as (launcher, cur):
+            assert launcher.check_conditions() is True
+            # `cur.queries` is available for assertions
+
+    Returns a 2-tuple so the type annotation matches reality (S1 review
+    finding) and so callers don't have to repeat the `with patch(...)`
+    boilerplate that the previous shape required at every test site.
     """
     cur = FakeCursor(vocab_change_counter, last_processed)
     fake_client = MagicMock()
@@ -83,7 +103,11 @@ def _build_launcher_with_state(
     job_queue = MagicMock()
     launcher = VocabEmbeddingLauncher(job_queue)
 
-    return launcher, cur, fake_client
+    with patch(
+        "api.app.launchers.vocab_embedding.AGEClient",
+        return_value=fake_client,
+    ):
+        yield launcher, cur
 
 
 class TestVocabEmbeddingLauncherConditions:
@@ -94,10 +118,7 @@ class TestVocabEmbeddingLauncherConditions:
         Standard case: vocab membership grew (counter went from 10 to 42),
         worker hasn't caught up — launcher fires.
         """
-        launcher, cur, fake_client = _build_launcher_with_state(
-            vocab_change_counter=42, last_processed=10
-        )
-        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+        with _patched_launcher(vocab_change_counter=42, last_processed=10) as (launcher, _cur):
             assert launcher.check_conditions() is True
 
     def test_no_op_when_counter_equals_last_processed(self):
@@ -106,10 +127,7 @@ class TestVocabEmbeddingLauncherConditions:
         Launcher does nothing — this is the path it will hit most of the
         time, when no new vocab has arrived between hourly ticks.
         """
-        launcher, cur, fake_client = _build_launcher_with_state(
-            vocab_change_counter=42, last_processed=42
-        )
-        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+        with _patched_launcher(vocab_change_counter=42, last_processed=42) as (launcher, _cur):
             assert launcher.check_conditions() is False
 
     def test_no_op_when_counter_below_last_processed(self):
@@ -118,10 +136,7 @@ class TestVocabEmbeddingLauncherConditions:
         last_processed got desynced). Don't fire — the worker would
         no-op anyway via its own gate.
         """
-        launcher, cur, fake_client = _build_launcher_with_state(
-            vocab_change_counter=5, last_processed=42
-        )
-        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+        with _patched_launcher(vocab_change_counter=5, last_processed=42) as (launcher, _cur):
             assert launcher.check_conditions() is False
 
     def test_threshold_is_any_positive_delta(self):
@@ -130,10 +145,7 @@ class TestVocabEmbeddingLauncherConditions:
         generation per-type is cheap; we don't want to delay a single
         new type by up to an hour just to batch. Delta of 1 fires.
         """
-        launcher, cur, fake_client = _build_launcher_with_state(
-            vocab_change_counter=11, last_processed=10
-        )
-        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+        with _patched_launcher(vocab_change_counter=11, last_processed=10) as (launcher, _cur):
             assert launcher.check_conditions() is True
 
     def test_queries_per_component_not_global_cursor(self):
@@ -144,24 +156,18 @@ class TestVocabEmbeddingLauncherConditions:
         global cursor; if we accidentally used the same one, the two
         launchers would reset each other's progress.
         """
-        launcher, cur, fake_client = _build_launcher_with_state(
-            vocab_change_counter=42, last_processed=10
-        )
-        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+        with _patched_launcher(vocab_change_counter=42, last_processed=10) as (launcher, cur):
             launcher.check_conditions()
 
-        # Exactly one query should hit the per-component cursor
+        # The per-component cursor is queried, with the component name as a param.
+        # Count assertion intentional: regression guard against either duplicating
+        # the query (e.g., accidental re-fetch on retry) or hitting the global cursor.
         per_component_queries = [
-            sql for sql, _params in cur.queries
+            (sql, params) for sql, params in cur.queries
             if "last_processed_vocab_change_counter" in sql
         ]
         assert len(per_component_queries) == 1
-        # And it should include the component name as a parameter
-        component_params = [
-            params for sql, params in cur.queries
-            if "last_processed_vocab_change_counter" in sql
-        ]
-        assert component_params[0] == ("builtin_vocabulary_embeddings",)
+        assert per_component_queries[0][1] == ("builtin_vocabulary_embeddings",)
 
         # The global cursor function (used by epistemic launcher) is NOT called
         assert not any("get_counter_delta" in sql for sql, _ in cur.queries)

--- a/tests/unit/launchers/test_vocab_embedding_launcher.py
+++ b/tests/unit/launchers/test_vocab_embedding_launcher.py
@@ -1,0 +1,191 @@
+"""
+VocabEmbeddingLauncher condition-check behavior (migration 069/070).
+
+The launcher's whole job is to decide "does the worker need to run?" by
+comparing vocabulary_change_counter against last_processed_vocab_change_counter
+for a named component. These tests pin that decision against scripted DB
+responses.
+
+Mirrors the pattern used by EpistemicRemeasurementLauncher — same shape,
+same cron, but reads a per-component cursor on system_initialization_status
+instead of the global cursor on graph_metrics. The two launchers must
+track progress independently; tests guard against accidentally coupling
+them.
+"""
+
+from typing import Any, List, Optional, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.app.launchers.vocab_embedding import VocabEmbeddingLauncher
+
+
+class FakeCursor:
+    """Scripted cursor — returns the next pre-programmed row per execute()."""
+
+    def __init__(self, vocab_change_counter: int, last_processed: int):
+        self.vocab_change_counter = vocab_change_counter
+        self.last_processed = last_processed
+        self.queries: List[Tuple[str, Optional[tuple]]] = []
+        self._next_row: Optional[tuple] = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def execute(self, sql: str, params: Optional[tuple] = None):
+        self.queries.append((sql, params))
+        if "vocabulary_change_counter" in sql:
+            self._next_row = (self.vocab_change_counter,)
+        elif "last_processed_vocab_change_counter" in sql:
+            self._next_row = (self.last_processed,)
+        else:
+            self._next_row = None
+
+    def fetchone(self):
+        return self._next_row
+
+
+class FakeConn:
+    def __init__(self, cur: FakeCursor):
+        self._cur = cur
+
+    def cursor(self):
+        return self._cur
+
+
+class FakePool:
+    def __init__(self, cur: FakeCursor):
+        self._cur = cur
+
+    def getconn(self):
+        return FakeConn(self._cur)
+
+    def putconn(self, conn):
+        pass
+
+
+def _build_launcher_with_state(
+    vocab_change_counter: int, last_processed: int
+) -> Tuple[VocabEmbeddingLauncher, FakeCursor]:
+    """
+    Build a VocabEmbeddingLauncher whose check_conditions reads from a
+    scripted FakeCursor. Patches AGEClient inside the launcher module
+    so we don't need a live container.
+    """
+    cur = FakeCursor(vocab_change_counter, last_processed)
+    fake_client = MagicMock()
+    fake_client.pool = FakePool(cur)
+
+    job_queue = MagicMock()
+    launcher = VocabEmbeddingLauncher(job_queue)
+
+    return launcher, cur, fake_client
+
+
+class TestVocabEmbeddingLauncherConditions:
+    """Migration 069/070: per-component counter-delta gate."""
+
+    def test_fires_when_counter_advanced_past_last_processed(self):
+        """
+        Standard case: vocab membership grew (counter went from 10 to 42),
+        worker hasn't caught up — launcher fires.
+        """
+        launcher, cur, fake_client = _build_launcher_with_state(
+            vocab_change_counter=42, last_processed=10
+        )
+        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+            assert launcher.check_conditions() is True
+
+    def test_no_op_when_counter_equals_last_processed(self):
+        """
+        Steady state: worker already processed up to the current counter.
+        Launcher does nothing — this is the path it will hit most of the
+        time, when no new vocab has arrived between hourly ticks.
+        """
+        launcher, cur, fake_client = _build_launcher_with_state(
+            vocab_change_counter=42, last_processed=42
+        )
+        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+            assert launcher.check_conditions() is False
+
+    def test_no_op_when_counter_below_last_processed(self):
+        """
+        Defensive boundary: counter went backward (operator reset, or
+        last_processed got desynced). Don't fire — the worker would
+        no-op anyway via its own gate.
+        """
+        launcher, cur, fake_client = _build_launcher_with_state(
+            vocab_change_counter=5, last_processed=42
+        )
+        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+            assert launcher.check_conditions() is False
+
+    def test_threshold_is_any_positive_delta(self):
+        """
+        Threshold is 1, not 10 like the epistemic launcher. Embedding
+        generation per-type is cheap; we don't want to delay a single
+        new type by up to an hour just to batch. Delta of 1 fires.
+        """
+        launcher, cur, fake_client = _build_launcher_with_state(
+            vocab_change_counter=11, last_processed=10
+        )
+        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+            assert launcher.check_conditions() is True
+
+    def test_queries_per_component_not_global_cursor(self):
+        """
+        The launcher must read last_processed_vocab_change_counter for
+        its named component — not the global mark_measurement_complete
+        cursor on graph_metrics. EpistemicRemeasurementLauncher uses the
+        global cursor; if we accidentally used the same one, the two
+        launchers would reset each other's progress.
+        """
+        launcher, cur, fake_client = _build_launcher_with_state(
+            vocab_change_counter=42, last_processed=10
+        )
+        with patch("api.app.launchers.vocab_embedding.AGEClient", return_value=fake_client):
+            launcher.check_conditions()
+
+        # Exactly one query should hit the per-component cursor
+        per_component_queries = [
+            sql for sql, _params in cur.queries
+            if "last_processed_vocab_change_counter" in sql
+        ]
+        assert len(per_component_queries) == 1
+        # And it should include the component name as a parameter
+        component_params = [
+            params for sql, params in cur.queries
+            if "last_processed_vocab_change_counter" in sql
+        ]
+        assert component_params[0] == ("builtin_vocabulary_embeddings",)
+
+        # The global cursor function (used by epistemic launcher) is NOT called
+        assert not any("get_counter_delta" in sql for sql, _ in cur.queries)
+        assert not any("mark_measurement_complete" in sql for sql, _ in cur.queries)
+
+
+class TestVocabEmbeddingLauncherJobData:
+    """Static parts of the launcher API."""
+
+    def test_job_type_is_vocab_embedding(self):
+        """Worker registry keys on 'vocab_embedding' — keep them in sync."""
+        launcher = VocabEmbeddingLauncher(MagicMock())
+        assert launcher.get_job_type() == "vocab_embedding"
+
+    def test_prepare_job_data_includes_component(self):
+        """Worker reads component from job_data to know which row to update."""
+        launcher = VocabEmbeddingLauncher(MagicMock(), component="builtin_vocabulary_embeddings")
+        data = launcher.prepare_job_data()
+        assert data["operation"] == "regenerate_missing_vocab_embeddings"
+        assert data["component"] == "builtin_vocabulary_embeddings"
+        assert "description" in data
+
+    def test_custom_component_threaded_through(self):
+        """Future use: multiple components could share the same launcher."""
+        launcher = VocabEmbeddingLauncher(MagicMock(), component="experimental_types")
+        data = launcher.prepare_job_data()
+        assert data["component"] == "experimental_types"

--- a/tests/unit/lib/test_vocab_embedding_counter.py
+++ b/tests/unit/lib/test_vocab_embedding_counter.py
@@ -1,0 +1,211 @@
+"""
+Counter bump + polarity-axis cache key behavior (migration 069).
+
+The bug the dev verification turned up: the polarity-axis cache in
+GroundingMixin keyed against vocabulary_change_counter, which only moves
+on row membership changes — not on embedding-content changes. Running
+`kg admin embedding regenerate --type vocabulary` populated 48 embeddings
+without bumping the counter, so the in-process cache held a stale
+(vocab_gen=N, axis=None) entry until process restart.
+
+Migration 069 introduces vocabulary_embedding_generation_counter. These
+tests pin two behaviors:
+
+1. The polarity-axis cache now reads the new counter, so any bump
+   invalidates the cache on the next call.
+
+2. The cache miss path computes a fresh axis from the now-embedded vocab
+   rows. (We don't exercise the full vocab embedding pipeline here —
+   that lives in integration tests; the unit-level invariant is "key
+   moves, cache rebuilds.")
+"""
+
+import numpy as np
+import pytest
+
+from api.app.lib.age_client.grounding import GroundingMixin
+
+
+class FakeAgeClient(GroundingMixin):
+    """Concrete GroundingMixin subclass — exercises real method dispatch.
+
+    Using a real class instead of MagicMock so `self._get_vocab_embedding_generation`
+    inside `_get_polarity_axis` calls the actual method, not a stub.
+    """
+
+    def __init__(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def reset_polarity_cache():
+    """Each test starts with empty polarity cache."""
+    from api.app.lib.age_client import grounding as gmod
+    with gmod._polarity_axis_cache_lock:
+        original = gmod._polarity_axis_cache
+        gmod._polarity_axis_cache = None
+    yield
+    with gmod._polarity_axis_cache_lock:
+        gmod._polarity_axis_cache = original
+
+
+class FakeCursor:
+    """Tiny cursor that scripts responses keyed on SQL substring."""
+
+    def __init__(self):
+        self.queries = []
+        # Counter value returned for the embedding-generation counter query
+        self.embedding_gen_counter = 0
+        # Whether the embedding pair query returns rows that yield a valid axis
+        self.pairs_available = True
+
+    def execute(self, sql, params=None):
+        self.queries.append(sql)
+        if "vocabulary_embedding_generation_counter" in sql:
+            self._next = [{"counter": self.embedding_gen_counter}]
+        elif "relationship_vocabulary" in sql and "embedding" in sql:
+            if self.pairs_available:
+                # Two opposing-pair embeddings — SUPPORTS at [1,0,0,0] and
+                # CONTRADICTS at [-1,0,0,0] yield axis [1,0,0,0] (normalized).
+                self._next = [
+                    {"relationship_type": "SUPPORTS",
+                     "embedding": [1.0, 0.0, 0.0, 0.0]},
+                    {"relationship_type": "CONTRADICTS",
+                     "embedding": [-1.0, 0.0, 0.0, 0.0]},
+                    {"relationship_type": "ENABLES",
+                     "embedding": [0.5, 0.5, 0.0, 0.0]},
+                    {"relationship_type": "PREVENTS",
+                     "embedding": [-0.5, -0.5, 0.0, 0.0]},
+                ]
+            else:
+                self._next = []
+        else:
+            self._next = []
+
+    def fetchone(self):
+        return self._next[0] if self._next else None
+
+    def fetchall(self):
+        return list(self._next)
+
+
+class TestPolarityAxisCacheKey:
+    """Migration 069: polarity cache keys on vocabulary_embedding_generation_counter."""
+
+    def test_get_vocab_embedding_generation_reads_new_counter(self):
+        """
+        _get_vocab_embedding_generation queries the
+        vocabulary_embedding_generation_counter row, not the legacy
+        vocabulary_change_counter. Pre-069 the cache keyed on the wrong
+        counter, so an embedding regen didn't move the key.
+        """
+        from api.app.lib.age_client.grounding import GroundingMixin
+
+        cur = FakeCursor()
+        cur.embedding_gen_counter = 42
+
+        client = FakeAgeClient()
+        result = GroundingMixin._get_vocab_embedding_generation(client, cur)
+
+        assert result == 42
+        # The query mentions the new counter by name
+        assert any(
+            "vocabulary_embedding_generation_counter" in q
+            for q in cur.queries
+        )
+        # And does NOT query the old key
+        assert not any(
+            "vocabulary_change_counter" in q for q in cur.queries
+        )
+
+    def test_axis_cache_hit_when_counter_unchanged(self):
+        """
+        Standard cache behavior: when the embedding-generation counter
+        hasn't moved, _get_polarity_axis returns the cached axis without
+        re-querying the vocab embeddings table.
+        """
+        from api.app.lib.age_client.grounding import GroundingMixin
+        from api.app.lib.age_client import grounding as gmod
+
+        # Seed cache at counter=5 with a known axis
+        with gmod._polarity_axis_cache_lock:
+            gmod._polarity_axis_cache = (
+                5, np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+            )
+
+        cur = FakeCursor()
+        cur.embedding_gen_counter = 5  # Same counter
+
+        client = FakeAgeClient()
+        axis = GroundingMixin._get_polarity_axis(client, cur)
+
+        # Got the cached axis back
+        assert axis is not None
+        np.testing.assert_array_equal(axis, np.array([1.0, 0.0, 0.0, 0.0]))
+        # Only the counter probe ran, not the embeddings query
+        assert not any(
+            "FROM kg_api.relationship_vocabulary" in q for q in cur.queries
+        )
+
+    def test_axis_cache_invalidates_when_counter_advances(self):
+        """
+        The bug 069 fixes: when embeddings get regenerated, the
+        counter bumps and the cached axis must be discarded.
+
+        Pre-069: cache keyed on vocabulary_change_counter, which didn't
+        move on embedding updates → stale cache served indefinitely.
+
+        Post-069: cache keyed on vocabulary_embedding_generation_counter
+        which the regen path now bumps → cache miss → axis recomputed.
+        """
+        from api.app.lib.age_client.grounding import GroundingMixin
+        from api.app.lib.age_client import grounding as gmod
+
+        # Seed cache at counter=5
+        stale_axis = np.array([0.5, 0.5, 0.0, 0.0], dtype=np.float64)
+        with gmod._polarity_axis_cache_lock:
+            gmod._polarity_axis_cache = (5, stale_axis)
+
+        # Simulate: regen bumped counter to 6
+        cur = FakeCursor()
+        cur.embedding_gen_counter = 6
+
+        client = FakeAgeClient()
+        axis = GroundingMixin._get_polarity_axis(client, cur)
+
+        # Cache missed (counter changed) and rebuilt from vocab embeddings
+        assert axis is not None
+        # The new axis is recomputed from the FakeCursor's seeded pair
+        # embeddings, not the stale value we put in
+        assert not np.array_equal(axis, stale_axis)
+        # The vocab embeddings query DID run (cache rebuild)
+        assert any(
+            "relationship_vocabulary" in q and "embedding" in q
+            for q in cur.queries
+        )
+
+    def test_axis_returns_none_when_no_complete_pairs(self):
+        """
+        Boundary: counter advances but the vocab table has no embedded
+        polarity pairs yet (e.g. mid-regen, only one half of each pair
+        has been processed). _get_polarity_axis returns None and the
+        cache is NOT updated — the next call will retry.
+        """
+        from api.app.lib.age_client.grounding import GroundingMixin
+        from api.app.lib.age_client import grounding as gmod
+
+        # No prior cache
+        with gmod._polarity_axis_cache_lock:
+            gmod._polarity_axis_cache = None
+
+        cur = FakeCursor()
+        cur.embedding_gen_counter = 1
+        cur.pairs_available = False  # No embedded pairs in vocab table yet
+
+        client = FakeAgeClient()
+        axis = GroundingMixin._get_polarity_axis(client, cur)
+
+        assert axis is None
+        # Cache should still be None — don't poison subsequent reads
+        with gmod._polarity_axis_cache_lock:
+            assert gmod._polarity_axis_cache is None

--- a/tests/unit/services/test_cold_start_counter_delta.py
+++ b/tests/unit/services/test_cold_start_counter_delta.py
@@ -1,0 +1,249 @@
+"""
+Cold-start uses vocabulary_change_counter delta (migration 069).
+
+The dev verification turned up this bug: cold-start ran once with an empty
+vocab table, marked `initialized=TRUE` with `types_initialized=0`, and the
+binary gate then permanently blocked re-runs even after later migrations
+seeded 48 builtin types. The fix replaces the binary flag with a
+counter-delta check against `last_processed_vocab_change_counter`.
+
+These tests pin the new gate behavior:
+
+1. Current counter > last_processed → work runs, processes missing types,
+   updates last_processed to the snapshot at start of run.
+
+2. Current counter == last_processed → no-op, no DB writes.
+
+3. Counter advanced but no types missing embeddings (e.g. only a
+   category change) → still update last_processed so the same delta
+   doesn't keep re-triggering.
+
+The fakes here replace `self.db` and `self.provider` so the worker's
+public API is exercised against scripted DB responses without needing
+a live container — matches the project's mocking way (fakes over mocks
+for control flow).
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.app.services.embedding_worker import EmbeddingWorker
+
+
+# ----------------------------------------------------------------------------
+# Fake DB
+# ----------------------------------------------------------------------------
+
+
+class FakeDb:
+    """
+    Scripts execute_query responses keyed on SQL substring. Records every
+    query for assertions. Lets tests simulate state transitions (counter
+    increments, last_processed updates) explicitly.
+    """
+
+    def __init__(
+        self,
+        vocab_change_counter: int = 0,
+        last_processed: int = 0,
+        missing_types: Optional[List[str]] = None,
+    ):
+        self.vocab_change_counter = vocab_change_counter
+        self.last_processed = last_processed
+        self.missing_types = missing_types or []
+        self.queries: List[Tuple[str, Optional[tuple]]] = []
+        # Track INSERT/UPDATE side effects on system_initialization_status
+        self.init_status_updates: List[Dict[str, Any]] = []
+
+    async def execute_query(self, sql: str, params: Optional[tuple] = None):
+        self.queries.append((sql.strip(), params))
+
+        if "vocabulary_change_counter" in sql and "SELECT counter" in sql:
+            return [{"counter": self.vocab_change_counter}]
+
+        if "last_processed_vocab_change_counter" in sql and "SELECT" in sql:
+            return [{"last_processed_vocab_change_counter": self.last_processed}]
+
+        if "FROM kg_api.relationship_vocabulary" in sql and "embedding IS NULL" in sql:
+            return [{"relationship_type": t} for t in self.missing_types]
+
+        if "v_builtin_types_missing_embeddings" in sql:
+            return [{"relationship_type": t} for t in self.missing_types]
+
+        if "INSERT INTO kg_api.embedding_generation_jobs" in sql:
+            return []
+
+        if "UPDATE kg_api.embedding_generation_jobs" in sql:
+            return []
+
+        if "UPDATE kg_api.system_initialization_status" in sql:
+            # Capture the snapshot the worker is committing
+            job_id, vocab_counter, count, provider, model, component = params
+            update = {
+                "job_id": job_id,
+                "vocab_change_counter": vocab_counter,
+                "count": count,
+                "component": component,
+            }
+            self.init_status_updates.append(update)
+            # Simulate the write-through so subsequent reads see it
+            if vocab_counter is not None:
+                self.last_processed = vocab_counter
+            return []
+
+        # Unhandled queries default to empty
+        return []
+
+
+def _make_worker(db: FakeDb) -> EmbeddingWorker:
+    """Build an EmbeddingWorker with stubbed dependencies."""
+    worker = EmbeddingWorker.__new__(EmbeddingWorker)
+    worker.db = db
+    worker.provider = MagicMock()
+    worker.provider.model_name = "test-model"
+    worker.provider_name = "test-provider"
+    # The actual embedding generation path isn't exercised here — these
+    # tests pin the *gate* behavior. _batch_generate_embeddings would
+    # require a live AI provider; we replace it with an inline stub that
+    # returns a result matching the requested types.
+    async def fake_batch(job_id, relationship_types, job_type):
+        from api.app.services.embedding_worker import EmbeddingJobResult
+        return EmbeddingJobResult(
+            job_id=job_id,
+            job_type=job_type,
+            target_count=len(relationship_types),
+            processed_count=len(relationship_types),
+            failed_count=0,
+            duration_ms=1,
+            embedding_model="test-model",
+            embedding_provider="test-provider",
+        )
+    worker._batch_generate_embeddings = fake_batch
+    return worker
+
+
+# ----------------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------------
+
+
+class TestRegenerateMissingIfVocabChanged:
+    """Migration 069 counter-delta gate behavior."""
+
+    def test_runs_work_when_counter_has_advanced(self):
+        """
+        Standard case: vocab counter advanced since last_processed, and
+        there are types missing embeddings. The work runs, the result
+        reports the count, and last_processed gets updated to the
+        snapshot captured at the start of the run.
+        """
+        db = FakeDb(
+            vocab_change_counter=42,
+            last_processed=10,
+            missing_types=["IMPLIES", "CAUSES", "ENABLES"],
+        )
+        worker = _make_worker(db)
+
+        result = asyncio.run(worker.regenerate_missing_if_vocab_changed())
+
+        assert result.processed_count == 3
+        assert result.target_count == 3
+
+        # last_processed was updated to the counter snapshot at start of run
+        assert len(db.init_status_updates) == 1
+        assert db.init_status_updates[0]["vocab_change_counter"] == 42
+        assert db.init_status_updates[0]["count"] == 3
+        assert db.init_status_updates[0]["component"] == "builtin_vocabulary_embeddings"
+
+    def test_no_op_when_counter_unchanged(self):
+        """
+        Gate behavior: when current_counter == last_processed, the method
+        skips all work. No INSERT/UPDATE to embedding_generation_jobs,
+        no UPDATE to system_initialization_status.
+
+        This is the steady-state path the launcher will hit when no
+        new vocab has arrived.
+        """
+        db = FakeDb(
+            vocab_change_counter=42,
+            last_processed=42,
+            missing_types=["IMPLIES"],  # Even if types ARE missing, gate stops us
+        )
+        worker = _make_worker(db)
+
+        result = asyncio.run(worker.regenerate_missing_if_vocab_changed())
+
+        assert result.processed_count == 0
+        assert result.target_count == 0
+        # No status update — gate held
+        assert db.init_status_updates == []
+        # No job record was created
+        assert not any(
+            "embedding_generation_jobs" in sql for sql, _ in db.queries
+        )
+
+    def test_no_op_when_counter_below_last_processed(self):
+        """
+        Boundary: counter < last_processed (shouldn't happen in practice
+        but defensive). Gate holds; no work runs.
+        """
+        db = FakeDb(
+            vocab_change_counter=5,
+            last_processed=42,
+            missing_types=["IMPLIES"],
+        )
+        worker = _make_worker(db)
+
+        result = asyncio.run(worker.regenerate_missing_if_vocab_changed())
+
+        assert result.processed_count == 0
+        assert db.init_status_updates == []
+
+    def test_counter_advanced_but_no_types_missing_updates_last_processed(self):
+        """
+        Edge case: counter advanced (e.g. a category-only change), but
+        no types are actually missing embeddings. The method still updates
+        last_processed so it doesn't keep re-checking the same delta on
+        every launcher tick.
+        """
+        db = FakeDb(
+            vocab_change_counter=42,
+            last_processed=10,
+            missing_types=[],  # All caught up
+        )
+        worker = _make_worker(db)
+
+        result = asyncio.run(worker.regenerate_missing_if_vocab_changed())
+
+        assert result.processed_count == 0
+        assert result.target_count == 0
+        # But last_processed still updated to the current counter
+        assert len(db.init_status_updates) == 1
+        assert db.init_status_updates[0]["vocab_change_counter"] == 42
+        assert db.init_status_updates[0]["count"] == 0
+
+    def test_initialize_builtin_embeddings_delegates_to_regenerate(self):
+        """
+        Backwards compatibility: the legacy entry point used by main.py's
+        startup sequence still exists, and goes through the same gate.
+        Migration 069 removed its dependence on the binary `initialized`
+        flag — a fresh boot after new builtin types are seeded will
+        process them, even if cold-start ran once before with count=0.
+        """
+        db = FakeDb(
+            vocab_change_counter=64,
+            last_processed=0,  # The dev-env scenario: was 0, never advanced
+            missing_types=[f"BUILTIN_TYPE_{i}" for i in range(48)],
+        )
+        worker = _make_worker(db)
+
+        result = asyncio.run(worker.initialize_builtin_embeddings())
+
+        # Pre-069 this would have short-circuited on the binary flag and
+        # returned target_count=0. Post-069 it picks up the missing types.
+        assert result.processed_count == 48
+        assert result.target_count == 48
+        assert db.init_status_updates[0]["vocab_change_counter"] == 64


### PR DESCRIPTION
## Summary

Three pre-existing bugs in the vocab embedding pipeline, surfaced during PR #420's verification step (the live `kg search related` query returned all-zero grounding until the API process restarted). All in the same subsystem; all small enough that fixing them together while context was fresh beat deferring.

Branches off `fix/feb-2-cluster` (#420) so the diff is just the 4 new commits — when #420 merges, GitHub will auto-update this PR's base to main.

## What the bugs were

1. **Polarity-axis cache keyed on the wrong counter.** It read `vocabulary_change_counter` (membership), but the path that updates vocab *embedding contents* (regen) doesn't touch that counter. A regenerated 48-row vocab table left the in-process cache stuck on `(vocab_gen=N, axis=None)` until the API process restarted.

2. **Cold-start used a binary `initialized` flag.** If cold-start ran when the vocab table was empty (count=0), the row was marked initialized=TRUE forever, and the 48 builtin types seeded by later migrations never got embeddings on subsequent boots.

3. **No background recovery.** Inline embedding-on-add covered ingestion; cold-start covered restarts. Neither covered long-running processes where the vocab table grew through other paths (migrations, manual SQL). The system had no hourly safety net like the one `EpistemicRemeasurementLauncher` already provides for epistemic remeasurement.

## Commits

| # | Type | What |
|---|------|------|
| C1 | `feat(schema)` | Migration 069: `vocabulary_embedding_generation_counter` row + `last_processed_vocab_change_counter` column on `system_initialization_status` |
| C2 | `fix(grounding)` | Embedding-storage paths bump the new counter; polarity-axis cache keys against it; verified live that `kg admin embedding regenerate` now invalidates the cache without a restart |
| C3 | `fix(embeddings)` | Cold-start uses last-processed-counter delta instead of binary flag; extracted shared workhorse `regenerate_missing_if_vocab_changed` for the launcher to reuse |
| C4 | `feat(workers)` | New `VocabEmbeddingLauncher` + worker + migration 070 (hourly schedule), mirrors `EpistemicRemeasurementLauncher` shape, uses per-component cursor so the two launchers don't interfere |

## Idempotency

Both new migrations (069, 070) verified idempotent against the dev DB:
- Migration 069 — `ON CONFLICT (metric_name) DO NOTHING`, `ADD COLUMN IF NOT EXISTS`, second run emits "column already exists, skipping"
- Migration 070 — `ON CONFLICT (name) DO UPDATE`, second run refreshes the row without erroring

## Test plan

- [x] `pytest tests/unit/ tests/api/` — 1104 passed, 15 skipped (zero regressions, +17 new tests across 3 files)
- [x] Each commit individually keeps the suite green
- [x] Live verification on dev container: counter bumps observed (0 → 48 after regen of 48 types), polarity-axis cache invalidates without restart, cold-start picks up missing embeddings after `UPDATE relationship_vocabulary SET embedding=NULL`, scheduled job row registered after API restart
- [ ] CI green