### PR TITLE
feat: ADR-501 Catalog Browse Facade (backend + CLI/MCP + web + FUSE)

### DIFF
--- a/api/app/lib/catalog_facade.py
+++ b/api/app/lib/catalog_facade.py
@@ -39,7 +39,7 @@ _CATALOG_REBUILD_LOCK = 0x0CA7A106  # "CATALOG" mnemonic
 _SORT_SQL = {
     "name": "n.name ASC",
     "child_count": "n.child_count DESC, n.name ASC",
-    "created": "(n.properties->>'creation_epoch') NULLS LAST, n.indexed_at ASC, n.name ASC",
+    "created": "(n.properties->>'creation_epoch')::bigint DESC NULLS LAST, n.indexed_at ASC, n.name ASC",
 }
 
 
@@ -85,47 +85,47 @@ class CatalogFacade:
         """
         conn = self.client.pool.getconn()
         try:
+            # Fast path: read epochs without the lock.
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 current = self._current_epoch(cur)
                 indexed = self._index_epoch(cur)
-                conn.commit()
+            conn.rollback()  # close the read txn cleanly
 
             if indexed is not None and indexed >= current:
                 return (False, current)
 
-            # Stale (or empty). Try to claim the rebuild lock; if another worker
-            # holds it, serve what we have.
-            with conn.cursor() as cur:
+            # Stale (or empty). Claim a TRANSACTION-scoped advisory lock: it is
+            # released automatically when this transaction commits or rolls back
+            # (including on exception), so there is no orphaned-lock risk and no
+            # dependency on a manual unlock or on reusing one connection. The
+            # rebuild's TRUNCATE+INSERT runs in this same transaction, so the
+            # lock is held for exactly the rebuild's duration and the single
+            # commit both publishes the new index and frees the lock.
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 cur.execute(
-                    "SELECT pg_try_advisory_lock(%s)", (_CATALOG_REBUILD_LOCK,)
+                    "SELECT pg_try_advisory_xact_lock(%s) AS got", (_CATALOG_REBUILD_LOCK,)
                 )
-                got_lock = cur.fetchone()[0]
-                conn.commit()
+                got_lock = cur.fetchone()["got"]
+                if not got_lock:
+                    # Another worker is rebuilding — serve what we have.
+                    conn.rollback()
+                    return (indexed is not None, current)
 
-            if not got_lock:
-                return (indexed is not None, current)
-
-            try:
                 # Re-check under lock: another worker may have just rebuilt.
-                with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                    indexed = self._index_epoch(cur)
-                    current = self._current_epoch(cur)
-                    conn.commit()
+                indexed = self._index_epoch(cur)
+                current = self._current_epoch(cur)
                 if indexed is not None and indexed >= current:
+                    conn.rollback()  # releases the lock
                     return (False, current)
 
-                self._rebuild(conn, current)
-                return (False, current)
-            finally:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        "SELECT pg_advisory_unlock(%s)", (_CATALOG_REBUILD_LOCK,)
-                    )
-                    conn.commit()
+            # Same transaction (lock still held): rebuild, then commit once.
+            self._rebuild(conn, current)
+            conn.commit()  # publishes the index and releases the xact lock
+            return (False, current)
         except Exception as e:
             logger.error(f"catalog ensure_fresh failed: {e}", exc_info=True)
-            conn.rollback()
-            # Best-effort: report not-stale with epoch 0 so callers still serve
+            conn.rollback()  # releases the lock if held
+            # Best-effort: report stale with epoch 0 so callers still serve
             # whatever index exists rather than erroring the browse request.
             return (True, 0)
         finally:
@@ -160,7 +160,10 @@ class CatalogFacade:
                 f"absent from document drill-down"
             )
 
-        # Atomic swap: truncate + bulk insert in one transaction.
+        # Atomic swap: truncate + bulk insert. The caller (ensure_fresh) owns
+        # the transaction and the advisory lock — it commits once after this
+        # returns, which both publishes the index and releases the lock. We do
+        # NOT commit here, so a failure leaves the prior index intact on rollback.
         from psycopg2.extras import execute_values, Json
 
         with conn.cursor() as cur:
@@ -192,7 +195,6 @@ class CatalogFacade:
                     edges,
                     page_size=1000,
                 )
-            conn.commit()
 
         logger.info(
             f"catalog rebuild complete: {len(nodes)} nodes, {len(edges)} edges "
@@ -297,20 +299,29 @@ class CatalogFacade:
         return rows
 
     def _fetch_documents(self) -> List[Dict[str, Any]]:
-        """DocumentMeta nodes with parent ontology ids and concept counts."""
+        """DocumentMeta nodes with parent ontology ids and concept counts.
+
+        The parent-ontology and concept legs are aggregated in SEPARATE WITH
+        stages rather than two OPTIONAL MATCHes off the same Source. Combining
+        them produces a sources×ontologies×concepts Cartesian fan-out that
+        DISTINCT/count collapse to the right values but only after materializing
+        the product — pathological on large documents. Sequential aggregation
+        keeps each leg's cost additive.
+        """
         rows = self.client._execute_cypher("""
             MATCH (d:DocumentMeta)
-            OPTIONAL MATCH (d)-[:HAS_SOURCE]->(s:Source)
-            OPTIONAL MATCH (s)-[:SCOPED_BY]->(o:Ontology)
-            OPTIONAL MATCH (s)<-[:APPEARS]-(c:Concept)
+            OPTIONAL MATCH (d)-[:HAS_SOURCE]->(s:Source)-[:SCOPED_BY]->(o:Ontology)
+            WITH d, collect(DISTINCT o.ontology_id) AS parent_ontology_ids
+            OPTIONAL MATCH (d)-[:HAS_SOURCE]->(s2:Source)<-[:APPEARS]-(c:Concept)
+            WITH d, parent_ontology_ids, count(DISTINCT c) AS concept_count
             RETURN d.document_id AS id,
                    d.filename AS name,
                    d.content_type AS content_type,
                    d.source_count AS source_count,
                    d.source_type AS source_type,
                    d.ontology AS ontology,
-                   collect(DISTINCT o.ontology_id) AS parent_ontology_ids,
-                   count(DISTINCT c) AS concept_count
+                   parent_ontology_ids,
+                   concept_count
         """) or []
         return rows
 

--- a/api/app/lib/catalog_facade.py
+++ b/api/app/lib/catalog_facade.py
@@ -1,0 +1,516 @@
+"""
+Catalog Facade (ADR-501)
+
+Read surface for hierarchical browse of the ontology -> document -> concept
+hierarchy. The AGE graph is the source of truth; this facade maintains a
+materialized index (kg_api.catalog_node + kg_api.catalog_edge) that is rebuilt
+whenever the graph epoch (graph_change_counter) advances.
+
+Membership is always derived from the graph's CANONICAL edges — never from the
+denormalized Source.document string, which lags during annealing reassignment
+(ADR-200):
+
+    (o:Ontology)<-[:SCOPED_BY]-(s:Source)              ontology contains source
+    (d:DocumentMeta)-[:HAS_SOURCE]->(s:Source)         document groups sources
+    (c:Concept)-[:APPEARS]->(s:Source)                 concept appears in source
+
+Derived hierarchy edges:
+    ontology -> document   via  (o)<-[:SCOPED_BY]-(s)<-[:HAS_SOURCE]-(d)
+    document -> concept    via  (d)-[:HAS_SOURCE]->(s)<-[:APPEARS]-(c)
+
+Concepts are DAG nodes: one concept may belong to many documents/ontologies.
+That is why membership lives in catalog_edge rather than a parent column.
+"""
+
+import logging
+from typing import List, Dict, Any, Optional, Tuple
+
+from psycopg2.extras import RealDictCursor
+
+logger = logging.getLogger(__name__)
+
+# Advisory-lock key for serializing rebuilds across workers. Arbitrary constant,
+# namespaced to the catalog. Only one worker rebuilds at a time; others serve
+# the (slightly) stale index until the rebuild commits.
+_CATALOG_REBUILD_LOCK = 0x0CA7A106  # "CATALOG" mnemonic
+
+# Sort fields accepted by list_children, mapped to safe ORDER BY clauses.
+# Whitelist only — never interpolate caller input into SQL.
+_SORT_SQL = {
+    "name": "n.name ASC",
+    "child_count": "n.child_count DESC, n.name ASC",
+    "created": "(n.properties->>'creation_epoch') NULLS LAST, n.indexed_at ASC, n.name ASC",
+}
+
+
+class CatalogFacade:
+    """Materialized-index read surface for catalog browse (ADR-501).
+
+    Constructed with an AGEClient; reuses its connection pool. Browse reads come
+    from the relational index; the index is rebuilt from the graph on epoch
+    advance via ensure_fresh().
+    """
+
+    def __init__(self, client):
+        """Store the AGE client and reuse its connection pool."""
+        self.client = client
+
+    # ------------------------------------------------------------------ epochs
+
+    def _current_epoch(self, cur) -> int:
+        """Current graph_change_counter — the same freshness signal artifacts use."""
+        cur.execute("SELECT kg_api.get_graph_epoch()")
+        row = cur.fetchone()
+        # RealDictCursor returns a dict; plain cursor a tuple.
+        if row is None:
+            return 0
+        val = list(row.values())[0] if isinstance(row, dict) else row[0]
+        return int(val) if val is not None else 0
+
+    def _index_epoch(self, cur) -> Optional[int]:
+        """Epoch the index was last built at, or None if never built."""
+        cur.execute("SELECT MAX(graph_epoch) AS e FROM kg_api.catalog_node")
+        row = cur.fetchone()
+        val = row["e"] if isinstance(row, dict) else (row[0] if row else None)
+        return int(val) if val is not None else None
+
+    # --------------------------------------------------------------- freshness
+
+    def ensure_fresh(self) -> Tuple[bool, int]:
+        """Rebuild the index if the graph has advanced past it.
+
+        Returns (served_stale, current_epoch). served_stale is True when the
+        index lagged but another worker holds the rebuild lock, so this call
+        serves the older snapshot rather than blocking.
+        """
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                current = self._current_epoch(cur)
+                indexed = self._index_epoch(cur)
+                conn.commit()
+
+            if indexed is not None and indexed >= current:
+                return (False, current)
+
+            # Stale (or empty). Try to claim the rebuild lock; if another worker
+            # holds it, serve what we have.
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_try_advisory_lock(%s)", (_CATALOG_REBUILD_LOCK,)
+                )
+                got_lock = cur.fetchone()[0]
+                conn.commit()
+
+            if not got_lock:
+                return (indexed is not None, current)
+
+            try:
+                # Re-check under lock: another worker may have just rebuilt.
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    indexed = self._index_epoch(cur)
+                    current = self._current_epoch(cur)
+                    conn.commit()
+                if indexed is not None and indexed >= current:
+                    return (False, current)
+
+                self._rebuild(conn, current)
+                return (False, current)
+            finally:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT pg_advisory_unlock(%s)", (_CATALOG_REBUILD_LOCK,)
+                    )
+                    conn.commit()
+        except Exception as e:
+            logger.error(f"catalog ensure_fresh failed: {e}", exc_info=True)
+            conn.rollback()
+            # Best-effort: report not-stale with epoch 0 so callers still serve
+            # whatever index exists rather than erroring the browse request.
+            return (True, 0)
+        finally:
+            self.client.pool.putconn(conn)
+
+    # ----------------------------------------------------------------- rebuild
+
+    def _rebuild(self, conn, epoch: int) -> None:
+        """Full rebuild of catalog_node + catalog_edge from the graph.
+
+        Runs three bounded aggregate Cypher passes (ontologies, documents,
+        concepts), projects them to rows via _project, and replaces the index
+        atomically. Membership comes only from canonical edges.
+        """
+        logger.info(f"Rebuilding catalog index at epoch {epoch}")
+
+        ontologies = self._fetch_ontologies()
+        documents = self._fetch_documents()
+        concepts = self._fetch_concepts()
+
+        nodes, edges, stats = self._project(ontologies, documents, concepts, epoch)
+
+        if stats["sourceless_docs"]:
+            logger.warning(
+                f"catalog rebuild: {stats['sourceless_docs']} DocumentMeta node(s) had "
+                f"no resolvable parent ontology via :SCOPED_BY — omitted from tree"
+            )
+        if stats["orphan_concepts"]:
+            logger.info(
+                f"catalog rebuild: {stats['orphan_concepts']} concept(s) not reachable "
+                f"from any DocumentMeta (no :HAS_SOURCE path) — present in search, "
+                f"absent from document drill-down"
+            )
+
+        # Atomic swap: truncate + bulk insert in one transaction.
+        from psycopg2.extras import execute_values, Json
+
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE kg_api.catalog_node, kg_api.catalog_edge")
+            if nodes:
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO kg_api.catalog_node
+                        (kind, node_id, name, name_lower, child_count,
+                         content_type, properties, graph_epoch)
+                    VALUES %s
+                    """,
+                    [
+                        (k, nid, nm, nl, cc, ct, Json(pr), ep)
+                        for (k, nid, nm, nl, cc, ct, pr, ep) in nodes
+                    ],
+                    page_size=1000,
+                )
+            if edges:
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO kg_api.catalog_edge
+                        (parent_kind, parent_id, child_kind, child_id, graph_epoch)
+                    VALUES %s
+                    ON CONFLICT DO NOTHING
+                    """,
+                    edges,
+                    page_size=1000,
+                )
+            conn.commit()
+
+        logger.info(
+            f"catalog rebuild complete: {len(nodes)} nodes, {len(edges)} edges "
+            f"at epoch {epoch}"
+        )
+
+    @staticmethod
+    def _project(
+        ontologies: List[Dict[str, Any]],
+        documents: List[Dict[str, Any]],
+        concepts: List[Dict[str, Any]],
+        epoch: int,
+    ) -> Tuple[List[Tuple], List[Tuple], Dict[str, int]]:
+        """Pure projection: graph fetch results -> (node rows, edge rows, stats).
+
+        Separated from DB I/O so the DAG invariants can be unit-tested:
+        a concept appearing in N documents yields N edges; an ontology's
+        child_count is its document count; sourceless documents and orphan
+        concepts are counted, not silently dropped.
+
+        Node tuple:  (kind, node_id, name, name_lower, child_count,
+                      content_type, properties, epoch)
+        Edge tuple:  (parent_kind, parent_id, child_kind, child_id, epoch)
+        """
+        nodes: List[Tuple] = []
+        edges: List[Tuple] = []
+        sourceless_docs = 0
+        orphan_concepts = 0
+
+        # Ontologies (root level) — children are documents.
+        for o in ontologies:
+            oid = o.get("id")
+            if not oid:
+                continue
+            name = o.get("name") or oid
+            props = {
+                k: o[k]
+                for k in ("lifecycle_state", "creation_epoch")
+                if o.get(k) is not None
+            }
+            nodes.append((
+                "ontology", oid, name, name.lower(),
+                int(o.get("doc_count") or 0), None, props, epoch,
+            ))
+
+        # Documents — parent = ontology (via SCOPED_BY), children = concepts.
+        for d in documents:
+            did = d.get("id")
+            if not did:
+                continue
+            name = d.get("name") or did
+            content_type = d.get("content_type")
+            props = {
+                k: d[k]
+                for k in ("source_count", "source_type", "ontology")
+                if d.get(k) is not None
+            }
+            nodes.append((
+                "document", did, name, name.lower(),
+                int(d.get("concept_count") or 0), content_type, props, epoch,
+            ))
+            parent_ids = [p for p in (d.get("parent_ontology_ids") or []) if p]
+            if not parent_ids:
+                sourceless_docs += 1
+            for pid in parent_ids:
+                edges.append(("ontology", pid, "document", did, epoch))
+
+        # Concepts — leaf (child_count 0); a concept may have many parent docs.
+        for c in concepts:
+            cid = c.get("id")
+            if not cid:
+                continue
+            name = c.get("name") or cid
+            nodes.append((
+                "concept", cid, name, name.lower(), 0, None, {}, epoch,
+            ))
+            parent_ids = [p for p in (c.get("parent_document_ids") or []) if p]
+            if not parent_ids:
+                orphan_concepts += 1
+            for pid in parent_ids:
+                edges.append(("document", pid, "concept", cid, epoch))
+
+        stats = {
+            "sourceless_docs": sourceless_docs,
+            "orphan_concepts": orphan_concepts,
+        }
+        return nodes, edges, stats
+
+    # ------------------------------------------------------- graph fetch passes
+
+    def _fetch_ontologies(self) -> List[Dict[str, Any]]:
+        """Ontology nodes with their direct document counts."""
+        rows = self.client._execute_cypher("""
+            MATCH (o:Ontology)
+            OPTIONAL MATCH (o)<-[:SCOPED_BY]-(:Source)<-[:HAS_SOURCE]-(d:DocumentMeta)
+            RETURN o.ontology_id AS id,
+                   o.name AS name,
+                   o.lifecycle_state AS lifecycle_state,
+                   o.creation_epoch AS creation_epoch,
+                   count(DISTINCT d) AS doc_count
+        """) or []
+        return rows
+
+    def _fetch_documents(self) -> List[Dict[str, Any]]:
+        """DocumentMeta nodes with parent ontology ids and concept counts."""
+        rows = self.client._execute_cypher("""
+            MATCH (d:DocumentMeta)
+            OPTIONAL MATCH (d)-[:HAS_SOURCE]->(s:Source)
+            OPTIONAL MATCH (s)-[:SCOPED_BY]->(o:Ontology)
+            OPTIONAL MATCH (s)<-[:APPEARS]-(c:Concept)
+            RETURN d.document_id AS id,
+                   d.filename AS name,
+                   d.content_type AS content_type,
+                   d.source_count AS source_count,
+                   d.source_type AS source_type,
+                   d.ontology AS ontology,
+                   collect(DISTINCT o.ontology_id) AS parent_ontology_ids,
+                   count(DISTINCT c) AS concept_count
+        """) or []
+        return rows
+
+    def _fetch_concepts(self) -> List[Dict[str, Any]]:
+        """Concept nodes with the document ids they appear in (DAG parents)."""
+        rows = self.client._execute_cypher("""
+            MATCH (c:Concept)
+            OPTIONAL MATCH (c)-[:APPEARS]->(:Source)<-[:HAS_SOURCE]-(d:DocumentMeta)
+            RETURN c.concept_id AS id,
+                   c.label AS name,
+                   collect(DISTINCT d.document_id) AS parent_document_ids
+        """) or []
+        return rows
+
+    # -------------------------------------------------------------- browse API
+
+    def list_children(
+        self,
+        parent_id: Optional[str],
+        parent_kind: Optional[str],
+        child_kind: str,
+        q: Optional[str] = None,
+        sort: str = "name",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """List the children of a node (or root ontologies when parent_id is None).
+
+        Returns a dict shaped for CatalogChildrenResponse: nodes, total, and the
+        pagination/echo fields. Fragment filter `q` is a case-insensitive
+        substring match on child names via the pg_trgm-backed index.
+        """
+        served_stale, _ = self.ensure_fresh()
+        order_by = _SORT_SQL.get(sort, _SORT_SQL["name"])
+        like = f"%{q.lower()}%" if q else None
+
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                if parent_id is None:
+                    # Root: top-level ontologies straight from catalog_node.
+                    where = ["n.kind = %s"]
+                    params: List[Any] = [child_kind]
+                    if like:
+                        where.append("n.name_lower LIKE %s")
+                        params.append(like)
+                    where_sql = " AND ".join(where)
+
+                    cur.execute(
+                        f"SELECT count(*) AS c FROM kg_api.catalog_node n WHERE {where_sql}",
+                        params,
+                    )
+                    total = cur.fetchone()["c"]
+
+                    cur.execute(
+                        f"""
+                        SELECT n.kind, n.node_id, n.name, n.child_count,
+                               n.content_type, n.properties
+                        FROM kg_api.catalog_node n
+                        WHERE {where_sql}
+                        ORDER BY {order_by}
+                        LIMIT %s OFFSET %s
+                        """,
+                        params + [limit, offset],
+                    )
+                    rows = cur.fetchall()
+                else:
+                    where = [
+                        "e.parent_kind = %s",
+                        "e.parent_id = %s",
+                        "e.child_kind = %s",
+                    ]
+                    params = [parent_kind, parent_id, child_kind]
+                    if like:
+                        where.append("n.name_lower LIKE %s")
+                        params.append(like)
+                    where_sql = " AND ".join(where)
+
+                    cur.execute(
+                        f"""
+                        SELECT count(*) AS c
+                        FROM kg_api.catalog_edge e
+                        JOIN kg_api.catalog_node n
+                          ON n.kind = e.child_kind AND n.node_id = e.child_id
+                        WHERE {where_sql}
+                        """,
+                        params,
+                    )
+                    total = cur.fetchone()["c"]
+
+                    cur.execute(
+                        f"""
+                        SELECT n.kind, n.node_id, n.name, n.child_count,
+                               n.content_type, n.properties
+                        FROM kg_api.catalog_edge e
+                        JOIN kg_api.catalog_node n
+                          ON n.kind = e.child_kind AND n.node_id = e.child_id
+                        WHERE {where_sql}
+                        ORDER BY {order_by}
+                        LIMIT %s OFFSET %s
+                        """,
+                        params + [limit, offset],
+                    )
+                    rows = cur.fetchall()
+                conn.commit()
+        finally:
+            self.client.pool.putconn(conn)
+
+        nodes = [self._row_to_node(r, parent_id) for r in rows]
+        return {
+            "parent_id": parent_id,
+            "parent_kind": parent_kind,
+            "child_kind": child_kind,
+            "nodes": nodes,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "query": q,
+            "stale": served_stale,
+        }
+
+    def get_node(self, node_id: str, kind: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        """Fetch a single node's full metadata (the stat/detail call).
+
+        If `kind` is omitted, resolves by node_id across kinds (ids are unique
+        in practice within their kind; ambiguity returns the first by kind order
+        ontology < document < concept).
+        """
+        self.ensure_fresh()
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                if kind:
+                    cur.execute(
+                        """
+                        SELECT kind, node_id, name, child_count, content_type,
+                               properties, graph_epoch, indexed_at
+                        FROM kg_api.catalog_node
+                        WHERE kind = %s AND node_id = %s
+                        """,
+                        (kind, node_id),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        SELECT kind, node_id, name, child_count, content_type,
+                               properties, graph_epoch, indexed_at
+                        FROM kg_api.catalog_node
+                        WHERE node_id = %s
+                        ORDER BY CASE kind
+                            WHEN 'ontology' THEN 0
+                            WHEN 'document' THEN 1
+                            WHEN 'concept'  THEN 2 END
+                        LIMIT 1
+                        """,
+                        (node_id,),
+                    )
+                row = cur.fetchone()
+                if not row:
+                    conn.commit()
+                    return None
+
+                # First parent (breadcrumb) — a concept may have many; pick one.
+                cur.execute(
+                    """
+                    SELECT parent_kind, parent_id
+                    FROM kg_api.catalog_edge
+                    WHERE child_kind = %s AND child_id = %s
+                    LIMIT 1
+                    """,
+                    (row["kind"], row["node_id"]),
+                )
+                parent = cur.fetchone()
+                conn.commit()
+        finally:
+            self.client.pool.putconn(conn)
+
+        node = self._row_to_node(row, parent["parent_id"] if parent else None)
+        node["graph_epoch"] = row.get("graph_epoch")
+        node["indexed_at"] = row.get("indexed_at")
+        return node
+
+    # ----------------------------------------------------------------- helpers
+
+    @staticmethod
+    def _row_to_node(row: Dict[str, Any], parent_id: Optional[str]) -> Dict[str, Any]:
+        """Map a catalog_node row to the CatalogNode dict shape."""
+        props = row.get("properties")
+        if isinstance(props, str):
+            import json as _json
+            try:
+                props = _json.loads(props)
+            except (ValueError, TypeError):
+                props = {}
+        return {
+            "kind": row["kind"],
+            "id": row["node_id"],
+            "name": row["name"],
+            "parent_id": parent_id,
+            "child_count": row.get("child_count"),
+            "content_type": row.get("content_type"),
+            "properties": props or {},
+        }

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -31,7 +31,7 @@ from .services.scheduled_jobs_manager import JobScheduler as ScheduledJobsManage
 from .services.worker_registry import register_all_workers, get_all_job_types, validate_lane_uniqueness
 from .services.lane_manager import LaneManager
 from .launchers import CategoryRefreshLauncher, VocabConsolidationLauncher, EpistemicRemeasurementLauncher, VocabEmbeddingLauncher, ProjectionLauncher, ArtifactCleanupLauncher, AnnealingLauncher
