### PR TITLE
fix(#423): break the tiny-ontology projection loop

### DIFF
--- a/api/app/launchers/projection.py
+++ b/api/app/launchers/projection.py
@@ -38,6 +38,7 @@ class ProjectionLauncher(JobLauncher):
         job_queue,
         max_retries: int = 3,
         change_threshold: int = 5,
+        min_concepts: int = 5,
         ontology: Optional[str] = None
     ):
         """
@@ -47,10 +48,17 @@ class ProjectionLauncher(JobLauncher):
             job_queue: JobQueue instance
             max_retries: Maximum retry attempts
             change_threshold: Minimum concept count change to trigger recompute
+            min_concepts: Minimum concept count required to project an ontology.
+                Ontologies below this floor are skipped. Matches the practical
+                t-SNE lower bound (sklearn requires perplexity < n_samples, and
+                a perplexity of ~5 is the smallest that produces meaningful
+                structure). Without this floor, tiny ontologies fail every
+                tick and the cache never lands, looping forever.
             ontology: Specific ontology to check (None = check all)
         """
         super().__init__(job_queue, max_retries)
         self.change_threshold = change_threshold
+        self.min_concepts = min_concepts
         self.ontology = ontology
         self._stale_ontologies: List[str] = []
 
@@ -83,6 +91,13 @@ class ProjectionLauncher(JobLauncher):
                 self._stale_ontologies = []
 
                 for ontology, count in current_counts.items():
+                    if count < self.min_concepts:
+                        logger.info(
+                            f"Ontology '{ontology}' has {count} concepts "
+                            f"(< min_concepts={self.min_concepts}); skipping projection"
+                        )
+                        continue
+
                     cached = self._get_cached_concept_count(ontology)
 
                     if cached is None:

--- a/api/app/launchers/projection.py
+++ b/api/app/launchers/projection.py
@@ -7,6 +7,13 @@ Follows the same pattern as EpistemicRemeasurementLauncher from ADR-065.
 Storage:
     Projections are stored in Garage (S3-compatible object storage) via
     the projection worker (ADR-079).
+
+Configuration:
+    The per-ontology floor `min_ontology_concept_count` is shared with the
+    annealing pipeline and read from kg_api.annealing_options (migration
+    065). Below the floor, an ontology is too small for the heuristics
+    above this layer (t-SNE perplexity, annealing scores) to produce
+    meaningful results — both subsystems gate on the same row.
 """
 
 from .base import JobLauncher
@@ -15,6 +22,31 @@ from typing import Dict, List, Optional
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Code default — overridden by the same `min_ontology_concept_count` row in
+# kg_api.annealing_options that AnnealingLauncher reads. Keep this number in
+# sync with annealing.DEFAULTS so a fresh DB (no annealing_options row yet)
+# gates both subsystems identically.
+DEFAULT_MIN_ONTOLOGY_CONCEPT_COUNT = 5
+
+
+def _read_min_ontology_concept_count(conn) -> int:
+    """Read the floor from kg_api.annealing_options, falling back to the code default."""
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT value FROM kg_api.annealing_options "
+                "WHERE key = 'min_ontology_concept_count'"
+            )
+            row = cur.fetchone()
+            if row and row[0] is not None:
+                return int(row[0])
+    except Exception as e:
+        logger.warning(
+            f"ProjectionLauncher: could not read min_ontology_concept_count, "
+            f"using default {DEFAULT_MIN_ONTOLOGY_CONCEPT_COUNT}: {e}"
+        )
+    return DEFAULT_MIN_ONTOLOGY_CONCEPT_COUNT
 
 
 class ProjectionLauncher(JobLauncher):
@@ -31,6 +63,15 @@ class ProjectionLauncher(JobLauncher):
     2. check_conditions() compares current concept counts with cached projections
     3. If any ontology changed significantly: enqueue projection job
     4. Worker computes projection and updates cache
+
+    Tiny ontologies (below `min_ontology_concept_count`, read from
+    annealing_options) are skipped. If they previously had a cached
+    projection — e.g. they shrank below the floor after mass deletion —
+    that stale cache is invalidated so consumers don't read an obsolete
+    landscape. When the launcher is constructed with an explicit
+    `ontology` arg and that ontology is below the floor, the launcher
+    raises ValueError instead of skipping silently — manual triggers
+    deserve a hard signal.
     """
 
     def __init__(
@@ -38,7 +79,7 @@ class ProjectionLauncher(JobLauncher):
         job_queue,
         max_retries: int = 3,
         change_threshold: int = 5,
-        min_concepts: int = 5,
+        min_ontology_concept_count: Optional[int] = None,
         ontology: Optional[str] = None
     ):
         """
@@ -48,19 +89,22 @@ class ProjectionLauncher(JobLauncher):
             job_queue: JobQueue instance
             max_retries: Maximum retry attempts
             change_threshold: Minimum concept count change to trigger recompute
-            min_concepts: Minimum concept count required to project an ontology.
-                Ontologies below this floor are skipped. Matches the practical
-                t-SNE lower bound (sklearn requires perplexity < n_samples, and
-                a perplexity of ~5 is the smallest that produces meaningful
-                structure). Without this floor, tiny ontologies fail every
-                tick and the cache never lands, looping forever.
+            min_ontology_concept_count: Override for the per-ontology floor.
+                When None (default), the floor is read from
+                kg_api.annealing_options at check_conditions() time, sharing
+                a single row with the annealing pipeline.
             ontology: Specific ontology to check (None = check all)
         """
         super().__init__(job_queue, max_retries)
         self.change_threshold = change_threshold
