### PR TITLE
fix(teardown): route operator.sh teardown through lib/teardown.sh

### DIFF
--- a/operator.sh
+++ b/operator.sh
@@ -442,31 +442,30 @@ cmd_upgrade() {
 cmd_teardown() {
     check_env
     load_config
-    cd "$DOCKER_DIR"
 
-    # Teardown is simple enough for host
-    local remove_volumes=false
-    local auto_yes=false
-
-    while [[ $# -gt 0 ]]; do
-        case $1 in
-            --full) remove_volumes=true; shift ;;
-            -y|--yes) auto_yes=true; shift ;;
-            *) shift ;;
-        esac
-    done
-
-    echo -e "${RED}${BOLD}TEARDOWN${NC}"
-    if [ "$auto_yes" = false ]; then
-        read -p "Type 'yes' to confirm: " -r
-        [[ "$REPLY" != "yes" ]] && echo "Cancelled" && exit 0
+    # Delegate to operator/lib/teardown.sh, which has the full
+    # implementation: overlay-aware compose down (honors GPU_MODE etc.),
+    # --remove-orphans, kg-owned vs. unrelated dangling-volume
+    # classification (PR #427), plus --keep-env / --remove-images /
+    # --include-operator flags that this entry point used to silently
+    # ignore.
+    #
+    # Pre-fix history: this function inlined a simplified `run_compose
+    # down -v` that left SHA-named anonymous volumes (e.g. the PG18
+    # cluster at /var/lib/postgresql/18/docker) orphaned after teardown
+    # --full. The lib script's dangling sweep was the actual fix; we
+    # were just bypassing it from the user-facing entry point.
+    local lib_teardown="$SCRIPT_DIR/operator/lib/teardown.sh"
+    if [ ! -x "$lib_teardown" ]; then
+        echo -e "${RED}✗ Cannot find $lib_teardown${NC}"
+        echo -e "${YELLOW}  Falling back to inline teardown${NC}"
+        cd "$DOCKER_DIR"
+        run_compose down -v --remove-orphans
+        echo -e "${GREEN}✓ Teardown complete (fallback path)${NC}"
+        return
     fi
 
-    local flags=""
-    [ "$remove_volumes" = true ] && flags="-v"
-
-    run_compose down $flags
-    echo -e "${GREEN}✓ Teardown complete${NC}"
+    exec "$lib_teardown" "$@"
 }
 
 # ============================================================================
@@ -780,7 +779,13 @@ ${BOLD}Lifecycle:${NC}
   restart <service|all>  Restart a service (or all)
   upgrade            Pull, migrate, restart
   update             Pull images only
-  teardown [--full]  Remove containers (--full: +volumes)
+  teardown [opts]    Remove platform (delegates to operator/lib/teardown.sh)
+                     --full              Containers + volumes + images + operator
+                     --remove-volumes    Volumes only (incl. dangling-volume sweep)
+                     --remove-images     Force image rebuild on next start
+                     --include-operator  Also remove the operator container
+                     --keep-env          Keep .env (default deletes secrets)
+                     -y, --yes           Skip confirmation prompts
 
 ${BOLD}Management:${NC}
   status             Show container status