-from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, oauth, sources, projection, artifacts, grants, query_definitions, documents, concepts, edges, graph, storage_admin, programs, admin_workers, models, epochs
+from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, oauth, sources, projection, artifacts, grants, query_definitions, documents, concepts, edges, graph, storage_admin, programs, admin_workers, models, epochs, catalog
 from .services.embedding_worker import get_embedding_worker
 from .lib.age_client import AGEClient
 from .lib.ai_providers import get_provider
@@ -526,6 +526,7 @@ app.include_router(documents.router)  # ADR-084: Document content retrieval
 app.include_router(documents.query_router)  # ADR-084: Document search
 app.include_router(concepts.router)  # ADR-089: Deterministic concept CRUD
 app.include_router(epochs.router)  # ADR-203: Graph epoch event log read surface
+app.include_router(catalog.router)  # ADR-501: Catalog browse facade
 app.include_router(edges.router)  # ADR-089: Deterministic edge CRUD
 app.include_router(graph.router)  # ADR-089: Batch graph operations
 app.include_router(storage_admin.router)  # Storage diagnostics

--- a/api/app/models/catalog.py
+++ b/api/app/models/catalog.py
@@ -1,0 +1,86 @@
+"""
+Catalog Browse Models (ADR-501)
+
+Pydantic models for the catalog browse facade — a deterministic projection of
+the ontology -> document -> concept hierarchy over the graph's canonical edges
+(:SCOPED_BY, :HAS_SOURCE, :APPEARS).
+
+These models are the surface-agnostic contract shared by CLI, MCP, web (ADR-700),
+and FUSE (ADR-069). They are intentionally NOT the WorkingGraph of ADR-500 —
+browse returns ordered rows, not a graph.
+"""
+
+from datetime import datetime
+from typing import Optional, List, Any, Dict, Literal
+from pydantic import BaseModel, Field
+
+
+# The fixed hierarchy levels. Self-describing via `kind` so a generic recursive
+# client (FUSE readdir, a tree widget) needs no per-level special-casing.
+CatalogKind = Literal["ontology", "document", "concept"]
+
+# Valid sort fields per the facade contract. "name" is the default everywhere;
+# "child_count" and "created" are opt-in.
+CATALOG_SORT_FIELDS = ["name", "child_count", "created"]
+
+
+class CatalogNode(BaseModel):
+    """A single node in the catalog hierarchy.
+
+    Neutral shape consumed identically by every client surface. `properties`
+    carries kind-specific extras only when requested via `?include=`, keeping the
+    default listing lean (ADR-501 §1).
+    """
+    kind: CatalogKind = Field(..., description="Hierarchy level: ontology | document | concept")
+    id: str = Field(..., description="Stable identifier (ontology_id, document_id, or concept_id)")
+    name: str = Field(..., description="Display label")
+    parent_id: Optional[str] = Field(
+        None,
+        description="Parent node id for breadcrumb/tree assembly (null at root level)",
+    )
+    child_count: Optional[int] = Field(
+        None,
+        description="Number of direct children (documents-in-ontology, concepts-in-document)",
+    )
+    content_type: Optional[str] = Field(
+        None,
+        description="Media type for document nodes: document | image | (future) audio | video",
+    )
+    properties: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Kind-specific extras, populated only when requested via include=",
+    )
+
+
+class CatalogChildrenResponse(BaseModel):
+    """Paginated listing of a node's children (GET /catalog/children)."""
+    parent_id: Optional[str] = Field(
+        None, description="The parent whose children are listed (null = root)"
+    )
+    parent_kind: Optional[CatalogKind] = Field(
+        None, description="Kind of the parent node (null at root)"
+    )
+    child_kind: CatalogKind = Field(
+        ..., description="Kind of the returned children"
+    )
+    nodes: List[CatalogNode] = Field(..., description="The child nodes for this page")
+    total: int = Field(..., description="Total matching children (before pagination)")
+    limit: int = Field(..., description="Page size used")
+    offset: int = Field(..., description="Page offset used")
+    query: Optional[str] = Field(
+        None, description="Fragment filter applied to this listing, if any"
+    )
+    stale: bool = Field(
+        False,
+        description="True if served from a catalog index lagging the current graph epoch",
+    )
+
+
+class CatalogNodeResponse(CatalogNode):
+    """Single node with full properties — the stat/detail call (GET /catalog/node/{id})."""
+    graph_epoch: Optional[int] = Field(
+        None, description="graph_change_counter at which this node's data was indexed"
+    )
+    indexed_at: Optional[datetime] = Field(
+        None, description="When the catalog index last refreshed this node"
+    )

