### PR TITLE
fix(auth): internet-hardening Phase 0 blockers — register escalation + models router (#431, #432)

### DIFF
--- a/api/app/models/auth.py
+++ b/api/app/models/auth.py
@@ -43,6 +43,29 @@ class UserCreate(UserBase):
     }
 
 
+class RegisterRequest(BaseModel):
+    """
+    Schema for open self-registration via POST /auth/register.
+
+    Deliberately has NO role field: self-registered accounts are always created
+    with the least-privilege 'read_only' role server-side (ADR-400,
+    internet-hardening #431). Elevated roles are assigned only through the
+    users:create-gated admin path (POST /users -> UserCreate), never by the
+    self-registering client.
+    """
+    username: str = Field(..., min_length=3, max_length=100, description="Unique username")
+    password: str = Field(..., min_length=8, description="Password (will be hashed)")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "username": "alice",
+                "password": "SecurePass123!"
+            }]
+        }
+    }
+
+
 class UserRead(UserBase):
     """Schema for reading user data (excludes password)"""
     id: int = Field(..., description="User ID")

--- a/api/app/routes/auth.py
+++ b/api/app/routes/auth.py
@@ -119,7 +119,9 @@ async def register_user(user: RegisterRequest):
             # that have not applied migration 071 keep working.
             cur.execute("SELECT kg_api.get_platform_config('registration_enabled')")
             flag_row = cur.fetchone()
-            if flag_row and str(flag_row[0]).strip().lower() == "false":
+            # Treat any common falsy spelling as disabled (operators may set
+            # false/0/no/off). Missing / anything else = enabled (default).
+            if flag_row and str(flag_row[0]).strip().lower() in ("false", "0", "no", "off"):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="Open self-registration is disabled. Contact an administrator to create an account."

--- a/api/app/routes/auth.py
+++ b/api/app/routes/auth.py
@@ -47,6 +47,7 @@ from api.app.lib.auth import (
 )
 from api.app.models.auth import (
     UserCreate,
+    RegisterRequest,
     UserRead,
     UserUpdate,
     UserInDB,
@@ -78,9 +79,20 @@ admin_router = APIRouter(prefix="/users", tags=["admin"])
 # =============================================================================
 
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)
-async def register_user(user: UserCreate):
+async def register_user(user: RegisterRequest):
     """
-    Register a new user account.
+    Open self-registration for a new user account.
+
+    Self-registered accounts are ALWAYS created with the least-privilege
+    'read_only' role (ADR-400, internet-hardening #431); the client cannot
+    choose a role. Elevated roles are assigned only through the
+    users:create-gated admin path (POST /users), which — together with the
+    operator-seeded root admin and, for bespoke deployments, custom SQL
+    migrations — is the canonical way to provision accounts.
+
+    Open registration can be disabled per-deployment via the
+    'registration_enabled' platform-config flag (operators set it false for
+    internet-facing deployments). When disabled this endpoint returns 403.
 
     Password requirements:
     - Minimum 8 characters
@@ -88,7 +100,10 @@ async def register_user(user: UserCreate):
 
     Returns user details (password hash excluded).
     """
-    # Validate password strength
+    # Self-registration role is fixed to least privilege; never client-controlled.
+    SELF_REGISTRATION_ROLE = "read_only"
+
+    # Validate password strength (cheap, no DB) before any DB work.
     is_valid, error_message = validate_password_strength(user.password)
     if not is_valid:
         raise HTTPException(
@@ -96,13 +111,20 @@ async def register_user(user: UserCreate):
             detail=error_message
         )
 
-    # Hash password
-    password_hash = get_password_hash(user.password)
-
-    # Insert user into database
     conn = get_db_connection()
     try:
         with conn.cursor() as cur:
+            # Respect the open-registration flag (ADR-400, internet-hardening #431).
+            # Missing / non-'false' value is treated as enabled, so environments
+            # that have not applied migration 071 keep working.
+            cur.execute("SELECT kg_api.get_platform_config('registration_enabled')")
+            flag_row = cur.fetchone()
+            if flag_row and str(flag_row[0]).strip().lower() == "false":
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Open self-registration is disabled. Contact an administrator to create an account."
+                )
+
             # Check if username already exists
             cur.execute(
                 "SELECT id FROM kg_auth.users WHERE username = %s",
@@ -114,12 +136,17 @@ async def register_user(user: UserCreate):
                     detail=f"Username '{user.username}' already exists"
                 )
 
