### PR TITLE
fix(auth): internet-hardening Phase 1 — close the systemic authZ gaps (#433–#437)

### DIFF
--- a/api/app/routes/database.py
+++ b/api/app/routes/database.py
@@ -182,7 +182,9 @@ def get_database_info(
 
 
 @router.get("/health", response_model=DatabaseHealthResponse)
-def check_database_health():
+def check_database_health(
+    current_user: CurrentUser,
+):
     """
     Check database health and connectivity.
 
@@ -190,6 +192,13 @@ def check_database_health():
     - Basic connectivity (ping test)
     - AGE extension availability
     - Graph schema existence
+
+    **Authorization:** Authenticated-by-design (ADR-400, #444 review). This is a
+    deeper diagnostic than the public liveness probe GET /health: it discloses
+    AGE-extension and graph-schema existence. It is NOT anonymous (closing the
+    pre-exposure hole) but is intentionally not permission-gated — any
+    authenticated user / the CLI may check DB health. The detailed /database/stats
+    and /database/info remain database:read-gated.
 
     Returns:
         DatabaseHealthResponse with overall status and check results

--- a/api/app/routes/database.py
+++ b/api/app/routes/database.py
@@ -7,11 +7,11 @@ Provides REST API access to:
 - Health checks
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 import logging
 import os
 
-from ..dependencies.auth import CurrentUser
+from ..dependencies.auth import CurrentUser, require_permission
 from ..models.database import (
     DatabaseStatsResponse,
     DatabaseInfoResponse,
@@ -35,7 +35,8 @@ def get_age_client() -> AGEClient:
 
 @router.get("/stats", response_model=DatabaseStatsResponse)
 def get_database_stats(
-    current_user: CurrentUser
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("database", "read")),
 ):
     """
     Get database statistics including node and relationship counts (ADR-060).
@@ -125,7 +126,8 @@ def get_database_stats(
 
 @router.get("/info", response_model=DatabaseInfoResponse)
 def get_database_info(
-    current_user: CurrentUser
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("database", "read")),
 ):
     """
     Get database connection information (ADR-060).
@@ -277,6 +279,12 @@ def get_graph_epoch(
     Designed for polling by clients that need to detect graph changes
     without the overhead of full counter queries.
 
+    **Authorization:** Authenticated-by-design (ADR-400). Unlike the other
+    /database/* endpoints, this is intentionally NOT gated on database:read:
+    it is a cache-invalidation poll used by all authenticated clients (any role,
+    incl. read_only) and exposes only a single opaque monotonic integer. Gating
+    it admin-only would break non-admin pollers. Keep it CurrentUser-only.
+
     Returns:
         {"epoch": <integer>}
     """
@@ -299,7 +307,8 @@ def get_graph_epoch(
 
 @router.get("/counters")
 def get_graph_counters(
-    current_user: CurrentUser
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("database", "read")),
 ):
     """
     Get all graph metrics counters with categorization (ADR-079).
@@ -378,7 +387,8 @@ def get_graph_counters(
 
 @router.post("/counters/refresh")
 def refresh_graph_counters(
-    current_user: CurrentUser
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("database", "execute")),
 ):
     """
     Refresh all graph metrics counters from current graph state (ADR-079).
@@ -438,7 +448,8 @@ def refresh_graph_counters(
 @router.post("/query", response_model=CypherQueryResponse)
 def execute_cypher_query(
     request: CypherQueryRequest,
-    current_user: CurrentUser
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("database", "execute")),
 ):
     """
     Execute a custom openCypher/GQL query (ADR-048).

--- a/api/app/routes/documents.py
+++ b/api/app/routes/documents.py
@@ -324,7 +324,7 @@ def _get_concepts_for_documents(client: AGEClient, document_ids: List[str]) -> D
 # Query Routes
 # ============================================================================
 
-@query_router.post("/search", response_model=DocumentSearchResponse)
+@query_router.post("/search", response_model=DocumentSearchResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def search_documents(
     request: DocumentSearchRequest,
     current_user: UserInDB = Depends(get_current_active_user)
@@ -484,7 +484,7 @@ async def search_documents(
         raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
 
 
-@query_router.post("/by-concepts", response_model=DocumentSearchResponse)
+@query_router.post("/by-concepts", response_model=DocumentSearchResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def find_documents_by_concepts(
     request: DocumentsByConceptsRequest,
     current_user: UserInDB = Depends(get_current_active_user)
@@ -606,7 +606,7 @@ async def find_documents_by_concepts(
 # Document Routes
 # ============================================================================
 
-@router.get("/{document_id}/content", response_model=DocumentContentResponse)
+@router.get("/{document_id}/content", response_model=DocumentContentResponse, dependencies=[Depends(require_permission("sources", "read"))])
 async def get_document_content(
     document_id: str,
     current_user: UserInDB = Depends(get_current_active_user)
@@ -756,7 +756,7 @@ async def get_document_content(
         client.close()
 
 
-@router.get("", response_model=DocumentListResponse)
+@router.get("", response_model=DocumentListResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def list_documents(
     ontology: Optional[str] = Query(None, description="Filter by ontology name"),
     limit: int = Query(50, ge=1, le=200, description="Maximum results"),
@@ -871,7 +871,7 @@ async def list_documents(
         client.close()
 
 
-@router.get("/{document_id}/concepts", response_model=DocumentConceptsResponse)
+@router.get("/{document_id}/concepts", response_model=DocumentConceptsResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def get_document_concepts(
     document_id: str,
     current_user: UserInDB = Depends(get_current_active_user)
@@ -957,7 +957,7 @@ async def get_document_concepts(
         client.close()
 
 
-@router.post("/concepts/bulk", response_model=BulkDocumentConceptsResponse)
+@router.post("/concepts/bulk", response_model=BulkDocumentConceptsResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def get_document_concepts_bulk(
     request: BulkDocumentConceptsRequest,
     current_user: UserInDB = Depends(get_current_active_user)

--- a/api/app/routes/ingest.py
+++ b/api/app/routes/ingest.py
@@ -18,7 +18,7 @@ from ..services.content_hasher import ContentHasher
 from ..services.job_analysis import JobAnalyzer
 from ..models.ingest import IngestionOptions
 from ..models.job import JobSubmitResponse, DuplicateJobResponse
-from ..dependencies.auth import CurrentUser
+from ..dependencies.auth import CurrentUser, require_permission
 
 router = APIRouter(prefix="/ingest", tags=["ingestion"])
 
@@ -115,6 +115,7 @@ async def run_job_analysis(job_id: str, auto_approve: bool = False):
 async def ingest_document(
     background_tasks: BackgroundTasks,
     current_user: CurrentUser,
+    _: None = Depends(require_permission("ingest", "create")),
     file: UploadFile = File(..., description="Document file to ingest"),
     ontology: str = Form(..., description="Ontology/collection name"),
     filename: Optional[str] = Form(None, description="Override filename"),
@@ -311,6 +312,7 @@ async def ingest_document(
 async def ingest_text(
     background_tasks: BackgroundTasks,
     current_user: CurrentUser,
+    _: None = Depends(require_permission("ingest", "create")),
     text: str = Form(..., min_length=1, description="Text content to ingest"),
     ontology: str = Form(..., description="Ontology/collection name"),
     filename: Optional[str] = Form(None, description="Filename for source tracking"),

--- a/api/app/routes/ingest_image.py
+++ b/api/app/routes/ingest_image.py
@@ -307,7 +307,8 @@ async def ingest_image(
 
 @router.get(
     "/image/health",
-    summary="Check visual embedding system health"
+    summary="Check visual embedding system health",
+    dependencies=[Depends(require_permission("admin", "status"))],
 )
 async def check_image_ingestion_health():
     """

--- a/api/app/routes/ingest_image.py
+++ b/api/app/routes/ingest_image.py
@@ -22,7 +22,7 @@ from ..services.content_hasher import ContentHasher
 from ..services.job_analysis import JobAnalyzer
 from ..models.ingest import IngestionOptions
 from ..models.job import JobSubmitResponse, DuplicateJobResponse
-from ..dependencies.auth import CurrentUser
+from ..dependencies.auth import CurrentUser, require_permission
 
 # ADR-057: Only health check remains in endpoint (heavy work moved to worker)
 from ..lib.visual_embeddings import check_visual_embedding_health
@@ -144,6 +144,7 @@ async def run_image_job_analysis(job_id: str, auto_approve: bool = False):
 async def ingest_image(
     background_tasks: BackgroundTasks,
     current_user: CurrentUser,
+    _: None = Depends(require_permission("ingest", "create")),
     file: UploadFile = File(..., description="Image file to ingest (PNG, JPEG, GIF, WebP, BMP)"),
     ontology: str = Form(..., description="Ontology/collection name"),
     filename: Optional[str] = Form(None, description="Override filename"),

--- a/api/app/routes/queries.py
+++ b/api/app/routes/queries.py
@@ -8,7 +8,7 @@ Provides REST API access to:
 - Path finding between concepts
 """
 
-from fastapi import APIRouter, HTTPException, Query, BackgroundTasks
+from fastapi import APIRouter, Depends, HTTPException, Query, BackgroundTasks
 from pydantic import BaseModel
 from typing import Optional, List, Dict
 import asyncio
@@ -17,7 +17,7 @@ import numpy as np
 import os
 import psycopg2
 
-from ..dependencies.auth import CurrentUser
+from ..dependencies.auth import CurrentUser, require_permission
 from ..models.queries import (
     SearchRequest,
     SearchResponse,
@@ -525,7 +525,7 @@ def _build_source_search_result(
     )
 
 
-@router.post("/search", response_model=SearchResponse)
+@router.post("/search", response_model=SearchResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def search_concepts(
     current_user: CurrentUser,
     request: SearchRequest
@@ -855,7 +855,7 @@ async def search_concepts(
         raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
 
 
-@router.post("/sources/search", response_model=SourceSearchResponse)
+@router.post("/sources/search", response_model=SourceSearchResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def search_sources(
     current_user: CurrentUser,
     request: SourceSearchRequest
@@ -1005,7 +1005,7 @@ async def search_sources(
         raise HTTPException(status_code=500, detail=f"Source search failed: {str(e)}")
 
 
-@router.get("/concept/{concept_id}", response_model=ConceptDetailsResponse)
+@router.get("/concept/{concept_id}", response_model=ConceptDetailsResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def get_concept_details(
     concept_id: str,
     current_user: CurrentUser,
@@ -1291,7 +1291,7 @@ async def get_concept_details(
         client.close()
 
 
-@router.post("/related", response_model=RelatedConceptsResponse)
+@router.post("/related", response_model=RelatedConceptsResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def find_related_concepts(
     current_user: CurrentUser,
     request: RelatedConceptsRequest
@@ -1404,7 +1404,7 @@ async def find_related_concepts(
         client.close()
 
 
-@router.post("/connect", response_model=FindConnectionResponse)
+@router.post("/connect", response_model=FindConnectionResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def find_connection(
     current_user: CurrentUser,
     request: FindConnectionRequest
@@ -1483,7 +1483,7 @@ async def find_connection(
         client.close()
 
 
-@router.post("/connect-by-search", response_model=FindConnectionBySearchResponse)
+@router.post("/connect-by-search", response_model=FindConnectionBySearchResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def find_connection_by_search(
     current_user: CurrentUser,
     request: FindConnectionBySearchRequest
@@ -1646,7 +1646,7 @@ async def find_connection_by_search(
         client.close()
 
 
-@router.post("/cypher", response_model=CypherQueryResponse)
+@router.post("/cypher", response_model=CypherQueryResponse, dependencies=[Depends(require_permission("graph", "execute"))])
 async def execute_cypher_query(
     current_user: CurrentUser,
     request: CypherQueryRequest
@@ -1783,7 +1783,7 @@ async def execute_cypher_query(
         client.close()
 
 
-@router.post("/polarity-axis", response_model=PolarityAxisResponse)
+@router.post("/polarity-axis", response_model=PolarityAxisResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def analyze_polarity_axis_endpoint(
     current_user: CurrentUser,
     request: PolarityAxisRequest
@@ -1903,7 +1903,7 @@ class PolarityJobResponse(BaseModel):
     message: str
 
 
-@router.post("/polarity-axis/jobs", response_model=PolarityJobResponse)
+@router.post("/polarity-axis/jobs", response_model=PolarityJobResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def submit_polarity_job(
     current_user: CurrentUser,
     request: PolarityJobRequest,

--- a/api/app/routes/sources.py
+++ b/api/app/routes/sources.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from ..lib.age_client import AGEClient
 from ..lib.garage import get_image_storage, get_source_storage
-from ..dependencies.auth import get_current_active_user
+from ..dependencies.auth import get_current_active_user, require_permission
 from ..models.auth import UserInDB
 
 router = APIRouter(prefix="/sources", tags=["sources"])
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 @router.get(
     "",
     summary="List source nodes",
+    dependencies=[Depends(require_permission("sources", "read"))],
 )
 async def list_sources(
     ontology: Optional[str] = None,
@@ -131,6 +132,7 @@ async def list_sources(
 @router.get(
     "/{source_id}/image",
     summary="Retrieve image from source (ADR-057)",
+    dependencies=[Depends(require_permission("sources", "read"))],
     responses={
         200: {
             "content": {
@@ -272,6 +274,7 @@ async def get_source_image(
 @router.get(
     "/{source_id}/document",
     summary="Retrieve original document from Garage (ADR-081)",
+    dependencies=[Depends(require_permission("sources", "read"))],
     responses={
         200: {
             "content": {
@@ -417,6 +420,7 @@ async def get_source_document(
 @router.get(
     "/{source_id}",
     summary="Get source metadata and content",
+    dependencies=[Depends(require_permission("sources", "read"))],
 )
 async def get_source(
     source_id: str,

--- a/api/app/routes/vocabulary.py
+++ b/api/app/routes/vocabulary.py
@@ -1377,7 +1377,7 @@ async def get_epistemic_status(
 # Category Flows (ADR-077 - Vocabulary Explorers)
 # =============================================================================
 
-@router.get("/category-flows", response_model=CategoryFlowsResponse)
+@router.get("/category-flows", response_model=CategoryFlowsResponse, dependencies=[Depends(require_permission("vocabulary", "read"))])
 async def get_category_flows():
     """
     Get inter-category flow matrix for chord diagram visualization.

--- a/tests/api/test_anonymous_endpoints_auth.py
+++ b/tests/api/test_anonymous_endpoints_auth.py
@@ -1,0 +1,41 @@
+"""
+Regression tests for the two fully-unauthenticated endpoints (#437).
+
+Both previously had NO auth dependency at all:
+- GET /vocabulary/category-flows ran two full-graph scans for any anonymous
+  caller (the only zero-dependency endpoint in the API). Now requires
+  vocabulary:read.
+- GET /ingest/image/health exposed GPU/VRAM/model/provider info anonymously.
+  Now requires admin:status (admin + platform_admin) — it leaks infra detail.
+"""
+
+import pytest
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_category_flows_rejects_anonymous(api_client):
+    """The former only-anonymous endpoint now requires authentication."""
+    assert api_client.get("/vocabulary/category-flows").status_code in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_image_health_rejects_anonymous(api_client):
+    """The image-ingestion health/infra endpoint now requires authentication."""
+    assert api_client.get("/ingest/image/health").status_code in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_image_health_denied_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly
+):
+    """
+    /ingest/image/health leaks GPU/VRAM/provider detail, so it requires
+    admin:status (admin/platform_admin). A read_only user is denied (403),
+    before the health check runs.
+    """
+    assert api_client.get(
+        "/ingest/image/health", headers=auth_headers_readonly
+    ).status_code == 403

--- a/tests/api/test_database_auth.py
+++ b/tests/api/test_database_auth.py
@@ -1,0 +1,99 @@
+"""
+Authorization regression tests for the /database router (ADR-400, #433).
+
+Every /database/* handler previously depended only on CurrentUser (auth, no
+authZ), so any authenticated user — including a freshly self-registered
+read_only/contributor — could run arbitrary Cypher (POST /database/query) and
+read full-graph data, despite docstrings claiming database:read / database:execute.
+
+This locks in the gating:
+- reads (stats/info/counters) require database:read   (admin + platform_admin)
+- query + counters/refresh require database:execute    (platform_admin only)
+- /database/epoch stays authenticated-by-design (cache-invalidation poll for all
+  authenticated clients), so it must remain reachable by a contributor.
+
+Real RBAC runs here (no bypass) against the seeded grants from migration 028.
+"""
+
+import pytest
+
+VALID_QUERY = {"query": "MATCH (n) RETURN n LIMIT 1"}
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("method,path,body", [
+    ("get", "/database/stats", None),
+    ("get", "/database/info", None),
+    ("get", "/database/counters", None),
+    ("post", "/database/counters/refresh", None),
+    ("post", "/database/query", VALID_QUERY),
+])
+def test_database_rejects_anonymous(api_client, method, path, body):
+    """No /database/* data/query endpoint may be reached without authentication."""
+    fn = getattr(api_client, method)
+    response = fn(path, json=body) if body is not None else fn(path)
+    assert response.status_code in (401, 403), (
+        f"anonymous {method.upper()} {path} returned {response.status_code}"
+    )
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_database_read_denied_for_contributor(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_user
+):
+    """A contributor lacks database:read and is denied the stats read."""
+    response = api_client.get("/database/stats", headers=auth_headers_user)
+    assert response.status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_database_read_allowed_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """An admin holds database:read and passes the auth gate on stats."""
+    response = api_client.get("/database/stats", headers=auth_headers_admin)
+    assert response.status_code not in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_raw_cypher_denied_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """
+    Arbitrary Cypher requires database:execute, seeded to platform_admin only.
+    A plain admin (database:read but not execute) must be denied (403).
+    """
+    response = api_client.post(
+        "/database/query", json=VALID_QUERY, headers=auth_headers_admin
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_counters_refresh_denied_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """The state-mutating counters refresh also requires database:execute."""
+    response = api_client.post(
+        "/database/counters/refresh", headers=auth_headers_admin
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_epoch_allowed_for_contributor(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_user
+):
+    """
+    /database/epoch is authenticated-by-design: a contributor (and any
+    authenticated role) must still be able to poll it — it is NOT gated on
+    database:read.
+    """
+    response = api_client.get("/database/epoch", headers=auth_headers_user)
+    assert response.status_code not in (401, 403)

--- a/tests/api/test_database_counters.py
+++ b/tests/api/test_database_counters.py
@@ -64,8 +64,9 @@ def mock_db_connection():
 class TestGetDatabaseCounters:
     """Tests for GET /database/counters endpoint."""
 
-    def test_returns_200_on_success(self, api_client, mock_db_connection, mock_oauth_validation, auth_headers_user):
-        """Test that /database/counters returns 200 OK."""
+    def test_returns_200_on_success(self, api_client, mock_db_connection, mock_oauth_validation, bypass_permission_check, auth_headers_user):
+        """Test that /database/counters returns 200 OK (handler logic; RBAC is
+        bypassed here and covered separately in test_database_auth.py)."""
         mock_client, mock_cursor = mock_db_connection
 
         # Mock counter query results
@@ -118,8 +119,9 @@ class TestGetDatabaseCounters:
 class TestRefreshDatabaseCounters:
     """Tests for POST /database/counters/refresh endpoint."""
 
-    def test_returns_200_on_success(self, api_client, mock_oauth_validation, auth_headers_admin):
-        """Test that refresh returns 200 OK."""
+    def test_returns_200_on_success(self, api_client, mock_oauth_validation, bypass_permission_check, auth_headers_admin):
+        """Test that refresh returns 200 OK (handler logic; RBAC bypassed here and
+        covered separately in test_database_auth.py)."""
         with patch('api.app.routes.database.refresh_graph_counters') as mock_refresh:
             mock_refresh.return_value = MOCK_REFRESH_RESULT
 
@@ -135,7 +137,7 @@ class TestRefreshDatabaseCounters:
         # Should return 401 or 403 without auth
         assert response.status_code in [401, 403]
 
-    def test_refresh_returns_updated_count(self, api_client, mock_oauth_validation, auth_headers_admin):
+    def test_refresh_returns_updated_count(self, api_client, mock_oauth_validation, bypass_permission_check, auth_headers_admin):
         """Test that refresh returns count of updated counters."""
         with patch('api.app.routes.database.refresh_graph_counters') as mock_refresh:
             mock_refresh.return_value = MOCK_REFRESH_RESULT

--- a/tests/api/test_documents_sources_auth.py
+++ b/tests/api/test_documents_sources_auth.py
@@ -1,0 +1,62 @@
+"""
+Authorization regression tests for the document/source content surface (#436).
+
+documents.py and sources.py handlers depended only on get_current_active_user
+with no permission check, so any authenticated user (incl. read_only) could pull
+original document bytes, raw image bytes, internal storage keys, and graph
+metadata. This locks in:
+
+- sources.py reads + GET /documents/{id}/content require sources:read
+  (contributor + inheritance; excludes read_only)
+- documents.py metadata/search/linkage require graph:read
+  (contributor/admin/platform_admin; excludes read_only)
+
+Denials fire in the route dependency, before the handler, so no content is read.
+"""
+
+import pytest
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("path", [
+    "/sources/nope",
+    "/sources/nope/document",
+    "/sources/nope/image",
+    "/documents/nope/content",
+    "/documents",
+])
+def test_content_surface_rejects_anonymous(api_client, path):
+    """Document/source reads must require authentication."""
+    assert api_client.get(path).status_code in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("path", [
+    "/sources/nope",            # sources:read
+    "/documents/nope/content",  # sources:read
+    "/documents",               # graph:read
+])
+def test_content_surface_denied_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly, path
+):
+    """read_only lacks both sources:read and graph:read — denied (403)."""
+    assert api_client.get(path, headers=auth_headers_readonly).status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_content_surface_allowed_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """
+    admin holds sources:read (inherited from contributor) and graph:read (040),
+    so it passes the gates — a missing id yields 404, not an auth rejection.
+    """
+    assert api_client.get(
+        "/sources/nope", headers=auth_headers_admin
+    ).status_code not in (401, 403)
+    assert api_client.get(
+        "/documents/nope/content", headers=auth_headers_admin
+    ).status_code not in (401, 403)

--- a/tests/api/test_endpoint_security.py
+++ b/tests/api/test_endpoint_security.py
@@ -62,12 +62,25 @@ def test_health_endpoint_public(api_client, mock_oauth_validation):
 
 @pytest.mark.api
 @pytest.mark.security
-def test_database_health_endpoint_public(api_client, mock_oauth_validation):
-    """Test /database/health is accessible without authentication"""
+def test_database_health_requires_authentication(api_client, mock_oauth_validation):
+    """
+    /database/health is authenticated-by-design (ADR-400, #444 review): unlike
+    the public liveness probe /health, it discloses AGE-extension/schema-existence
+    and must reject anonymous callers. It is NOT permission-gated — any
+    authenticated user may check it.
+    """
     response = api_client.get("/database/health")
+    assert response.status_code in (401, 403)
 
-    # May return 200 (healthy) or 503 (unhealthy) depending on DB state
-    assert response.status_code in [200, 503]
+
+@pytest.mark.api
+@pytest.mark.security
+def test_database_health_allowed_for_authenticated(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly
+):
+    """Any authenticated user (even read_only) may check /database/health."""
+    response = api_client.get("/database/health", headers=auth_headers_readonly)
+    assert response.status_code not in (401, 403)
 
 
 @pytest.mark.api

--- a/tests/api/test_ingestion_auth.py
+++ b/tests/api/test_ingestion_auth.py
@@ -1,0 +1,71 @@
+"""
+Authorization regression tests for the ingestion entry points (ADR-400, #434).
+
+POST /ingest, /ingest/text and /ingest/image depended only on CurrentUser and
+never enforced the seeded ingest:create grant (contributor), despite docstrings
+claiming it. Any authenticated principal — including read_only, or an
+anonymous-then-self-registered account — could enqueue LLM-cost-bearing jobs
+(denial-of-wallet). These tests lock in require_permission('ingest','create').
+
+A permission denial fires in the dependency, before the handler body, so the
+read_only/anonymous cases never enqueue a job — no ingestion side effects.
+"""
+
+import pytest
+
+# Minimal valid bodies so the ONLY failure is the auth gate (not 422 form errors).
+ENDPOINTS = [
+    ("/ingest", {"file": ("t.txt", b"hello world")}, {"ontology": "testonto"}),
+    ("/ingest/text", None, {"text": "hello world", "ontology": "testonto"}),
+    ("/ingest/image", {"file": ("t.png", b"\x89PNG\r\n\x1a\n")}, {"ontology": "testonto"}),
+]
+
+
+@pytest.fixture
+def read_only_headers(create_test_oauth_token):
+    """A read_only user (id=102) in the DB + a matching token. read_only does
+    NOT hold ingest:create, so it exercises the authZ denial path."""
+    from api.app.dependencies.auth import get_db_connection
+
+    conn = get_db_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO kg_auth.users (id, username, password_hash, primary_role, created_at)
+                VALUES (102, '_test_readonly', '$2b$12$mock', 'read_only', NOW())
+                ON CONFLICT (id) DO NOTHING
+                """
+            )
+            conn.commit()
+    finally:
+        conn.close()
+    token = create_test_oauth_token(user_id=102, role="read_only")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("path,files,data", ENDPOINTS)
+def test_ingest_rejects_anonymous(api_client, path, files, data):
+    """No ingestion endpoint may be reached without authentication."""
+    response = api_client.post(path, files=files, data=data)
+    assert response.status_code in (401, 403), (
+        f"anonymous POST {path} returned {response.status_code}"
+    )
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("path,files,data", ENDPOINTS)
+def test_ingest_denied_for_read_only(
+    api_client, mock_oauth_validation, read_only_headers, path, files, data
+):
+    """
+    read_only lacks ingest:create, so every ingestion entry point must reject it
+    with 403 — closing the denial-of-wallet path for the lowest-privilege account.
+    """
+    response = api_client.post(path, files=files, data=data, headers=read_only_headers)
+    assert response.status_code == 403, (
+        f"read_only POST {path} returned {response.status_code} — ingest:create not enforced"
+    )

--- a/tests/api/test_ingestion_auth.py
+++ b/tests/api/test_ingestion_auth.py
@@ -21,29 +21,6 @@ ENDPOINTS = [
 ]
 
 
-@pytest.fixture
-def read_only_headers(create_test_oauth_token):
-    """A read_only user (id=102) in the DB + a matching token. read_only does
-    NOT hold ingest:create, so it exercises the authZ denial path."""
-    from api.app.dependencies.auth import get_db_connection
-
-    conn = get_db_connection()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO kg_auth.users (id, username, password_hash, primary_role, created_at)
-                VALUES (102, '_test_readonly', '$2b$12$mock', 'read_only', NOW())
-                ON CONFLICT (id) DO NOTHING
-                """
-            )
-            conn.commit()
-    finally:
-        conn.close()
-    token = create_test_oauth_token(user_id=102, role="read_only")
-    return {"Authorization": f"Bearer {token}"}
-
-
 @pytest.mark.api
 @pytest.mark.security
 @pytest.mark.parametrize("path,files,data", ENDPOINTS)
@@ -59,13 +36,14 @@ def test_ingest_rejects_anonymous(api_client, path, files, data):
 @pytest.mark.security
 @pytest.mark.parametrize("path,files,data", ENDPOINTS)
 def test_ingest_denied_for_read_only(
-    api_client, mock_oauth_validation, read_only_headers, path, files, data
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly,
+    path, files, data
 ):
     """
     read_only lacks ingest:create, so every ingestion entry point must reject it
     with 403 — closing the denial-of-wallet path for the lowest-privilege account.
     """
-    response = api_client.post(path, files=files, data=data, headers=read_only_headers)
+    response = api_client.post(path, files=files, data=data, headers=auth_headers_readonly)
     assert response.status_code == 403, (
         f"read_only POST {path} returned {response.status_code} — ingest:create not enforced"
     )

--- a/tests/api/test_queries_auth.py
+++ b/tests/api/test_queries_auth.py
@@ -1,0 +1,68 @@
+"""
+Authorization regression tests for the graph query surface (queries.py, #435).
+
+Every /query/* handler depended only on CurrentUser despite docstrings claiming
+graph:read — so any authenticated user (incl. read_only) could read concepts,
+sources, provenance, and run raw Cypher (POST /query/cypher), and enqueue
+auto-approved polarity compute jobs. This locks in:
+
+- read/search/connect/polarity endpoints require graph:read
+  (contributor + admin + platform_admin; excludes read_only)
+- POST /query/cypher requires graph:execute (platform_admin only)
+
+Gates are declared as route-level dependencies. Denials fire before the handler,
+so no search/compute side effects occur in the denial tests.
+"""
+
+import pytest
+
+CYPHER_BODY = {"query": "MATCH (n) RETURN n LIMIT 1"}
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_query_rejects_anonymous(api_client):
+    """Representative read + raw-cypher endpoints reject anonymous callers."""
+    assert api_client.get("/query/concept/does-not-exist").status_code in (401, 403)
+    assert api_client.post("/query/cypher", json=CYPHER_BODY).status_code in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_query_read_denied_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly
+):
+    """read_only lacks graph:read and is denied the concept read + raw cypher."""
+    assert api_client.get(
+        "/query/concept/does-not-exist", headers=auth_headers_readonly
+    ).status_code == 403
+    assert api_client.post(
+        "/query/cypher", json=CYPHER_BODY, headers=auth_headers_readonly
+    ).status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_query_read_allowed_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """admin holds graph:read (via 040) and passes the gate (404 for a fake id)."""
+    response = api_client.get(
+        "/query/concept/does-not-exist", headers=auth_headers_admin
+    )
+    assert response.status_code not in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_raw_cypher_denied_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """
+    POST /query/cypher requires graph:execute, seeded to platform_admin only.
+    A plain admin (graph:read but not execute) must be denied (403).
+    """
+    response = api_client.post(
+        "/query/cypher", json=CYPHER_BODY, headers=auth_headers_admin
+    )
+    assert response.status_code == 403

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,6 +355,21 @@ def auth_headers_admin(create_test_oauth_token):
 
 
 @pytest.fixture
+def auth_headers_readonly(create_test_oauth_token):
+    """
+    Provide authorization headers for a read_only role (user_id=102).
+
+    read_only is the standalone least-privilege role — it holds only
+    concepts:read / vocabulary:read / jobs:read{owner=self} and deliberately
+    lacks graph:read, ingest:create, sources:read, etc. Use it to exercise the
+    authZ-denial path. Pair with ensure_test_users_in_db so PermissionChecker
+    resolves the role from the DB row.
+    """
+    token = create_test_oauth_token(user_id=102, role="read_only")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
 def expired_oauth_token(create_test_oauth_token):
     """
     Provide an expired OAuth token for testing token expiration.
@@ -503,7 +518,8 @@ def ensure_test_users_in_db():
                 INSERT INTO kg_auth.users (id, username, password_hash, primary_role, created_at)
                 VALUES
                     (100, '_test_user', '$2b$12$mock', 'contributor', NOW()),
-                    (101, '_test_admin', '$2b$12$mock', 'admin', NOW())
+                    (101, '_test_admin', '$2b$12$mock', 'admin', NOW()),
+                    (102, '_test_readonly', '$2b$12$mock', 'read_only', NOW())
                 ON CONFLICT (id) DO NOTHING
             """)
             conn.commit()