--- a/api/app/routes/catalog.py
+++ b/api/app/routes/catalog.py
@@ -1,0 +1,166 @@
+"""
+Catalog browse endpoints (ADR-501).
+
+A deterministic, hierarchical view of what is actually in the knowledge graph:
+ontology -> document -> concept. Unlike semantic search (ADR-500 programs,
+vector search), browse is structural and cheap — it answers "what's in here?"
+rather than "what's similar to X?".
+
+The hierarchy is fixed and self-describing via each node's `kind`, so a generic
+recursive client (FUSE readdir, a web tree, the CLI) walks it without per-level
+special-casing:
+
+    root      -> ontology
+    ontology  -> document
+    document  -> concept   (leaf)
+
+Membership is projected from the graph's canonical edges (:SCOPED_BY,
+:HAS_SOURCE, :APPEARS), never from the denormalized Source.document string
+(ADR-200). See CatalogFacade for the index/freshness model.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query as QueryParam
+import logging
+from typing import Optional
+
+from ..dependencies.auth import CurrentUser, require_permission
+from ..models.catalog import (
+    CatalogNode,
+    CatalogChildrenResponse,
+    CatalogNodeResponse,
+    CATALOG_SORT_FIELDS,
+)
+from ..lib.catalog_facade import CatalogFacade
+from api.app.lib.age_client import AGEClient
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/catalog", tags=["catalog"])
+
+# Fixed parent-kind -> child-kind mapping. The only valid transitions.
+_CHILD_OF = {None: "ontology", "ontology": "document", "document": "concept"}
+
+
+def get_age_client() -> AGEClient:
+    """Get an AGE client instance (per-request, closed in finally)."""
+    return AGEClient()
+
+
+@router.get(
+    "/children",
+    response_model=CatalogChildrenResponse,
+    dependencies=[Depends(require_permission("catalog", "read"))],
+)
+async def list_children(
+    current_user: CurrentUser,
+    parent: Optional[str] = QueryParam(
+        None, description="Parent node id. Omit (or empty) to list root ontologies."
+    ),
+    parent_kind: Optional[str] = QueryParam(
+        None, description="Kind of the parent: ontology | document. Resolved automatically if omitted."
+    ),
+    q: Optional[str] = QueryParam(
+        None, description="Fragment filter: case-insensitive substring match on child names."
+    ),
+    sort: str = QueryParam("name", description=f"Sort field: {', '.join(CATALOG_SORT_FIELDS)}"),
+    limit: int = QueryParam(100, ge=1, le=1000),
+    offset: int = QueryParam(0, ge=0),
+):
+    """
+    List the children of a catalog node, or root ontologies when `parent` is omitted.
+
+    **Authorization:** Requires `catalog:read` permission.
+
+    Examples:
+        GET /catalog/children                              -> all ontologies
+        GET /catalog/children?parent=ont_abc&parent_kind=ontology   -> its documents
+        GET /catalog/children?parent=sha256:...&parent_kind=document -> its concepts
+        GET /catalog/children?q=neural                     -> ontologies matching "neural"
+    """
+    if sort not in CATALOG_SORT_FIELDS:
+        raise HTTPException(status_code=400, detail=f"Invalid sort field '{sort}'")
+
+    parent = parent or None  # normalize empty string to None (root)
+
+    client = get_age_client()
+    try:
+        facade = CatalogFacade(client)
+
+        # Resolve parent_kind if a parent was given without one.
+        if parent is not None and parent_kind is None:
+            node = facade.get_node(parent)
+            if node is None:
+                raise HTTPException(status_code=404, detail=f"Catalog node '{parent}' not found")
+            parent_kind = node["kind"]
+
+        if parent_kind not in _CHILD_OF:
+            # parent_kind == 'concept' (leaf) or an unknown kind.
+            raise HTTPException(
+                status_code=400,
+                detail=f"Nodes of kind '{parent_kind}' have no children",
+            )
+
+        child_kind = _CHILD_OF[parent_kind]
+
+        result = facade.list_children(
+            parent_id=parent,
+            parent_kind=parent_kind,
+            child_kind=child_kind,
+            q=q,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+        )
+        return CatalogChildrenResponse(
+            parent_id=result["parent_id"],
+            parent_kind=result["parent_kind"],
+            child_kind=result["child_kind"],
+            nodes=[CatalogNode(**n) for n in result["nodes"]],
+            total=result["total"],
+            limit=result["limit"],
+            offset=result["offset"],
+            query=result["query"],
+            stale=result["stale"],
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Catalog children listing failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Catalog listing failed: {str(e)}")
+    finally:
+        client.close()
+
+
+@router.get(
+    "/node/{node_id:path}",
+    response_model=CatalogNodeResponse,
+    dependencies=[Depends(require_permission("catalog", "read"))],
+)
+async def get_node(
+    node_id: str,
+    current_user: CurrentUser,
+    kind: Optional[str] = QueryParam(
+        None, description="Disambiguate kind if a node id collides across kinds."
+    ),
+):
+    """
+    Get a single catalog node's full metadata (the stat/detail call).
+
+    **Authorization:** Requires `catalog:read` permission.
+
+    `node_id` is a path param accepting slashes (document ids look like
+    `sha256:...`). Example: GET /catalog/node/ont_abc123?kind=ontology
+    """
+    client = get_age_client()
+    try:
+        facade = CatalogFacade(client)
+        node = facade.get_node(node_id, kind=kind)
+        if node is None:
+            raise HTTPException(status_code=404, detail=f"Catalog node '{node_id}' not found")
+        return CatalogNodeResponse(**node)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Catalog node fetch failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Catalog node fetch failed: {str(e)}")
+    finally:
+        client.close()

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -74,6 +74,9 @@ import {
   // ADR-203: Graph epoch event log
   ConceptLifetimeResponse,
   EpochListResponse,
+  // ADR-501: Catalog browse
+  CatalogChildrenResponse,
+  CatalogNodeResponse,
 } from '../types';
 
 export class KnowledgeGraphClient {
@@ -2411,6 +2414,37 @@ export class KnowledgeGraphClient {
    */
   async getStorageRetention(): Promise<any> {
     const response = await this.client.get('/admin/storage/retention');
+    return response.data;
+  }
+
+  // ===========================================================================
+  // Catalog browse (ADR-501)
+  // ===========================================================================
+
+  /**
+   * List the children of a catalog node, or root ontologies when `parent` is
+   * omitted. Deterministic ontology -> document -> concept browse (ADR-501).
+   */
+  async listCatalogChildren(params?: {
+    parent?: string;
+    parent_kind?: string;
+    q?: string;
+    sort?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<CatalogChildrenResponse> {
+    const response = await this.client.get('/catalog/children', { params });
+    return response.data;
+  }
+
+  /**
+   * Get a single catalog node's full metadata (the stat/detail call).
+   */
+  async getCatalogNode(nodeId: string, kind?: string): Promise<CatalogNodeResponse> {
+    const response = await this.client.get(
+      `/catalog/node/${encodeURIComponent(nodeId)}`,
+      { params: kind ? { kind } : undefined }
+    );
     return response.data;
   }
 }

--- a/cli/src/cli/catalog.ts
+++ b/cli/src/cli/catalog.ts
@@ -1,0 +1,172 @@
+/**
+ * Catalog Browse Commands (ADR-501)
+ *
+ * Filesystem-like browse of the knowledge graph's ontology -> document ->
+ * concept hierarchy. Answers "what's actually in here?" structurally, as
+ * opposed to semantic search (`kg search`).
+ *
+ *   kg catalog ls                 → list ontologies (root)
+ *   kg catalog ls <id>            → list children of a node (kind auto-resolved)
+ *   kg catalog ls <id> -q neural  → filter children by name fragment
+ *   kg catalog stat <id>          → single-node detail (the stat call)
+ *
+ * Every subcommand supports --json for scripting / machine consumption.
+ */
+
+import { Command } from 'commander';
+import { createClientFromEnv } from '../api/client';
+import * as colors from './colors';
+import { coloredCount, separator } from './colors';
+import { setCommandHelp } from './help-formatter';
+import type { CatalogNode } from '../types';
+
+/** Pluralize a node kind for summary lines (ontology -> ontologies). */
+function pluralKind(kind: string): string {
+  return kind === 'ontology' ? 'ontologies' : `${kind}s`;
+}
+
+/** Glyph per node kind — keeps the tree scannable at a glance. */
+function kindGlyph(kind: string): string {
+  switch (kind) {
+    case 'ontology': return '▸';
+    case 'document': return '▤';
+    case 'concept': return '•';
+    default: return '-';
+  }
+}
+
+/** Render one catalog row in the formatted (non-JSON) view. */
+function printNode(node: CatalogNode): void {
+  const glyph = kindGlyph(node.kind);
+  const count =
+    node.child_count != null && node.kind !== 'concept'
+      ? colors.status.dim(`  (${node.child_count})`)
+      : '';
+  const ct = node.content_type ? colors.status.dim(` [${node.content_type}]`) : '';
+  console.log(`  ${glyph} ${colors.ui.value(node.name)}${count}${ct}`);
+  console.log(`      ${colors.status.dim(node.id)}`);
+}
+
+export const catalogCommand = setCommandHelp(
+  new Command('catalog'),
+  'Browse the graph: ontologies → documents → concepts',
+  'Deterministic, filesystem-like browse of what is stored in the knowledge graph. ' +
+    'Walk from ontologies down to documents and concepts, filter by name fragment, ' +
+    'and inspect single nodes. Distinct from "kg search" (semantic) and "kg storage" ' +
+    '(raw S3 admin). Add --json to any subcommand for machine-readable output.'
+)
+  .showHelpAfterError('(add --help for additional information)')
+  .showSuggestionAfterError()
+  .addCommand(
+    new Command('ls')
+      .description('List children of a node, or root ontologies if no id given')
+      .argument('[id]', 'Parent node id (ontology or document). Omit to list ontologies.')
+      .option('-k, --kind <kind>', 'Parent kind hint (ontology|document) if id is ambiguous')
+      .option('-q, --query <fragment>', 'Filter children by case-insensitive name fragment')
+      .option('-s, --sort <field>', 'Sort: name | child_count | created', 'name')
+      .option('-l, --limit <n>', 'Max results', '100')
+      .option('-o, --offset <n>', 'Pagination offset', '0')
+      .option('--json', 'Output raw JSON instead of formatted text for scripting')
+      .action(async (id: string | undefined, options: any) => {
+        try {
+          const client = createClientFromEnv();
+          const result = await client.listCatalogChildren({
+            parent: id,
+            parent_kind: options.kind,
+            q: options.query,
+            sort: options.sort,
+            limit: parseInt(options.limit, 10),
+            offset: parseInt(options.offset, 10),
+          });
+
+          if (options.json) {
+            console.log(JSON.stringify(result, null, 2));
+            return;
+          }
+
+          console.log('\n' + separator());
+          const where = id ? `children of ${id}` : 'ontologies';
+          console.log(colors.ui.title(`Catalog — ${where}`));
+          console.log(separator());
+
+          if (result.nodes.length === 0) {
+            console.log(`\n  ${colors.status.dim('(empty)')}`);
+          } else {
+            console.log('');
+            result.nodes.forEach(printNode);
+          }
+
+          const shown = result.offset + result.nodes.length;
+          const label =
+            result.total === 1 ? result.child_kind : pluralKind(result.child_kind);
+          console.log(
+            `\n  ${colors.stats.label(label + ':')} ` +
+              `${coloredCount(result.total)} total` +
+              (shown < result.total ? colors.status.dim(`  (showing ${result.offset + 1}-${shown})`) : '')
+          );
+          if (result.query) {
+            console.log(`  ${colors.stats.label('Filter:')} ${colors.ui.value(result.query)}`);
+          }
+          if (result.stale) {
+            console.log(`  ${colors.status.dim('⚠ index lagging current graph epoch — counts may be slightly behind')}`);
+          }
+          console.log('\n' + separator());
+        } catch (error: any) {
+          console.error(colors.status.error('✗ Failed to list catalog'));
+          console.error(colors.status.error(error.response?.data?.detail || error.message));
+          process.exit(1);
+        }
+      })
+  )
+  .addCommand(
+    new Command('stat')
+      .description('Show full metadata for a single catalog node')
+      .argument('<id>', 'Node id (ontology_id, document_id, or concept_id)')
+      .option('-k, --kind <kind>', 'Disambiguate kind if id collides across kinds')
+      .option('--json', 'Output raw JSON instead of formatted text for scripting')
+      .action(async (id: string, options: any) => {
+        try {
+          const client = createClientFromEnv();
+          const node = await client.getCatalogNode(id, options.kind);
+
+          if (options.json) {
+            console.log(JSON.stringify(node, null, 2));
+            return;
+          }
+
+          console.log('\n' + separator());
+          console.log(colors.ui.title(`${kindGlyph(node.kind)} ${node.name}`));
+          console.log(separator());
+          console.log(`\n  ${colors.ui.key('Kind:')} ${colors.ui.value(node.kind)}`);
+          console.log(`  ${colors.ui.key('ID:')} ${colors.ui.value(node.id)}`);
+          if (node.parent_id) {
+            console.log(`  ${colors.ui.key('Parent:')} ${colors.ui.value(node.parent_id)}`);
+          }
+          if (node.child_count != null && node.kind !== 'concept') {
+            console.log(`  ${colors.ui.key('Children:')} ${coloredCount(node.child_count)}`);
+          }
+          if (node.content_type) {
+            console.log(`  ${colors.ui.key('Content type:')} ${colors.ui.value(node.content_type)}`);
+          }
+          if (node.graph_epoch != null) {
+            console.log(`  ${colors.ui.key('Indexed at epoch:')} ${colors.ui.value(String(node.graph_epoch))}`);
+          }
+          const props = Object.entries(node.properties || {});
+          if (props.length > 0) {
+            console.log(`\n  ${colors.stats.section('Properties')}`);
+            for (const [k, v] of props) {
+              console.log(`    ${colors.ui.key(k + ':')} ${colors.ui.value(String(v))}`);
+            }
+          }
+          console.log('\n' + separator());
+        } catch (error: any) {
+          if (error.response?.status === 404) {
+            console.error(colors.status.error(`✗ Catalog node '${id}' not found`));
+          } else {
+            console.error(colors.status.error('✗ Failed to stat catalog node'));
+            console.error(colors.status.error(error.response?.data?.detail || error.message));
+          }
+          process.exit(1);
+        }
+      })
+  );

--- a/cli/src/cli/commands.ts
+++ b/cli/src/cli/commands.ts
@@ -28,6 +28,7 @@ import { conceptCommand } from './concept';
 import { edgeCommand } from './edge';
 import { batchCommand } from './batch';
 import { storageCommand } from './storage';
+import { catalogCommand } from './catalog';
 import { programCommand } from './program';
 import { registerLoginCommand } from './login';
 import { registerLogoutCommand } from './logout';
@@ -123,6 +124,7 @@ export async function registerCommands(program: Command) {
     queryDefCommand,
     programCommand,   // ADR-500: GraphProgram notarization
     storageCommand,
+    catalogCommand,   // ADR-501: Catalog browse facade
   ];
 
   subcommands.forEach(cmd => {

--- a/cli/src/mcp-server.ts
+++ b/cli/src/mcp-server.ts
@@ -1399,6 +1399,63 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
           },
         },
       },
+      {
+        name: 'catalog',
+        description: `Browse what is actually stored in the knowledge graph (ADR-501).
+
+A deterministic, filesystem-like view of the ontology -> document -> concept hierarchy. Use this to answer "what's in here?" structurally — by document or domain — as opposed to the 'search' tool, which finds concepts by semantic similarity. This is the right tool when you want to enumerate the corpus, drill into a specific document's concepts, or let a reasoning chain navigate by source rather than by meaning.
+
+The hierarchy is fixed and self-describing via each node's 'kind':
+  root      -> ontology   (knowledge domains)
+  ontology  -> document   (ingested sources; may be text or image)
+  document  -> concept    (leaf — extracted concepts appearing in that document)
+
+A concept can appear under many documents (the graph is a DAG, not a tree). Membership is read from the graph's canonical edges, so it stays correct even as autonomous annealing (ADR-200) reorganizes ontologies.
+
+Actions:
+  - ls:   list children of a node (or root ontologies if no id). Supports a name fragment filter.
+  - stat: full metadata for one node by id.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            action: {
+              type: 'string',
+              enum: ['ls', 'stat'],
+              description: "'ls' to list children, 'stat' for single-node detail",
+            },
+            id: {
+              type: 'string',
+              description: "For ls: parent node id (omit to list root ontologies). For stat: the node id to inspect.",
+            },
+            kind: {
+              type: 'string',
+              enum: ['ontology', 'document', 'concept'],
+              description: 'Optional kind hint to disambiguate an id that collides across kinds.',
+            },
+            query: {
+              type: 'string',
+              description: 'ls only: case-insensitive name fragment to filter children by.',
+            },
+            sort: {
+              type: 'string',
+              enum: ['name', 'child_count', 'created'],
+              description: 'ls only: sort order for children (default name).',
+              default: 'name',
+            },
+            limit: {
+              type: 'number',
+              description: 'ls only: max children per page (1-1000, default 100).',
+              default: 100,
+            },
+            offset: {
+              type: 'number',
+              description: 'ls only: pagination offset (default 0).',
+              default: 0,
+            },
+          },
+          required: ['action'],
+        },
+      },
     ],
   };
 });
@@ -3227,6 +3284,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         });
         return {
           content: [{ type: 'text', text: formatEpochList(result) }],
+        };
+      }
+
+      case 'catalog': {
+        const action = toolArgs.action as string;
+        if (action === 'stat') {
+          if (!toolArgs.id) {
+            throw new Error("catalog 'stat' requires an 'id'");
+          }
+          const node = await client.getCatalogNode(
+            toolArgs.id as string,
+            toolArgs.kind as string | undefined
+          );
+          return {
+            content: [{ type: 'text', text: JSON.stringify(node, null, 2) }],
+          };
+        }
+        // default: ls
+        const result = await client.listCatalogChildren({
+          parent: toolArgs.id as string | undefined,
+          parent_kind: toolArgs.kind as string | undefined,
+          q: toolArgs.query as string | undefined,
+          sort: toolArgs.sort as string | undefined,
+          limit: toolArgs.limit as number | undefined,
+          offset: toolArgs.offset as number | undefined,
+        });
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       }
 

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -1461,3 +1461,37 @@ export interface ProgramListItem {
   statement_count: number;
   created_at: string;
 }
+
+// ===========================================================================
+// ADR-501: Catalog browse facade
+// ===========================================================================
+
+/** A single node in the catalog hierarchy (ontology | document | concept). */
+export interface CatalogNode {
+  kind: 'ontology' | 'document' | 'concept';
+  id: string;
+  name: string;
+  parent_id?: string | null;
+  child_count?: number | null;
+  content_type?: string | null;
+  properties: Record<string, any>;
+}
+
+/** Paginated listing of a node's children (GET /catalog/children). */
+export interface CatalogChildrenResponse {
+  parent_id?: string | null;
+  parent_kind?: 'ontology' | 'document' | 'concept' | null;
+  child_kind: 'ontology' | 'document' | 'concept';
+  nodes: CatalogNode[];
+  total: number;
+  limit: number;
+  offset: number;
+  query?: string | null;
+  stale: boolean;
+}
+
+/** Single node with full metadata (GET /catalog/node/{id}). */
+export interface CatalogNodeResponse extends CatalogNode {
+  graph_epoch?: number | null;
+  indexed_at?: string | null;
+}

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -100,6 +100,7 @@ _Pathfinding, projections, diversity, search_
 | [ADR-076.1](./query-search/ADR-076.1-pathfinding-baseline.md) | Pathfinding Performance Baseline | Accepted |
 | [ADR-084](./query-search/ADR-084-document-search.md) | Document-Level Search | Proposed |
 | [ADR-500](./query-search/ADR-500-graph-program-dsl-and-ast-architecture.md) | Graph Program DSL and AST Architecture | Draft |
+| [ADR-501](./query-search/ADR-501-catalog-browse-facade.md) | Catalog Browse Facade | Proposed |
 
 ## Vocabulary
 _Relationships, grounding, categorization_

--- a/docs/architecture/query-search/ADR-501-catalog-browse-facade.md
+++ b/docs/architecture/query-search/ADR-501-catalog-browse-facade.md
@@ -1,0 +1,236 @@
+---
+status: Proposed
+date: 2026-05-30
+deciders:
+  - aaronsb
+  - claude
+related: [500, 700, 084, 085, 069, 200, 201, 233]
+---
+
+# ADR-501: Catalog Browse Facade
+
+## Context
+
+The knowledge graph has no first-class way to answer the simplest question a user
+or reasoning agent can ask: **"what is actually in here?"**
+
+Today, discovery is concept-first and search-first. You find concepts by semantic
+similarity (`/query/search`), traverse relationships (`/query/related`), or run a
+GraphProgram (ADR-500). All of these assume you already know roughly what you're
+looking for. None of them let you *browse* the corpus the way you'd browse a
+filesystem — start at the top, see what domains exist, drill into one, see its
+documents, drill into a document, see its concepts.
+
+This gap matters more now than it used to, for three reasons:
+
+1. **The hierarchy became a living structure.** ADR-200's annealing worker is
+   autonomously functional (`api/app/workers/annealing_worker.py`). Every cycle it
+   scores ontologies, recomputes centroids, derives `OVERLAPS`/`SPECIALIZES`/
+   `GENERALIZES` edges, and — in autonomous mode (migration 053, the default) —
+   reorganizes the graph by merging, cleaving, dissolving, and renaming ontologies
+   (ADR-206 verb vocabulary). The organizational structure of the graph now
+   *changes on its own*. A user who hasn't looked in a week has no way to see what
+   it looks like today.
+
+2. **The hierarchy already exists as canonical graph edges.** ADR-200 promoted
+   ontologies from a denormalized `Source.document` string to first-class
+   `:Ontology` nodes with `:SCOPED_BY` edges (migration 044). The edges are
+   canonical; `Source.document` is now a lagging cache. The browse hierarchy is
+   therefore not new data — it is a **projection of edges the graph already
+   maintains**:
+
+   ```cypher
+   (:Ontology)<-[:SCOPED_BY]-(:Source)           // ontology → its source chunks
+   (:DocumentMeta)-[:HAS_SOURCE]->(:Source)       // document → its chunks (ADR-051)
+   (:Concept)-[:APPEARS]->(:Source)               // concept ↔ where it appears
+   ```
+
+3. **Four client surfaces each reinvent listing.** CLI, MCP, web, and the FUSE
+   driver (ADR-069) all need "list the children of X." Today each constructs its
+   own queries: the CLI has `kg ontology list/files`, the web has bespoke
+   `getSubgraph` composition, FUSE hand-builds `/query/*` calls in its readdir
+   handlers. There is no shared catalog contract, so the four drift.
+
+The `kg artifact` / `kg storage` usability work (issue #233) is a symptom of the
+same root cause: without a browse surface, users can't tell what computed results
+or source data the system holds, and the storage/artifact boundary reads as
+confusing implementation detail.
+
+### What this is NOT
+
+This is **not** a new storage system, a new node type, or a new graph engine. It
+is a read projection. It is also **not** the semantic-query path — it does not
+replace ADR-500's set-algebra programs or vector search. Browse is deterministic,
+cheap, and structural; search is probabilistic and expansion-oriented. Keeping the
+two separate is a core decision here, not an accident.
+
+### Adjacent work this composes with
+
+- **ADR-700 (Ontology Explorer, Draft)** specifies the *web visualization* of this
+  data — overview treemap, detail view with a searchable document list, bridge
+  view. ADR-700's detail view is a **consumer** of this facade, not a competitor.
+  This ADR provides the API substrate 700 currently lacks.
+- **ADR-069 (FUSE, shipped)** already draws the deterministic path grammar
+  `/ontology/<name>/documents/<file>`. Its stable half (ontology → documents) is
+  exactly this catalog; its emergent half (query directories → concepts by
+  similarity) stays as-is. The facade lets FUSE's readdir handlers become thin
+  adapters over a shared contract.
+- **ADR-201 (graph_accel)** is deliberately *not* the backing store here — see
+  Alternatives.
+
+## Decision
+
+Introduce a **Catalog Browse Facade**: a single API-layer service that projects the
+ontology → document → concept hierarchy as listable, paginated, sortable,
+fragment-filterable nodes, consumed identically by CLI, MCP, web, and FUSE.
+
+### 1. The `CatalogNode` DTO
+
+A neutral, surface-agnostic shape — *not* the `WorkingGraph` of ADR-500. Browse
+returns rows, not a graph.
+
+```python
+class CatalogNode(BaseModel):
+    kind: Literal["ontology", "document", "concept"]
+    id: str                       # stable identifier (ontology_id, document_id, concept_id)
+    name: str                     # display label
+    parent_id: Optional[str]      # for breadcrumb / tree assembly
+    child_count: Optional[int]    # documents-in-ontology, concepts-in-document, etc.
+    content_type: Optional[str]   # "document" | "image" | (future) "audio" | "video"
+    properties: Dict[str, Any]    # kind-specific extras, opt-in via ?include=
+    # storage/freshness extras surfaced only under verbose / explicit include:
+    #   ontology: lifecycle_state, mass/coherence/protection scores (ADR-200)
+    #   document: source_count, ingested_at, owner_id
+    #   concept:  grounding strength, evidence count
+```
+
+Requirements imposed by FUSE (design for them up front): **stable `id`** (inode
+mapping), **stat-able metadata** (size/content_type/mtime-or-epoch), and
+**`child_count` without an N+1 query** (readdir must be one round-trip).
+
+### 2. Browse endpoints
+
+Two endpoints under a new `/catalog` router, both `read`-gated via
+`get_current_active_user` and RBAC (ADR-400 baseline):
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /catalog/children` | List children of a node: `?parent=<id or ""root">&kind=<...>&q=<fragment>&sort=<field>&limit=&offset=` |
+| `GET /catalog/node/{id}` | Single node with full properties (the `stat` / detail call) |
+
+`parent=""` (root) returns the ontology level. The hierarchy is fixed-depth and
+self-describing via `kind`, so a generic recursive client (FUSE, a tree widget)
+needs no special-casing per level.
+
+### 3. The terse selector grammar is sugar over the facade
+
+A path selector — `ontology:foo / document:bar / concept:baz` — compiles to
+`/catalog/children` calls, exactly as ADR-500 treats text DSL as compiling to its
+JSON AST. The selector is a *navigation* convenience; it is not a graph program and
+does not gain set-algebra operators. Where a user wants expansion, they hand the
+catalog node's `id` to a GraphProgram as a seed. The seam stays explicit:
+
+- **path selector → browse** (deterministic, structural, cheap)
+- **graph program (ADR-500) → expansion** (set-algebra, semantic)
+
+### 4. Canonical source: edges, never the string
+
+The facade traverses `:Ontology` / `:SCOPED_BY` / `:HAS_SOURCE` / `:APPEARS`. It
+**must not** read `Source.document` for membership — that string lags during
+annealing reassignment (ADR-200). This is a permanent design constraint, not a
+migration artifact.
+
+### 5. Filtering: three named tiers, only the first in scope now
+
+| Tier | Mechanism | Scope |
+|------|-----------|-------|
+| **Fragment** ("type a few chars") | Postgres `pg_trgm` / `ILIKE` on labels + names | **This ADR** — makes listings feel instant, no embeddings |
+| **Semantic** | reuse existing cosine (concept embeddings in AGE; source embeddings in `kg_api.source_embeddings`) | reuse existing endpoints; wire as a filter mode later |
+| **BM25 / full-text** | Postgres `tsvector` / `ts_rank` (net-new — no FTS index exists today) | **Deferred** to a follow-on ADR; flagged, not silently dropped |
+
+### 6. Single insertion point: the Python API facade
+
+The only layer all four clients share is the API. The facade lands as
+`api/app/lib/catalog_facade.py` (composition over existing graph/query facades) +
+`api/app/routes/catalog.py` (thin handler). Each client then gets a thin wrapper —
+this per-endpoint "client tax" (~4 parallel changes: TS client method, CLI command,
+MCP tool action, web client method, FUSE handler) is irreducible given the current
+architecture (ADR-013 unified only CLI+MCP; web and FUSE remain separate), but a
+thin facade minimizes it. A small Postgres-side property/count index (refreshed on
+graph epoch bump, ADR-203) backs fast `child_count` and fragment filtering without
+per-request graph aggregation.
+
+## Consequences
+
+### Positive
+
+- **Answers "what's in here?"** for humans and reasoning agents — browse by
+  document/ontology, not only by concept or similarity.
+- **Makes the autonomous graph observable.** Annealing reshapes the hierarchy
+  (ADR-200/206); the catalog is how a returning user sees the current shape.
+- **Closes issue #233.** Storage location (inline/Garage) becomes an opt-in
+  `properties` field; freshness/regenerate/cleanup become node-level concerns;
+  `kg storage` (raw S3 admin) vs `kg artifact`/catalog (semantic) boundary becomes
+  legible because the catalog shows *meaning*, not buckets.
+- **Turns FUSE's stable half into a thin adapter** over a shared contract instead
+  of bespoke readdir queries (ADR-069).
+- **Gives ADR-700 its missing substrate** — the Ontology Explorer detail view
+  consumes `/catalog/children` rather than inventing its own listing path.
+- **One contract, four surfaces** — reduces the existing drift between CLI/MCP/web/
+  FUSE listing logic.
+
+### Negative
+
+- **The four-client tax is real.** Even with a shared API facade, each surface
+  needs a wrapper. This ADR minimizes but does not eliminate it.
+- **A second read index to keep fresh.** The property/count index must invalidate
+  on epoch bump; a missed invalidation shows stale counts (bounded, not
+  corrupting — counts, not truth).
+- **`child_count` at scale** needs the index; naive aggregation per readdir would
+  be O(children) graph queries. The index is therefore not optional for FUSE.
+
+### Neutral
+
+- Browse and search remain deliberately separate code paths. Users wanting
+  semantic results still use ADR-500 / vector search; the catalog seeds them.
+- Media-type awareness (`content_type`) is carried through but the catalog does not
+  itself render or transcode media; it only lists and describes.
+
+## Alternatives Considered
+
+### Back the catalog with graph_accel (ADR-201)
+
+Rejected. `graph_accel` is verified to hold **Concept topology only** — node IDs +
+edges + one app-id property, no ontology/document membership, no node properties, no
+substring index, no counts (`graph-accel/core/src/graph.rs`). A catalog needs
+exactly the opposite profile: property-rich, count-aware, fragment-searchable
+listing. graph_accel stays for traversal-heavy expansion (neighborhood,
+pathfinding); a catalog node action *may* hand off to it, but it cannot back the
+listing.
+
+### Extend the ADR-500 DSL with a tree/listing operator
+
+Rejected. The DSL's value is a closed set-algebra (`+ − & ? !`) over concept sets
+returning a `WorkingGraph`. A folder listing is a different shape (ordered,
+paginated, parent/child rows) and coercing it into WorkingGraph would either
+distort the DSL's invariants or produce an awkward hybrid. Browse rides as
+`ApiOp`-style endpoints the DSL *can seed from*, not as a new operator.
+
+### Fold this into ADR-700 (Ontology Explorer)
+
+Rejected. ADR-700 is a web-explorer visualization spec. Merging a cross-cutting,
+four-surface API contract into a single-surface viz ADR would couple the API's
+lifecycle to the web UI's and hide the contract from CLI/MCP/FUSE readers. Keeping
+the facade as its own ADR lets 700 (and 069, and the CLI) cite it as a dependency.
+
+### Read `Source.document` for membership
+
+Rejected. It is a denormalized cache that lags during annealing reassignment
+(ADR-200). Canonical membership is the `:SCOPED_BY` edge.
+
+### Ship all three filter tiers at once
+
+Rejected for the first cut. Fragment match (pg_trgm) delivers the "instant
+listing" feel with no new infrastructure. BM25 requires a net-new full-text index
+(none exists today) and would balloon scope. It is explicitly deferred to a
+follow-on ADR rather than silently omitted.

--- a/docs/reference/mcp/README.md
+++ b/docs/reference/mcp/README.md
@@ -3,7 +3,7 @@
 > **Auto-Generated Documentation**
 > 
 > Generated from MCP server tool schemas.
-> Last updated: 2026-05-26
+> Last updated: 2026-05-30
 
 ---
 
@@ -28,9 +28,8 @@ These tools enable semantic search, concept exploration, and graph traversal dir
 - [`document`](#document) - Work with documents: list all, show content, or get concepts (ADR-084).
 - [`graph`](#graph) - Create, edit, delete, and list concepts and edges in the knowledge graph (ADR-089).
 - [`program`](#program) - Compose and execute GraphProgram queries against the knowledge graph (ADR-500).
-- [`session_context`](tools/session_context.md) - Read recent concepts at the start of a session (cross-session memory for MCP agents).
-- [`session_ingest`](tools/session_context.md) - Save a session summary before disconnect/compaction so the next session sees the context.
 - [`epoch`](#epoch) - Read the graph epoch event log (ADR-203).
+- [`catalog`](#catalog) - Browse what is actually stored in the knowledge graph (ADR-501).
 
 ---
 
@@ -552,5 +551,40 @@ For the per-concept re-evidence stream (which Concepts were touched in which epo
 - `cursor` (`number`) - Pagination cursor — returns events with event_id < cursor. Omit for the first page.
 - `limit` (`number`) - Max events per page (1-500, default 50)
   - Default: `50`
+
+---
+
+### catalog
+
+Browse what is actually stored in the knowledge graph (ADR-501).
+
+A deterministic, filesystem-like view of the ontology -> document -> concept hierarchy. Use this to answer "what's in here?" structurally — by document or domain — as opposed to the 'search' tool, which finds concepts by semantic similarity. This is the right tool when you want to enumerate the corpus, drill into a specific document's concepts, or let a reasoning chain navigate by source rather than by meaning.
+
+The hierarchy is fixed and self-describing via each node's 'kind':
+  root      -> ontology   (knowledge domains)
+  ontology  -> document   (ingested sources; may be text or image)
+  document  -> concept    (leaf — extracted concepts appearing in that document)
+
+A concept can appear under many documents (the graph is a DAG, not a tree). Membership is read from the graph's canonical edges, so it stays correct even as autonomous annealing (ADR-200) reorganizes ontologies.
+
+Actions:
+  - ls:   list children of a node (or root ontologies if no id). Supports a name fragment filter.
+  - stat: full metadata for one node by id.
+
+**Parameters:**
+
+- `action` (`string`) **(required)** - 'ls' to list children, 'stat' for single-node detail
+  - Allowed values: `ls`, `stat`
+- `id` (`string`) - For ls: parent node id (omit to list root ontologies). For stat: the node id to inspect.
+- `kind` (`string`) - Optional kind hint to disambiguate an id that collides across kinds.
+  - Allowed values: `ontology`, `document`, `concept`
+- `query` (`string`) - ls only: case-insensitive name fragment to filter children by.
+- `sort` (`string`) - ls only: sort order for children (default name).
+  - Allowed values: `name`, `child_count`, `created`
+  - Default: `"name"`
+- `limit` (`number`) - ls only: max children per page (1-1000, default 100).
+  - Default: `100`
+- `offset` (`number`) - ls only: pagination offset (default 0).
+  - Default: `0`
 
 ---

--- a/docs/reference/mcp/tools/catalog.md
+++ b/docs/reference/mcp/tools/catalog.md
@@ -1,0 +1,38 @@
+# catalog
+
+> Auto-generated from MCP tool schema
+
+### catalog
+
+Browse what is actually stored in the knowledge graph (ADR-501).
+
+A deterministic, filesystem-like view of the ontology -> document -> concept hierarchy. Use this to answer "what's in here?" structurally — by document or domain — as opposed to the 'search' tool, which finds concepts by semantic similarity. This is the right tool when you want to enumerate the corpus, drill into a specific document's concepts, or let a reasoning chain navigate by source rather than by meaning.
+
+The hierarchy is fixed and self-describing via each node's 'kind':
+  root      -> ontology   (knowledge domains)
+  ontology  -> document   (ingested sources; may be text or image)
+  document  -> concept    (leaf — extracted concepts appearing in that document)
+
+A concept can appear under many documents (the graph is a DAG, not a tree). Membership is read from the graph's canonical edges, so it stays correct even as autonomous annealing (ADR-200) reorganizes ontologies.
+
+Actions:
+  - ls:   list children of a node (or root ontologies if no id). Supports a name fragment filter.
+  - stat: full metadata for one node by id.
+
+**Parameters:**
+
+- `action` (`string`) **(required)** - 'ls' to list children, 'stat' for single-node detail
+  - Allowed values: `ls`, `stat`
+- `id` (`string`) - For ls: parent node id (omit to list root ontologies). For stat: the node id to inspect.
+- `kind` (`string`) - Optional kind hint to disambiguate an id that collides across kinds.
+  - Allowed values: `ontology`, `document`, `concept`
+- `query` (`string`) - ls only: case-insensitive name fragment to filter children by.
+- `sort` (`string`) - ls only: sort order for children (default name).
+  - Allowed values: `name`, `child_count`, `created`
+  - Default: `"name"`
+- `limit` (`number`) - ls only: max children per page (1-1000, default 100).
+  - Default: `100`
+- `offset` (`number`) - ls only: pagination offset (default 0).
+  - Default: `0`
+
+---

--- a/fuse/kg_fuse/api_client.py
+++ b/fuse/kg_fuse/api_client.py
@@ -121,6 +121,27 @@ class KnowledgeGraphClient:
             log.warning(f"Failed to fetch graph epoch: {e}")
             return -1
 
+    async def catalog_children(
+        self,
+        parent: Optional[str] = None,
+        parent_kind: Optional[str] = None,
+        q: Optional[str] = None,
+        limit: int = 200,
+    ) -> dict:
+        """List children of a catalog node, or root ontologies if parent is None.
+
+        Thin wrapper over GET /catalog/children (ADR-501). Returns the raw
+        response dict; mapping to FUSE shapes is done by catalog_adapter.
+        """
+        params: dict = {"limit": limit}
+        if parent:
+            params["parent"] = parent
+        if parent_kind:
+            params["parent_kind"] = parent_kind
+        if q:
+            params["q"] = q
+        return await self.get("/catalog/children", params=params)
+
     async def close(self) -> None:
         """Close the HTTP client."""
         if self._client is not None:

--- a/fuse/kg_fuse/catalog_adapter.py
+++ b/fuse/kg_fuse/catalog_adapter.py
@@ -1,0 +1,76 @@
+"""Catalog facade adapter (ADR-501).
+
+Pure transforms between the /catalog browse API and the shapes the FUSE inode
+layer needs. Kept dependency-free (no pyfuse3, no httpx) so the mapping logic is
+unit-testable in isolation — the directory layer wires these into readdir.
+
+The catalog facade is the shared, deterministic projection of the
+ontology -> document -> concept hierarchy (canonical :SCOPED_BY / :HAS_SOURCE /
+:APPEARS edges). FUSE's stable half (the /ontology/ and documents/ levels) reads
+from it so the four clients (CLI, MCP, web, FUSE) share one contract.
+
+Impedance note: FUSE addresses ontologies by NAME (its inode model is
+name-keyed), but /catalog/children traverses by node id. So we expose the
+ontology name->id map from the root listing; document listing resolves the id
+from that map before querying the next level down.
+"""
+
+from typing import Optional
+
+
+def ontology_entries(catalog_root_response: dict) -> list[dict]:
+    """Map a root /catalog/children response to ontology descriptors.
+
+    Returns one dict per ontology: {"name", "ontology_id", "child_count"}.
+    Nodes missing a name fall back to their id; nodes missing an id are skipped
+    (they cannot be addressed).
+    """
+    out = []
+    for node in (catalog_root_response or {}).get("nodes", []):
+        oid = node.get("id")
+        if not oid:
+            continue
+        out.append({
+            "name": node.get("name") or oid,
+            "ontology_id": oid,
+            "child_count": node.get("child_count"),
+        })
+    return out
+
+
+def ontology_name_to_id(catalog_root_response: dict) -> dict:
+    """Build a {name: ontology_id} map from a root /catalog/children response.
+
+    On duplicate names (should not happen — ontology names are unique) the
+    first wins, matching how FUSE's name-keyed inodes resolve.
+    """
+    mapping: dict = {}
+    for ont in ontology_entries(catalog_root_response):
+        mapping.setdefault(ont["name"], ont["ontology_id"])
+    return mapping
+
+
+def document_entries(catalog_children_response: dict) -> list[dict]:
+    """Map a document-level /catalog/children response to document descriptors.
+
+    Returns one dict per document: {"filename", "document_id", "content_type"}.
+    content_type defaults to "document" when absent (text). Documents without an
+    id are skipped. Mirrors the shape FUSE's _list_documents previously got from
+    /documents so the inode-creation path is unchanged.
+    """
+    out = []
+    for node in (catalog_children_response or {}).get("nodes", []):
+        did = node.get("id")
+        if not did:
+            continue
+        out.append({
+            "filename": node.get("name") or did,
+            "document_id": did,
+            "content_type": node.get("content_type") or "document",
+        })
+    return out
+
+
+def is_image(content_type: Optional[str]) -> bool:
+    """True if a document descriptor is an image (drives the raw+`.md` split)."""
+    return content_type == "image"

--- a/fuse/kg_fuse/filesystem/base.py
+++ b/fuse/kg_fuse/filesystem/base.py
@@ -76,6 +76,9 @@ class BaseMixin(pyfuse3.Operations):
 
         # Write support: pending ontologies and ingestion buffers
         self._pending_ontologies: set[str] = set()  # Ontologies created but no documents yet
+        # ADR-501: ontology name -> id, populated by _list_ontologies from the
+        # catalog facade so the document level (addressed by id) can resolve.
+        self._ontology_id_by_name: dict[str, str] = {}
         self._write_buffers: dict[int, bytes] = {}  # inode -> content being written
         self._write_info: dict[int, dict] = {}  # inode -> {ontology, filename}
 

--- a/fuse/kg_fuse/filesystem/directory.py
+++ b/fuse/kg_fuse/filesystem/directory.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 import pyfuse3
 
+from .. import catalog_adapter
 from ..models import InodeEntry
 from .ingestion import _is_image_file
 
@@ -270,13 +271,18 @@ class DirectoryMixin:
             return cached
 
         try:
-            data = await self._api.get("/ontology/")
-            ontologies = data.get("ontologies", [])
+            # ADR-501: read the ontology level from the shared catalog facade
+            # (canonical :SCOPED_BY edges) rather than /ontology/. Cache the
+            # name->id map so _list_documents can resolve the next level, which
+            # the catalog addresses by id (FUSE addresses by name).
+            data = await self._api.catalog_children(limit=500)
+            ontologies = catalog_adapter.ontology_entries(data)
+            self._ontology_id_by_name = catalog_adapter.ontology_name_to_id(data)
 
             entries = []
             seen_names = set()
             for ont in ontologies:
-                name = ont.get("ontology", "unknown")
+                name = ont["name"]
                 seen_names.add(name)
                 # Allocate inode for this ontology
                 inode = self._get_or_create_ontology_inode(name)
@@ -356,15 +362,29 @@ class DirectoryMixin:
         info_inode = self._get_or_create_info_inode(".documents", parent_inode, ontology)
         entries.append((info_inode, ".documents"))
 
-        # Get documents from API
+        # Get documents from the catalog facade (ADR-501). The catalog addresses
+        # the document level by the parent ontology's id, so resolve the name
+        # via the map populated by _list_ontologies; fall back to listing
+        # ontologies if this is a cold path (e.g. direct lookup before readdir).
         try:
-            data = await self._api.get("/documents", params={"ontology": ontology, "limit": 100})
-            documents = data.get("documents", [])
+            ontology_id = self._ontology_id_by_name.get(ontology)
+            if ontology_id is None:
+                await self._list_ontologies()
+                ontology_id = self._ontology_id_by_name.get(ontology)
+
+            if ontology_id is None:
+                log.warning(f"No ontology id for '{ontology}' — cannot list documents")
+                documents = []
+            else:
+                data = await self._api.catalog_children(
+                    parent=ontology_id, parent_kind="ontology", limit=200
+                )
+                documents = catalog_adapter.document_entries(data)
 
             for doc in documents:
-                filename = doc.get("filename", doc.get("document_id", "unknown"))
-                document_id = doc.get("document_id")
-                content_type = doc.get("content_type", "document")
+                filename = doc["filename"]
+                document_id = doc["document_id"]
+                content_type = doc["content_type"]
 
                 if content_type == "image":
                     # Image: two entries — raw image bytes + companion .md

--- a/fuse/kg_fuse/filesystem/directory.py
+++ b/fuse/kg_fuse/filesystem/directory.py
@@ -364,16 +364,28 @@ class DirectoryMixin:
 
         # Get documents from the catalog facade (ADR-501). The catalog addresses
         # the document level by the parent ontology's id, so resolve the name
-        # via the map populated by _list_ontologies; fall back to listing
-        # ontologies if this is a cold path (e.g. direct lookup before readdir).
+        # via the map populated by _list_ontologies.
         try:
             ontology_id = self._ontology_id_by_name.get(ontology)
             if ontology_id is None:
-                await self._list_ontologies()
+                # Cold path or stale map (e.g. annealing renamed this ontology,
+                # ADR-200). Refresh the name->id map directly from the catalog
+                # root — bypassing _list_ontologies' dir-cache early return,
+                # which would otherwise leave a stale/empty map in place.
+                try:
+                    root = await self._api.catalog_children(limit=500)
+                    self._ontology_id_by_name = catalog_adapter.ontology_name_to_id(root)
+                except Exception as e:
+                    log.warning(f"Failed to refresh ontology name->id map: {e}")
                 ontology_id = self._ontology_id_by_name.get(ontology)
 
             if ontology_id is None:
-                log.warning(f"No ontology id for '{ontology}' — cannot list documents")
+                # Genuinely absent — the ontology was renamed or removed
+                # out-of-band. Surface it rather than silently showing empty.
+                log.warning(
+                    f"Ontology '{ontology}' not found in catalog (renamed or "
+                    f"removed?) — listing no documents"
+                )
                 documents = []
             else:
                 data = await self._api.catalog_children(

--- a/fuse/tests/test_catalog_adapter.py
+++ b/fuse/tests/test_catalog_adapter.py
@@ -1,0 +1,88 @@
+"""Tests for the catalog facade adapter (ADR-501).
+
+Pure mapping logic between /catalog/children responses and the shapes the FUSE
+inode layer needs. No pyfuse3 / httpx — these run anywhere.
+"""
+
+from kg_fuse import catalog_adapter as A
+
+
+class TestOntologyEntries:
+    def test_maps_nodes_to_descriptors(self):
+        resp = {
+            "nodes": [
+                {"kind": "ontology", "id": "ont_1", "name": "Physics", "child_count": 3},
+                {"kind": "ontology", "id": "ont_2", "name": "Bio", "child_count": 0},
+            ]
+        }
+        out = A.ontology_entries(resp)
+        assert out == [
+            {"name": "Physics", "ontology_id": "ont_1", "child_count": 3},
+            {"name": "Bio", "ontology_id": "ont_2", "child_count": 0},
+        ]
+
+    def test_skips_nodes_without_id(self):
+        resp = {"nodes": [{"kind": "ontology", "id": None, "name": "ghost"}]}
+        assert A.ontology_entries(resp) == []
+
+    def test_falls_back_to_id_when_name_missing(self):
+        resp = {"nodes": [{"kind": "ontology", "id": "ont_x"}]}
+        assert A.ontology_entries(resp)[0]["name"] == "ont_x"
+
+    def test_empty_and_none(self):
+        assert A.ontology_entries({}) == []
+        assert A.ontology_entries(None) == []
+
+
+class TestNameToId:
+    def test_builds_map(self):
+        resp = {
+            "nodes": [
+                {"id": "ont_1", "name": "Physics"},
+                {"id": "ont_2", "name": "Bio"},
+            ]
+        }
+        assert A.ontology_name_to_id(resp) == {"Physics": "ont_1", "Bio": "ont_2"}
+
+    def test_first_wins_on_duplicate_name(self):
+        resp = {
+            "nodes": [
+                {"id": "ont_1", "name": "Dup"},
+                {"id": "ont_2", "name": "Dup"},
+            ]
+        }
+        assert A.ontology_name_to_id(resp) == {"Dup": "ont_1"}
+
+
+class TestDocumentEntries:
+    def test_maps_documents(self):
+        resp = {
+            "nodes": [
+                {"kind": "document", "id": "sha256:abc", "name": "paper.md", "content_type": "document"},
+                {"kind": "document", "id": "sha256:img", "name": "fig.png", "content_type": "image"},
+            ]
+        }
+        out = A.document_entries(resp)
+        assert out[0] == {"filename": "paper.md", "document_id": "sha256:abc", "content_type": "document"}
+        assert out[1]["content_type"] == "image"
+
+    def test_content_type_defaults_to_document(self):
+        resp = {"nodes": [{"kind": "document", "id": "d1", "name": "x"}]}
+        assert A.document_entries(resp)[0]["content_type"] == "document"
+
+    def test_skips_documents_without_id(self):
+        resp = {"nodes": [{"kind": "document", "id": "", "name": "x"}]}
+        assert A.document_entries(resp) == []
+
+    def test_filename_falls_back_to_id(self):
+        resp = {"nodes": [{"kind": "document", "id": "sha256:zzz"}]}
+        assert A.document_entries(resp)[0]["filename"] == "sha256:zzz"
+
+
+class TestIsImage:
+    def test_image(self):
+        assert A.is_image("image") is True
+
+    def test_non_image(self):
+        assert A.is_image("document") is False
+        assert A.is_image(None) is False

--- a/schema/migrations/073_catalog_index.sql
+++ b/schema/migrations/073_catalog_index.sql
@@ -1,0 +1,133 @@
+-- Migration 073: Catalog Browse Index + RBAC (ADR-501)
+--
+-- Backs the catalog browse facade — a deterministic projection of the
+-- ontology -> document -> concept hierarchy. The graph (Apache AGE) is the
+-- source of truth; these relational tables are a materialized read index that
+-- makes listing fast: child-counts without per-readdir aggregation, and
+-- fragment (substring) filtering via pg_trgm without scanning the graph.
+--
+-- Why two tables: the hierarchy is a DAG, not a tree. A concept appears in
+-- MANY documents and ontologies (automatic cross-domain merging is a defining
+-- feature, ADR-068/ADR-200), so a concept has many parents. Membership is
+-- therefore an edge relation, separate from node identity:
+--
+--   catalog_node  — one row per distinct node (identity, name, own child_count)
+--   catalog_edge  — parent -> child membership edges (the DAG)
+--
+-- Freshness model (ADR-501 §5, ADR-203): every row carries the
+-- graph_change_counter (graph epoch) it was built at. The facade compares the
+-- index epoch to kg_api.get_graph_epoch() — the same signal artifact freshness
+-- uses (migration 035) — and rebuilds when the graph has advanced. Annealing
+-- (ADR-200) mutates the hierarchy autonomously, so counts may briefly lag a
+-- cycle and then self-heal. Membership is always rebuilt live from canonical
+-- :SCOPED_BY / :HAS_SOURCE / :APPEARS edges — never from the Source.document
+-- denormalized string.
+--
+-- Idempotent: safe to run multiple times.
+
+BEGIN;
+
+-- =============================================================================
+-- Extension: pg_trgm for fragment / substring matching on node names
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- =============================================================================
+-- Catalog Node Table — node identity + own metadata
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS kg_api.catalog_node (
+    kind          VARCHAR(16)  NOT NULL,   -- 'ontology' | 'document' | 'concept'
+    node_id       TEXT         NOT NULL,   -- ontology_id | document_id | concept_id
+    name          TEXT         NOT NULL,   -- display label
+    name_lower    TEXT         NOT NULL,   -- lower(name) for case-insensitive trigram match
+    child_count   INTEGER      NOT NULL DEFAULT 0,  -- direct children this node has
+    content_type  VARCHAR(32),             -- document nodes: 'document'|'image'|future media
+    properties    JSONB        NOT NULL DEFAULT '{}'::jsonb,  -- kind-specific extras
+    graph_epoch   INTEGER      NOT NULL,   -- graph_change_counter when this row was built
+    indexed_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (kind, node_id)
+);
+
+COMMENT ON TABLE kg_api.catalog_node IS
+'ADR-501: materialized identity/metadata for catalog nodes (ontology/document/concept). Source of truth is the AGE graph; rebuilt on graph epoch advance.';
+COMMENT ON COLUMN kg_api.catalog_node.child_count IS
+'Number of direct children (documents-in-ontology, concepts-in-document); 0 for leaf concepts.';
+COMMENT ON COLUMN kg_api.catalog_node.graph_epoch IS
+'graph_change_counter at build time; compared to kg_api.get_graph_epoch() for staleness.';
+
+-- Root-level listing (ontologies) and per-kind scans, ordered by name.
+CREATE INDEX IF NOT EXISTS idx_catalog_node_kind
+    ON kg_api.catalog_node (kind, name);
+
+-- Fragment / substring filter on names (case-insensitive) across all nodes.
+CREATE INDEX IF NOT EXISTS idx_catalog_node_name_trgm
+    ON kg_api.catalog_node USING gin (name_lower gin_trgm_ops);
+
+-- =============================================================================
+-- Catalog Edge Table — parent -> child membership (the DAG)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS kg_api.catalog_edge (
+    parent_kind   VARCHAR(16)  NOT NULL,   -- 'ontology' | 'document'
+    parent_id     TEXT         NOT NULL,
+    child_kind    VARCHAR(16)  NOT NULL,   -- 'document' | 'concept'
+    child_id      TEXT         NOT NULL,
+    graph_epoch   INTEGER      NOT NULL,
+    PRIMARY KEY (parent_kind, parent_id, child_kind, child_id)
+);
+
+COMMENT ON TABLE kg_api.catalog_edge IS
+'ADR-501: parent->child membership edges projecting canonical :SCOPED_BY (ontology<-document) and :HAS_SOURCE/:APPEARS (document<-concept). A concept may have many parent documents (DAG).';
+
+-- List a parent's children: the hot path. Join to catalog_node for name/filter.
+CREATE INDEX IF NOT EXISTS idx_catalog_edge_parent
+    ON kg_api.catalog_edge (parent_kind, parent_id, child_kind);
+
+-- Reverse lookup: which parents does a child belong to (breadcrumbs).
+CREATE INDEX IF NOT EXISTS idx_catalog_edge_child
+    ON kg_api.catalog_edge (child_kind, child_id);
+
+-- =============================================================================
+-- RBAC: register the 'catalog' resource and grant read broadly
+-- =============================================================================
+-- Browse ("what is in the graph?") is the most basic read capability. Every
+-- authenticated role gets catalog:read, mirroring the read-only baseline that
+-- read_only holds for graph objects (migration 040). No scoping at the resource
+-- level: the facade applies per-row ownership/visibility at query time where
+-- relevant.
+
+INSERT INTO kg_auth.resources (resource_type, description, available_actions, supports_scoping, registered_by)
+VALUES (
+    'catalog',
+    'Hierarchical browse of ontologies, documents, and concepts (ADR-501)',
+    ARRAY['read'],
+    FALSE,
+    'system'
+)
+ON CONFLICT (resource_type) DO NOTHING;
+
+INSERT INTO kg_auth.role_permissions (role_name, resource_type, action, scope_type, scope_filter, granted)
+VALUES
+    ('read_only',      'catalog', 'read', 'global', NULL, TRUE),
+    ('contributor',    'catalog', 'read', 'global', NULL, TRUE),
+    ('curator',        'catalog', 'read', 'global', NULL, TRUE),
+    ('admin',          'catalog', 'read', 'global', NULL, TRUE),
+    ('platform_admin', 'catalog', 'read', 'global', NULL, TRUE)
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- Record Migration
+-- =============================================================================
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (73, 'catalog_index')
+ON CONFLICT (version) DO NOTHING;
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 073: catalog browse index (node + edge) + RBAC installed';
+END $$;
+
+COMMIT;

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -1,0 +1,205 @@
+"""
+Tests for the catalog browse facade (ADR-501).
+
+Covers:
+- Pydantic models (CatalogNode / responses) and kind validation
+- The pure DAG projection (_project): canonical-edge membership, multi-parent
+  concepts, child_count derivation, sourceless/orphan accounting
+- Row -> node mapping (JSON property parsing)
+- Sort-field whitelist
+- RBAC gating (no auth -> 401/403)
+
+The projection tests are the important correctness coverage: they pin the DAG
+invariant that a concept appearing in N documents produces N membership edges,
+and that membership derives only from the canonical-edge fetch results (never
+the Source.document string).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app.lib.catalog_facade import CatalogFacade, _SORT_SQL
+from api.app.models.catalog import (
+    CatalogNode,
+    CatalogChildrenResponse,
+    CatalogNodeResponse,
+    CATALOG_SORT_FIELDS,
+)
+
+
+@pytest.fixture
+def client():
+    """FastAPI test client."""
+    from api.app.main import app
+    return TestClient(app)
+
+
+# ============================================================
+# Models
+# ============================================================
+
+class TestCatalogModels:
+    def test_catalog_node_minimal(self):
+        node = CatalogNode(kind="ontology", id="ont_1", name="Philosophy")
+        assert node.kind == "ontology"
+        assert node.parent_id is None
+        assert node.properties == {}
+
+    def test_catalog_node_rejects_bad_kind(self):
+        with pytest.raises(Exception):
+            CatalogNode(kind="galaxy", id="x", name="x")
+
+    def test_children_response_shape(self):
+        resp = CatalogChildrenResponse(
+            parent_id="ont_1",
+            parent_kind="ontology",
+            child_kind="document",
+            nodes=[CatalogNode(kind="document", id="d1", name="paper.pdf",
+                               parent_id="ont_1", child_count=12,
+                               content_type="document")],
+            total=1, limit=100, offset=0, query=None, stale=False,
+        )
+        assert resp.child_kind == "document"
+        assert resp.nodes[0].content_type == "document"
+
+    def test_node_response_carries_freshness(self):
+        resp = CatalogNodeResponse(
+            kind="concept", id="c1", name="Entropy", graph_epoch=42,
+        )
+        assert resp.graph_epoch == 42
+
+
+# ============================================================
+# Pure DAG projection
+# ============================================================
+
+class TestProjection:
+    def test_ontology_child_count_is_doc_count(self):
+        nodes, edges, stats = CatalogFacade._project(
+            ontologies=[{"id": "ont_1", "name": "Physics", "doc_count": 3}],
+            documents=[], concepts=[], epoch=5,
+        )
+        onto = [n for n in nodes if n[0] == "ontology"][0]
+        assert onto[1] == "ont_1"
+        assert onto[4] == 3  # child_count slot
+        assert onto[7] == 5  # epoch slot
+        assert edges == []
+
+    def test_document_links_to_parent_ontology(self):
+        nodes, edges, stats = CatalogFacade._project(
+            ontologies=[{"id": "ont_1", "name": "Physics", "doc_count": 1}],
+            documents=[{
+                "id": "sha256:doc1", "name": "relativity.pdf",
+                "content_type": "document", "concept_count": 7,
+                "parent_ontology_ids": ["ont_1"],
+            }],
+            concepts=[], epoch=1,
+        )
+        doc = [n for n in nodes if n[0] == "document"][0]
+        assert doc[4] == 7              # concept_count -> child_count
+        assert doc[5] == "document"     # content_type
+        assert ("ontology", "ont_1", "document", "sha256:doc1", 1) in edges
+        assert stats["sourceless_docs"] == 0
+
+    def test_concept_with_multiple_parents_yields_multiple_edges(self):
+        """The DAG invariant: one concept, two documents -> two edges."""
+        nodes, edges, stats = CatalogFacade._project(
+            ontologies=[],
+            documents=[],
+            concepts=[{
+                "id": "c_entropy", "name": "Entropy",
+                "parent_document_ids": ["sha256:docA", "sha256:docB"],
+            }],
+            epoch=9,
+        )
+        concept = [n for n in nodes if n[0] == "concept"][0]
+        assert concept[4] == 0  # leaf: child_count 0
+        concept_edges = [e for e in edges if e[3] == "c_entropy"]
+        assert len(concept_edges) == 2
+        assert ("document", "sha256:docA", "concept", "c_entropy", 9) in edges
+        assert ("document", "sha256:docB", "concept", "c_entropy", 9) in edges
+
+    def test_sourceless_document_counted_not_dropped(self):
+        nodes, edges, stats = CatalogFacade._project(
+            ontologies=[],
+            documents=[{"id": "d_orphan", "name": "loose.pdf",
+                        "parent_ontology_ids": []}],
+            concepts=[], epoch=1,
+        )
+        # Node still present (searchable) but no membership edge.
+        assert any(n[1] == "d_orphan" for n in nodes)
+        assert edges == []
+        assert stats["sourceless_docs"] == 1
+
+    def test_orphan_concept_counted_not_dropped(self):
+        nodes, edges, stats = CatalogFacade._project(
+            ontologies=[], documents=[],
+            concepts=[{"id": "c_loose", "name": "Floaty",
+                       "parent_document_ids": []}],
+            epoch=1,
+        )
+        assert any(n[1] == "c_loose" for n in nodes)
+        assert edges == []
+        assert stats["orphan_concepts"] == 1
+
+    def test_rows_without_ids_skipped(self):
+        nodes, edges, stats = CatalogFacade._project(
+            ontologies=[{"id": None, "name": "ghost"}],
+            documents=[{"id": "", "name": "ghost"}],
+            concepts=[{"name": "ghost"}],
+            epoch=1,
+        )
+        assert nodes == []
+        assert edges == []
+
+    def test_name_lower_is_populated(self):
+        nodes, _, _ = CatalogFacade._project(
+            ontologies=[{"id": "o1", "name": "MixedCase", "doc_count": 0}],
+            documents=[], concepts=[], epoch=1,
+        )
+        assert nodes[0][3] == "mixedcase"  # name_lower slot
+
+
+# ============================================================
+# Mapping + whitelists
+# ============================================================
+
+class TestHelpers:
+    def test_row_to_node_parses_json_string_properties(self):
+        node = CatalogFacade._row_to_node(
+            {"kind": "ontology", "node_id": "o1", "name": "X",
+             "child_count": 2, "content_type": None,
+             "properties": '{"lifecycle_state": "active"}'},
+            parent_id=None,
+        )
+        assert node["properties"]["lifecycle_state"] == "active"
+        assert node["id"] == "o1"
+
+    def test_row_to_node_handles_dict_properties(self):
+        node = CatalogFacade._row_to_node(
+            {"kind": "concept", "node_id": "c1", "name": "Y",
+             "child_count": 0, "content_type": None,
+             "properties": {"a": 1}},
+            parent_id="d1",
+        )
+        assert node["properties"] == {"a": 1}
+        assert node["parent_id"] == "d1"
+
+    def test_sort_whitelist_matches_documented_fields(self):
+        # Every documented sort field must have a safe ORDER BY clause.
+        for field in CATALOG_SORT_FIELDS:
+            assert field in _SORT_SQL
+
+
+# ============================================================
+# RBAC gating
+# ============================================================
+
+class TestCatalogAuth:
+    def test_children_requires_auth(self, client):
+        resp = client.get("/catalog/children")
+        assert resp.status_code in (401, 403)
+
+    def test_node_requires_auth(self, client):
+        resp = client.get("/catalog/node/ont_1")
+        assert resp.status_code in (401, 403)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,6 +33,7 @@ import { EdgeExplorerWorkspace } from './components/vocabulary/EdgeExplorerWorks
 import { VocabularyChordWorkspace } from './components/vocabulary/VocabularyChordWorkspace';
 import { EmbeddingLandscapeWorkspace } from './components/embeddings';
 import { DocumentExplorerWorkspace } from './components/documents/DocumentExplorerWorkspace';
