### PR TITLE
fix(auth): internet-hardening Phase 2 — read gates, disabled-account bypass, CLI coherence (#438–#440)

### DIFF
--- a/api/app/routes/artifacts.py
+++ b/api/app/routes/artifacts.py
@@ -20,7 +20,7 @@ from ..models.artifact import (
     REPRESENTATIONS
 )
 from ..models.auth import UserInDB
-from ..dependencies.auth import get_current_user, get_db_connection
+from ..dependencies.auth import get_current_active_user, get_db_connection
 from ..lib.garage import get_artifact_storage
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ async def list_artifacts(
     owner_id: Optional[int] = Query(None, description="Filter by owner (admin only)"),
     limit: int = Query(50, ge=1, le=500, description="Maximum artifacts to return"),
     offset: int = Query(0, ge=0, description="Number to skip for pagination"),
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     List artifacts with optional filtering.
@@ -156,7 +156,7 @@ async def list_artifacts(
 )
 async def get_artifact(
     artifact_id: int,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Get artifact metadata by ID.
@@ -229,7 +229,7 @@ async def get_artifact(
 )
 async def get_artifact_payload(
     artifact_id: int,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Get artifact with full payload.
@@ -328,7 +328,7 @@ async def get_artifact_payload(
 )
 async def create_artifact(
     artifact: ArtifactCreate,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Create a new artifact.
@@ -447,7 +447,7 @@ async def create_artifact(
 )
 async def delete_artifact(
     artifact_id: int,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Delete an artifact.
@@ -479,8 +479,11 @@ async def delete_artifact(
             user_id = current_user.id
             user_role = current_user.role
 
-            if owner_id is not None and owner_id != user_id:
-                if user_role not in ("admin", "platform_admin"):
+            # Non-admins may act only on their OWN artifacts; system-owned
+            # artifacts (owner_id IS NULL) are admin-only (#439 — the previous
+            # `owner_id is not None` guard skipped the check for NULL owners).
+            if user_role not in ("admin", "platform_admin"):
+                if owner_id is None or owner_id != user_id:
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
                         detail="Access denied to delete this artifact"
@@ -524,7 +527,7 @@ class RegenerateResponse(BaseModel):
 async def regenerate_artifact(
     artifact_id: int,
     background_tasks: BackgroundTasks,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Regenerate an artifact using its stored parameters.
@@ -563,8 +566,10 @@ async def regenerate_artifact(
             artifact_type, parameters, owner_id, ontology, query_def_id = row
 
             # Check ownership
-            if owner_id is not None and owner_id != current_user.id:
-                if current_user.role not in ("admin", "platform_admin"):
+            # Non-admins may act only on their OWN artifacts; system-owned
+            # artifacts (owner_id IS NULL) are admin-only (#439).
+            if current_user.role not in ("admin", "platform_admin"):
+                if owner_id is None or owner_id != current_user.id:
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
                         detail="Access denied to regenerate this artifact"

--- a/api/app/routes/grants.py
+++ b/api/app/routes/grants.py
@@ -21,7 +21,7 @@ from ..models.grants import (
     GrantCreateResponse
 )
 from ..models.auth import UserInDB
-from ..dependencies.auth import get_current_user, get_db_connection
+from ..dependencies.auth import get_current_active_user, get_db_connection
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ def _get_resource_owner(cur, resource_type: str, resource_id: str) -> Optional[i
 async def list_groups(
     include_system: bool = Query(True, description="Include system groups (public, admins)"),
     include_member_count: bool = Query(True, description="Include member count for each group"),
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     List all groups.
@@ -185,7 +185,7 @@ async def list_groups(
 )
 async def create_group(
     group: GroupCreate,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Create a new group.
@@ -262,7 +262,7 @@ async def create_group(
 async def list_group_members(
     group_id: int,
     include_implicit: bool = Query(False, description="For public group, include all users (implicit members)"),
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     List members of a group.
@@ -359,7 +359,7 @@ async def list_group_members(
 async def add_group_member(
     group_id: int,
     request: AddMemberRequest,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Add a user to a group.
@@ -453,7 +453,7 @@ async def add_group_member(
 async def remove_group_member(
     group_id: int,
     user_id: int,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Remove a user from a group.
@@ -505,7 +505,7 @@ async def remove_group_member(
 )
 async def create_grant(
     grant: GrantCreate,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Create a resource access grant.
@@ -616,7 +616,7 @@ async def create_grant(
 async def list_resource_grants(
     resource_type: str,
     resource_id: str,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     List all grants for a specific resource.
@@ -672,7 +672,7 @@ async def list_resource_grants(
 )
 async def revoke_grant(
     grant_id: int,
-    current_user: UserInDB = Depends(get_current_user)
+    current_user: UserInDB = Depends(get_current_active_user)
 ):
     """
     Revoke (delete) a resource access grant.

--- a/api/app/routes/ontology.py
+++ b/api/app/routes/ontology.py
@@ -259,7 +259,7 @@ async def create_ontology(
         client.close()
 
 
-@router.get("/", response_model=OntologyListResponse)
+@router.get("/", response_model=OntologyListResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def list_ontologies(
     current_user: CurrentUser
 ):
@@ -383,7 +383,7 @@ def _row_to_proposal(row) -> AnnealingProposal:
         "suggested_description": row.get("suggested_description"),
     })
 
-@router.get("/proposals", response_model=AnnealingProposalListResponse)
+@router.get("/proposals", response_model=AnnealingProposalListResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def list_proposals(
     status: str = QueryParam(None, description="Filter by status: pending, approved, rejected, expired"),
     proposal_type: str = QueryParam(None, description="Filter by type: CLEAVE, DISSOLVE, MERGE, RENAME, NO_ACTION, ESCALATE, ADJUST_CONTROL (legacy: promotion, demotion)"),
@@ -449,7 +449,7 @@ async def list_proposals(
         client.close()
 
 
-@router.get("/proposals/{proposal_id}", response_model=AnnealingProposal)
+@router.get("/proposals/{proposal_id}", response_model=AnnealingProposal, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_proposal(
     proposal_id: int,
     current_user: CurrentUser = None,
@@ -930,7 +930,7 @@ async def get_ecological_pressure_history(
 # Ontology CRUD (paths with {ontology_name} parameter)
 # =========================================================================
 
-@router.get("/{ontology_name}", response_model=OntologyInfoResponse)
+@router.get("/{ontology_name}", response_model=OntologyInfoResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_ontology_info(
     ontology_name: str,
     current_user: CurrentUser
@@ -1047,7 +1047,7 @@ async def get_ontology_info(
         client.close()
 
 
-@router.get("/{ontology_name}/node", response_model=OntologyNodeResponse)
+@router.get("/{ontology_name}/node", response_model=OntologyNodeResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_ontology_node(
     ontology_name: str,
     current_user: CurrentUser
@@ -1102,7 +1102,7 @@ async def get_ontology_node(
         client.close()
 
 
-@router.get("/{ontology_name}/files", response_model=OntologyFilesResponse)
+@router.get("/{ontology_name}/files", response_model=OntologyFilesResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_ontology_files(
     ontology_name: str,
     current_user: CurrentUser
@@ -1560,7 +1560,7 @@ async def rename_ontology(
 # =========================================================================
 
 
-@router.get("/{ontology_name}/scores", response_model=OntologyScores)
+@router.get("/{ontology_name}/scores", response_model=OntologyScores, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_ontology_scores(
     ontology_name: str,
     current_user: CurrentUser,
@@ -1683,7 +1683,7 @@ async def compute_all_ontology_scores(
         client.close()
 
 
-@router.get("/{ontology_name}/candidates", response_model=ConceptDegreeResponse)
+@router.get("/{ontology_name}/candidates", response_model=ConceptDegreeResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_ontology_candidates(
     ontology_name: str,
     current_user: CurrentUser,
@@ -1726,7 +1726,7 @@ async def get_ontology_candidates(
         client.close()
 
 
-@router.get("/{ontology_name}/affinity", response_model=AffinityResponse)
+@router.get("/{ontology_name}/affinity", response_model=AffinityResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_ontology_affinity(
     ontology_name: str,
     current_user: CurrentUser,
@@ -1776,7 +1776,7 @@ async def get_ontology_affinity(
 # =========================================================================
 
 
-@router.get("/{ontology_name}/edges", response_model=OntologyEdgesResponse)
+@router.get("/{ontology_name}/edges", response_model=OntologyEdgesResponse, dependencies=[Depends(require_permission("ontologies", "read"))])
 async def get_ontology_edges(
     ontology_name: str,
     current_user: CurrentUser,

--- a/api/app/routes/programs.py
+++ b/api/app/routes/programs.py
@@ -36,7 +36,7 @@ from ..services.program_validator import (
 )
 from ..services.program_executor import execute_program
 from ..models.auth import UserInDB
-from ..dependencies.auth import get_current_user, get_db_connection
+from ..dependencies.auth import get_current_active_user, get_db_connection
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ router = APIRouter(prefix="/programs", tags=["programs"])
 )
 async def create_program(
     submission: ProgramSubmission,
-    current_user: UserInDB = Depends(get_current_user),
+    current_user: UserInDB = Depends(get_current_active_user),
 ):
     """
     Validate a GraphProgram and store it as a notarized program.
@@ -132,7 +132,7 @@ async def create_program(
 )
 async def validate_program_endpoint(
     submission: ProgramSubmission,
-    current_user: UserInDB = Depends(get_current_user),
+    current_user: UserInDB = Depends(get_current_active_user),
 ):
     """
     Validate a GraphProgram without storing it.
@@ -149,7 +149,7 @@ async def validate_program_endpoint(
 )
 async def execute_program_endpoint(
     request: ProgramExecuteRequest,
-    current_user: UserInDB = Depends(get_current_user),
+    current_user: UserInDB = Depends(get_current_active_user),
 ):
     """
     Execute a GraphProgram or chain of programs server-side.
@@ -327,7 +327,7 @@ def _load_program_definition(program_id: int, current_user: UserInDB) -> dict:
 async def list_programs(
     search: Optional[str] = Query(None, description="Search name/description"),
     limit: int = Query(20, ge=1, le=100),
-    current_user: UserInDB = Depends(get_current_user),
+    current_user: UserInDB = Depends(get_current_active_user),
 ):
     """
     List stored programs with optional text search.
@@ -393,7 +393,7 @@ async def list_programs(
 )
 async def get_program(
     program_id: int,
-    current_user: UserInDB = Depends(get_current_user),
+    current_user: UserInDB = Depends(get_current_active_user),
 ):
     """
     Retrieve a notarized program by ID.

--- a/api/app/routes/projection.py
+++ b/api/app/routes/projection.py
@@ -6,7 +6,7 @@ Endpoints for embedding landscape visualization:
 - POST /projection/{ontology}/regenerate - Trigger projection recomputation
 """
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, Field
 from typing import Optional, Literal, List, Dict, Any
 import logging
@@ -18,7 +18,7 @@ from api.app.workers.projection_worker import (
     invalidate_cached_projection
 )
 from api.app.services.job_queue import get_job_queue
-from api.app.dependencies.auth import CurrentUser
+from api.app.dependencies.auth import CurrentUser, require_permission
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +172,7 @@ class AlgorithmInfoResponse(BaseModel):
     default: str = "tsne"
 
 
-@router.get("/algorithms", response_model=AlgorithmInfoResponse)
+@router.get("/algorithms", response_model=AlgorithmInfoResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def get_available_algorithms(
     current_user: CurrentUser
 ):
@@ -187,7 +187,7 @@ async def get_available_algorithms(
     )
 
 
-@router.get("/{ontology}", response_model=ProjectionDatasetResponse)
+@router.get("/{ontology}", response_model=ProjectionDatasetResponse, dependencies=[Depends(require_permission("graph", "read"))])
 async def get_projection(
     ontology: str,
     request: Request,
@@ -225,7 +225,7 @@ async def get_projection(
     return ProjectionDatasetResponse(**dataset)
 
 
-@router.post("/{ontology}/regenerate", response_model=RegenerateResponse)
+@router.post("/{ontology}/regenerate", response_model=RegenerateResponse, dependencies=[Depends(require_permission("graph", "create"))])
 async def regenerate_projection(
     ontology: str,
     background_tasks: BackgroundTasks,
@@ -394,7 +394,7 @@ async def regenerate_projection(
     )
 
 
-@router.delete("/{ontology}")
+@router.delete("/{ontology}", dependencies=[Depends(require_permission("graph", "delete"))])
 async def invalidate_projection(
     ontology: str,
     current_user: CurrentUser

--- a/api/app/routes/vocabulary.py
+++ b/api/app/routes/vocabulary.py
@@ -122,7 +122,7 @@ def get_vocabulary_manager() -> VocabularyManager:
 # Status and Information Endpoints
 # =============================================================================
 
-@router.get("/status", response_model=VocabularyStatusResponse)
+@router.get("/status", response_model=VocabularyStatusResponse, dependencies=[Depends(require_permission("vocabulary", "read"))])
 async def get_vocabulary_status(
     current_user: CurrentUser
 ):
@@ -196,7 +196,7 @@ async def get_vocabulary_status(
         raise HTTPException(status_code=500, detail=f"Failed to get vocabulary status: {str(e)}")
 
 
-@router.get("/types", response_model=EdgeTypeListResponse)
+@router.get("/types", response_model=EdgeTypeListResponse, dependencies=[Depends(require_permission("vocabulary", "read"))])
 async def list_edge_types(
     current_user: CurrentUser,
     include_inactive: bool = Query(False, description="Include inactive types"),
@@ -682,7 +682,7 @@ async def generate_embeddings(
         raise HTTPException(status_code=500, detail=f"Failed to generate embeddings: {str(e)}")
 
 
-@router.get("/category-scores/{relationship_type}", response_model=CategoryScoresResponse)
+@router.get("/category-scores/{relationship_type}", response_model=CategoryScoresResponse, dependencies=[Depends(require_permission("vocabulary", "read"))])
 async def get_category_scores(
     relationship_type: str,
     current_user: CurrentUser
@@ -852,7 +852,7 @@ async def refresh_categories(
 
 # ========== Similarity Analysis Endpoints (ADR-053) ==========
 
-@router.get("/similar/{relationship_type}", response_model=VocabularySimilarityResponse)
+@router.get("/similar/{relationship_type}", response_model=VocabularySimilarityResponse, dependencies=[Depends(require_permission("vocabulary", "read"))])
 async def get_similar_types(
     relationship_type: str,
     current_user: CurrentUser,
@@ -990,7 +990,7 @@ async def get_similar_types(
         raise HTTPException(status_code=500, detail=f"Failed to compute similarities: {str(e)}")
 
 
-@router.get("/analyze/{relationship_type}", response_model=VocabularyAnalysisDetailResponse)
+@router.get("/analyze/{relationship_type}", response_model=VocabularyAnalysisDetailResponse, dependencies=[Depends(require_permission("vocabulary", "read"))])
 async def analyze_vocabulary_type(
     relationship_type: str,
     current_user: CurrentUser
@@ -1194,6 +1194,7 @@ async def measure_epistemic_status(
 @router.get(
     "/epistemic-status",
     response_model=EpistemicStatusListResponse,
+    dependencies=[Depends(require_permission("vocabulary", "read"))],
     summary="List vocabulary types with epistemic status",
     description="Get all vocabulary types with their epistemic status classifications and statistics."
 )
@@ -1293,6 +1294,7 @@ async def list_epistemic_status(
 @router.get(
     "/epistemic-status/{relationship_type}",
     response_model=EpistemicStatusInfo,
+    dependencies=[Depends(require_permission("vocabulary", "read"))],
     summary="Get epistemic status for specific vocabulary type",
     description="Get detailed epistemic status information for a specific relationship type."
 )

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -47,8 +47,6 @@ import {
   ListBackupsResponse,
   RestoreRequest,
   RestoreResponse,
-  ResetRequest,
-  ResetResponse,
   ResourceCreate,
   ResourceRead,
   ResourceUpdate,
@@ -1305,14 +1303,6 @@ export class KnowledgeGraphClient {
       }
     });
 
-    return response.data;
-  }
-
-  /**
-   * Reset database (destructive - requires authentication)
-   */
-  async resetDatabase(request: ResetRequest): Promise<ResetResponse> {
-    const response = await this.client.post('/admin/reset', request);
     return response.data;
   }
 

--- a/cli/src/cli/database.ts
+++ b/cli/src/cli/database.ts
@@ -11,7 +11,7 @@ import { setCommandHelp } from './help-formatter';
 export const databaseCommand = setCommandHelp(
   new Command('database'),
   'Database operations and information',
-  'Database operations and information. Provides read-only queries for PostgreSQL + Apache AGE database health, statistics, and connection details.'
+  'Database operations and information for PostgreSQL + Apache AGE: health, statistics, and connection details. Note: `db query` executes arbitrary openCypher (including mutations) and requires database:execute (platform_admin); the stats/info/health reads require database:read (admin).'
 )
   .alias('db')  // Short alias
   .showHelpAfterError('(add --help for additional information)')

--- a/cli/src/cli/rbac.ts
+++ b/cli/src/cli/rbac.ts
@@ -87,7 +87,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to list resources'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin or curator role\n'));
+          console.error(colors.status.warning('  Requires admin or platform_admin role\n'));
         } else {
           console.error(`  ${error.response?.data?.detail || error.message}\n`);
         }
@@ -123,7 +123,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to create resource type'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin role\n'));
+          console.error(colors.status.warning('  Requires platform_admin role\n'));
         } else if (error.response?.status === 409) {
           console.error(`  Resource type '${options.type}' already exists\n`);
         } else {
@@ -201,7 +201,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to list roles'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin or curator role\n'));
+          console.error(colors.status.warning('  Requires admin or platform_admin role\n'));
         } else {
           console.error(`  ${error.response?.data?.detail || error.message}\n`);
         }
@@ -246,7 +246,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
         if (error.response?.status === 404) {
           console.error(`  Role '${roleName}' not found\n`);
         } else if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin or curator role\n'));
+          console.error(colors.status.warning('  Requires admin or platform_admin role\n'));
         } else {
           console.error(`  ${error.response?.data?.detail || error.message}\n`);
         }
@@ -283,7 +283,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to create role'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin role\n'));
+          console.error(colors.status.warning('  Requires platform_admin role\n'));
         } else if (error.response?.status === 409) {
           console.error(`  Role '${options.name}' already exists\n`);
         } else {
@@ -408,7 +408,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to list permissions'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin or curator role\n'));
+          console.error(colors.status.warning('  Requires admin or platform_admin role\n'));
         } else {
           console.error(`  ${error.response?.data?.detail || error.message}\n`);
         }
@@ -446,7 +446,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to grant permission'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin role\n'));
+          console.error(colors.status.warning('  Requires platform_admin role\n'));
         } else if (error.response?.status === 404) {
           console.error('  Role or resource type not found\n');
         } else if (error.response?.status === 409) {
@@ -471,7 +471,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
         if (error.response?.status === 404) {
           console.error(`  Permission ${permissionId} not found\n`);
         } else if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin role\n'));
+          console.error(colors.status.warning('  Requires platform_admin role\n'));
         } else {
           console.error(`  ${error.response?.data?.detail || error.message}\n`);
         }
@@ -545,7 +545,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to list user roles'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin or curator role\n'));
+          console.error(colors.status.warning('  Requires admin or platform_admin role\n'));
         } else {
           console.error(`  ${error.response?.data?.detail || error.message}\n`);
         }
@@ -578,7 +578,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
       } catch (error: any) {
         console.error(colors.status.error('\n✗ Failed to assign role'));
         if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin role\n'));
+          console.error(colors.status.warning('  Requires platform_admin role\n'));
         } else if (error.response?.status === 404) {
           console.error('  User or role not found\n');
         } else if (error.response?.status === 409) {
@@ -603,7 +603,7 @@ export function createRbacCommand(client: KnowledgeGraphClient): Command {
         if (error.response?.status === 404) {
           console.error(`  Assignment ${assignmentId} not found\n`);
         } else if (error.response?.status === 401 || error.response?.status === 403) {
-          console.error(colors.status.warning('  Requires admin role\n'));
+          console.error(colors.status.warning('  Requires platform_admin role\n'));
         } else {
           console.error(`  ${error.response?.data?.detail || error.message}\n`);
         }

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -730,28 +730,6 @@ export interface RestoreResponse {
   external_deps_handled?: string;
 }
 
-export interface ResetRequest {
-  username: string;
-  password: string;
-  confirm: boolean;
-  clear_logs?: boolean;
-  clear_checkpoints?: boolean;
-}
-
-export interface SchemaValidation {
-  constraints_count: number;
-  vector_index_exists: boolean;
-  node_count: number;
-  schema_test_passed: boolean;
-}
-
-export interface ResetResponse {
-  success: boolean;
-  schema_validation: SchemaValidation;
-  message: string;
-  warnings: string[];
-}
-
 // ========== RBAC Types (ADR-028) ==========
 
 // Resource Types

--- a/docs/reference/cli/commands/database.md
+++ b/docs/reference/cli/commands/database.md
@@ -4,7 +4,7 @@
 
 ## database (db)
 
-Database operations and information. Provides read-only queries for PostgreSQL + Apache AGE database health, statistics, and connection details.
+Database operations and information for PostgreSQL + Apache AGE: health, statistics, and connection details. Note: `db query` executes arbitrary openCypher (including mutations) and requires database:execute (platform_admin); the stats/info/health reads require database:read (admin).
 
 **Usage:**
 ```bash

--- a/tests/api/test_artifact_owner_guard_auth.py
+++ b/tests/api/test_artifact_owner_guard_auth.py
@@ -1,0 +1,83 @@
+"""
+Regression tests for the #439 fixes:
+
+1. NULL-owner artifact bypass — DELETE/regenerate guarded with
+   `if owner_id is not None and owner_id != user_id` skipped the check entirely
+   for system-owned artifacts (owner_id IS NULL), letting any authenticated user
+   delete/regenerate them. Now non-admins are denied on NULL-owner artifacts.
+2. get_current_user -> get_current_active_user across artifacts/programs/grants
+   (disabled-account bypass). The disabled-rejection behavior of
+   get_current_active_user is unit-tested in test_auth_dependencies.py; here we
+   confirm these endpoints still require authentication after the swap.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def system_artifact_id():
+    """Insert a system-owned (owner_id IS NULL) artifact; yield id; clean up."""
+    from api.app.dependencies.auth import get_db_connection
+
+    conn = get_db_connection()
+    artifact_id = None
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO kg_api.artifacts
+                    (artifact_type, representation, owner_id, graph_epoch, parameters, inline_result)
+                VALUES ('query_result', 'api_direct', NULL, 0, '{}'::jsonb, '{}'::jsonb)
+                RETURNING id
+                """
+            )
+            artifact_id = cur.fetchone()[0]
+            conn.commit()
+        yield artifact_id
+    finally:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM kg_api.artifacts WHERE id = %s", (artifact_id,))
+            conn.commit()
+        conn.close()
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_delete_system_artifact_denied_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly,
+    system_artifact_id,
+):
+    """A non-admin must NOT be able to delete a system-owned (NULL-owner) artifact."""
+    response = api_client.delete(
+        f"/artifacts/{system_artifact_id}", headers=auth_headers_readonly
+    )
+    assert response.status_code == 403, (
+        f"read_only could reach DELETE on a NULL-owner artifact ({response.status_code})"
+    )
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_regenerate_system_artifact_denied_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly,
+    system_artifact_id,
+):
+    """Likewise for regenerate on a system-owned artifact."""
+    response = api_client.post(
+        f"/artifacts/{system_artifact_id}/regenerate", headers=auth_headers_readonly
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("method,path", [
+    ("delete", "/artifacts/1"),
+    ("post", "/artifacts/1/regenerate"),
+    ("post", "/programs"),
+    ("get", "/groups"),
+])
+def test_swapped_endpoints_still_require_auth(api_client, method, path):
+    """After the get_current_active_user swap, these endpoints still reject anonymous."""
+    fn = getattr(api_client, method)
+    assert fn(path).status_code in (401, 403)

--- a/tests/api/test_read_gates_auth.py
+++ b/tests/api/test_read_gates_auth.py
@@ -1,0 +1,79 @@
+"""
+Authorization regression tests for the Phase 2 read-gate cluster (#438).
+
+projection.py, ontology.py and vocabulary.py read endpoints took only
+CurrentUser while docstrings claimed a permission. This locks in:
+
+- projection reads/algorithms -> graph:read; regenerate -> graph:create;
+  invalidate -> graph:delete
+- all ontology read endpoints -> ontologies:read
+- all vocabulary read endpoints -> vocabulary:read
+
+read_only lacks graph:read and ontologies:read (denied there) but DOES hold
+vocabulary:read (baseline) — so it is allowed on vocabulary reads. That split is
+exactly what these tests assert.
+"""
+
+import pytest
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("path", [
+    "/projection/nope",
+    "/projection/algorithms",
+    "/ontology/nope",
+    "/vocabulary/status",
+])
+def test_read_gates_reject_anonymous(api_client, path):
+    assert api_client.get(path).status_code in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+@pytest.mark.parametrize("path", [
+    "/projection/nope",   # graph:read
+    "/projection/algorithms",  # graph:read
+    "/ontology/nope",     # ontologies:read
+])
+def test_graph_and_ontology_reads_denied_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly, path
+):
+    """read_only lacks graph:read and ontologies:read -> 403."""
+    assert api_client.get(path, headers=auth_headers_readonly).status_code == 403
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_vocabulary_read_allowed_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly
+):
+    """read_only DOES hold vocabulary:read (baseline) -> not an auth rejection."""
+    assert api_client.get(
+        "/vocabulary/status", headers=auth_headers_readonly
+    ).status_code not in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_graph_ontology_reads_allowed_for_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """admin holds graph:read (040) and ontologies:read (inherited) -> passes gate."""
+    assert api_client.get(
+        "/projection/nope", headers=auth_headers_admin
+    ).status_code not in (401, 403)
+    assert api_client.get(
+        "/ontology/nope", headers=auth_headers_admin
+    ).status_code not in (401, 403)
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_projection_delete_denied_for_read_only(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly
+):
+    """invalidate_projection requires graph:delete (admin/platform_admin)."""
+    assert api_client.delete(
+        "/projection/nope", headers=auth_headers_readonly
+    ).status_code == 403


### PR DESCRIPTION
The medium-severity batch of the internet-hardening effort, measured against ADR-400. Tracking: #442. Follows Phase 0 (#430, #443) and Phase 1 (#444), all merged.

## #438 — projection / ontology / vocabulary read gates
A cluster of read endpoints took only `CurrentUser` while docstrings claimed a permission (sibling mutators gated correctly — clear drift).
- projection: reads → `graph:read`, regenerate → `graph:create`, invalidate → `graph:delete`
- ontology: all 10 reads → `ontologies:read`
- vocabulary: all 7 reads → `vocabulary:read`

## #439 — disabled-account bypass + NULL-owner artifact guard
- `get_current_user` (no `disabled` check) → `get_current_active_user` across `artifacts.py`, `programs.py`, `grants.py`. A disabled-but-tokened account was fully functional.
- NULL-owner artifact bypass: the ownership guard skipped entirely for system-owned artifacts (`owner_id IS NULL`). Inverted so non-admins act only on their own; system artifacts are admin-only (DELETE + regenerate).

## #440 — CLI coherence
- `rbac.ts` role guidance corrected (reads → admin/platform_admin, mutations → platform_admin; curator has no rbac grant).
- `database` group relabeled (it runs mutating Cypher, not "read-only"); per-action gates documented.
- Removed dead `resetDatabase()` (POSTed to the removed `/admin/reset`). Left `AuthChallenge`/`login()` (TODO-tracked for OAuth re-impl).

## Tests
New: `test_read_gates_auth.py`, `test_artifact_owner_guard_auth.py` (inserts a real NULL-owner artifact and asserts read_only is denied DELETE + regenerate). All gates verified against seeded grants — read_only correctly denied on graph/ontology but **allowed** on vocabulary (it holds `vocabulary:read`). **Full API suite: 483 passed, 15 skipped.** CLI builds clean.

Remaining: Phase 3 (low — #441: admin_workers cancel vs jobs:cancel scoping, oauth_clients:write admin gap).