--- a/operator.sh
+++ b/operator.sh
@@ -440,32 +440,70 @@ cmd_upgrade() {
 }
 
 cmd_teardown() {
-    check_env
-    load_config
-
-    # Delegate to operator/lib/teardown.sh, which has the full
-    # implementation: overlay-aware compose down (honors GPU_MODE etc.),
-    # --remove-orphans, kg-owned vs. unrelated dangling-volume
-    # classification (PR #427), plus --keep-env / --remove-images /
-    # --include-operator flags that this entry point used to silently
-    # ignore.
+    # Delegate to operator/lib/teardown.sh when present (dev / git
+    # checkout install). That script has the full implementation:
+    # overlay-aware compose down (honors GPU_MODE etc.), --remove-
+    # orphans, kg-owned vs. unrelated dangling-volume classification
+    # (PR #427), plus --keep-env / --remove-images / --include-operator
+    # flags that the inline fallback below doesn't support.
     #
     # Pre-fix history: this function inlined a simplified `run_compose
     # down -v` that left SHA-named anonymous volumes (e.g. the PG18
     # cluster at /var/lib/postgresql/18/docker) orphaned after teardown
     # --full. The lib script's dangling sweep was the actual fix; we
     # were just bypassing it from the user-facing entry point.
+    #
+    # Deliberately NOT calling check_env here — the lib script handles
+    # missing .env explicitly (one of the things PR #427 added), and
+    # check_env's hard-exit would defeat that path. The inline fallback
+    # below also tolerates missing .env via run_compose's lazy load.
     local lib_teardown="$SCRIPT_DIR/operator/lib/teardown.sh"
-    if [ ! -x "$lib_teardown" ]; then
-        echo -e "${RED}✗ Cannot find $lib_teardown${NC}"
-        echo -e "${YELLOW}  Falling back to inline teardown${NC}"
-        cd "$DOCKER_DIR"
-        run_compose down -v --remove-orphans
-        echo -e "${GREEN}✓ Teardown complete (fallback path)${NC}"
-        return
+    if [ -x "$lib_teardown" ]; then
+        exec "$lib_teardown" "$@"
     fi
 
-    exec "$lib_teardown" "$@"
+    # Inline fallback — used by curl-installer / standalone deployments
+    # where install.sh doesn't ship operator/lib/. MUST match the
+    # safety profile of the lib script (preserve volumes by default,
+    # prompt before destructive action). DO NOT make this `down -v`
+    # by default: a user typing `./operator.sh teardown` (no args)
+    # expects a stop, not a data wipe.
+    load_config
+    cd "$DOCKER_DIR"
+
+    local remove_volumes=false
+    local auto_yes=false
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --full|--remove-volumes) remove_volumes=true; shift ;;
+            -y|--yes) auto_yes=true; shift ;;
+            -h|--help)
+                echo "Usage: $0 teardown [--full|--remove-volumes] [-y|--yes]"
+                echo ""
+                echo "Note: standalone fallback path. For --keep-env, --remove-images,"
+                echo "--include-operator, install the full git checkout."
+                return 0
+                ;;
+            *) shift ;;
+        esac
+    done
+
+    echo -e "${RED}${BOLD}TEARDOWN${NC}"
+    if [ "$remove_volumes" = true ]; then
+        echo -e "${RED}⚠️  All database data and uploaded files will be LOST!${NC}"
+    else
+        echo -e "${GREEN}✓ Volumes will be preserved${NC}"
+    fi
+    if [ "$auto_yes" = false ]; then
+        read -p "Type 'yes' to confirm: " -r
+        [[ "$REPLY" != "yes" ]] && echo "Cancelled" && exit 0
+    fi
+
+    local flags="--remove-orphans"
+    [ "$remove_volumes" = true ] && flags="$flags -v"
+
+    run_compose down $flags
+    echo -e "${GREEN}✓ Teardown complete${NC}"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #427. The dangling-volume sweep added there lived in `operator/lib/teardown.sh`, but `./operator.sh teardown --full` — the user-facing entry — went through a separate, simplified `cmd_teardown` in the top-level `operator.sh` that just did `run_compose down -v`. So the fix was real but invisible from the path users actually invoke.

Confirmed empirically: after #427 merged, `./operator.sh teardown --full` still left four orphaned SHA-named anonymous volumes (two PG18 clusters, two web node_modules) — the exact failure mode #427 was meant to close.

## Change

`cmd_teardown` now `exec`s `operator/lib/teardown.sh` and forwards `\"$@\"`. All the lib script's flags become passable from the top-level entry:

| Flag | Effect |
|---|---|
| `--full` | Containers + volumes + images + operator |
| `--remove-volumes` | Volumes only (incl. dangling-volume sweep from #427) |
| `--remove-images` | Force image rebuild on next start |
| `--include-operator` | Also remove the operator container |
| `--keep-env` | Keep `.env` (default deletes secrets) |
| `-y, --yes` | Skip confirmation prompts |

Fallback inline path retained in case `operator/lib/teardown.sh` is missing (partial-install edge case).

Help text in `operator.sh` updated to document the now-passable flags.

## Test plan

- [ ] `./operator.sh teardown --full` on a host with running platform + leftover anonymous volumes: confirm overlay-aware compose down fires AND dangling-volume sweep prompts for kg-owned volumes (per #427's classification)
- [ ] `./operator.sh teardown --keep-env --full`: confirms flag passthrough — `.env` survives
- [ ] `./operator.sh teardown -y --full` on a shared host: confirm unrelated dangling volumes (other projects) are NOT auto-removed
- [ ] `./operator.sh teardown` (no args): basic stop, operator preserved (matches lib script default)
- [ ] `./operator.sh teardown --help`: should now show the lib script's full help (since `exec` replaces the process)