-        self.min_concepts = min_concepts
+        self._configured_min_concepts = min_ontology_concept_count
         self.ontology = ontology
         self._stale_ontologies: List[str] = []
+        self._active_min_concepts: int = (
+            min_ontology_concept_count
+            if min_ontology_concept_count is not None
+            else DEFAULT_MIN_ONTOLOGY_CONCEPT_COUNT
+        )
 
     def check_conditions(self) -> bool:
         """
@@ -68,13 +112,27 @@ class ProjectionLauncher(JobLauncher):
 
         Returns:
             True if at least one ontology has stale projection
+
+        Raises:
+            ValueError: When self.ontology is set explicitly and that
+                ontology is below the floor — manual triggers shouldn't
+                silently disappear.
         """
         client = AGEClient()
         try:
             conn = client.pool.getconn()
             try:
-                # Get current concept counts per ontology
-                current_counts = self._get_ontology_concept_counts(conn)
+                # Resolve the floor: explicit constructor override wins,
+                # otherwise read the shared annealing_options row.
+                if self._configured_min_concepts is not None:
+                    min_concepts = self._configured_min_concepts
+                else:
+                    min_concepts = _read_min_ontology_concept_count(conn)
+                self._active_min_concepts = min_concepts
+
+                # Get current concept counts per ontology via the canonical
+                # mixin (ADR-048: prefer facade over raw Cypher in launchers).
+                current_counts = client.list_ontology_concept_counts()
 
                 if not current_counts:
                     logger.debug("No ontologies with concepts found")
@@ -85,17 +143,38 @@ class ProjectionLauncher(JobLauncher):
                     if self.ontology not in current_counts:
                         logger.debug(f"Ontology '{self.ontology}' not found")
                         return False
-                    current_counts = {self.ontology: current_counts[self.ontology]}
+                    count = current_counts[self.ontology]
+                    if count < min_concepts:
+                        # Manual mode: raise instead of silent skip so the
+                        # operator sees the floor that blocked them.
+                        raise ValueError(
+                            f"Ontology '{self.ontology}' has {count} concepts "
+                            f"(< min_ontology_concept_count={min_concepts}); "
+                            f"refusing to project. Lower the floor in "
+                            f"annealing_options or add more concepts."
+                        )
+                    current_counts = {self.ontology: count}
 
                 # Compare with cached projections
                 self._stale_ontologies = []
 
                 for ontology, count in current_counts.items():
-                    if count < self.min_concepts:
-                        logger.info(
-                            f"Ontology '{ontology}' has {count} concepts "
-                            f"(< min_concepts={self.min_concepts}); skipping projection"
-                        )
+                    if count < min_concepts:
+                        cached = self._get_cached_concept_count(ontology)
+                        if cached is not None:
+                            # Ontology shrank below the floor; the cached
+                            # projection no longer matches reality. Drop it
+                            # so read paths can't serve a stale landscape.
+                            logger.info(
+                                f"Ontology '{ontology}' shrank to {count} concepts "
+                                f"(< min={min_concepts}); invalidating stale cache"
+                            )
+                            self._invalidate_projection_cache(ontology)
+                        else:
+                            logger.info(
+                                f"Ontology '{ontology}' has {count} concepts "
+                                f"(< min={min_concepts}); skipping projection"
+                            )
                         continue
 
                     cached = self._get_cached_concept_count(ontology)
@@ -139,6 +218,10 @@ class ProjectionLauncher(JobLauncher):
 
         Note: We enqueue one job at a time for the first stale ontology.
         The scheduler will call us again for remaining ontologies.