### PR DESCRIPTION
Closes the five **high** blockers from the 2026-05-28 endpoint security audit, measured against the operative model in **ADR-400**. Tracking: #442. Follows the Phase 0 criticals (#430, #443).

These all share one root cause: handlers that authenticated but never authorized, despite docstrings claiming a permission. Each `(resource, action)` pair below is confirmed seeded in the migrations (no dead-checks).

| # | Surface | Gate added |
|---|---------|-----------|
| #433 | `/database/*` | reads → `database:read`; `POST /query` + `counters/refresh` → `database:execute`. `/database/epoch` documented authenticated-by-design (polling). |
| #434 | `/ingest`, `/ingest/text`, `/ingest/image` | `ingest:create` (closes denial-of-wallet) |
| #435 | `queries.py` (9 endpoints) | reads/search/connect/polarity → `graph:read`; `POST /query/cypher` → `graph:execute` |
| #436 | `documents.py` + `sources.py` | content/source reads → `sources:read`; metadata/search/linkage → `graph:read` |
| #437 | `GET /vocabulary/category-flows`, `GET /ingest/image/health` | the two fully-anonymous endpoints → `vocabulary:read` / `admin:status` |

## Notes
- Endpoints with non-defaulted request-body params use route-level `dependencies=[...]` rather than a signature param (avoids parameter-ordering issues).
- Shared test fixture: added a `read_only` user (id=102) + `auth_headers_readonly` to conftest; used across the new auth tests.
- Reconciled two pre-existing `test_database_counters` handler tests that assumed the old ungated behavior (bypass RBAC; authZ now covered in `test_database_auth.py`).

## Tests
New: `test_database_auth.py`, `test_ingestion_auth.py`, `test_queries_auth.py`, `test_documents_sources_auth.py`, `test_anonymous_endpoints_auth.py` — each asserts anonymous rejection + a real authZ denial (read_only/admin) against seeded grants. **Full API suite: 466 passed, 15 skipped.**

Remaining: Phase 2 (medium — #438/#439/#440) and Phase 3 (low — #441) per the audit's phased plan.