### PR TITLE
fix(gpu): stop over-claiming VRAM on AMD ROCm (and CPU/CUDA)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -112,5 +112,9 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:8000/health || exit 1
 
-# Start FastAPI server with uvicorn (multi-worker in both dev and prod)
-CMD ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+# Start FastAPI server with uvicorn.
+# Single worker: each uvicorn worker is a separate Python process and would
+# load its own copy of any local embedding model (and ROCm/CUDA runtime
+# context on GPU variants) — 2 workers ≈ 2× memory for no async-throughput
+# gain on this workload. Ingestion runs in the queue, not the request path.
+CMD ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/api/Dockerfile.rocm-host
+++ b/api/Dockerfile.rocm-host
@@ -51,4 +51,4 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:8000/health || exit 1
 
-CMD ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+CMD ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/api/app/lib/visual_embeddings.py
+++ b/api/app/lib/visual_embeddings.py
@@ -87,6 +87,7 @@ class VisualEmbeddingGenerator:
     def _load_transformers(self):
         """Load model via transformers AutoModel + AutoProcessor."""
         from transformers import AutoModel, AutoProcessor
+        import torch
 
         load_kwargs = {
             "trust_remote_code": self.trust_remote_code,
@@ -94,59 +95,52 @@ class VisualEmbeddingGenerator:
         if self.model_revision:
             load_kwargs["revision"] = self.model_revision
 
+        # On GPU, load weights in fp16 to halve VRAM footprint. The vision
+        # tower's accuracy is unaffected at fp16 for embedding extraction.
+        # CPU stays fp32 — fp16 on CPU is slower, not smaller in any way
+        # that matters here.
+        on_accelerator = self.device in ('cuda', 'mps')
+        if on_accelerator:
+            load_kwargs["torch_dtype"] = torch.float16
+
+        processor_kwargs = {"trust_remote_code": self.trust_remote_code, "use_fast": True}
+        if self.model_revision:
+            processor_kwargs["revision"] = self.model_revision
+
         try:
             # Try loading from local cache first
             try:
-                if self.device in ('cuda', 'mps'):
-                    self.model = AutoModel.from_pretrained(
-                        self.model_name,
-                        device_map="auto",
-                        local_files_only=True,
-                        **load_kwargs
-                    )
-                else:
-                    self.model = AutoModel.from_pretrained(
-                        self.model_name,
-                        low_cpu_mem_usage=False,
-                        local_files_only=True,
-                        **load_kwargs
-                    )
-
-                processor_kwargs = {"trust_remote_code": self.trust_remote_code, "use_fast": True}
-                if self.model_revision:
-                    processor_kwargs["revision"] = self.model_revision
+                self.model = AutoModel.from_pretrained(
+                    self.model_name,
+                    local_files_only=True,
+                    **load_kwargs,
+                )
                 self.processor = AutoProcessor.from_pretrained(
                     self.model_name,
                     local_files_only=True,
-                    **processor_kwargs
+                    **processor_kwargs,
                 )
                 logger.info(f"  Loaded vision model from cache")
 
             except (OSError, ValueError):
                 logger.warning(f"  Vision model not in cache, downloading...")
-
-                if self.device in ('cuda', 'mps'):
-                    self.model = AutoModel.from_pretrained(
-                        self.model_name,
-                        device_map="auto",
-                        **load_kwargs
-                    )
-                else:
-                    self.model = AutoModel.from_pretrained(
-                        self.model_name,
-                        low_cpu_mem_usage=False,
-                        **load_kwargs
-                    )
-
-                processor_kwargs = {"trust_remote_code": self.trust_remote_code, "use_fast": True}
-                if self.model_revision:
-                    processor_kwargs["revision"] = self.model_revision
+                self.model = AutoModel.from_pretrained(
+                    self.model_name,
+                    **load_kwargs,
+                )
                 self.processor = AutoProcessor.from_pretrained(
                     self.model_name,
-                    **processor_kwargs
+                    **processor_kwargs,
                 )
                 logger.info(f"  Downloaded and cached vision model")
 
+            # Explicit .to(device) instead of device_map="auto": the auto
+            # path goes through accelerate, which keeps hook + buffer
+            # machinery resident for sharding we don't need on a sub-GB
+            # single-tower vision model. The text loader uses the same
+            # explicit pattern (see embedding_model_manager.py).
+            if on_accelerator:
+                self.model = self.model.to(self.device)
             self.model.eval()
             logger.info(
                 f"Vision model loaded: {self.model_name} on {self.device}"

--- a/api/app/lib/visual_embeddings.py
+++ b/api/app/lib/visual_embeddings.py
@@ -102,6 +102,11 @@ class VisualEmbeddingGenerator:
         on_accelerator = self.device in ('cuda', 'mps')
         if on_accelerator:
             load_kwargs["torch_dtype"] = torch.float16
+        else:
+            # Preserve the pre-refactor CPU semantics: HF transformers'
+            # low_cpu_mem_usage default has flipped between releases. Pin
+            # it explicitly so behavior doesn't drift with the dependency.
+            load_kwargs["low_cpu_mem_usage"] = False
 
         processor_kwargs = {"trust_remote_code": self.trust_remote_code, "use_fast": True}
         if self.model_revision:
@@ -137,13 +142,25 @@ class VisualEmbeddingGenerator:
             # Explicit .to(device) instead of device_map="auto": the auto
             # path goes through accelerate, which keeps hook + buffer
             # machinery resident for sharding we don't need on a sub-GB
-            # single-tower vision model. The text loader uses the same
-            # explicit pattern (see embedding_model_manager.py).
+            # single-tower vision model. The text loader uses .to(device)
+            # too (see embedding_model_manager.py); the dtype side
+            # diverges because the text loader's tokenizer outputs are
+            # integer token IDs that don't need recasting, while the
+            # vision processor outputs fp32 pixel_values that must match
+            # the (possibly fp16) model weights — see _to_model_inputs.
             if on_accelerator:
                 self.model = self.model.to(self.device)
             self.model.eval()
+
+            # Cache the model dtype for input casting on every forward.
+            # When the model loaded at fp16, the processor will still
+            # produce fp32 pixel_values; passing them through without a
+            # cast raises RuntimeError("Input type ... and weight type
+            # ... should be the same") on the conv stem.
+            self._model_dtype = next(self.model.parameters()).dtype
+
             logger.info(
-                f"Vision model loaded: {self.model_name} on {self.device}"
+                f"Vision model loaded: {self.model_name} on {self.device} (dtype={self._model_dtype})"
             )
 
         except Exception as e:
@@ -181,6 +198,21 @@ class VisualEmbeddingGenerator:
             logger.error(f"Failed to load vision model: {e}")
             raise
 
+    def _to_model_inputs(self, inputs):
+        """Move processor outputs to device, casting floating tensors to model dtype.
+
+        The processor produces fp32 pixel_values regardless of model precision.
+        When the model is loaded at fp16, that mismatch raises at the conv
+        stem. Cast only floating-point tensors — integer attention masks
+        etc. must stay integer.
+        """
+        import torch
+        target_dtype = getattr(self, '_model_dtype', None) or torch.float32
+        return {
+            k: (v.to(self.device, dtype=target_dtype) if v.is_floating_point() else v.to(self.device))
+            for k, v in inputs.items()
+        }
+
     def generate_embedding(self, image_bytes: bytes) -> np.ndarray:
         """
         Generate embedding for an image.
@@ -197,12 +229,20 @@ class VisualEmbeddingGenerator:
             image = Image.open(BytesIO(image_bytes)).convert('RGB')
 
             if self.loader == 'transformers':
-                inputs = self.processor(images=image, return_tensors='pt').to(self.device)
+                inputs = self._to_model_inputs(
+                    self.processor(images=image, return_tensors='pt')
+                )
 
                 with torch.no_grad():
                     outputs = self.model(**inputs)
-                    # CLS token (first token) as embedding
-                    embedding = outputs.last_hidden_state[:, 0, :].squeeze().cpu().numpy()
+                    # CLS token (first token) as embedding. Cast to fp32 on
+                    # GPU before .cpu() so the numpy array we hand back to
+                    # callers is fp32 regardless of the model's compute
+                    # dtype — preserves the output contract that pre-dates
+                    # the fp16-on-GPU change.
+                    embedding = (
+                        outputs.last_hidden_state[:, 0, :].squeeze().float().cpu().numpy()
+                    )
 
                 # L2 normalize
                 norm = np.linalg.norm(embedding)
@@ -242,11 +282,15 @@ class VisualEmbeddingGenerator:
             ]
 
             if self.loader == 'transformers':
-                inputs = self.processor(images=pil_images, return_tensors='pt').to(self.device)
+                inputs = self._to_model_inputs(
+                    self.processor(images=pil_images, return_tensors='pt')
+                )
 
                 with torch.no_grad():
                     outputs = self.model(**inputs)
-                    embeddings = outputs.last_hidden_state[:, 0, :].cpu().numpy()
+                    # Cast to fp32 on GPU (see generate_embedding's note on
+                    # output contract).
+                    embeddings = outputs.last_hidden_state[:, 0, :].float().cpu().numpy()
 
                 norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
                 embeddings = embeddings / np.maximum(norms, 1e-10)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -227,6 +227,15 @@ async def startup_event():
     register_all_workers(queue)
     logger.info(f"✅ Workers registered: {', '.join(get_all_job_types())}")
 
+    # ADR-100: elect the dispatch leader early — before model load — so the
+    # non-leader (under --workers N) can skip GPU-heavy resources it would
+    # never use. The leader runs ingestion jobs (which need the visual
+    # model); non-leaders only handle HTTP, which uses text embeddings for
+    # query encoding. Skipping visual on non-leaders saves ~350MB weights
+    # + accelerate/processor overhead per non-leader process.
+    global _is_dispatch_leader
+    _is_dispatch_leader = _try_acquire_dispatch_lock(queue)
+
     # IMPORTANT: Initialize embedding infrastructure BEFORE starting any jobs
     # (fixes race condition where jobs start before EmbeddingWorker is ready)
 
@@ -251,25 +260,32 @@ async def startup_event():
             "or repair the local model configuration."
         )
 
-    # Initialize visual embedding generator (profile-driven, migration 055)
-    try:
-        from .lib.visual_embeddings import init_visual_embedding_generator
-        visual_gen = await init_visual_embedding_generator()
-        if visual_gen:
-            logger.info(f"✅ Visual embedding generator initialized: {visual_gen.get_model_name()} ({visual_gen.get_embedding_dimension()} dims)")
-        else:
-            logger.info("📍 Visual embeddings: disabled (text-only profile or API-based)")
-    except Exception as e:
-        # ADR-101: parity with the text-embedding honesty fix at line 199.
-        # "Features may be limited" obscured the actual state — the profile
-        # asks for visual embeddings, the load failed, so every image ingest
-        # will raise. State that, instead of softening.
-        logger.error(f"❌ Failed to initialize visual embedding generator: {e}")
-        logger.error(
-            "   Visual embedding profile is active but the generator could not load. "
-            "Image ingestion will fail until this is resolved. "
-            "Fix: switch to a text-only profile, or repair the visual model configuration."
-        )
+    # Initialize visual embedding generator (profile-driven, migration 055).
+    # Only the dispatch leader loads this: visual embeddings are produced by
+    # ingestion jobs, which only run on the leader. Non-leader workers would
+    # claim ~350MB+ of VRAM (weights + processor + accelerate runtime) for a
+    # model they would never call.
+    if _is_dispatch_leader:
+        try:
+            from .lib.visual_embeddings import init_visual_embedding_generator
+            visual_gen = await init_visual_embedding_generator()
+            if visual_gen:
+                logger.info(f"✅ Visual embedding generator initialized: {visual_gen.get_model_name()} ({visual_gen.get_embedding_dimension()} dims)")
+            else:
+                logger.info("📍 Visual embeddings: disabled (text-only profile or API-based)")
+        except Exception as e:
+            # ADR-101: parity with the text-embedding honesty fix at line 199.
+            # "Features may be limited" obscured the actual state — the profile
+            # asks for visual embeddings, the load failed, so every image ingest
+            # will raise. State that, instead of softening.
+            logger.error(f"❌ Failed to initialize visual embedding generator: {e}")
+            logger.error(
+                "   Visual embedding profile is active but the generator could not load. "
+                "Image ingestion will fail until this is resolved. "
+                "Fix: switch to a text-only profile, or repair the visual model configuration."
+            )
+    else:
+        logger.info("ℹ️  Non-leader worker — skipping visual embedding generator (ingestion runs on leader)")
 
     # ADR-041: Validate API keys at startup (non-blocking)
     try:
@@ -390,11 +406,9 @@ async def startup_event():
         logger.error(f"⚠️  Failed to resume interrupted jobs: {e}", exc_info=True)
 
     # ADR-100: Only one uvicorn worker should run the lane manager, scheduler,
-    # and scheduled jobs manager. With --workers 2, each process calls startup_event().
-    # Use a PostgreSQL advisory lock (non-blocking) to elect a leader.
-    global _is_dispatch_leader
-    _is_dispatch_leader = _try_acquire_dispatch_lock(queue)
-
+    # and scheduled jobs manager. Leader was elected earlier (before model
+    # load) so non-leaders can skip GPU-heavy resources; here we just branch
+    # on the existing election result.
     if _is_dispatch_leader:
         # ADR-100: Start lane manager (poll-and-claim dispatch)
         global lane_manager

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -42,10 +42,12 @@ services:
   api:
     # Override standalone container_name back to dev name
     container_name: kg-api-dev
-    # Multi-worker for concurrent request handling (matches production).
-    # Hot reload (--reload) is incompatible with --workers, so restart
+    # Single worker (matches production). Each uvicorn worker is a separate
+    # process and would load its own copy of any local embedding model; the
+    # API workload is async and doesn't benefit from extra workers on this
+    # box. Hot reload (--reload) is incompatible with --workers, so restart
     # the container after code changes: ./operator.sh restart api
-    command: ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+    command: ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]
     build:
       context: ..
       dockerfile: api/Dockerfile

--- a/docker/docker-compose.gpu-amd-host.yml
+++ b/docker/docker-compose.gpu-amd-host.yml
@@ -40,3 +40,14 @@ services:
     ipc: host
     # Note: HSA_OVERRIDE_GFX_VERSION and ROCR_VISIBLE_DEVICES can be set in .env
     # if needed, but empty values break ROCm initialization
+    environment:
+      # Reduce VRAM fragmentation under PyTorch's caching allocator.
+      # expandable_segments lets the allocator grow a single segment instead
+      # of reserving large contiguous chunks up front; on long-running API
+      # processes this typically cuts reserved-but-unallocated VRAM materially.
+      - PYTORCH_HIP_ALLOC_CONF=expandable_segments:True
+    # Single uvicorn worker on the GPU variant: each worker is a separate
+    # Python process and would load its own copy of the embedding model(s)
+    # + ROCm runtime context into VRAM. One process is enough for the API's
+    # async workload; ingestion runs in the job queue regardless.
+    command: ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/docker/docker-compose.gpu-amd.yml
+++ b/docker/docker-compose.gpu-amd.yml
@@ -46,3 +46,14 @@ services:
       - video
     # Note: HSA_OVERRIDE_GFX_VERSION and ROCR_VISIBLE_DEVICES can be set in .env
     # if needed, but empty values break ROCm initialization
+    environment:
+      # Reduce VRAM fragmentation under PyTorch's caching allocator.
+      # expandable_segments lets the allocator grow a single segment instead of
+      # reserving large contiguous chunks up front; on long-running API
+      # processes this typically cuts reserved-but-unallocated VRAM materially.
+      - PYTORCH_HIP_ALLOC_CONF=expandable_segments:True
+    # Single uvicorn worker on the GPU variant: each worker is a separate
+    # Python process and would load its own copy of the embedding model(s)
+    # + ROCm runtime context into VRAM. One process is enough for the API's
+    # async workload; ingestion runs in the job queue regardless.
+    command: ["uvicorn", "api.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]


### PR DESCRIPTION
## Summary

Five compounding sources of unnecessary memory pressure on the embedding path, most visible on AMD GPUs with limited VRAM.

| # | Fix | File(s) |
|---|---|---|
| 1 | `--workers 2` → `--workers 1` (each uvicorn worker was a separate Python process loading its own copy of the model + ROCm runtime context) | `api/Dockerfile`, `api/Dockerfile.rocm-host`, `docker/docker-compose.dev.yml` |
| 2 | Vision model loads as `torch_dtype=torch.float16` on GPU (was fp32 — silent 2× weight blow-up) | `api/app/lib/visual_embeddings.py` |
| 3 | Drop `device_map=\"auto\"` for vision tower, use explicit `.to(self.device)` (accelerate sharding machinery is overhead for a sub-GB single tower) | `api/app/lib/visual_embeddings.py` |
| 4 | Gate `init_visual_embedding_generator()` on `_is_dispatch_leader` — only the leader runs ingestion, so non-leader workers were loading vision weights they would never use. Dispatch lock acquisition moved earlier in startup. | `api/app/main.py` |
| 5 | `PYTORCH_HIP_ALLOC_CONF=expandable_segments:True` on both ROCm compose variants — reduces reserved-but-unallocated VRAM under PyTorch's caching allocator | `docker/docker-compose.gpu-amd.yml`, `docker/docker-compose.gpu-amd-host.yml` |

Diagnosis caught during this work: the running API image on AMD-host can silently be a **CUDA-built torch** if a prior CPU build cached \`kg-api:latest\` (compose's local-build tag is variant-agnostic). Surfaced separately — not fixed in this PR. Worth a follow-up that mirrors the ADR-101 GHCR tag scheme for local builds.

## Test plan

- [ ] On an AMD-host machine, rebuild with \`./operator.sh stop && GPU_MODE=amd-host ./operator.sh start\` (forces fresh build picking up \`Dockerfile.rocm-host\`)
- [ ] Verify in container: \`docker exec kg-api-dev python -c \"import torch; print(torch.__version__, torch.version.hip, torch.cuda.is_available())\"\` — expect a \`+rocm\` torch with \`is_available()=True\`
- [ ] Check uvicorn startup log shows one worker, not two
- [ ] On non-leader worker scenario (if running with >1 worker via override), confirm log line \"Non-leader worker — skipping visual embedding generator\"
- [ ] Ingest a document with images — visual embeddings still get produced (on the leader)
- [ ] Search queries still work (text embedding still loaded on all workers)
- [ ] CPU variant: \`./operator.sh start\` (no GPU mode) — verify API still healthy on \`--workers 1\`