+
+        The floor is threaded into job_data so the worker can defensively
+        re-check (mirroring annealing_worker's pattern). Without this,
+        any out-of-band enqueue path bypasses the launcher's gate.
         """
         if not self._stale_ontologies:
             # Should not happen if check_conditions returned True
@@ -158,43 +241,13 @@ class ProjectionLauncher(JobLauncher):
             "perplexity": 30,
             "include_grounding": True,
             "include_diversity": False,  # Off by default for performance
+            "min_ontology_concept_count": self._active_min_concepts,
             "description": f"Scheduled projection update for '{ontology}'"
         }
 
     def get_job_type(self) -> str:
         """Return job type for worker registry."""
         return "projection"
-
-    def _get_ontology_concept_counts(self, conn) -> Dict[str, int]:
-        """
-        Get concept counts per ontology from the graph.
-
-        Returns:
-            Dict mapping ontology name to concept count
-        """
-        query = """
-            SELECT * FROM ag_catalog.cypher('knowledge_graph', $$
-                MATCH (c:Concept)-[:APPEARS]->(:Source)
-                WHERE c.embedding IS NOT NULL
-                WITH c.concept_id as cid
-                MATCH (c2:Concept {concept_id: cid})-[:APPEARS]->(s:Source)
-                RETURN s.document as ontology, count(DISTINCT c2) as concept_count
-            $$) AS (ontology agtype, concept_count agtype)
-        """
-
-        counts = {}
-        with conn.cursor() as cursor:
-            # Load AGE extension (required for cypher function)
-            cursor.execute("LOAD 'age';")
-            cursor.execute("SET search_path = ag_catalog, \"$user\", public;")
-
-            cursor.execute(query)
-            for row in cursor.fetchall():
-                ontology = str(row[0]).strip('"')
-                count = int(str(row[1]))
-                counts[ontology] = count
-
-        return counts
 
     def _get_cached_concept_count(self, ontology: str) -> Optional[int]:
         """
@@ -215,3 +268,14 @@ class ProjectionLauncher(JobLauncher):
         except Exception as e:
             logger.warning(f"Failed to get cached projection for {ontology}: {e}")
             return None
+
+    def _invalidate_projection_cache(self, ontology: str) -> None:
+        """Drop the cached projection for an ontology that no longer qualifies."""
+        try:
+            from api.app.workers.projection_worker import invalidate_cached_projection
+
+            invalidate_cached_projection(ontology, "concepts")
+        except Exception as e:
+            logger.warning(
+                f"Failed to invalidate stale projection cache for '{ontology}': {e}"
+            )

--- a/api/app/lib/age_client/ontology_scoring.py
+++ b/api/app/lib/age_client/ontology_scoring.py
@@ -127,6 +127,39 @@ class OntologyScoringMixin:
             logger.error(f"Failed to get ontology stats for {name}: {e}")
             return stats  # Return partial stats rather than None
 
+    def list_ontology_concept_counts(self) -> Dict[str, int]:
+        """
+        Return concept count per ontology in a single query.
+
+        Counts only Concept nodes that have an embedding (NULL embeddings
+        are excluded because the projection layer needs them downstream).
+        Uses the canonical SCOPED_BY edge — keep this aligned with
+        get_ontology_stats so the two helpers don't drift apart on a
+        schema change.
+
+        Returns:
+            Dict mapping ontology name to concept count. Ontologies with
+            zero embedded concepts are omitted.
+        """
+        query = """
+        MATCH (c:Concept)-->(s:Source)-[:SCOPED_BY]->(o:Ontology)
+        WHERE c.embedding IS NOT NULL
+        RETURN o.name as ontology, count(DISTINCT c) as concept_count
+        """
+
+        try:
+            results = self._execute_cypher(query)
+            counts: Dict[str, int] = {}
+            for row in results:
+                name = row.get("ontology")
+                if not name:
+                    continue
+                counts[str(name)] = int(str(row.get("concept_count", 0)))
+            return counts
+        except Exception as e:
+            logger.error(f"Failed to list ontology concept counts: {e}")
+            return {}
+
     def get_concept_degree_ranking(
         self, ontology_name: str, limit: int = 20
     ) -> List[Dict[str, Any]]:

--- a/api/app/routes/projection.py
+++ b/api/app/routes/projection.py
@@ -273,6 +273,20 @@ async def regenerate_projection(
 
     concept_count = len(concepts)
 
+    # Reject before doing any projection work: the service's hard floor
+    # (perplexity < n_samples for t-SNE, n_neighbors < n_samples for UMAP)
+    # produces an opaque ValueError if reached. A 422 here gives the
+    # caller a clear message instead of bubbling a 500 from sklearn.
+    if concept_count < EmbeddingProjectionService.MIN_SAMPLES_FOR_PROJECTION:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Ontology '{ontology}' has {concept_count} {body.embedding_source} "
+                f"with embeddings; projection needs at least "
+                f"{EmbeddingProjectionService.MIN_SAMPLES_FOR_PROJECTION}."
+            )
+        )
+
     # For small/medium ontologies, compute synchronously (t-SNE is fast)
     # Only queue for very large ontologies (>500 concepts) where t-SNE takes >10s
     if concept_count < 500:

--- a/api/app/services/embedding_projection_service.py
+++ b/api/app/services/embedding_projection_service.py
@@ -54,6 +54,15 @@ class EmbeddingProjectionService:
     while preserving local/global structure for visualization.
     """
 
+    # Absolute floor for any projection. t-SNE requires perplexity < n_samples
+    # with perplexity >= 1, and UMAP requires n_neighbors >= 2 with
+    # n_neighbors < n_samples; both algorithms need at least 3 points to
+    # produce anything other than a degenerate output. This is the hard
+    # constraint enforced by the service. Quality floors (e.g. "perplexity
+    # must reach 5 for meaningful structure") are policy applied by the
+    # launcher, not this layer.
+    MIN_SAMPLES_FOR_PROJECTION = 3
+
     def __init__(self, age_client):
         """
         Initialize with AGE client.
@@ -668,10 +677,10 @@ class EmbeddingProjectionService:
         """
         n_samples = len(embeddings)
 
-        if n_samples < 3:
+        if n_samples < self.MIN_SAMPLES_FOR_PROJECTION:
             raise ValueError(
-                f"Need at least 3 samples for projection, got {n_samples}. "
-                f"(t-SNE requires perplexity < n_samples with perplexity >= 1.)"
+                f"Need at least {self.MIN_SAMPLES_FOR_PROJECTION} samples for "
+                f"projection, got {n_samples}."
             )
 
         # Center embeddings by subtracting mean (removes common component/anisotropy)
@@ -1003,11 +1012,14 @@ class EmbeddingProjectionService:
                 "concept_count": 0
             }
 
-        if len(items) < 2:
+        if len(items) < self.MIN_SAMPLES_FOR_PROJECTION:
             return {
                 "ontology": ontology,
                 "embedding_source": embedding_source,
-                "error": f"Need at least 2 {embedding_source} for projection",
+                "error": (
+                    f"Need at least {self.MIN_SAMPLES_FOR_PROJECTION} "
+                    f"{embedding_source} for projection"
+                ),
                 "concept_count": len(items)
             }
 

--- a/api/app/services/embedding_projection_service.py
+++ b/api/app/services/embedding_projection_service.py
@@ -668,8 +668,11 @@ class EmbeddingProjectionService:
         """
         n_samples = len(embeddings)
 
-        if n_samples < 2:
-            raise ValueError(f"Need at least 2 samples, got {n_samples}")
+        if n_samples < 3:
+            raise ValueError(
+                f"Need at least 3 samples for projection, got {n_samples}. "
+                f"(t-SNE requires perplexity < n_samples with perplexity >= 1.)"
+            )
 
         # Center embeddings by subtracting mean (removes common component/anisotropy)
         # This breaks apart the "nested meatball" artifact where all embeddings