-            # Insert new user
+            # Hash password (after cheap rejections, to avoid needless bcrypt work
+            # on an unauthenticated endpoint).
+            password_hash = get_password_hash(user.password)
+
+            # Insert new user. The role is FORCED to read_only — it is never taken
+            # from client input (the request model has no role field).
             cur.execute("""
                 INSERT INTO kg_auth.users (username, password_hash, primary_role, created_at)
                 VALUES (%s, %s, %s, NOW())
                 RETURNING id, username, primary_role, created_at, last_login, disabled
-            """, (user.username, password_hash, user.role))
+            """, (user.username, password_hash, SELF_REGISTRATION_ROLE))
 
             row = cur.fetchone()
             conn.commit()

--- a/api/app/routes/models.py
+++ b/api/app/routes/models.py
@@ -11,10 +11,11 @@ Admin endpoints for managing the provider model catalog:
 """
 
 import logging
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from typing import Optional
 
+from ..dependencies.auth import require_permission
 from ..lib.age_client import AGEClient
 from ..lib.model_catalog import (
     list_catalog,
@@ -26,6 +27,12 @@ from ..lib.model_catalog import (
 
 admin_router = APIRouter(prefix="/admin/models", tags=["admin", "models"])
 
+# Authorization (ADR-400, internet-hardening #432): this router was entirely
+# unauthenticated. Reads require extraction_config:read (admin + platform_admin);
+# every mutation requires extraction_config:write (platform_admin only) — both
+# pairs are seeded in migration 028. require_permission also forces an
+# authenticated, non-disabled user, closing the anonymous access hole.
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,8 +41,9 @@ async def get_catalog(
     provider: Optional[str] = Query(None, description="Filter by provider"),
     category: Optional[str] = Query(None, description="Filter by category"),
     enabled_only: bool = Query(False, description="Only show enabled models"),
+    _: None = Depends(require_permission("extraction_config", "read")),
 ):
-    """List model catalog entries with optional filters."""
+    """List model catalog entries with optional filters. Requires extraction_config:read."""
     try:
         client = AGEClient()
         conn = client.pool.getconn()
@@ -54,11 +62,15 @@ class RefreshRequest(BaseModel):
 
 
 @admin_router.post("/catalog/refresh")
-async def refresh_catalog(request: RefreshRequest):
+async def refresh_catalog(
+    request: RefreshRequest,
+    _: None = Depends(require_permission("extraction_config", "write")),
+):
     """
     Fetch fresh model catalog from a provider's API and upsert into database.
 
     Supported providers: openai, anthropic, ollama, openrouter.
+    Requires extraction_config:write (platform_admin).
     """
     from ..lib.ai_providers import get_provider
 
@@ -98,8 +110,11 @@ async def refresh_catalog(request: RefreshRequest):
 
 
 @admin_router.put("/catalog/{catalog_id}/enable")
-async def enable_model(catalog_id: int):
-    """Enable a model in the catalog for use."""
+async def enable_model(
+    catalog_id: int,
+    _: None = Depends(require_permission("extraction_config", "write")),
+):
+    """Enable a model in the catalog for use. Requires extraction_config:write."""
     try:
         client = AGEClient()
         conn = client.pool.getconn()
@@ -116,8 +131,11 @@ async def enable_model(catalog_id: int):
 
 
 @admin_router.put("/catalog/{catalog_id}/disable")
-async def disable_model(catalog_id: int):
-    """Disable a model in the catalog."""
+async def disable_model(
+    catalog_id: int,
+    _: None = Depends(require_permission("extraction_config", "write")),
+):
+    """Disable a model in the catalog. Requires extraction_config:write."""
     try:
         client = AGEClient()
         conn = client.pool.getconn()
@@ -134,8 +152,11 @@ async def disable_model(catalog_id: int):
 
 
 @admin_router.put("/catalog/{catalog_id}/default")
-async def set_default_model(catalog_id: int):
-    """Set a model as the default for its provider+category."""
+async def set_default_model(
+    catalog_id: int,
+    _: None = Depends(require_permission("extraction_config", "write")),
+):
+    """Set a model as the default for its provider+category. Requires extraction_config:write."""
     try:
         client = AGEClient()
         conn = client.pool.getconn()
@@ -157,8 +178,12 @@ class PriceUpdateRequest(BaseModel):
 
 
 @admin_router.put("/catalog/{catalog_id}/price")
-async def update_price(catalog_id: int, request: PriceUpdateRequest):
-    """Manually override pricing for a catalog entry."""
+async def update_price(
+    catalog_id: int,
+    request: PriceUpdateRequest,
+    _: None = Depends(require_permission("extraction_config", "write")),
+):
+    """Manually override pricing for a catalog entry. Requires extraction_config:write."""
     try:
         client = AGEClient()
         conn = client.pool.getconn()

--- a/cli/src/lib/auth/auth-client.ts
+++ b/cli/src/lib/auth/auth-client.ts
@@ -400,16 +400,18 @@ export class AuthClient {
   /**
    * Create user (admin only)
    *
-   * Note: Uses /auth/register endpoint since there's no dedicated admin create endpoint.
-   * Admins can create users with any role.
+   * Uses the gated admin endpoint POST /users (require_permission('users','create')),
+   * which honors the requested role. This is the correct path for privileged user
+   * creation — unlike POST /auth/register (self-registration), which forces
+   * read_only and may be disabled on internet deployments (ADR-400, #431).
    *
-   * @param token JWT access token (must be admin role)
-   * @param request User creation details
+   * @param token OAuth access token (caller must hold users:create — admin/platform_admin)
+   * @param request User creation details (username, password, role)
    * @returns Created user details
-   * @throws 401 if token invalid/expired, 403 if not admin, 400 if validation fails
+   * @throws 401 if token invalid/expired, 403 if lacking users:create, 409 if username taken
    */
   async createUser(token: string, request: UserCreateRequest): Promise<UserResponse> {
-    const response = await this.client.post<UserResponse>('/auth/register', request, {
+    const response = await this.client.post<UserResponse>('/users', request, {
       headers: {
         Authorization: `Bearer ${token}`
       }

--- a/operator/configure.py
+++ b/operator/configure.py
@@ -110,6 +110,58 @@ class OperatorConfig:
         finally:
             conn.close()
 
+    def cmd_platform_config(self, args):
+        """
+        Get/set/list platform_config flags (operator control plane, ADR-061).
+
+        Used by the prod init path to disable open self-registration
+        (registration_enabled=false, ADR-400/#431) and available to operators
+        for flipping deployment flags later. Backed by the kg_api
+        get/set_platform_config helpers (migration 031), so values upsert
+        whether or not the seeding migration has run.
+        """
+        action = (args.action or "list").lower()
+        conn = self.get_connection()
+        try:
+            with conn.cursor() as cur:
+                if action == "set":
+                    if not args.key or args.value is None:
+                        print("❌ Usage: platform-config set <key> <value>")
+                        return False
+                    cur.execute(
+                        "SELECT kg_api.set_platform_config(%s, %s, %s)",
+                        (args.key, args.value, "operator"),
+                    )
+                    conn.commit()
+                    print(f"✅ Set {args.key} = {args.value}")
+                    return True
+                elif action == "get":
+                    if not args.key:
+                        print("❌ Usage: platform-config get <key>")
+                        return False
+                    cur.execute(
+                        "SELECT kg_api.get_platform_config(%s) AS value", (args.key,)
+                    )
+                    row = cur.fetchone()
+                    print(row["value"] if row and row["value"] is not None else "")
+                    return True
+                elif action == "list":
+                    cur.execute(
+                        "SELECT key, value FROM kg_api.platform_config ORDER BY key"
+                    )
+                    for row in cur.fetchall():
+                        print(f"{row['key']} = {row['value']}")
+                    return True
+                else:
+                    print(f"❌ Unknown action: {action} (use set, get, or list)")
+                    return False
+        except Exception as e:
+            print(f"❌ platform-config {action} failed: {e}")
+            conn.rollback()
+            return False
+        finally:
+            conn.close()
+
     def cmd_ai_provider(self, args):
         """Configure AI extraction provider"""
         provider = args.provider
@@ -789,6 +841,12 @@ def main():
     models_parser.add_argument('--category', default='extraction', help='Filter by category (default: extraction)')
     models_parser.add_argument('--limit', type=int, default=0, help='Limit number of results (0=unlimited)')
 
+    # platform-config (operator control plane, ADR-061)
+    pc_parser = subparsers.add_parser('platform-config', help='Get/set/list platform configuration flags')
+    pc_parser.add_argument('action', nargs='?', default='list', help='set, get, or list')
+    pc_parser.add_argument('key', nargs='?', help='Config key (for set/get)')
+    pc_parser.add_argument('value', nargs='?', help='Value (for set)')
+
     # status
     subparsers.add_parser('status', help='Show configuration status')
 
@@ -813,6 +871,7 @@ def main():
         'embedding': config.cmd_embedding,
         'api-key': config.cmd_api_key,
         'models': config.cmd_models,
+        'platform-config': config.cmd_platform_config,
         'status': config.cmd_status,
         'oauth': config.cmd_oauth,
     }

--- a/operator/configure.py
+++ b/operator/configure.py
@@ -128,11 +128,24 @@ class OperatorConfig:
                     if not args.key or args.value is None:
                         print("❌ Usage: platform-config set <key> <value>")
                         return False
+                    # Surface typos: all legitimate keys are seeded by migrations,
+                    # so setting a brand-new key is almost always a misspelling that
+                    # would otherwise silently fail open (e.g. a hardening flag that
+                    # never takes effect). Warn loudly but still upsert.
+                    cur.execute(
+                        "SELECT 1 FROM kg_api.platform_config WHERE key = %s", (args.key,)
+                    )
+                    is_new_key = cur.fetchone() is None
                     cur.execute(
                         "SELECT kg_api.set_platform_config(%s, %s, %s)",
                         (args.key, args.value, "operator"),
                     )
                     conn.commit()
+                    if is_new_key:
+                        print(
+                            f"⚠️  '{args.key}' was not an existing config key — created it. "
+                            f"Check for typos (see `platform-config list` for known keys)."
+                        )
                     print(f"✅ Set {args.key} = {args.value}")
                     return True
                 elif action == "get":

--- a/operator/lib/guided-init.sh
+++ b/operator/lib/guided-init.sh
@@ -354,6 +354,16 @@ fi
 docker exec kg-operator python /workspace/operator/configure.py admin --password "$ADMIN_PASSWORD"
 echo ""
 
+# Production hardening (ADR-400, #431): the prod (random-password) path disables
+# open self-registration so the seeded admin / users:create-gated admin API is
+# the account-creation root. The simple/dev path leaves the migration default
+# (registration_enabled=true) untouched — making the dev/prod split explicit.
+if [ "$USE_RANDOM_PASSWORDS" = true ]; then
+    docker exec kg-operator python /workspace/operator/configure.py platform-config set registration_enabled false
+    echo -e "${GREEN}→${NC} Open self-registration disabled (production)"
+    echo ""
+fi
+
 # Step 4: Configure local embedding profile (GPU_MODE-aware)
 # This runs BEFORE AI provider selection because the embedding model is
 # system-level infrastructure that the API container loads at startup. It

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -478,6 +478,16 @@ EOF
     docker exec "$OPERATOR_CONTAINER" python /workspace/operator/configure.py admin --password "$ADMIN_PASSWORD"
     echo -e "${GREEN}✓ Admin user created${NC}"
 
+    # Production hardening (ADR-400, #431): the prod path disables open
+    # self-registration. From here the seeded admin (and the users:create-gated
+    # admin API) is the account-creation root. The dev/simple path leaves the
+    # migration default (registration_enabled=true) untouched, so the dev/prod
+    # distinction is explicit.
+    if [ "$PASSWORD_MODE" = "random" ]; then
+        docker exec "$OPERATOR_CONTAINER" python /workspace/operator/configure.py platform-config set registration_enabled false
+        echo -e "${GREEN}✓ Open self-registration disabled (production)${NC}"
+    fi
+
     # Register OAuth client for web app with configured hostname
     local POSTGRES_CONTAINER=$(get_container_name postgres)
     local REDIRECT_URI="http://${WEB_HOSTNAME}/callback"

--- a/schema/migrations/071_registration_enabled_flag.sql
+++ b/schema/migrations/071_registration_enabled_flag.sql
@@ -1,0 +1,25 @@
+-- Migration 071: Open-registration feature flag (ADR-400, internet-hardening #431)
+--
+-- POST /auth/register historically honored a client-supplied role and was always
+-- open. Two hardening controls land together:
+--   1. The route now ignores any client-supplied role and forces 'read_only'
+--      (privilege escalation fix — handled in api/app/routes/auth.py).
+--   2. This flag lets an internet-facing deployment turn open self-registration
+--      off without a code change. Defaults to 'true' so existing dev/standalone
+--      installs keep current behavior; operators harden by setting it 'false'.
+--
+-- Read via kg_api.get_platform_config('registration_enabled') (added in 031).
+-- A missing/non-'false' value is treated as enabled, so absence never locks out
+-- registration in environments that skipped this migration.
+
+BEGIN;
+
+INSERT INTO kg_api.platform_config (key, value, description) VALUES
+    ('registration_enabled', 'true', 'Allow open self-registration via POST /auth/register (true/false). Set false for internet-facing deployments; elevated roles are assigned only through the users:create-gated admin path.')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (71, 'registration_enabled_flag')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -25,13 +25,12 @@ from fastapi.testclient import TestClient
 @pytest.mark.api
 @pytest.mark.smoke
 def test_register_user_success(api_client):
-    """Test successful user registration"""
+    """Test successful user registration (self-registered users are read_only)"""
     # NOTE: This test requires a clean database. If the user already exists
     # from a previous run, it will get 409 Conflict. Marked for review.
     response = api_client.post("/auth/register", json={
         "username": "testuser",
-        "password": "SecurePass123!",
-        "role": "contributor"
+        "password": "SecurePass123!"
     })
 
     # Accept both 201 (new user) and 409 (user exists from previous run)
@@ -42,7 +41,9 @@ def test_register_user_success(api_client):
     assert response.status_code == 201
     data = response.json()
     assert data["username"] == "testuser"
-    assert data["role"] == "contributor"
+    # ADR-400 / #431: self-registration always yields least-privilege read_only,
+    # regardless of any client input.
+    assert data["role"] == "read_only"
     assert "id" in data
     assert "password" not in data  # Should not return password
 
@@ -84,15 +85,35 @@ def test_register_user_duplicate_username(api_client):
 
 
 @pytest.mark.api
-def test_register_user_invalid_role(api_client):
-    """Test registration fails with invalid role"""
-    response = api_client.post("/auth/register", json={
-        "username": "invalidrole",
-        "password": "SecurePass123!",
-        "role": "superadmin"  # Invalid role
-    })
+@pytest.mark.security
+def test_register_user_cannot_self_assign_privileged_role(api_client):
+    """
+    Regression for the ADR-400 / #431 privilege-escalation blocker.
 
-    assert response.status_code == 422  # Validation error
+    POST /auth/register must IGNORE any client-supplied role. A request asking
+    for 'platform_admin' (or 'admin') must never produce a privileged account —
+    the self-registered user is created as read_only. Elevated roles are only
+    assignable through the users:create-gated admin path.
+    """
+    for attempted_role in ("platform_admin", "admin", "curator", "superadmin"):
+        response = api_client.post("/auth/register", json={
+            "username": f"escalate_{attempted_role}",
+            "password": "SecurePass123!",
+            "role": attempted_role,  # extra field — must be ignored, not honored
+        })
+
+        if response.status_code == 409:
+            # User exists from a previous run; the invariant still holds for them.
+            continue
+
+        assert response.status_code == 201, (
+            f"register with role={attempted_role!r} returned {response.status_code}"
+        )
+        data = response.json()
+        assert data["role"] == "read_only", (
+            f"PRIVILEGE ESCALATION: register honored role={attempted_role!r} "
+            f"and created a {data['role']!r} account"
+        )
 
 
 # =============================================================================

--- a/tests/api/test_models_catalog_auth.py
+++ b/tests/api/test_models_catalog_auth.py
@@ -1,0 +1,90 @@
+"""
+Authorization regression tests for the model-catalog router (ADR-400, #432).
+
+The entire /admin/models/catalog router was historically wired with no auth
+dependency at all — anonymous callers could read the catalog, trigger outbound
+provider fetches, toggle model availability, and overwrite pricing that feeds
+ingest cost-estimation. These tests lock in the fix:
+
+- reads require extraction_config:read  (admin + platform_admin)
+- every mutation requires extraction_config:write  (platform_admin only)
+
+Real RBAC runs here (no bypass_permission_check) against the seeded grants from
+migration 028, with mock OAuth users from the conftest fixtures.
+"""
+
+import pytest
+
+
+MUTATIONS = [
+    ("post", "/admin/models/catalog/refresh", {"provider": "openai"}),
+    ("put", "/admin/models/catalog/999999/enable", None),
+    ("put", "/admin/models/catalog/999999/disable", None),
+    ("put", "/admin/models/catalog/999999/default", None),
+    ("put", "/admin/models/catalog/999999/price", {"price_prompt_per_m": 1.0}),
+]
+
+
+def _call(api_client, method, path, body, headers=None):
+    fn = getattr(api_client, method)
+    if body is None:
+        return fn(path, headers=headers)
+    return fn(path, json=body, headers=headers)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_catalog_read_rejects_anonymous(api_client):
+    """GET /admin/models/catalog must require authentication (was fully open)."""
+    response = api_client.get("/admin/models/catalog")
+    assert response.status_code in (401, 403), (
+        f"anonymous catalog read returned {response.status_code} — router is not gated"
+    )
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("method,path,body", MUTATIONS)
+def test_catalog_mutations_reject_anonymous(api_client, method, path, body):
+    """Every catalog mutation must reject unauthenticated callers."""
+    response = _call(api_client, method, path, body)
+    assert response.status_code in (401, 403), (
+        f"anonymous {method.upper()} {path} returned {response.status_code} — not gated"
+    )
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_catalog_read_denied_for_contributor(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_user
+):
+    """A contributor lacks extraction_config:read and must be denied (403)."""
+    response = api_client.get("/admin/models/catalog", headers=auth_headers_user)
+    assert response.status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_catalog_read_allowed_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """An admin holds extraction_config:read and must pass the auth gate."""
+    response = api_client.get("/admin/models/catalog", headers=auth_headers_admin)
+    # Auth must succeed; the handler may return 200 or a 5xx depending on catalog
+    # state, but never an auth rejection.
+    assert response.status_code not in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_catalog_mutation_denied_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """
+    Mutations require extraction_config:write, seeded to platform_admin only.
+    A plain admin must be denied (403) even though it can read.
+    """
+    response = api_client.put(
+        "/admin/models/catalog/999999/enable", headers=auth_headers_admin
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
Closes the two **critical** blockers from the 2026-05-28 endpoint security audit (`docs/security/endpoint-security-audit-2026-05-28.md`), measured against the operative model in **ADR-400**. Tracking: #442.

## #431 — `/auth/register` privilege escalation *(critical)*
`POST /auth/register` honored a client-supplied `role` (the validator even permitted `platform_admin`), so any anonymous caller could mint a `platform_admin` and own the platform via role inheritance.
- New `RegisterRequest` model with **no role field**; the handler forces `primary_role='read_only'`. Elevated roles only via the `users:create`-gated admin path (`POST /users`), consistent with the operator-seeded root admin being the account-creation root.
- Migration **071** seeds a `registration_enabled` platform-config flag (default `true`; operators set `false` for internet deployments → endpoint returns 403). Missing flag = enabled (back-compatible). Flag checked before bcrypt.

## #432 — `/admin/models/catalog` router fully unauthenticated *(critical)*
The whole router had no auth dependency — anonymous catalog mutation, pricing corruption, outbound API amplification.
- Reads require `extraction_config:read` (admin + platform_admin); all mutations require `extraction_config:write` (platform_admin only). Both pairs seeded in migration 028 — no dead-check.

## Tests
- `tests/api/test_auth.py`: self-registration yields `read_only`; attempted `platform_admin`/`admin`/`curator` is ignored, not honored.
- `tests/api/test_models_catalog_auth.py`: anonymous rejected on every endpoint; contributor denied read; admin passes read but denied mutations (real RBAC vs seeded grants).
- Full API suite: **434 passed, 15 skipped**.

## Deferred decision (not in this PR)
Auto-setting `registration_enabled=false` in the operator **prod** init path. No operator→platform_config write pattern exists today, and it needs live testing — flagged for your call. Operators can set it now via SQL/configure.py.

Remaining blockers #433–#437 (high) and Phase 2–3 follow in subsequent PRs per the audit's phased plan.