+import { CatalogExplorerWorkspace } from './components/catalog/CatalogExplorerWorkspace';
 
 import './explorers'; // Import to register explorers
 
@@ -132,6 +133,7 @@ const AppContent: React.FC = () => {
         <Route path="/explore/2d" element={<RedirectPreservingSearch to="/explore/graph" />} />
         <Route path="/explore/3d" element={<RedirectPreservingSearch to="/explore/graph" />} />
         <Route path="/explore/documents" element={<DocumentExplorerWorkspace />} />
+        <Route path="/explore/catalog" element={<CatalogExplorerWorkspace />} />
 
         {/* Block Editor */}
         <Route path="/blocks" element={<BlockEditorWorkspace />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -7,6 +7,7 @@
 
 import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
 import type { SubgraphResponse } from '../types/graph';
+import type { CatalogChildrenResponse, CatalogNodeResponse } from '../types/catalog';
 import type {
   JobStatus,
   JobListFilters,
@@ -2011,6 +2012,37 @@ class APIClient {
     }>;
   }> {
     const response = await this.client.get(`/documents/${encodeURIComponent(documentId)}/content`);
+    return response.data;
+  }
+
+  // ===========================================================================
+  // Catalog browse (ADR-501)
+  // ===========================================================================
+
+  /**
+   * List the children of a catalog node, or root ontologies when `parent` is
+   * omitted. Deterministic ontology -> document -> concept browse (ADR-501).
+   */
+  async listCatalogChildren(params?: {
+    parent?: string;
+    parent_kind?: string;
+    q?: string;
+    sort?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<CatalogChildrenResponse> {
+    const response = await this.client.get('/catalog/children', { params });
+    return response.data;
+  }
+
+  /**
+   * Get a single catalog node's full metadata (the stat/detail call).
+   */
+  async getCatalogNode(nodeId: string, kind?: string): Promise<CatalogNodeResponse> {
+    const response = await this.client.get(
+      `/catalog/node/${encodeURIComponent(nodeId)}`,
+      { params: kind ? { kind } : undefined }
+    );
     return response.data;
   }
 }

--- a/web/src/components/catalog/CatalogExplorerWorkspace.tsx
+++ b/web/src/components/catalog/CatalogExplorerWorkspace.tsx
@@ -1,0 +1,41 @@
+/**
+ * Catalog Explorer Workspace (ADR-501)
+ *
+ * Route-mounted wrapper for the Catalog Explorer. Mirrors
+ * DocumentExplorerWorkspace: holds the explorer's settings, provides a
+ * settings rail, and renders the self-fetching explorer component. The tree
+ * session state lives in catalogExplorerStore so it survives navigation.
+ */
+
+import React, { useState } from 'react';
+import { Settings } from 'lucide-react';
+import { IconRailPanel } from '../shared/IconRailPanel';
+import { CatalogExplorer } from '../../explorers/CatalogExplorer/CatalogExplorer';
+import { SettingsPanel } from '../../explorers/CatalogExplorer/SettingsPanel';
+import { DEFAULT_SETTINGS } from '../../explorers/CatalogExplorer/types';
+import type { CatalogExplorerSettings } from '../../explorers/CatalogExplorer/types';
+
+export const CatalogExplorerWorkspace: React.FC = () => {
+  const [settings, setSettings] = useState<CatalogExplorerSettings>(DEFAULT_SETTINGS);
+  const [activeRailTab, setActiveRailTab] = useState('settings');
+
+  return (
+    <div className="flex h-full">
+      <IconRailPanel
+        tabs={[
+          {
+            id: 'settings',
+            icon: Settings,
+            label: 'Settings',
+            content: <SettingsPanel settings={settings} onChange={setSettings} />,
+          },
+        ]}
+        activeTab={activeRailTab}
+        onTabChange={setActiveRailTab}
+      />
+      <div className="flex-1 min-w-0">
+        <CatalogExplorer data={{}} settings={settings} onSettingsChange={setSettings} />
+      </div>
+    </div>
+  );
+};

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -33,6 +33,7 @@ import {
   Waypoints,
   PieChart,
   Layers,
+  FolderTree,
   AlertTriangle,
   X,
 } from 'lucide-react';
@@ -75,6 +76,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
     if (path === '/') return 'Home';
     if (path.startsWith('/explore/graph')) return 'Force Graph';
     if (path.startsWith('/explore/documents')) return 'Document Explorer';
+    if (path.startsWith('/explore/catalog')) return 'Catalog Explorer';
     if (path.startsWith('/blocks')) return 'Block Editor';
     if (path.startsWith('/ingest')) return 'Ingest';
     if (path.startsWith('/jobs')) return 'Jobs';
@@ -135,6 +137,12 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
               label="Document Explorer"
               isActive={isActive('/explore/documents')}
               onClick={() => navigate('/explore/documents')}
+            />
+            <SidebarItem
+              icon={FolderTree}
+              label="Catalog Explorer"
+              isActive={isActive('/explore/catalog')}
+              onClick={() => navigate('/explore/catalog')}
             />
             <SidebarItem
               icon={GitBranch}

--- a/web/src/explorers/CatalogExplorer/CatalogDetailPanel.tsx
+++ b/web/src/explorers/CatalogExplorer/CatalogDetailPanel.tsx
@@ -1,0 +1,96 @@
+/**
+ * Catalog Detail Panel (ADR-501)
+ *
+ * Shows full metadata for the selected catalog node, hydrated from
+ * /catalog/node/{id} (the stat call) so we pick up graph_epoch / indexed_at
+ * and any kind-specific properties not carried in the tree listing.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { apiClient } from '../../api/client';
+import type { CatalogNode, CatalogNodeResponse } from '../../types/catalog';
+
+interface CatalogDetailPanelProps {
+  node: CatalogNode | null;
+}
+
+const KIND_LABEL: Record<string, string> = {
+  ontology: 'Ontology',
+  document: 'Document',
+  concept: 'Concept',
+};
+
+export const CatalogDetailPanel: React.FC<CatalogDetailPanelProps> = ({ node }) => {
+  const [detail, setDetail] = useState<CatalogNodeResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!node) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    apiClient
+      .getCatalogNode(node.id, node.kind)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch(() => {
+        if (!cancelled) setDetail(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [node]);
+
+  if (!node) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        Select a node to see its details.
+      </div>
+    );
+  }
+
+  const d = detail || node;
+  const props = Object.entries((d as CatalogNodeResponse).properties || {});
+
+  return (
+    <div className="p-4 space-y-3 text-sm">
+      <div>
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+          {KIND_LABEL[d.kind] || d.kind}
+        </div>
+        <div className="font-medium break-words">{d.name}</div>
+      </div>
+
+      <dl className="space-y-1.5">
+        <Row label="ID" value={d.id} mono />
+        {d.kind !== 'concept' && d.child_count != null && (
+          <Row label="Children" value={String(d.child_count)} />
+        )}
+        {d.content_type && <Row label="Content type" value={d.content_type} />}
+        {(d as CatalogNodeResponse).graph_epoch != null && (
+          <Row label="Indexed at epoch" value={String((d as CatalogNodeResponse).graph_epoch)} />
+        )}
+        {props.map(([k, v]) => (
+          <Row key={k} label={k} value={String(v)} />
+        ))}
+      </dl>
+
+      {loading && <div className="text-xs text-muted-foreground">Refreshing…</div>}
+    </div>
+  );
+};
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex gap-2">
+      <dt className="text-muted-foreground min-w-[7rem] flex-shrink-0">{label}</dt>
+      <dd className={`break-words ${mono ? 'font-mono text-xs' : ''}`}>{value}</dd>
+    </div>
+  );
+}

--- a/web/src/explorers/CatalogExplorer/CatalogDetailPanel.tsx
+++ b/web/src/explorers/CatalogExplorer/CatalogDetailPanel.tsx
@@ -1,14 +1,74 @@
 /**
  * Catalog Detail Panel (ADR-501)
  *
- * Shows full metadata for the selected catalog node, hydrated from
- * /catalog/node/{id} (the stat call) so we pick up graph_epoch / indexed_at
- * and any kind-specific properties not carried in the tree listing.
+ * Shows metadata for the selected catalog node. The base stat comes from
+ * /catalog/node/{id}; kind-specific enrichment reuses existing endpoints (no
+ * new API paths):
+ *   - concept:  getConceptDetails  → description, grounding, search terms
+ *   - document: getDocumentContent → stored content preview (text/image)
+ *   - ontology: listOntologies     → document / concept / source counts
  */
 
 import React, { useEffect, useState } from 'react';
+import { Copy, Download, Check } from 'lucide-react';
 import { apiClient } from '../../api/client';
 import type { CatalogNode, CatalogNodeResponse } from '../../types/catalog';
+
+/** Trigger a browser download of `content` as `filename` (no new endpoint —
+ *  builds a Blob from data already in hand). */
+function downloadBlob(content: string, filename: string, mime = 'text/plain') {
+  const url = URL.createObjectURL(new Blob([content], { type: mime }));
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** Copy + download actions for a piece of content. Copy uses the async
+ *  clipboard API; download writes a Blob. Both operate on data already
+ *  fetched — no extra requests. */
+const ActionRow: React.FC<{
+  copyText?: string;
+  download?: { content: string; filename: string; mime?: string };
+  copyLabel?: string;
+}> = ({ copyText, download, copyLabel = 'Copy' }) => {
+  const [copied, setCopied] = useState(false);
+  const doCopy = async () => {
+    if (!copyText) return;
+    try {
+      await navigator.clipboard.writeText(copyText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked — no-op */
+    }
+  };
+  return (
+    <div className="flex gap-2 pt-1">
+      {copyText && (
+        <button
+          onClick={doCopy}
+          className="flex items-center gap-1 px-2 py-1 text-xs rounded border border-border hover:bg-muted"
+        >
+          {copied ? <Check className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
+          {copied ? 'Copied' : copyLabel}
+        </button>
+      )}
+      {download && (
+        <button
+          onClick={() => downloadBlob(download.content, download.filename, download.mime)}
+          className="flex items-center gap-1 px-2 py-1 text-xs rounded border border-border hover:bg-muted"
+        >
+          <Download className="w-3 h-3" />
+          Download
+        </button>
+      )}
+    </div>
+  );
+};
 
 interface CatalogDetailPanelProps {
   node: CatalogNode | null;
@@ -59,12 +119,13 @@ export const CatalogDetailPanel: React.FC<CatalogDetailPanelProps> = ({ node }) 
   const props = Object.entries((d as CatalogNodeResponse).properties || {});
 
   return (
-    <div className="p-4 space-y-3 text-sm">
+    <div className="p-4 space-y-3 text-sm overflow-auto">
       <div>
         <div className="text-xs uppercase tracking-wide text-muted-foreground">
           {KIND_LABEL[d.kind] || d.kind}
         </div>
         <div className="font-medium break-words">{d.name}</div>
+        <ActionRow copyText={d.id} copyLabel="Copy ID" />
       </div>
 
       <dl className="space-y-1.5">
@@ -81,10 +142,260 @@ export const CatalogDetailPanel: React.FC<CatalogDetailPanelProps> = ({ node }) 
         ))}
       </dl>
 
+      {/* Kind-specific enrichment, reusing existing endpoints. */}
+      {node.kind === 'concept' && <ConceptDetail conceptId={node.id} />}
+      {node.kind === 'document' && (
+        <DocumentDetail documentId={node.id} filename={node.name} contentType={node.content_type} />
+      )}
+      {node.kind === 'ontology' && <OntologyDetail name={node.name} />}
+
       {loading && <div className="text-xs text-muted-foreground">Refreshing…</div>}
     </div>
   );
 };
+
+// ---------------------------------------------------------------------------
+// Concept: description + grounding + search terms (getConceptDetails)
+// ---------------------------------------------------------------------------
+
+const ConceptDetail: React.FC<{ conceptId: string }> = ({ conceptId }) => {
+  const [data, setData] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    apiClient
+      .getConceptDetails(conceptId)
+      .then((d) => !cancelled && setData(d))
+      .catch(() => !cancelled && setData(null))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [conceptId]);
+
+  if (loading) return <Loading />;
+  if (!data) return null;
+
+  const terms: string[] = data.search_terms || [];
+
+  return (
+    <div className="space-y-2 border-t border-border pt-3">
+      {data.description && (
+        <div>
+          <SectionLabel>Description</SectionLabel>
+          <p className="leading-snug">{data.description}</p>
+          <ActionRow copyText={data.description} copyLabel="Copy description" />
+        </div>
+      )}
+      <dl className="space-y-1.5">
+        {data.grounding_display && <Row label="Grounding" value={data.grounding_display} />}
+        {typeof data.grounding_strength === 'number' && (
+          <Row label="Grounding strength" value={data.grounding_strength.toFixed(2)} />
+        )}
+        {typeof data.evidence_count === 'number' && (
+          <Row label="Evidence" value={String(data.evidence_count)} />
+        )}
+      </dl>
+      {terms.length > 0 && (
+        <div>
+          <SectionLabel>Search terms</SectionLabel>
+          <div className="flex flex-wrap gap-1">
+            {terms.map((t) => (
+              <SearchTermChip key={t} term={t} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Document: stored content preview (getDocumentContent / image)
+// ---------------------------------------------------------------------------
+
+const DocumentDetail: React.FC<{
+  documentId: string;
+  filename: string;
+  contentType?: string | null;
+}> = ({ documentId, filename, contentType }) => {
+  const [text, setText] = useState<string | null>(null);
+  const [firstSourceId, setFirstSourceId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+    apiClient
+      .getDocumentContent(documentId)
+      .then((d) => {
+        if (cancelled) return;
+        // Prefer joined chunk text; fall back to a stringified content blob.
+        const joined =
+          Array.isArray(d.chunks) && d.chunks.length > 0
+            ? d.chunks.map((c) => c.full_text).join('\n\n')
+            : typeof d.content === 'string'
+            ? d.content
+            : JSON.stringify(d.content ?? '', null, 2);
+        setText(joined);
+        if (Array.isArray(d.chunks) && d.chunks.length > 0) {
+          setFirstSourceId(d.chunks[0].source_id);
+        }
+      })
+      .catch(() => !cancelled && setError(true))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId]);
+
+  const isImage = contentType === 'image';
+
+  const downloadImage = async () => {
+    if (!firstSourceId) return;
+    // Reuses the existing /sources/{id}/image endpoint (returns a blob URL).
+    const url = await apiClient.getSourceImageUrl(firstSourceId);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  if (loading) return <Loading />;
+
+  return (
+    <div className="space-y-1 border-t border-border pt-3">
+      <SectionLabel>{isImage ? 'Stored content (prose)' : 'Content'}</SectionLabel>
+      {error ? (
+        <p className="text-xs text-muted-foreground">Content unavailable.</p>
+      ) : (
+        <>
+          <pre className="text-xs whitespace-pre-wrap break-words max-h-96 overflow-auto bg-muted/50 rounded p-2">
+            {text}
+          </pre>
+          <ActionRow
+            copyText={text || undefined}
+            copyLabel={isImage ? 'Copy prose' : 'Copy text'}
+            download={
+              text != null
+                ? {
+                    content: text,
+                    filename: isImage ? `${filename}.prose.txt` : filename,
+                    mime: 'text/plain',
+                  }
+                : undefined
+            }
+          />
+          {isImage && firstSourceId && (
+            <button
+              onClick={downloadImage}
+              className="flex items-center gap-1 px-2 py-1 text-xs rounded border border-border hover:bg-muted mt-1"
+            >
+              <Download className="w-3 h-3" />
+              Download image
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Ontology: basic stats (listOntologies — already returns per-ontology counts)
+// ---------------------------------------------------------------------------
+
+const OntologyDetail: React.FC<{ name: string }> = ({ name }) => {
+  const [stats, setStats] = useState<{
+    source_count: number;
+    file_count: number;
+    concept_count: number;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    apiClient
+      .listOntologies()
+      .then((res) => {
+        if (cancelled) return;
+        const match = res.ontologies.find((o) => o.ontology === name);
+        setStats(
+          match
+            ? {
+                source_count: match.source_count,
+                file_count: match.file_count,
+                concept_count: match.concept_count,
+              }
+            : null
+        );
+      })
+      .catch(() => !cancelled && setStats(null))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  if (loading) return <Loading />;
+  if (!stats) return null;
+
+  return (
+    <div className="space-y-1 border-t border-border pt-3">
+      <SectionLabel>Statistics</SectionLabel>
+      <dl className="space-y-1.5">
+        <Row label="Documents" value={String(stats.file_count)} />
+        <Row label="Source chunks" value={String(stats.source_count)} />
+        <Row label="Concepts" value={String(stats.concept_count)} />
+      </dl>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
+function Loading() {
+  return <div className="text-xs text-muted-foreground border-t border-border pt-3">Loading…</div>;
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return <div className="text-xs uppercase tracking-wide text-muted-foreground mb-1">{children}</div>;
+}
+
+/** A search-term chip that copies its term to the clipboard on click. */
+function SearchTermChip({ term }: { term: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(term);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      /* clipboard blocked — no-op */
+    }
+  };
+  return (
+    <button
+      onClick={copy}
+      title="Click to copy"
+      className={`px-1.5 py-0.5 rounded text-xs transition-colors ${
+        copied ? 'bg-green-500/20 text-green-600' : 'bg-muted hover:bg-muted-foreground/20'
+      }`}
+    >
+      {copied ? 'Copied!' : term}
+    </button>
+  );
+}
 
 function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (

--- a/web/src/explorers/CatalogExplorer/CatalogExplorer.tsx
+++ b/web/src/explorers/CatalogExplorer/CatalogExplorer.tsx
@@ -1,0 +1,100 @@
+/**
+ * Catalog Explorer (ADR-501)
+ *
+ * Deterministic, folder-style browse of the knowledge graph:
+ * ontology -> document -> concept. Answers "what's actually in here?" — the
+ * structural complement to the semantic graph/search explorers.
+ *
+ * Self-fetching (like DocumentExplorer): it pulls each tree level from
+ * /catalog on demand rather than consuming a preloaded rawGraphData blob, so
+ * its ExplorerProps.data is unused.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Search, RefreshCw, FolderTree } from 'lucide-react';
+import type { ExplorerProps } from '../../types/explorer';
+import { useCatalogExplorerStore } from '../../store/catalogExplorerStore';
+import { CatalogTree } from './CatalogTree';
+import { CatalogDetailPanel } from './CatalogDetailPanel';
+import type { CatalogExplorerData, CatalogExplorerSettings } from './types';
+import { DEFAULT_SETTINGS } from './types';
+
+export const CatalogExplorer: React.FC<
+  ExplorerProps<CatalogExplorerData, CatalogExplorerSettings>
+> = ({ settings }) => {
+  const effective = settings || DEFAULT_SETTINGS;
+
+  const filter = useCatalogExplorerStore((s) => s.filter);
+  const setFilter = useCatalogExplorerStore((s) => s.setFilter);
+  const selected = useCatalogExplorerStore((s) => s.selected);
+  const stale = useCatalogExplorerStore((s) => s.stale);
+  const reset = useCatalogExplorerStore((s) => s.reset);
+
+  // Debounce the filter input into the store (which drives re-fetch). Reset
+  // cached children when the filter changes so collapsed branches re-query
+  // under the new fragment on next expand.
+  const [input, setInput] = useState(filter);
+  const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounce.current) clearTimeout(debounce.current);
+    debounce.current = setTimeout(() => {
+      if (input !== filter) {
+        reset();
+        setFilter(input);
+      }
+    }, 300);
+    return () => {
+      if (debounce.current) clearTimeout(debounce.current);
+    };
+  }, [input, filter, reset, setFilter]);
+
+  const refresh = useCallback(() => {
+    reset();
+    setFilter(filter); // no-op value change; reset() already cleared caches
+  }, [reset, setFilter, filter]);
+
+  return (
+    <div className="flex h-full">
+      {/* Tree pane */}
+      <div className="flex flex-col flex-1 min-w-0 border-r border-border">
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+          <FolderTree className="w-4 h-4 text-amber-500 flex-shrink-0" />
+          <span className="text-sm font-medium">Catalog</span>
+          <div className="flex-1" />
+          <div className="relative">
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Filter by name…"
+              className="pl-7 pr-2 py-1 text-sm bg-background border border-border rounded w-48 focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+          <button
+            onClick={refresh}
+            title="Refresh from graph"
+            className="p-1 rounded hover:bg-muted text-muted-foreground"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+        </div>
+
+        {stale && (
+          <div className="px-3 py-1 text-xs text-amber-600 bg-amber-500/10 border-b border-border">
+            Index is catching up to recent graph changes — counts may lag briefly.
+          </div>
+        )}
+
+        <div className="flex-1 overflow-auto">
+          <CatalogTree settings={effective} />
+        </div>
+      </div>
+
+      {/* Detail pane */}
+      <div className="w-80 flex-shrink-0 overflow-auto">
+        <CatalogDetailPanel node={selected} />
+      </div>
+    </div>
+  );
+};

--- a/web/src/explorers/CatalogExplorer/CatalogTree.tsx
+++ b/web/src/explorers/CatalogExplorer/CatalogTree.tsx
@@ -1,0 +1,220 @@
+/**
+ * Catalog Tree (ADR-501)
+ *
+ * Lazy-expanding folder tree over the ontology -> document -> concept
+ * hierarchy. Each level is fetched on demand from /catalog/children via the
+ * shared apiClient and cached in catalogExplorerStore so a browse session
+ * survives navigation. Leaf concepts are not expandable.
+ *
+ * Reuses the project's design tokens (Tailwind semantic classes already used
+ * across explorers) and lucide icons rather than introducing new styling.
+ */
+
+import React, { useCallback, useEffect } from 'react';
+import {
+  ChevronRight,
+  ChevronDown,
+  FolderTree,
+  FileText,
+  Image as ImageIcon,
+  Circle,
+  Loader2,
+} from 'lucide-react';
+import { apiClient } from '../../api/client';
+import {
+  useCatalogExplorerStore,
+  CATALOG_ROOT_KEY,
+} from '../../store/catalogExplorerStore';
+import type { CatalogNode, CatalogKind } from '../../types/catalog';
+import type { CatalogExplorerSettings } from './types';
+
+/** Which kind a node's children are, per the fixed hierarchy. */
+const CHILD_KIND: Record<CatalogKind, CatalogKind | null> = {
+  ontology: 'document',
+  document: 'concept',
+  concept: null,
+};
+
+function NodeIcon({ node }: { node: CatalogNode }) {
+  if (node.kind === 'ontology') return <FolderTree className="w-4 h-4 text-amber-500" />;
+  if (node.kind === 'document') {
+    return node.content_type === 'image' ? (
+      <ImageIcon className="w-4 h-4 text-sky-500" />
+    ) : (
+      <FileText className="w-4 h-4 text-sky-400" />
+    );
+  }
+  return <Circle className="w-2.5 h-2.5 text-muted-foreground ml-0.5" />;
+}
+
+interface TreeRowProps {
+  node: CatalogNode;
+  depth: number;
+  settings: CatalogExplorerSettings;
+}
+
+const TreeRow: React.FC<TreeRowProps> = ({ node, depth, settings }) => {
+  const expanded = useCatalogExplorerStore((s) => s.expanded[node.id] || false);
+  const children = useCatalogExplorerStore((s) => s.childrenByParent[node.id]);
+  const total = useCatalogExplorerStore((s) => s.totalByParent[node.id]);
+  const loading = useCatalogExplorerStore((s) => s.loading[node.id] || false);
+  const selected = useCatalogExplorerStore((s) => s.selected?.id === node.id);
+  const filter = useCatalogExplorerStore((s) => s.filter);
+  const setChildren = useCatalogExplorerStore((s) => s.setChildren);
+  const setExpanded = useCatalogExplorerStore((s) => s.setExpanded);
+  const setLoading = useCatalogExplorerStore((s) => s.setLoading);
+  const setSelected = useCatalogExplorerStore((s) => s.setSelected);
+  const setStale = useCatalogExplorerStore((s) => s.setStale);
+
+  const childKind = CHILD_KIND[node.kind];
+  const expandable = childKind !== null;
+
+  const fetchChildren = useCallback(async () => {
+    if (!childKind) return;
+    setLoading(node.id, true);
+    try {
+      const res = await apiClient.listCatalogChildren({
+        parent: node.id,
+        parent_kind: node.kind,
+        q: filter || undefined,
+        sort: settings.sort,
+        limit: 200,
+      });
+      setChildren(node.id, res.nodes, res.total);
+      setStale(res.stale);
+    } finally {
+      setLoading(node.id, false);
+    }
+  }, [node.id, node.kind, childKind, filter, settings.sort, setChildren, setLoading, setStale]);
+
+  const toggle = useCallback(() => {
+    if (!expandable) {
+      setSelected(node);
+      return;
+    }
+    const next = !expanded;
+    setExpanded(node.id, next);
+    setSelected(node);
+    if (next && children === undefined) {
+      void fetchChildren();
+    }
+  }, [expandable, expanded, node, children, setExpanded, setSelected, fetchChildren]);
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-1.5 py-1 px-2 rounded cursor-pointer hover:bg-muted ${
+          selected ? 'bg-muted' : ''
+        }`}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        onClick={toggle}
+      >
+        <span className="w-4 flex-shrink-0">
+          {expandable ? (
+            loading ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />
+            ) : expanded ? (
+              <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />
+            )
+          ) : null}
+        </span>
+        <NodeIcon node={node} />
+        <span className="text-sm truncate flex-1">{node.name}</span>
+        {settings.showCounts && node.child_count != null && node.kind !== 'concept' && (
+          <span className="text-xs text-muted-foreground tabular-nums">{node.child_count}</span>
+        )}
+      </div>
+
+      {expanded && children && (
+        <div>
+          {children.length === 0 ? (
+            <div
+              className="text-xs text-muted-foreground italic py-1"
+              style={{ paddingLeft: `${(depth + 1) * 16 + 28}px` }}
+            >
+              {filter ? 'no matches' : 'empty'}
+            </div>
+          ) : (
+            children.map((child) => (
+              <TreeRow key={`${child.kind}:${child.id}`} node={child} depth={depth + 1} settings={settings} />
+            ))
+          )}
+          {total != null && children.length < total && (
+            <div
+              className="text-xs text-muted-foreground py-1"
+              style={{ paddingLeft: `${(depth + 1) * 16 + 28}px` }}
+            >
+              showing {children.length} of {total}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface CatalogTreeProps {
+  settings: CatalogExplorerSettings;
+}
+
+/** Root of the tree — fetches and renders the ontology level. */
+export const CatalogTree: React.FC<CatalogTreeProps> = ({ settings }) => {
+  const roots = useCatalogExplorerStore((s) => s.childrenByParent[CATALOG_ROOT_KEY]);
+  const total = useCatalogExplorerStore((s) => s.totalByParent[CATALOG_ROOT_KEY]);
+  const loading = useCatalogExplorerStore((s) => s.loading[CATALOG_ROOT_KEY] || false);
+  const filter = useCatalogExplorerStore((s) => s.filter);
+  const setChildren = useCatalogExplorerStore((s) => s.setChildren);
+  const setLoading = useCatalogExplorerStore((s) => s.setLoading);
+  const setStale = useCatalogExplorerStore((s) => s.setStale);
+
+  const fetchRoots = useCallback(async () => {
+    setLoading(CATALOG_ROOT_KEY, true);
+    try {
+      const res = await apiClient.listCatalogChildren({
+        q: filter || undefined,
+        sort: settings.sort,
+        limit: 500,
+      });
+      setChildren(CATALOG_ROOT_KEY, res.nodes, res.total);
+      setStale(res.stale);
+    } finally {
+      setLoading(CATALOG_ROOT_KEY, false);
+    }
+  }, [filter, settings.sort, setChildren, setLoading, setStale]);
+
+  // Fetch root ontologies on mount, when the filter changes, or sort changes.
+  useEffect(() => {
+    void fetchRoots();
+  }, [fetchRoots]);
+
+  if (loading && roots === undefined) {
+    return (
+      <div className="flex items-center justify-center py-8 text-muted-foreground">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading catalog…
+      </div>
+    );
+  }
+
+  if (roots && roots.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground text-sm">
+        {filter ? `No ontologies match “${filter}”` : 'The knowledge graph is empty.'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-1">
+      {(roots || []).map((node) => (
+        <TreeRow key={`${node.kind}:${node.id}`} node={node} depth={0} settings={settings} />
+      ))}
+      {total != null && (roots?.length || 0) < total && (
+        <div className="text-xs text-muted-foreground px-2 py-1">
+          showing {roots?.length || 0} of {total} ontologies
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/explorers/CatalogExplorer/SettingsPanel.tsx
+++ b/web/src/explorers/CatalogExplorer/SettingsPanel.tsx
@@ -1,0 +1,43 @@
+/**
+ * Catalog Explorer Settings Panel (ADR-501)
+ *
+ * Minimal controls: child-count badges toggle and sort order. Follows the
+ * SettingsPanelProps contract used by the other explorer plugins.
+ */
+
+import React from 'react';
+import type { SettingsPanelProps } from '../../types/explorer';
+import type { CatalogExplorerSettings } from './types';
+
+export const SettingsPanel: React.FC<SettingsPanelProps<CatalogExplorerSettings>> = ({
+  settings,
+  onChange,
+}) => {
+  return (
+    <div className="p-3 space-y-3 text-sm">
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={settings.showCounts}
+          onChange={(e) => onChange({ ...settings, showCounts: e.target.checked })}
+        />
+        Show child counts
+      </label>
+
+      <div className="space-y-1">
+        <label className="block text-muted-foreground">Sort children by</label>
+        <select
+          value={settings.sort}
+          onChange={(e) =>
+            onChange({ ...settings, sort: e.target.value as CatalogExplorerSettings['sort'] })
+          }
+          className="w-full bg-background border border-border rounded px-2 py-1"
+        >
+          <option value="name">Name</option>
+          <option value="child_count">Child count</option>
+          <option value="created">Created</option>
+        </select>
+      </div>
+    </div>
+  );
+};

--- a/web/src/explorers/CatalogExplorer/index.ts
+++ b/web/src/explorers/CatalogExplorer/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Catalog Explorer — Plugin Definition (ADR-501)
+ *
+ * Folder-style browse of the ontology -> document -> concept hierarchy.
+ * Self-fetching like DocumentExplorer (its dataTransformer is a no-op), so it
+ * mounts via its own workspace wrapper rather than ExplorerView's graph-data
+ * pipeline. Registered for parity and future registry-driven listings.
+ */
+
+import { FolderTree } from 'lucide-react';
+import type { ExplorerPlugin } from '../../types/explorer';
+import { CatalogExplorer } from './CatalogExplorer';
+import { SettingsPanel } from './SettingsPanel';
+import type { CatalogExplorerData, CatalogExplorerSettings } from './types';
+import { DEFAULT_SETTINGS } from './types';
+
+export const CatalogExplorerPlugin: ExplorerPlugin<
+  CatalogExplorerData,
+  CatalogExplorerSettings
+> = {
+  config: {
+    id: 'catalog',
+    type: 'hierarchy',
+    name: 'Catalog Explorer',
+    description: 'Browse ontologies → documents → concepts',
+    icon: FolderTree,
+    requiredDataShape: 'tree',
+  },
+  component: CatalogExplorer,
+  settingsPanel: SettingsPanel,
+  // Self-fetching: data comes from /catalog on demand, not from rawGraphData.
+  dataTransformer: () => ({}) as CatalogExplorerData,
+  defaultSettings: DEFAULT_SETTINGS,
+};
+
+import { registerExplorer } from '../registry';
+registerExplorer(CatalogExplorerPlugin);

--- a/web/src/explorers/CatalogExplorer/types.ts
+++ b/web/src/explorers/CatalogExplorer/types.ts
@@ -1,0 +1,24 @@
+/**
+ * CatalogExplorer Types (ADR-501)
+ *
+ * The Catalog Explorer is a tree/folder browse of the ontology -> document ->
+ * concept hierarchy. Unlike the graph explorers it is self-fetching: it pulls
+ * each level from /catalog on demand rather than transforming a preloaded
+ * rawGraphData blob (mirrors DocumentExplorer's workspace-driven model).
+ */
+
+export interface CatalogExplorerSettings {
+  /** Show child-count badges next to ontology/document rows. */
+  showCounts: boolean;
+  /** Sort order passed through to /catalog/children. */
+  sort: 'name' | 'child_count' | 'created';
+}
+
+export const DEFAULT_SETTINGS: CatalogExplorerSettings = {
+  showCounts: true,
+  sort: 'name',
+};
+
+/** The explorer self-fetches, so its data prop is unused — kept for the
+ *  ExplorerPlugin contract. */
+export type CatalogExplorerData = Record<string, never>;

--- a/web/src/store/catalogExplorerStore.ts
+++ b/web/src/store/catalogExplorerStore.ts
@@ -1,0 +1,80 @@
+/**
+ * Catalog Explorer Session Store (ADR-501)
+ *
+ * Holds the lazy-expanded tree state for the Catalog Explorer so a browse
+ * session survives navigating away and back. Mirrors documentExplorerStore:
+ * in-memory (survives mount/unmount within a session) but NOT persisted to
+ * localStorage — the catalog is a projection of a graph that autonomous
+ * annealing (ADR-200) reorganizes, so a stale expanded-tree snapshot would
+ * go wrong the moment the graph changes. The durable record is the graph
+ * itself; we re-fetch each level on demand.
+ *
+ * The tree is keyed by node id. `childrenByParent` caches the children we've
+ * already fetched for an expanded node; `expanded` tracks which nodes are
+ * open. The root listing (ontologies) is cached under the ROOT_KEY sentinel.
+ */
+
+import { create } from 'zustand';
+import type { CatalogNode } from '../types/catalog';
+
+/** Sentinel parent key for the root (ontology) level. */
+export const CATALOG_ROOT_KEY = '__root__';
+
+interface CatalogExplorerStore {
+  /** Children fetched per parent id (or CATALOG_ROOT_KEY for ontologies). */
+  childrenByParent: Record<string, CatalogNode[]>;
+  /** Total child count per parent, for "showing N of M" affordances. */
+  totalByParent: Record<string, number>;
+  /** Which node ids are currently expanded in the tree. */
+  expanded: Record<string, boolean>;
+  /** Parent ids whose children are currently being fetched. */
+  loading: Record<string, boolean>;
+  /** The currently-selected node (drives the detail panel). */
+  selected: CatalogNode | null;
+  /** Active name-fragment filter applied to listings. */
+  filter: string;
+  /** True if the last listing was served from a lagging index. */
+  stale: boolean;
+
+  setChildren: (parentKey: string, nodes: CatalogNode[], total: number) => void;
+  setExpanded: (nodeId: string, open: boolean) => void;
+  setLoading: (parentKey: string, loading: boolean) => void;
+  setSelected: (node: CatalogNode | null) => void;
+  setFilter: (filter: string) => void;
+  setStale: (stale: boolean) => void;
+  /** Drop all cached children/expansion — used when the filter changes or on
+   *  an explicit refresh, so the next render re-fetches against the graph. */
+  reset: () => void;
+}
+
+export const useCatalogExplorerStore = create<CatalogExplorerStore>((set) => ({
+  childrenByParent: {},
+  totalByParent: {},
+  expanded: {},
+  loading: {},
+  selected: null,
+  filter: '',
+  stale: false,
+
+  setChildren: (parentKey, nodes, total) =>
+    set((s) => ({
+      childrenByParent: { ...s.childrenByParent, [parentKey]: nodes },
+      totalByParent: { ...s.totalByParent, [parentKey]: total },
+    })),
+  setExpanded: (nodeId, open) =>
+    set((s) => ({ expanded: { ...s.expanded, [nodeId]: open } })),
+  setLoading: (parentKey, loading) =>
+    set((s) => ({ loading: { ...s.loading, [parentKey]: loading } })),
+  setSelected: (selected) => set({ selected }),
+  setFilter: (filter) => set({ filter }),
+  setStale: (stale) => set({ stale }),
+  reset: () =>
+    set({
+      childrenByParent: {},
+      totalByParent: {},
+      expanded: {},
+      loading: {},
+      selected: null,
+      stale: false,
+    }),
+}));

--- a/web/src/types/catalog.ts
+++ b/web/src/types/catalog.ts
@@ -1,0 +1,39 @@
+/**
+ * Catalog browse types (ADR-501)
+ *
+ * Mirror of the API's CatalogNode DTO. Shared by the web client and the
+ * Catalog Explorer. The hierarchy is fixed and self-describing via `kind`:
+ * ontology -> document -> concept.
+ */
+
+export type CatalogKind = 'ontology' | 'document' | 'concept';
+
+/** A single node in the catalog hierarchy. */
+export interface CatalogNode {
+  kind: CatalogKind;
+  id: string;
+  name: string;
+  parent_id?: string | null;
+  child_count?: number | null;
+  content_type?: string | null;
+  properties: Record<string, any>;
+}
+
+/** Paginated listing of a node's children (GET /catalog/children). */
+export interface CatalogChildrenResponse {
+  parent_id?: string | null;
+  parent_kind?: CatalogKind | null;
+  child_kind: CatalogKind;
+  nodes: CatalogNode[];
+  total: number;
+  limit: number;
+  offset: number;
+  query?: string | null;
+  stale: boolean;
+}
+
+/** Single node with full metadata (GET /catalog/node/{id}). */
+export interface CatalogNodeResponse extends CatalogNode {
+  graph_epoch?: number | null;
+  indexed_at?: string | null;
+}


### PR DESCRIPTION
## Summary

Implements **ADR-501: Catalog Browse Facade** — a deterministic, hierarchical "what's actually in here?" view of the knowledge graph (`ontology → document → concept`), surfaced across all four clients from one shared API contract.

Browse complements (does not replace) semantic search: it's structural, cheap, and read-only. Membership is projected from the graph's **canonical edges** (`:SCOPED_BY` / `:HAS_SOURCE` / `:APPEARS`), never the denormalized `Source.document` string — so it stays correct under autonomous annealing (ADR-200). Closes the gap behind #233.

## What's included (6 commits, one per layer)

- **ADR-501** (Proposed) — design, with adjacency to ADR-700 (Ontology Explorer consumes this), ADR-069 (FUSE), ADR-500 (DSL seam), ADR-201 (why not graph_accel).
- **Backend** — `CatalogNode` DTO; `catalog_facade.py` (epoch-invalidated materialized index `catalog_node`+`catalog_edge`, DAG-correct projection, pg_trgm fragment filter, advisory-locked rebuild); `/catalog/children` + `/catalog/node/{id}` with `catalog:read` RBAC; migration 073. **16 pytest passing.**
- **CLI + MCP** (shared TS client per ADR-013) — `kg catalog ls/stat` (filesystem-like, `--json`); `catalog` MCP tool (ls/stat actions). **46 CLI tests passing.**
- **Web** — Catalog Explorer: lazy-expanding tree + per-kind detail panel, registered via the ExplorerPlugin pattern; substrate for ADR-700.
- **FUSE** — driver's deterministic half (`/ontology/`, `documents/`) reads from the catalog via a pure, dependency-free adapter. **12 adapter tests passing.**
- **Detail-panel enrichment** — reusing existing endpoints only (no new paths): concept → description/grounding/clickable search-term chips; document → content preview + copy/download (+ image download); ontology → stats. Copy-ID on every node.

## Freshness model

Every index row carries the `graph_change_counter` it was built at (same signal as artifact freshness, ADR-035/203). The facade rebuilds on epoch advance; counts may briefly lag after an annealing cycle and self-heal. Membership is always rebuilt live from canonical edges — bounded staleness on *counts*, never wrong membership.

## Verification

- **Python** 16 ✓ · **CLI** 46 ✓ · **FUSE adapter** 12 ✓ · **web** `tsc` build clean.
- Exercised end-to-end against a **real ingested document** (1 ontology → 1 doc → 32 concepts): CLI drill-down + fragment filter + stat; web tree + per-kind detail panel (verified in-browser, no console errors); migration 073 applied to dev DB; `/catalog` over HTTP returns 401/200/400/404 correctly.

## NOT verified in this session (see follow-up issue)

- **Live FUSE mount** — `pyfuse3` isn't importable in the dev environment, and the FUSE driver publishes separately (installed 0.11.0). Adapter logic is unit-tested; the mounted `ls /mnt/knowledge/ontology/.../documents/` path needs verification next session after publish.

## Reuse notes

Leans on existing infrastructure throughout — shared `apiClient`/`KnowledgeGraphClient`, `IconRailPanel`, `SidebarItem`, lucide icons, Tailwind tokens, and existing endpoints (`getConceptDetails`, `getDocumentContent`, `listOntologies`, `getSourceImageUrl`). No duplicate functions or new backend paths for the enrichment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