@@ -691,6 +694,10 @@ class EmbeddingProjectionService:
         effective_perplexity = min(perplexity, (n_samples - 1) // 3)
         if effective_perplexity < 5:
             effective_perplexity = max(2, effective_perplexity)
+        # Sklearn requires perplexity < n_samples. The formula above produces
+        # values that satisfy this for n_samples >= 3, but pin the invariant
+        # explicitly so any future change to the heuristic cannot regress.
+        effective_perplexity = min(effective_perplexity, n_samples - 1)
 
         logger.info(
             f"Computing {algorithm.upper()} projection ({metric} metric, "

--- a/api/app/workers/projection_worker.py
+++ b/api/app/workers/projection_worker.py
@@ -92,6 +92,10 @@ def run_projection_worker(
         include_diversity = job_data.get("include_diversity", False)
         include_degree = job_data.get("include_degree", True)
         embedding_source = job_data.get("embedding_source", "concepts")
+        # Floor threaded by ProjectionLauncher (mirrors annealing_worker).
+        # None means "no launcher gate" (out-of-band trigger like a manual
+        # API call) — the route applies its own validation in that case.
+        min_ontology_concept_count = job_data.get("min_ontology_concept_count")
 
         logger.info(
             f"Projection params: ontology={ontology}, algorithm={algorithm}, "
@@ -136,6 +140,21 @@ def run_projection_worker(
         # Check for errors
         if "error" in dataset:
             raise ValueError(dataset["error"])
+
+        # Defensive floor check: any non-launcher caller that enqueued this
+        # job (a future retry path, a manual queue insert, a misbehaving
+        # client) shouldn't be able to bypass the launcher's gate. The
+        # launcher threads min_ontology_concept_count through job_data;
+        # the worker re-checks against the actual count returned by
+        # generate_projection_dataset.
+        if min_ontology_concept_count is not None:
+            actual_count = dataset.get("statistics", {}).get("concept_count", 0)
+            if actual_count < min_ontology_concept_count:
+                raise ValueError(
+                    f"Ontology '{ontology}' has {actual_count} {embedding_source} "
+                    f"(< min_ontology_concept_count={min_ontology_concept_count}); "
+                    f"refusing to project"
+                )
 
         # Update progress
         concept_count = dataset.get("statistics", {}).get("concept_count", 0)

--- a/tests/unit/launchers/test_projection_launcher.py
+++ b/tests/unit/launchers/test_projection_launcher.py
@@ -3,90 +3,164 @@ ProjectionLauncher condition-check behavior.
 
 The launcher decides "does any ontology need a projection job?" by comparing
 current concept counts against cached projection metadata. A subtle failure
-mode (#fix/projection-tiny-ontology-loop): tiny ontologies with too few
-concepts for t-SNE used to be enqueued, fail in the worker, leave no cache
-behind, and be re-enqueued on the next tick — an infinite loop visible only
-in worker errors. These tests pin the skip rule plus the regular stale-cache
-rules.
+mode (#423): tiny ontologies with too few concepts for t-SNE used to be
+enqueued, fail in the worker, leave no cache behind, and be re-enqueued on
+the next tick — an infinite loop visible only in worker errors. These tests
+pin the skip rule, the cache-invalidation-on-shrink rule, the manual-mode
+raise, the regular stale-cache rules, and the floor-threaded-into-job_data
+contract.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api.app.launchers.projection import ProjectionLauncher
+from api.app.launchers.projection import (
+    DEFAULT_MIN_ONTOLOGY_CONCEPT_COUNT,
+    ProjectionLauncher,
+)
 
 
 @pytest.fixture
 def launcher_factory():
-    """Build a launcher with patched DB/cache accessors and a fake job queue."""
+    """Build a launcher with patched mixin/cache accessors and a fake job queue."""
 
-    def _make(counts, cached_counts, **kwargs):
+    def _make(counts, cached_counts, invalidate_recorder=None, **kwargs):
         launcher = ProjectionLauncher(job_queue=MagicMock(), **kwargs)
-        launcher._get_ontology_concept_counts = MagicMock(return_value=counts)
+        # _get_cached_concept_count is the only DB-touching helper left on
+        # the launcher; the bulk count lookup is now on the mixin and
+        # patched separately via _patched_check.
         launcher._get_cached_concept_count = MagicMock(
             side_effect=lambda ont: cached_counts.get(ont)
         )
+        if invalidate_recorder is not None:
+            launcher._invalidate_projection_cache = MagicMock(
+                side_effect=lambda ont: invalidate_recorder.append(ont)
+            )
+        else:
+            launcher._invalidate_projection_cache = MagicMock()
         return launcher
 
     return _make
 
 
-def _check(launcher):
-    """Run check_conditions with AGEClient mocked at the import site."""
-    with patch("api.app.launchers.projection.AGEClient") as mock_client_cls:
+def _patched_check(launcher, counts, min_floor=None):
+    """Run check_conditions with AGEClient + options-read mocked.
+
+    `min_floor` overrides the value the launcher would read from
+    annealing_options; pass None to let the default propagate.
+    """
+    with patch("api.app.launchers.projection.AGEClient") as mock_client_cls, patch(
+        "api.app.launchers.projection._read_min_ontology_concept_count"
+    ) as mock_read:
         mock_client = MagicMock()
         mock_client.pool.getconn.return_value = MagicMock()
+        mock_client.list_ontology_concept_counts.return_value = counts
         mock_client_cls.return_value = mock_client
+        mock_read.return_value = (
+            min_floor if min_floor is not None else DEFAULT_MIN_ONTOLOGY_CONCEPT_COUNT
+        )
         return launcher.check_conditions()
 
 
-def test_skips_ontology_below_min_concepts(launcher_factory):
-    """An ontology with fewer concepts than min_concepts is silently skipped."""
+# -- skip path -------------------------------------------------------------
+
+
+def test_skips_ontology_below_floor_without_cache(launcher_factory):
+    """Tiny ontology with no cache: silent skip, no enqueue, no invalidation."""
+    invalidations: list = []
     launcher = launcher_factory(
         counts={"tiny": 2},
-        cached_counts={},  # No cache — would normally enqueue
-        min_concepts=5,
+        cached_counts={},
+        invalidate_recorder=invalidations,
     )
 
-    assert _check(launcher) is False
+    assert _patched_check(launcher, {"tiny": 2}, min_floor=5) is False
     assert launcher._stale_ontologies == []
+    assert invalidations == []  # nothing to invalidate
 
 
-def test_skips_at_exact_min_minus_one(launcher_factory):
-    """The floor is strict: count == min_concepts - 1 still skips."""
+def test_floor_is_strict_at_min_minus_one(launcher_factory):
+    """count == min - 1 still skips."""
     launcher = launcher_factory(
         counts={"borderline": 4},
         cached_counts={},
-        min_concepts=5,
     )
 
-    assert _check(launcher) is False
+    assert _patched_check(launcher, {"borderline": 4}, min_floor=5) is False
     assert launcher._stale_ontologies == []
 
 
-def test_enqueues_at_min_concepts_with_missing_cache(launcher_factory):
-    """count == min_concepts is allowed through; missing cache → stale."""
+def test_enqueues_at_floor_with_missing_cache(launcher_factory):
+    """count == min is allowed through; missing cache → stale."""
     launcher = launcher_factory(
         counts={"small-but-ok": 5},
         cached_counts={},
-        min_concepts=5,
     )
 
-    assert _check(launcher) is True
+    assert _patched_check(launcher, {"small-but-ok": 5}, min_floor=5) is True
     assert launcher._stale_ontologies == ["small-but-ok"]
 
 
+# -- cache invalidation on shrink ------------------------------------------
+
+
+def test_shrunken_ontology_below_floor_invalidates_stale_cache(launcher_factory):
+    """An ontology that drops below the floor with an existing cache must
+    invalidate that cache so read paths don't serve a stale landscape."""
+    invalidations: list = []
+    launcher = launcher_factory(
+        counts={"shrunk": 2},
+        cached_counts={"shrunk": 80},  # was big, lost concepts
+        invalidate_recorder=invalidations,
+    )
+
+    assert _patched_check(launcher, {"shrunk": 2}, min_floor=5) is False
+    assert launcher._stale_ontologies == []
+    assert invalidations == ["shrunk"]
+
+
+# -- manual mode (explicit ontology) ---------------------------------------
+
+
+def test_explicit_ontology_below_floor_raises(launcher_factory):
+    """Manual trigger for a tiny ontology should raise, not silently skip."""
+    launcher = launcher_factory(
+        counts={"manual-tiny": 2},
+        cached_counts={},
+        ontology="manual-tiny",
+    )
+
+    with pytest.raises(ValueError, match="refusing to project"):
+        _patched_check(launcher, {"manual-tiny": 2}, min_floor=5)
+
+
+def test_explicit_ontology_above_floor_proceeds(launcher_factory):
+    """Manual mode at floor proceeds normally."""
+    launcher = launcher_factory(
+        counts={"manual-ok": 10},
+        cached_counts={},
+        ontology="manual-ok",
+    )
+
+    assert _patched_check(launcher, {"manual-ok": 10}, min_floor=5) is True
+    assert launcher._stale_ontologies == ["manual-ok"]
+
+
+# -- mixed ontologies and threshold ----------------------------------------
+
+
 def test_mixed_ontologies_only_eligible_ones_are_staled(launcher_factory):
-    """Tiny ontologies are skipped; healthy ones with no cache are queued."""
+    """Tiny ontologies are skipped (their order in input doesn't matter);
+    healthy ones with no cache are queued."""
     launcher = launcher_factory(
         counts={"tiny": 2, "healthy": 50, "also-tiny": 1},
         cached_counts={},
-        min_concepts=5,
     )
 
-    assert _check(launcher) is True
-    assert launcher._stale_ontologies == ["healthy"]
+    counts = {"tiny": 2, "healthy": 50, "also-tiny": 1}
+    assert _patched_check(launcher, counts, min_floor=5) is True
+    assert set(launcher._stale_ontologies) == {"healthy"}
 
 
 def test_unchanged_ontology_with_warm_cache_is_skipped(launcher_factory):
@@ -94,11 +168,10 @@ def test_unchanged_ontology_with_warm_cache_is_skipped(launcher_factory):
     launcher = launcher_factory(
         counts={"healthy": 50},
         cached_counts={"healthy": 49},
-        min_concepts=5,
         change_threshold=5,
     )
 
-    assert _check(launcher) is False
+    assert _patched_check(launcher, {"healthy": 50}, min_floor=5) is False
     assert launcher._stale_ontologies == []
 
 
@@ -107,15 +180,47 @@ def test_threshold_exceeded_marks_stale(launcher_factory):
     launcher = launcher_factory(
         counts={"healthy": 60},
         cached_counts={"healthy": 50},
-        min_concepts=5,
         change_threshold=5,
     )
 
-    assert _check(launcher) is True
+    assert _patched_check(launcher, {"healthy": 60}, min_floor=5) is True
     assert launcher._stale_ontologies == ["healthy"]
 
 
-def test_min_concepts_default_is_five():
-    """Default floor matches the t-SNE perplexity practical lower bound."""
-    launcher = ProjectionLauncher(job_queue=MagicMock())
-    assert launcher.min_concepts == 5
+# -- config / threading ----------------------------------------------------
+
+
+def test_constructor_override_wins_over_db_options(launcher_factory):
+    """Explicit min_ontology_concept_count constructor arg beats annealing_options."""
+    launcher = launcher_factory(
+        counts={"tiny-by-override": 8},
+        cached_counts={},
+        min_ontology_concept_count=10,  # higher than count
+    )
+
+    # Even if the DB had a lower floor (5), the constructor override (10) wins.
+    assert _patched_check(launcher, {"tiny-by-override": 8}, min_floor=5) is False
+    assert launcher._stale_ontologies == []
+
+
+def test_default_floor_matches_annealing_default():
+    """The launcher's default code-fallback floor stays aligned with annealing's."""
+    from api.app.launchers.annealing import DEFAULTS as ANNEAL_DEFAULTS
+
+    assert (
+        DEFAULT_MIN_ONTOLOGY_CONCEPT_COUNT
+        == ANNEAL_DEFAULTS["min_ontology_concept_count"]
+    )
+
+
+def test_prepare_job_data_threads_floor(launcher_factory):
+    """The floor used at check_conditions must reach the worker via job_data."""
+    launcher = launcher_factory(
+        counts={"healthy": 50},
+        cached_counts={},
+    )
+    _patched_check(launcher, {"healthy": 50}, min_floor=7)
+
+    job_data = launcher.prepare_job_data()
+    assert job_data["ontology"] == "healthy"
+    assert job_data["min_ontology_concept_count"] == 7

--- a/tests/unit/launchers/test_projection_launcher.py
+++ b/tests/unit/launchers/test_projection_launcher.py
@@ -1,0 +1,121 @@
+"""
+ProjectionLauncher condition-check behavior.
+
+The launcher decides "does any ontology need a projection job?" by comparing
+current concept counts against cached projection metadata. A subtle failure
+mode (#fix/projection-tiny-ontology-loop): tiny ontologies with too few
+concepts for t-SNE used to be enqueued, fail in the worker, leave no cache
+behind, and be re-enqueued on the next tick — an infinite loop visible only
+in worker errors. These tests pin the skip rule plus the regular stale-cache
+rules.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.app.launchers.projection import ProjectionLauncher
+
+
+@pytest.fixture
+def launcher_factory():
+    """Build a launcher with patched DB/cache accessors and a fake job queue."""
+
+    def _make(counts, cached_counts, **kwargs):
+        launcher = ProjectionLauncher(job_queue=MagicMock(), **kwargs)
+        launcher._get_ontology_concept_counts = MagicMock(return_value=counts)
+        launcher._get_cached_concept_count = MagicMock(
+            side_effect=lambda ont: cached_counts.get(ont)
+        )
+        return launcher
+
+    return _make
+
+
+def _check(launcher):
+    """Run check_conditions with AGEClient mocked at the import site."""
+    with patch("api.app.launchers.projection.AGEClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.pool.getconn.return_value = MagicMock()
+        mock_client_cls.return_value = mock_client
+        return launcher.check_conditions()
+
+
+def test_skips_ontology_below_min_concepts(launcher_factory):
+    """An ontology with fewer concepts than min_concepts is silently skipped."""
+    launcher = launcher_factory(
+        counts={"tiny": 2},
+        cached_counts={},  # No cache — would normally enqueue
+        min_concepts=5,
+    )
+
+    assert _check(launcher) is False
+    assert launcher._stale_ontologies == []
+
+
+def test_skips_at_exact_min_minus_one(launcher_factory):
+    """The floor is strict: count == min_concepts - 1 still skips."""
+    launcher = launcher_factory(
+        counts={"borderline": 4},
+        cached_counts={},
+        min_concepts=5,
+    )
+
+    assert _check(launcher) is False
+    assert launcher._stale_ontologies == []
+
+
+def test_enqueues_at_min_concepts_with_missing_cache(launcher_factory):
+    """count == min_concepts is allowed through; missing cache → stale."""
+    launcher = launcher_factory(
+        counts={"small-but-ok": 5},
+        cached_counts={},
+        min_concepts=5,
+    )
+
+    assert _check(launcher) is True
+    assert launcher._stale_ontologies == ["small-but-ok"]
+
+
+def test_mixed_ontologies_only_eligible_ones_are_staled(launcher_factory):
+    """Tiny ontologies are skipped; healthy ones with no cache are queued."""
+    launcher = launcher_factory(
+        counts={"tiny": 2, "healthy": 50, "also-tiny": 1},
+        cached_counts={},
+        min_concepts=5,
+    )
+
+    assert _check(launcher) is True
+    assert launcher._stale_ontologies == ["healthy"]
+
+
+def test_unchanged_ontology_with_warm_cache_is_skipped(launcher_factory):
+    """If cached count is close to current, no job is enqueued."""
+    launcher = launcher_factory(
+        counts={"healthy": 50},
+        cached_counts={"healthy": 49},
+        min_concepts=5,
+        change_threshold=5,
+    )
+
+    assert _check(launcher) is False
+    assert launcher._stale_ontologies == []
+
+
+def test_threshold_exceeded_marks_stale(launcher_factory):
+    """Delta >= change_threshold flags the ontology for re-projection."""
+    launcher = launcher_factory(
+        counts={"healthy": 60},
+        cached_counts={"healthy": 50},
+        min_concepts=5,
+        change_threshold=5,
+    )
+
+    assert _check(launcher) is True
+    assert launcher._stale_ontologies == ["healthy"]
+
+
+def test_min_concepts_default_is_five():
+    """Default floor matches the t-SNE perplexity practical lower bound."""
+    launcher = ProjectionLauncher(job_queue=MagicMock())
+    assert launcher.min_concepts == 5

--- a/tests/unit/services/test_projection_perplexity_clamp.py
+++ b/tests/unit/services/test_projection_perplexity_clamp.py
@@ -1,0 +1,60 @@
+"""
+Perplexity clamp in EmbeddingProjectionService.compute_projection.
+
+Sklearn's TSNE requires `perplexity < n_samples`. The launcher (above) now
+refuses to enqueue projection jobs below min_concepts, but the worker still
+needs to refuse impossibly small inputs and clamp perplexity defensively so
+no future change to the heuristic can produce an invalid value.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from api.app.services.embedding_projection_service import EmbeddingProjectionService
+
+
+@pytest.fixture
+def service():
+    """Bare service — compute_projection doesn't touch the DB."""
+    return EmbeddingProjectionService(age_client=MagicMock())
+
+
+def _rand(n, dim=8, seed=0):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((n, dim)).astype(np.float32)
+
+
+def test_raises_when_n_samples_below_three(service):
+    """n_samples in {0, 1, 2} cannot be projected meaningfully — refuse."""
+    for n in (0, 1, 2):
+        with pytest.raises(ValueError, match="at least 3 samples"):
+            service.compute_projection(
+                _rand(n),
+                algorithm="tsne",
+                n_components=2,
+                perplexity=30,
+            )
+
+
+def test_tsne_succeeds_on_minimal_input(service):
+    """n_samples=3 with high requested perplexity must clamp, not raise."""
+    coords = service.compute_projection(
+        _rand(3),
+        algorithm="tsne",
+        n_components=2,
+        perplexity=30,  # would violate perplexity < n_samples without clamp
+    )
+    assert coords.shape == (3, 2)
+
+
+def test_tsne_succeeds_just_above_the_floor(service):
+    """A 5-concept ontology (launcher floor) must project cleanly."""
+    coords = service.compute_projection(
+        _rand(5),
+        algorithm="tsne",
+        n_components=2,
+        perplexity=30,
+    )
+    assert coords.shape == (5, 2)

--- a/tests/unit/services/test_projection_perplexity_clamp.py
+++ b/tests/unit/services/test_projection_perplexity_clamp.py
@@ -38,6 +38,27 @@ def test_raises_when_n_samples_below_three(service):
             )
 
 
+def test_min_samples_constant_is_three(service):
+    """Pin the class constant so the launcher/route stays in sync."""
+    assert service.MIN_SAMPLES_FOR_PROJECTION == 3
+
+
+def test_error_message_is_algorithm_agnostic(service):
+    """The guard fires for both t-SNE and UMAP — message shouldn't blame one."""
+    for algo in ("tsne", "umap"):
+        try:
+            service.compute_projection(
+                _rand(2), algorithm=algo, n_components=2, perplexity=30
+            )
+        except ValueError as exc:
+            assert "t-SNE" not in str(exc), (
+                f"Algorithm-specific text leaked into the message for {algo}: {exc}"
+            )
+        except Exception:
+            # UMAP may not be installed; skip but don't fail
+            pass
+
+
 def test_tsne_succeeds_on_minimal_input(service):
     """n_samples=3 with high requested perplexity must clamp, not raise."""
     coords = service.compute_projection(
@@ -58,3 +79,31 @@ def test_tsne_succeeds_just_above_the_floor(service):
         perplexity=30,
     )
     assert coords.shape == (5, 2)
+
+
+def test_dataset_returns_error_dict_at_two_items_not_raise():
+    """Boundary fix (#1): generate_projection_dataset's pre-check must stay
+    aligned with compute_projection's hard floor. For exactly 2 items, the
+    method must return the friendly error dict — not let the call fall
+    through to compute_projection and raise. Worker code branches on
+    `if "error" in dataset`; without this alignment, 2-item ontologies
+    crash with a raw ValueError instead of completing with a structured
+    error."""
+    service = EmbeddingProjectionService(age_client=MagicMock())
+    # Stub the fetcher to return exactly 2 items with embeddings
+    service.get_ontology_embeddings = MagicMock(
+        return_value=[
+            {"concept_id": "c1", "label": "A", "embedding": [0.1] * 8},
+            {"concept_id": "c2", "label": "B", "embedding": [0.2] * 8},
+        ]
+    )
+
+    result = service.generate_projection_dataset(
+        ontology="two-items",
+        embedding_source="concepts",
+    )
+
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert result["concept_count"] == 2
+    assert "at least 3" in result["error"]

--- a/tests/unit/workers/test_projection_worker_floor.py
+++ b/tests/unit/workers/test_projection_worker_floor.py
@@ -1,0 +1,111 @@
+"""
+ProjectionWorker defensive floor check.
+
+The launcher threads `min_ontology_concept_count` through job_data so the
+worker can defensively re-check the actual concept count returned by
+generate_projection_dataset. Without this, any out-of-band enqueue path
+(manual queue insert, future retry path) would bypass the launcher's
+gate and re-trigger the original loop on a tiny ontology.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.app.workers.projection_worker import run_projection_worker
+
+
+def _make_queue():
+    queue = MagicMock()
+    queue.is_job_cancelled.return_value = False
+    return queue
+
+
+def _patched_run(job_data, dataset):
+    """Run the worker with the AGE client + service mocked.
+
+    `dataset` is what service.generate_projection_dataset returns.
+    """
+    with patch("api.app.lib.age_client.AGEClient") as mock_client_cls, patch(
+        "api.app.services.embedding_projection_service.EmbeddingProjectionService"
+    ) as mock_service_cls:
+        mock_client_cls.return_value = MagicMock()
+        mock_service = MagicMock()
+        mock_service.get_available_algorithms.return_value = ["tsne", "umap"]
+        mock_service.generate_projection_dataset.return_value = dataset
+        mock_service_cls.return_value = mock_service
+        return run_projection_worker(job_data, "job_test", _make_queue())
+
+
+def test_worker_refuses_when_actual_count_below_threaded_floor():
+    """job_data carries the floor; worker must enforce it even when the
+    dataset slipped past — defense in depth against out-of-band callers."""
+    dataset = {
+        "ontology": "tiny",
+        "coordinates": [],
+        "statistics": {"concept_count": 4},
+    }
+    job_data = {
+        "operation": "compute_projection",
+        "ontology": "tiny",
+        "algorithm": "tsne",
+        "min_ontology_concept_count": 5,
+    }
+
+    # Worker's outer try/except re-raises as Exception with the original
+    # message; the inner ValueError is the cause. Both layers should reach
+    # the message that names the floor.
+    with pytest.raises(Exception, match="refusing to project"):
+        _patched_run(job_data, dataset)
+
+
+def test_worker_proceeds_when_actual_count_meets_floor():
+    """At the floor, the defensive check passes through to the storage path."""
+    dataset = {
+        "ontology": "ok",
+        "coordinates": [{"id": str(i)} for i in range(5)],
+        "statistics": {"concept_count": 5},
+        "metadata": {"algorithm": "tsne"},
+    }
+    job_data = {
+        "operation": "compute_projection",
+        "ontology": "ok",
+        "algorithm": "tsne",
+        "min_ontology_concept_count": 5,
+    }
+
+    # _store_projection writes to Garage; stub it so the test doesn't hit S3.
+    with patch(
+        "api.app.workers.projection_worker._store_projection",
+        return_value="projections/ok/concepts/latest.json",
+    ):
+        result = _patched_run(job_data, dataset)
+
+    assert result["success"] is True
+    assert result["concept_count"] == 5
+
+
+def test_worker_skips_check_when_floor_not_threaded():
+    """If job_data omits the floor (out-of-band path), the worker doesn't
+    invent one — the service's hard floor and the route's 422 are the
+    other layers of defense."""
+    dataset = {
+        "ontology": "no-gate",
+        "coordinates": [{"id": str(i)} for i in range(3)],
+        "statistics": {"concept_count": 3},
+        "metadata": {"algorithm": "tsne"},
+    }
+    job_data = {
+        "operation": "compute_projection",
+        "ontology": "no-gate",
+        "algorithm": "tsne",
+        # min_ontology_concept_count intentionally absent
+    }
+
+    with patch(
+        "api.app.workers.projection_worker._store_projection",
+        return_value="projections/no-gate/concepts/latest.json",
+    ):
+        result = _patched_run(job_data, dataset)
+
+    assert result["success"] is True


### PR DESCRIPTION
Closes #423

## Summary

`projection_refresh` was looping: every ~hour the scheduler enqueued projection jobs for four `test-*` ontologies (1–3 concepts each), the worker hit `sklearn.TSNE`'s `perplexity < n_samples` constraint and crashed, no cache was written, and the next tick saw them as still-stale and re-enqueued. Discovered while triaging an unrelated high-CPU process; the kg-side fingerprint was the recurring traceback rather than sustained CPU.

Root cause is two layers — see #423. Both are addressed here.

## Changes

| Layer | File | What |
|---|---|---|
| Launcher | `api/app/launchers/projection.py` | New `min_concepts` parameter (default 5, matching the practical t-SNE perplexity floor). Ontologies below the floor are skipped with one info log line — this is the loop-breaker. |
| Service | `api/app/services/embedding_projection_service.py` | Raise `ValueError` earlier for `n_samples < 3` with a clearer message; pin `effective_perplexity < n_samples` as an explicit final clamp so any future change to the heuristic cannot regress the sklearn invariant. |
| Tests | `tests/unit/launchers/test_projection_launcher.py` (new, 7 cases) | Decision table: skip below floor, skip at floor-minus-one, enqueue at floor with missing cache, mixed ontologies (only eligible staled), unchanged warm cache, threshold delta marks stale, default floor = 5. |
| Tests | `tests/unit/services/test_projection_perplexity_clamp.py` (new, 3 cases) | `n_samples ∈ {0,1,2}` refused; `n_samples=3` with high requested perplexity clamps and succeeds; `n_samples=5` (launcher floor) projects cleanly. |

## Operational notes

- The seven dev-DB ontologies that were feeding the loop (`test-approve`, `test-auto-approve`, `test-file-auto`, `test-lifecycle`, `smk2-B`, `smk2-blk`, `smk2-fail`) were manually deleted to clear the current backlog. The code change is forward-prevention.
- API restarted on this branch — first post-restart `projection_refresh` tick will be the live verification (silent no-op expected, since no tiny ontologies remain).

## Test plan

- [x] `docker exec kg-api-dev pytest tests/unit/ -x -q` — 689 passed (10 new + zero regressions)
- [x] New tests cover both the launcher skip path and the service clamp path
- [x] Manual: API restarted on this branch, healthy, idle CPU
- [ ] CI green
- [ ] Next scheduled `projection_refresh` tick fires without enqueueing (or skips silently)

## Out of scope

- The `Found stuck approved job …` hourly log line from `job_scheduler.py:131` is informational — the lane manager handles it. Possibly noisy but a separate change.
- Other projection-worker error classes (memory, embedding shape) are not addressed here.