### PR TITLE
fix(ci): npm publish via OIDC Trusted Publishing (no token)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,13 +1,18 @@
 name: Publish CLI to npm
 
-# Publishes @aaronsb/kg-cli to the npm registry.
+# Publishes @aaronsb/kg-cli to the npm registry via OIDC Trusted Publishing.
 #
-# npm retired classic Automation tokens, and a granular token alone still trips
-# npm's 2FA-on-publish enforcement (EOTP) from a non-interactive shell. The
-# working pattern (proven in the jira-cloud repo) is to publish with
-# `id-token: write` + `--provenance`: npm attests the build via GitHub OIDC,
-# which satisfies the publish policy alongside the NPM_TOKEN secret. The token
-# must be a granular access token with read+write on the @aaronsb scope.
+# No npm token is used. npm retired classic Automation tokens, and a granular
+# token still trips npm's 2FA-on-publish enforcement (EOTP) in a non-interactive
+# shell. Instead we authenticate via GitHub OIDC against the Trusted Publisher
+# configured for @aaronsb/kg-cli on npmjs.com (Package Settings -> Trusted
+# Publisher -> GitHub Actions: aaronsb/knowledge-graph-system, workflow
+# publish-npm.yml). This bypasses 2FA, needs no secret, and never expires.
+#
+# Requirements: `id-token: write` permission, and npm >= 11.5.1 (the version
+# that added OIDC publish auth — newer than what Node 22 bundles, so we upgrade
+# npm explicitly). Do NOT set NODE_AUTH_TOKEN: a token would take precedence
+# over OIDC and reintroduce the EOTP failure.
 #
 # Trigger: on a pushed v* tag, or manually via workflow_dispatch.
 #
@@ -56,6 +61,10 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # Node 22 bundles npm 10.x; OIDC Trusted Publishing auth needs >= 11.5.1.
+      - name: Upgrade npm for OIDC publishing
+        run: npm install -g npm@latest
+
       # cli/package-lock.json is gitignored in this repo, so `npm ci` (which
       # requires a committed lockfile) is not usable here — use `npm install`.
       - name: Install dependencies
@@ -82,9 +91,8 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.already_published == 'false'
         working-directory: cli
+        # Auth is via OIDC (Trusted Publisher) — intentionally no NODE_AUTH_TOKEN.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,10 +2,12 @@ name: Publish CLI to npm
 
 # Publishes @aaronsb/kg-cli to the npm registry.
 #
-# npm retired the interactive OTP flow for automation, and a normal `npm login`
-# token cannot clear browser 2FA from a non-interactive shell (the EOTP failure
-# documented in publish.sh). So publishing runs here in CI using the NPM_TOKEN
-# repository secret (a 90-day automation token), which bypasses 2FA.
+# npm retired classic Automation tokens, and a granular token alone still trips
+# npm's 2FA-on-publish enforcement (EOTP) from a non-interactive shell. The
+# working pattern (proven in the jira-cloud repo) is to publish with
+# `id-token: write` + `--provenance`: npm attests the build via GitHub OIDC,
+# which satisfies the publish policy alongside the NPM_TOKEN secret. The token
+# must be a granular access token with read+write on the @aaronsb scope.
 #
 # Trigger: on a pushed v* tag, or manually via workflow_dispatch.
 #
@@ -35,6 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required so npm can mint an OIDC token and attach build provenance,
+      # which is what lets a granular token publish without an interactive OTP.
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -48,7 +53,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       # cli/package-lock.json is gitignored in this repo, so `npm ci` (which
@@ -77,7 +82,7 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.already_published == 'false'
         working-directory: cli
-        run: npm publish --access public
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Fixes the npm publish path for v0.14.0

The original `publish-npm.yml` (merged in #449) used `NPM_TOKEN`, which never worked:
- **E404** with a read/wrong token, then **EOTP** with a granular *Publish* token — npm retired classic Automation tokens, and granular tokens still trip npm's 2FA-on-publish in a non-interactive shell.

### Solution: OIDC Trusted Publishing (the jira-cloud pattern, done fully)
- `permissions: id-token: write` + `npm publish --provenance` — npm attests the build via GitHub OIDC.
- **Upgrade npm to ≥11.5.1** (Node 22 ships 10.x, which lacks OIDC *publish auth*; provenance signed but auth fell back to the token → EOTP).
- **Removed `NODE_AUTH_TOKEN`** entirely — a token takes precedence over OIDC. Auth is now purely the Trusted Publisher configured for `@aaronsb/kg-cli` on npmjs.com.

Requires the npmjs.com Trusted Publisher to point at repo `aaronsb/knowledge-graph-system`, workflow `publish-npm.yml` (now configured).

### Verified
✅ Ran on this branch — `@aaronsb/kg-cli@0.13.0` published to npm **with provenance attestations** (https://www.npmjs.com/package/@aaronsb/kg-cli).

### Bonus
No token means **nothing to rotate** — eliminates the 90-day `NPM_TOKEN` expiry liability the release reviewer flagged. The `NPM_TOKEN` secret is now unused and can be deleted.