### PR TITLE
fix: post-v0.14.0 verification follow-ups (CLI docs + FUSE ontology)

### DIFF
--- a/cli/scripts/simple-doc-gen.mjs
+++ b/cli/scripts/simple-doc-gen.mjs
@@ -109,7 +109,13 @@ async function main() {
   // (This previously kept a hardcoded module list that went stale and dropped
   // commands such as `catalog`.) `documentedCommands` is the array of Command
   // objects the CLI registers under `kg`, exported from commands.ts.
-  const { documentedCommands } = await import('../dist/cli/commands.js');
+  let documentedCommands;
+  try {
+    ({ documentedCommands } = await import('../dist/cli/commands.js'));
+  } catch (err) {
+    console.error('✗ Could not load ../dist/cli/commands.js — run `npm run build` first.');
+    throw err;
+  }
   const commands = documentedCommands.map(cmd => extractMetadata(cmd));
 
   console.log(`📋 Extracted ${commands.length} commands from the registry\n`);

--- a/cli/scripts/simple-doc-gen.mjs
+++ b/cli/scripts/simple-doc-gen.mjs
@@ -105,41 +105,14 @@ function generateMarkdown(cmd, depth = 2) {
 async function main() {
   console.log('🔍 Generating CLI documentation (simple mode)...\n');
 
-  // Import command definitions directly
-  const modules = [
-    { name: 'health', path: '../dist/cli/health.js' },
-    { name: 'config', path: '../dist/cli/config.js' },
-    { name: 'login', path: '../dist/cli/login.js' },
-    { name: 'logout', path: '../dist/cli/logout.js' },
-    { name: 'oauth', path: '../dist/cli/oauth.js' },
-    { name: 'ingest', path: '../dist/cli/ingest.js' },
-    { name: 'jobs', path: '../dist/cli/jobs.js' },
-    { name: 'search', path: '../dist/cli/search.js' },
-    { name: 'database', path: '../dist/cli/database.js' },
-    { name: 'ontology', path: '../dist/cli/ontology.js' },
-    { name: 'vocabulary', path: '../dist/cli/vocabulary.js' },
-    { name: 'admin', path: '../dist/cli/admin.js' },
-  ];
+  // Drive the docs from the CLI's own command registry so the two never drift.
+  // (This previously kept a hardcoded module list that went stale and dropped
+  // commands such as `catalog`.) `documentedCommands` is the array of Command
+  // objects the CLI registers under `kg`, exported from commands.ts.
+  const { documentedCommands } = await import('../dist/cli/commands.js');
+  const commands = documentedCommands.map(cmd => extractMetadata(cmd));
 
-  const commands = [];
-
-  for (const mod of modules) {
-    try {
-      const imported = await import(mod.path);
-      const cmdExport = imported[`${mod.name}Command`] || imported[`${mod.name}Command_obj`] || imported.default || imported[mod.name + 'Cmd'];
-
-      if (cmdExport) {
-        commands.push(extractMetadata(cmdExport));
-        console.log(`✓ Loaded ${mod.name}`);
-      } else {
-        console.log(`⚠ Could not find command export in ${mod.name}`);
-      }
-    } catch (err) {
-      console.log(`✗ Failed to import ${mod.name}:`, err.message);
-    }
-  }
-
-  console.log(`\n📋 Extracted ${commands.length} commands\n`);
+  console.log(`📋 Extracted ${commands.length} commands from the registry\n`);
 
   // Create output directory
   const outDir = path.join(__dirname, '../../docs/reference/cli');

--- a/cli/src/cli/commands.ts
+++ b/cli/src/cli/commands.ts
@@ -30,9 +30,9 @@ import { batchCommand } from './batch';
 import { storageCommand } from './storage';
 import { catalogCommand } from './catalog';
 import { programCommand } from './program';
-import { registerLoginCommand } from './login';
-import { registerLogoutCommand } from './logout';
-import { registerOAuthCommand } from './oauth';
+import { registerLoginCommand, loginCommand_obj } from './login';
+import { registerLogoutCommand, logoutCommand_obj } from './logout';
+import { registerOAuthCommand, oauthCommand } from './oauth';
 import { createVerbRouter } from './verb-router';
 import { createHelpCommand } from './help';
 import { createClientFromEnv } from '../api/client';
@@ -81,6 +81,54 @@ async function showBanner() {
   console.log(); // Empty line
 }
 
+/**
+ * Subcommands registered under `kg`, in display order.
+ *
+ * Module-level and exported so the doc generator
+ * (cli/scripts/simple-doc-gen.mjs) derives the command list from the same
+ * source the CLI registers — this is what prevents the two from drifting (the
+ * generator previously kept its own hardcoded list, which silently went stale
+ * and dropped commands like `catalog`).
+ */
+export const subcommands: Command[] = [
+  healthCommand,
+  configCommand,
+  mcpConfigCommand,
+  ingestCommand,
+  jobsCommand,
+  searchCommand,
+  documentCommand,  // ADR-084: Document search
+  databaseCommand,
+  ontologyCommand,
+  sourceCommand,
+  vocabularyCommand,
+  conceptCommand,   // ADR-089: Concept CRUD
+  edgeCommand,      // ADR-089: Edge CRUD
+  batchCommand,     // ADR-089: Batch operations
+  adminCommand,
+  polarityCommand,
+  projectionCommand,
+  artifactCommand,
+  groupCommand,
+  queryDefCommand,
+  programCommand,   // ADR-500: GraphProgram notarization
+  storageCommand,
+  catalogCommand,   // ADR-501: Catalog browse facade
+];
+
+/**
+ * Full set of top-level commands for documentation: the subcommands plus the
+ * auth commands. The auth commands are wired into the program via their own
+ * register*() functions (which attach actions/options), but they also expose
+ * Command objects so the doc generator can describe them.
+ */
+export const documentedCommands: Command[] = [
+  ...subcommands,
+  loginCommand_obj,
+  logoutCommand_obj,
+  oauthCommand,
+];
+
 export async function registerCommands(program: Command) {
   // Show banner ONLY if kg is run without any arguments
   if (process.argv.length === 2) {
@@ -100,33 +148,8 @@ export async function registerCommands(program: Command) {
   // Create client for command that need it
   const client = createClientFromEnv();
 
-  // Register subcommands with colored help
-  const subcommands = [
-    healthCommand,
-    configCommand,
-    mcpConfigCommand,
-    ingestCommand,
-    jobsCommand,
-    searchCommand,
-    documentCommand,  // ADR-084: Document search
-    databaseCommand,
-    ontologyCommand,
-    sourceCommand,
-    vocabularyCommand,
-    conceptCommand,   // ADR-089: Concept CRUD
-    edgeCommand,      // ADR-089: Edge CRUD
-    batchCommand,     // ADR-089: Batch operations
-    adminCommand,
-    polarityCommand,
-    projectionCommand,
-    artifactCommand,
-    groupCommand,
-    queryDefCommand,
-    programCommand,   // ADR-500: GraphProgram notarization
-    storageCommand,
-    catalogCommand,   // ADR-501: Catalog browse facade
-  ];
-
+  // Register subcommands with colored help (see the exported `subcommands`
+  // registry above — single source of truth shared with the doc generator).
   subcommands.forEach(cmd => {
     configureColoredHelp(cmd);
     program.addCommand(cmd);

--- a/cli/src/cli/commands.ts
+++ b/cli/src/cli/commands.ts
@@ -121,6 +121,9 @@ export const subcommands: Command[] = [
  * auth commands. The auth commands are wired into the program via their own
  * register*() functions (which attach actions/options), but they also expose
  * Command objects so the doc generator can describe them.
+ *
+ * Order mirrors runtime registration (subcommands first, then auth) so the
+ * generated docs match `kg --help`; keep them aligned if registration moves.
  */
 export const documentedCommands: Command[] = [
   ...subcommands,

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -3,7 +3,7 @@
 > **Auto-Generated Documentation**
 > 
 > Generated from CLI source code.
-> Last updated: 2026-05-26
+> Last updated: 2026-05-31
 
 ---
 
@@ -11,29 +11,38 @@
 
 - [`health`](#health) - Check API server health and retrieve service information. Verifies the server is running and responsive. Use this as a first diagnostic step before running other commands.
 - [`config` (cfg)](#config) - Manage kg CLI configuration settings. Controls API connection, authentication tokens, MCP tool preferences, and job auto-approval. Configuration stored in JSON file (typically ~/.kg/config.json).
-- [`mcp-config`](commands/) - Manage MCP server configuration (allowlists, server settings).
-- [`login`](#login) - Authenticate with username and password - creates personal OAuth client credentials (required for admin commands)
-- [`logout`](#logout) - End authentication session - revokes OAuth client and clears credentials (use --forget to also clear saved username)
-- [`oauth`](#oauth) - Manage OAuth clients (list, create for MCP, revoke)
+- [`mcp-config`](#mcp-config) - Manage path allowlist for secure file/directory ingestion from MCP server.
+
+Security Model (ADR-062):
+- Fail-secure validation (blocked patterns checked first)
+- Explicit allowlist (no access without configuration)
+- CLI-only management (agent can read, not write)
+- Path resolution prevents traversal attacks
+
+Configuration stored in: ~/.config/kg/mcp-allowed-paths.json
 - [`ingest`](#ingest) - Ingest documents into the knowledge graph. Processes documents and extracts concepts, relationships, and evidence. Supports three modes: single file (one document), directory (batch ingest multiple files), and raw text (ingest text directly without a file). All operations create jobs (ADR-014) that can be monitored via "kg job" commands. Workflow: submit → chunk (semantic boundaries ~1000 words with overlap) → create job → optional approval → process (LLM extract, embed concepts, match existing, insert graph) → complete.
 - [`job` (jobs)](#job) - Manage and monitor ingestion jobs through their lifecycle (pending → approval → processing → completed/failed)
 - [`search`](#search) - Search and explore the knowledge graph using vector similarity, graph traversal, and path finding
-- [`document`](commands/) - Document search and content retrieval (ADR-084).
-- [`database` (db)](#database) - Database operations and information. Provides read-only queries for PostgreSQL + Apache AGE database health, statistics, and connection details.
+- [`document` (doc)](#document) - Search for documents using semantic similarity and retrieve their content from Garage storage. Documents are aggregated from source chunks, ranked by their best matching chunk similarity (ADR-084).
+- [`database` (db)](#database) - Database operations and information for PostgreSQL + Apache AGE: health, statistics, and connection details. Note: `db query` executes arbitrary openCypher (including mutations) and requires database:execute (platform_admin); the stats/info/health reads require database:read (admin).
 - [`ontology` (onto)](#ontology) - Manage ontologies (knowledge domains). Ontologies are named collections that organize concepts into knowledge domains. Each ontology groups related documents and concepts together, making it easier to organize and query knowledge by topic or project.
-- [`source`](commands/) - Retrieve source content (text or image).
-- [`vocabulary` (vocab)](commands/vocabulary.md) - Edge vocabulary management and consolidation (ADR-032/047/053).
-- [`concept`](commands/) - Deterministic concept CRUD (ADR-089).
-- [`edge`](commands/) - Deterministic edge CRUD (ADR-089).
-- [`batch`](commands/) - Batch graph operations (ADR-089).
-- [`admin`](commands/admin.md) - System administration: status, backup/restore, scheduler, workers, users, RBAC, embedding/extraction/keys.
-- [`polarity`](commands/) - Polarity-axis analysis (ADR-070).
-- [`projection`](commands/) - Embedding landscape projection (ADR-078).
-- [`artifact`](commands/) - Manage saved artifacts (ADR-083).
-- [`group`](commands/) - Groups and resource grants (ADR-082).
-- [`query-def`](commands/) - Stored query definitions (ADR-083).
-- [`program`](commands/) - GraphProgram notarization (ADR-500).
-- [`storage`](commands/) - Garage S3 storage diagnostics.
+- [`source`](#source) - Retrieve and manage source documents stored in Garage. Source documents are the original files ingested into the knowledge graph, preserved for model evolution and re-extraction (ADR-081).
+- [`vocabulary` (vocab)](#vocabulary) - Edge vocabulary management and consolidation. Manages relationship types between concepts including builtin types (30 predefined), custom types (LLM-extracted from documents), categories (semantic groupings), consolidation (AI-assisted merging via AITL - ADR-032), and auto-categorization (probabilistic via embeddings - ADR-047). Features zone-based management (GREEN/WATCH/DANGER/EMERGENCY) and LLM-determined relationship direction (ADR-049).
+- [`concept` (c)](#concept) - Create, list, show, and delete concepts. Concepts are the fundamental nodes in the knowledge graph. When creating concepts, the description is embedded and similarity-matched against existing concepts (same as automatic ingestion). Use matching modes to control duplicate handling.
+- [`edge` (e)](#edge) - Create, list, and delete edges between concepts. Edges represent relationships like IMPLIES, SUPPORTS, CONTRADICTS, etc. Use --from/--to with concept IDs or --from-label/--to-label for semantic lookup by label.
+- [`batch` (b)](#batch) - Batch operations for creating concepts and edges in a single transaction. Import JSON files that define concepts and their relationships. All operations are atomic - if any item fails, the entire batch is rolled back.
+- [`admin`](#admin) - System administration and management - health monitoring, backup/restore, database operations, user/RBAC management, AI model configuration (requires authentication for destructive operations)
+- [`polarity`](#polarity) - Analyze bidirectional semantic dimensions between concept poles
+- [`projection` (proj)](#projection) - Manage t-SNE/UMAP projections of concept embeddings. Projections reduce high-dimensional embeddings to 3D coordinates for the Embedding Landscape Explorer visualization. Use this to compute, view, and manage projection datasets.
+- [`artifact` (art)](#artifact) - Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Artifacts support multi-tier storage: small payloads inline in PostgreSQL, large payloads in Garage S3. Each artifact tracks its graph_epoch for freshness detection.
+- [`group` (grp)](#group) - Manage groups for collaborative access control. Groups allow sharing resources with multiple users. System groups (public, admins) are managed by the platform.
+- [`query-def` (qd)](#query-def) - Manage saved query definitions - recipes that can be re-executed to generate artifacts. Supports block diagrams, cypher queries, searches, polarity analyses, and connection paths.
+- [`program` (prog)](#program) - Validate, store, and retrieve GraphProgram ASTs (ADR-500). Programs are notarized server-side to ensure safety before execution.
+- [`storage`](#storage) - Read-only diagnostics for S3-compatible object storage. List objects, inspect metadata, verify integrity after cascade deletes, and view retention policies. Useful for integration testing and debugging storage behavior.
+- [`catalog`](#catalog) - Deterministic, filesystem-like browse of what is stored in the knowledge graph. Walk from ontologies down to documents and concepts, filter by name fragment, and inspect single nodes. Distinct from "kg search" (semantic) and "kg storage" (raw S3 admin). Add --json to any subcommand for machine-readable output.
+- [`login`](#login) - Authenticate with username and password - creates personal OAuth client credentials (required for admin commands)
+- [`logout`](#logout) - End authentication session - revokes OAuth client and clears credentials (use --forget to also clear saved username)
+- [`oauth`](#oauth) - Manage OAuth clients (list, create for MCP, revoke)
 
 ---
 
@@ -256,118 +265,167 @@ kg dto [options]
 ```
 
 
-## login
+## mcp-config
 
-Authenticate with username and password - creates personal OAuth client credentials (required for admin commands)
+Manage path allowlist for secure file/directory ingestion from MCP server.
+
+Security Model (ADR-062):
+- Fail-secure validation (blocked patterns checked first)
+- Explicit allowlist (no access without configuration)
+- CLI-only management (agent can read, not write)
+- Path resolution prevents traversal attacks
+
+Configuration stored in: ~/.config/kg/mcp-allowed-paths.json
 
 **Usage:**
 ```bash
-kg login [options]
+kg mcp-config [options]
+```
+
+**Subcommands:**
+
+- `init-allowlist` - Initialize allowlist with safe defaults
+- `allow-dir` - Add allowed directory
+- `remove-dir` - Remove allowed directory
+- `allow-pattern` - Add allowed file pattern
+- `remove-pattern` - Remove allowed file pattern
+- `block-pattern` - Add blocked file pattern (security)
+- `unblock-pattern` - Remove blocked file pattern
+- `show-allowlist` - Show current allowlist configuration
+- `test-path` - Test if a path would be allowed
+- `oauth` - Create OAuth client for MCP server
+
+---
+
+### init-allowlist
+
+Initialize allowlist with safe defaults
+
+**Usage:**
+```bash
+kg init-allowlist [options]
+```
+
+### allow-dir
+
+Add allowed directory
+
+**Usage:**
+```bash
+kg allow-dir <directory>
+```
+
+**Arguments:**
+
+- `<directory>` - Directory path (supports ~ and glob patterns like ~/Projects/*/docs)
+
+### remove-dir
+
+Remove allowed directory
+
+**Usage:**
+```bash
+kg remove-dir <directory>
+```
+
+**Arguments:**
+
+- `<directory>` - Directory path to remove
+
+### allow-pattern
+
+Add allowed file pattern
+
+**Usage:**
+```bash
+kg allow-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Glob pattern (e.g., "**/*.md", "**/*.png")
+
+### remove-pattern
+
+Remove allowed file pattern
+
+**Usage:**
+```bash
+kg remove-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Pattern to remove
+
+### block-pattern
+
+Add blocked file pattern (security)
+
+**Usage:**
+```bash
+kg block-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Glob pattern to block (e.g., "**/.env*", "**/*.key")
+
+### unblock-pattern
+
+Remove blocked file pattern
+
+**Usage:**
+```bash
+kg unblock-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Pattern to unblock
+
+### show-allowlist
+
+Show current allowlist configuration
+
+**Usage:**
+```bash
+kg show-allowlist [options]
 ```
 
 **Options:**
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-u, --username <username>` | Username (will prompt if not provided - can be saved for future logins) | - |
-| `-p, --password <password>` | Password (will prompt if not provided - for scripted/non-interactive use) | - |
-| `-f, --force` | Replace existing credentials (use after platform redeploy) | - |
-| `--remember-username` | Save username for future logins (default in non-interactive mode) | - |
-| `--no-remember-username` | Do not save username | - |
+| `--json` | Output as JSON | - |
 
+### test-path
 
-## logout
-
-End authentication session - revokes OAuth client and clears credentials (use --forget to also clear saved username)
+Test if a path would be allowed
 
 **Usage:**
 ```bash
-kg logout [options]
+kg test-path <path>
 ```
 
-**Options:**
+**Arguments:**
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--forget` | Also forget saved username (requires username prompt on next login) | - |
+- `<path>` - File or directory path to test
 
+### oauth
 
-## oauth
-
-Manage OAuth clients (list, create for MCP, revoke)
+Create OAuth client for MCP server
 
 **Usage:**
 ```bash
 kg oauth [options]
 ```
 
-**Subcommands:**
-
-- `clients` (`list`) - List your personal OAuth clients
-- `create` - Create OAuth client for external tools (MCP, FUSE, scripts)
-- `create-mcp` - Create OAuth client for MCP server (alias for: create --for mcp)
-- `revoke` - Revoke an OAuth client
-
----
-
-### clients (list)
-
-List your personal OAuth clients
-
-**Usage:**
-```bash
-kg clients [options]
-```
-
-### create
-
-Create OAuth client for external tools (MCP, FUSE, scripts)
-
-**Usage:**
-```bash
-kg create [options]
-```
-
 **Options:**
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--name <name>` | Custom client name | - |
-| `--for <target>` | Target: mcp, fuse, or generic (shows appropriate setup instructions) | - |
-
-### create-mcp
-
-Create OAuth client for MCP server (alias for: create --for mcp)
-
-**Usage:**
-```bash
-kg create-mcp [options]
-```
-
-**Options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--name <name>` | Custom client name | - |
-
-### revoke
-
-Revoke an OAuth client
-
-**Usage:**
-```bash
-kg revoke <client-id>
-```
-
-**Arguments:**
-
-- `<client-id>` - Required
-
-**Options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--force` | Force revocation even if it's your current CLI client | - |
 
 
 ## ingest
@@ -889,6 +947,7 @@ kg related <concept-id>
 | `-t, --types <types...>` | Filter by relationship types (IMPLIES, ENABLES, SUPPORTS, etc. - see kg vocab list) | - |
 | `--include-epistemic <statuses...>` | Only include relationships with these epistemic statuses (ADR-065): AFFIRMATIVE, CONTESTED, CONTRADICTORY, HISTORICAL | - |
 | `--exclude-epistemic <statuses...>` | Exclude relationships with these epistemic statuses (ADR-065) | - |
+| `--no-grounding` | Disable grounding strength calculation (ADR-044 probabilistic truth convergence) for faster results | - |
 | `--json` | Output raw JSON instead of formatted text for scripting | - |
 
 ### connect
@@ -944,9 +1003,109 @@ kg sources <query>
 | `--json` | Output raw JSON instead of formatted text for scripting | - |
 
 
+## document (doc)
+
+Search for documents using semantic similarity and retrieve their content from Garage storage. Documents are aggregated from source chunks, ranked by their best matching chunk similarity (ADR-084).
+
+**Usage:**
+```bash
+kg document [options]
+```
+
+**Subcommands:**
+
+- `search` - Find documents that match a query using semantic search. Results show documents ranked by their best matching chunk similarity. Use --details to show full concept information for the top result.
+- `list` - List all documents (DocumentMeta nodes) in the knowledge graph. Filter by ontology to see documents from specific collections.
+- `show` - Retrieve and display the full content of a document from Garage storage. Shows the original document text plus source chunks created during ingestion.
+- `concepts` - Show all concepts extracted from a specific document. Displays concept names, IDs, and the source chunks where they appear. Use --details for full concept information including evidence and relationships.
+
+---
+
+### search
+
+Find documents that match a query using semantic search. Results show documents ranked by their best matching chunk similarity. Use --details to show full concept information for the top result.
+
+**Usage:**
+```bash
+kg search <query>
+```
+
+**Arguments:**
+
+- `<query>` - Search query (natural language)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --ontology <name>` | Filter by ontology name | - |
+| `-s, --min-similarity <n>` | Minimum similarity threshold (0-1) | `"0.5"` |
+| `-l, --limit <n>` | Maximum results | `"20"` |
+| `-d, --details` | Show full concept details for top result | - |
+| `-j, --json` | Output raw JSON | - |
+
+### list
+
+List all documents (DocumentMeta nodes) in the knowledge graph. Filter by ontology to see documents from specific collections.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --ontology <name>` | Filter by ontology name (partial match) | - |
+| `-l, --limit <n>` | Maximum documents to return | `"50"` |
+| `--offset <n>` | Skip N documents (pagination) | `"0"` |
+| `-j, --json` | Output raw JSON | - |
+
+### show
+
+Retrieve and display the full content of a document from Garage storage. Shows the original document text plus source chunks created during ingestion.
+
+**Usage:**
+```bash
+kg show <document-id>
+```
+
+**Arguments:**
+
+- `<document-id>` - Document ID (e.g., sha256:abc123...)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-c, --chunks` | Show source chunks instead of full document | - |
+| `-j, --json` | Output raw JSON | - |
+
+### concepts
+
+Show all concepts extracted from a specific document. Displays concept names, IDs, and the source chunks where they appear. Use --details for full concept information including evidence and relationships.
+
+**Usage:**
+```bash
+kg concepts <document-id>
+```
+
+**Arguments:**
+
+- `<document-id>` - Document ID (e.g., sha256:abc123...)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-d, --details` | Show full concept details (evidence, relationships, grounding) | - |
+| `-j, --json` | Output raw JSON | - |
+
+
 ## database (db)
 
-Database operations and information. Provides read-only queries for PostgreSQL + Apache AGE database health, statistics, and connection details.
+Database operations and information for PostgreSQL + Apache AGE: health, statistics, and connection details. Note: `db query` executes arbitrary openCypher (including mutations) and requires database:execute (platform_admin); the stats/info/health reads require database:read (admin).
 
 **Usage:**
 ```bash
@@ -1346,4 +1505,2326 @@ kg anneal [options]
 | `--demotion-threshold <threshold>` | Protection score below which to consider demotion | `"0.15"` |
 | `--promotion-min-degree <degree>` | Minimum concept degree for promotion candidacy | `"10"` |
 | `--max-proposals <count>` | Maximum proposals per cycle | `"5"` |
+
+
+## source
+
+Retrieve and manage source documents stored in Garage. Source documents are the original files ingested into the knowledge graph, preserved for model evolution and re-extraction (ADR-081).
+
+**Usage:**
+```bash
+kg source [options]
+```
+
+**Subcommands:**
+
+- `list` - List source nodes (chunks) in the graph. Sources are chunks of ingested documents. Filter by ontology name to see sources from specific documents.
+- `get` - Download the original source document from Garage storage. This returns the complete document as it was before chunking, not individual chunks. Useful for verification, re-processing, or archival. Output goes to stdout by default (for piping) or to a file with -o.
+- `info` - Display metadata for a source node including document name, paragraph number, content type, garage_key, and embedding status.
+
+---
+
+### list
+
+List source nodes (chunks) in the graph. Sources are chunks of ingested documents. Filter by ontology name to see sources from specific documents.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --ontology <name>` | Filter by ontology/document name (partial match) | - |
+| `-l, --limit <n>` | Maximum sources to return | `"50"` |
+| `--offset <n>` | Skip N sources (pagination) | `"0"` |
+| `-j, --json` | Output raw JSON | - |
+
+### get
+
+Download the original source document from Garage storage. This returns the complete document as it was before chunking, not individual chunks. Useful for verification, re-processing, or archival. Output goes to stdout by default (for piping) or to a file with -o.
+
+**Usage:**
+```bash
+kg get <source-id>
+```
+
+**Arguments:**
+
+- `<source-id>` - Source ID (e.g., sha256:abc123_chunk1)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --output <file>` | Save to file instead of stdout | - |
+| `-m, --metadata` | Show source metadata instead of content | - |
+
+### info
+
+Display metadata for a source node including document name, paragraph number, content type, garage_key, and embedding status.
+
+**Usage:**
+```bash
+kg info <source-id>
+```
+
+**Arguments:**
+
+- `<source-id>` - Source ID
+
+
+## vocabulary (vocab)
+
+Edge vocabulary management and consolidation. Manages relationship types between concepts including builtin types (30 predefined), custom types (LLM-extracted from documents), categories (semantic groupings), consolidation (AI-assisted merging via AITL - ADR-032), and auto-categorization (probabilistic via embeddings - ADR-047). Features zone-based management (GREEN/WATCH/DANGER/EMERGENCY) and LLM-determined relationship direction (ADR-049).
+
+**Usage:**
+```bash
+kg vocabulary [options]
+```
+
+**Subcommands:**
+
+- `status` - Show current vocabulary status including size, zone (GREEN/WATCH/DANGER/EMERGENCY per ADR-032), aggressiveness, and thresholds.
+- `list` - List all edge types with statistics, categories, and confidence scores (ADR-047).
+- `consolidate` - AI-assisted vocabulary consolidation workflow (AITL - AI-in-the-loop, ADR-032). Analyzes vocabulary via embeddings, identifies similar pairs above threshold, presents merge recommendations.
+- `merge` - Manually merge one edge type into another. Redirects all edges from deprecated type to target type.
+- `generate-embeddings` - Generate vector embeddings for vocabulary types (required for consolidation and categorization).
+- `category-scores` - Show category similarity scores for a specific relationship type (ADR-047).
+- `refresh-categories` - Refresh category assignments for vocabulary types using latest embeddings (ADR-047, ADR-053).
+- `search` - Search for vocabulary terms by natural language query. Useful when creating edges to find the best relationship type.
+- `similar` - Find similar edge types via embedding similarity (ADR-053). Shows types with highest cosine similarity - useful for synonym detection and consolidation.
+- `opposite` - Find opposite (least similar) edge types via embedding similarity (ADR-053). Shows types with lowest cosine similarity.
+- `analyze` - Detailed analysis of vocabulary type for quality assurance (ADR-053). Shows category fit and potential miscategorization.
+- `config` - Show or update vocabulary configuration. No args: display config. With args: update properties (e.g., "kg vocab config vocab_max 275").
+- `profiles` - Manage aggressiveness profiles (Bezier curves for consolidation behavior)
+- `epistemic-status` - Epistemic status classification for vocabulary types (ADR-065). Shows knowledge validation state based on grounding patterns.
+- `sync` - Sync missing edge types from graph to vocabulary (ADR-077). Discovers edge types used in the graph but not registered in vocabulary table/VocabType nodes. Use --dry-run first to preview, then --execute to sync.
+
+---
+
+### status
+
+Show current vocabulary status including size, zone (GREEN/WATCH/DANGER/EMERGENCY per ADR-032), aggressiveness, and thresholds.
+
+**Usage:**
+```bash
+kg status [options]
+```
+
+### list
+
+List all edge types with statistics, categories, and confidence scores (ADR-047).
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--inactive` | Include inactive/deprecated types | - |
+| `--no-builtin` | Exclude builtin types | - |
+| `--sort <fields>` | Sort by comma-separated fields: edges, type, conf, grounding, category, status (default: edges) | - |
+| `--json` | Output as JSON for programmatic use | - |
+
+### consolidate
+
+AI-assisted vocabulary consolidation workflow (AITL - AI-in-the-loop, ADR-032). Analyzes vocabulary via embeddings, identifies similar pairs above threshold, presents merge recommendations.
+
+**Usage:**
+```bash
+kg consolidate [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --target <size>` | Target vocabulary size | `"90"` |
+| `--threshold <value>` | Auto-execute threshold (0.0-1.0) | `"0.90"` |
+| `--dry-run` | Preview candidates without executing (no merges, no pruning) | - |
+| `--no-prune-unused` | Skip pruning vocabulary types with 0 uses | - |
+
+### merge
+
+Manually merge one edge type into another. Redirects all edges from deprecated type to target type.
+
+**Usage:**
+```bash
+kg merge <deprecated-type> <target-type>
+```
+
+**Arguments:**
+
+- `<deprecated-type>` - Edge type to deprecate (becomes inactive)
+- `<target-type>` - Target edge type to merge into (receives all edges)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-r, --reason <text>` | Reason for merge (audit trail) | - |
+| `-u, --user <email>` | User performing the merge | `"cli-user"` |
+
+### generate-embeddings
+
+Generate vector embeddings for vocabulary types (required for consolidation and categorization).
+
+**Usage:**
+```bash
+kg generate-embeddings [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force` | Regenerate ALL embeddings regardless of existing state | - |
+| `--all` | Process all active types (not just missing) | - |
+
+### category-scores
+
+Show category similarity scores for a specific relationship type (ADR-047).
+
+**Usage:**
+```bash
+kg category-scores <type>
+```
+
+**Arguments:**
+
+- `<type>` - Relationship type to analyze (e.g., CAUSES, ENABLES)
+
+### refresh-categories
+
+Refresh category assignments for vocabulary types using latest embeddings (ADR-047, ADR-053).
+
+**Usage:**
+```bash
+kg refresh-categories [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--computed-only` | Refresh only types with category_source=computed | - |
+
+### search
+
+Search for vocabulary terms by natural language query. Useful when creating edges to find the best relationship type.
+
+**Usage:**
+```bash
+kg search <query>
+```
+
+**Arguments:**
+
+- `<query>` - Natural language search term (e.g., "prevents", "leads to", "causes")
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--limit <n>` | Number of results to return (1-20) | `"5"` |
+| `--json` | Output as JSON for scripting | - |
+
+### similar
+
+Find similar edge types via embedding similarity (ADR-053). Shows types with highest cosine similarity - useful for synonym detection and consolidation.
+
+**Usage:**
+```bash
+kg similar <type>
+```
+
+**Arguments:**
+
+- `<type>` - Relationship type to analyze (e.g., IMPLIES)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--limit <n>` | Number of results to return (1-100) | `"10"` |
+
+### opposite
+
+Find opposite (least similar) edge types via embedding similarity (ADR-053). Shows types with lowest cosine similarity.
+
+**Usage:**
+```bash
+kg opposite <type>
+```
+
+**Arguments:**
+
+- `<type>` - Relationship type to analyze (e.g., IMPLIES)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--limit <n>` | Number of results to return (1-100) | `"5"` |
+
+### analyze
+
+Detailed analysis of vocabulary type for quality assurance (ADR-053). Shows category fit and potential miscategorization.
+
+**Usage:**
+```bash
+kg analyze <type>
+```
+
+**Arguments:**
+
+- `<type>` - Relationship type to analyze (e.g., STORES)
+
+### config
+
+Show or update vocabulary configuration. No args: display config. With args: update properties (e.g., "kg vocab config vocab_max 275").
+
+**Usage:**
+```bash
+kg config [properties]
+```
+
+**Arguments:**
+
+- `<properties>` - Property assignments: key value [key value...]
+
+### profiles
+
+Manage aggressiveness profiles (Bezier curves for consolidation behavior)
+
+**Usage:**
+```bash
+kg profiles [options]
+```
+
+**Subcommands:**
+
+- `list` - List all aggressiveness profiles including builtin (8 predefined) and custom profiles. Shows profile name, control points, description, and builtin flag.
+- `show` - Show details for a specific aggressiveness profile including Bezier parameters and timestamps.
+- `create` - Create a custom aggressiveness profile with Bezier curve parameters.
+- `delete` - Delete a custom aggressiveness profile. Cannot delete builtin profiles.
+
+---
+
+#### list
+
+List all aggressiveness profiles including builtin (8 predefined) and custom profiles. Shows profile name, control points, description, and builtin flag.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+#### show
+
+Show details for a specific aggressiveness profile including Bezier parameters and timestamps.
+
+**Usage:**
+```bash
+kg show <name>
+```
+
+**Arguments:**
+
+- `<name>` - Profile name
+
+#### create
+
+Create a custom aggressiveness profile with Bezier curve parameters.
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name <name>` | Profile name (3-50 chars) | - |
+| `--x1 <n>` | First control point X (0.0-1.0) | - |
+| `--y1 <n>` | First control point Y (-2.0 to 2.0) | - |
+| `--x2 <n>` | Second control point X (0.0-1.0) | - |
+| `--y2 <n>` | Second control point Y (-2.0 to 2.0) | - |
+| `--description <desc>` | Profile description (min 10 chars) | - |
+
+#### delete
+
+Delete a custom aggressiveness profile. Cannot delete builtin profiles.
+
+**Usage:**
+```bash
+kg delete <name>
+```
+
+**Arguments:**
+
+- `<name>` - Profile name to delete
+
+### epistemic-status
+
+Epistemic status classification for vocabulary types (ADR-065). Shows knowledge validation state based on grounding patterns.
+
+**Usage:**
+```bash
+kg epistemic-status [options]
+```
+
+**Subcommands:**
+
+- `list` - List all vocabulary types with their epistemic status classifications and statistics.
+- `show` - Show detailed epistemic status for a specific vocabulary type.
+- `measure` - Run epistemic status measurement for all vocabulary types (ADR-065).
+
+---
+
+#### list
+
+List all vocabulary types with their epistemic status classifications and statistics.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--status <status>` | Filter by status: WELL_GROUNDED, MIXED_GROUNDING, WEAK_GROUNDING, POORLY_GROUNDED, CONTRADICTED, HISTORICAL, INSUFFICIENT_DATA | - |
+
+#### show
+
+Show detailed epistemic status for a specific vocabulary type.
+
+**Usage:**
+```bash
+kg show <type>
+```
+
+**Arguments:**
+
+- `<type>` - Relationship type to show (e.g., IMPLIES, SUPPORTS)
+
+#### measure
+
+Run epistemic status measurement for all vocabulary types (ADR-065).
+
+**Usage:**
+```bash
+kg measure [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--sample-size <n>` | Edges to sample per type (default: 100) | `100` |
+| `--no-store` | Run measurement without storing to database | - |
+| `--verbose` | Include detailed statistics in output | - |
+
+### sync
+
+Sync missing edge types from graph to vocabulary (ADR-077). Discovers edge types used in the graph but not registered in vocabulary table/VocabType nodes. Use --dry-run first to preview, then --execute to sync.
+
+**Usage:**
+```bash
+kg sync [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--dry-run` | Preview missing types without syncing (default) | `true` |
+| `--execute` | Actually sync missing types to vocabulary | `false` |
+| `--json` | Output as JSON for scripting | - |
+
+
+## concept (c)
+
+Create, list, show, and delete concepts. Concepts are the fundamental nodes in the knowledge graph. When creating concepts, the description is embedded and similarity-matched against existing concepts (same as automatic ingestion). Use matching modes to control duplicate handling.
+
+**Usage:**
+```bash
+kg concept [options]
+```
+
+**Subcommands:**
+
+- `list` - List concepts with optional filters. Shows concept ID, label, ontology, and creation method.
+- `show` - Show detailed information about a concept by ID.
+- `create` - Create a new concept. Description is embedded and similarity-matched against existing concepts.
+- `delete` - Delete a concept by ID. Requires --force flag or interactive confirmation.
+
+---
+
+### list
+
+List concepts with optional filters. Shows concept ID, label, ontology, and creation method.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ontology <name>` | Filter by ontology | - |
+| `--label <text>` | Filter by label (contains) | - |
+| `--creation-method <method>` | Filter by creation method (cli, mcp, api, llm_extraction, import) | - |
+| `--limit <n>` | Maximum results (default: 50) | `"50"` |
+| `--offset <n>` | Pagination offset | `"0"` |
+| `--json` | Output as JSON | - |
+
+### show
+
+Show detailed information about a concept by ID.
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Concept ID (e.g., c_abc123)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output as JSON | - |
+
+### create
+
+Create a new concept. Description is embedded and similarity-matched against existing concepts.
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--label <name>` | Concept label (required) | - |
+| `--ontology <name>` | Target ontology (required) | - |
+| `--description <text>` | Concept description (used for embedding match) | - |
+| `--search-terms <terms>` | Comma-separated search terms | - |
+| `--matching-mode <mode>` | auto|force_create|match_only (default: auto) | `"auto"` |
+| `--json` | Output as JSON | - |
+| `-i, --interactive` | Guided wizard mode | - |
+| `-y, --yes` | Skip confirmation prompts | - |
+
+### delete
+
+Delete a concept by ID. Requires --force flag or interactive confirmation.
+
+**Usage:**
+```bash
+kg delete <id>
+```
+
+**Arguments:**
+
+- `<id>` - Concept ID to delete
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--cascade` | Also delete orphaned synthetic sources | - |
+| `-f, --force` | Skip confirmation | - |
+| `--json` | Output as JSON | - |
+
+
+## edge (e)
+
+Create, list, and delete edges between concepts. Edges represent relationships like IMPLIES, SUPPORTS, CONTRADICTS, etc. Use --from/--to with concept IDs or --from-label/--to-label for semantic lookup by label.
+
+**Usage:**
+```bash
+kg edge [options]
+```
+
+**Subcommands:**
+
+- `list` - List edges with optional filters.
+- `create` - Create an edge between two concepts.
+- `delete` - Delete an edge by its composite key (from, type, to).
+
+---
+
+### list
+
+List edges with optional filters.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--from <id>` | Filter by source concept ID | - |
+| `--to <id>` | Filter by target concept ID | - |
+| `--type <type>` | Filter by relationship type | - |
+| `--category <cat>` | Filter by category | - |
+| `--limit <n>` | Maximum results (default: 50) | `"50"` |
+| `--offset <n>` | Pagination offset | `"0"` |
+| `--json` | Output as JSON | - |
+
+### create
+
+Create an edge between two concepts.
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--from <id>` | Source concept ID | - |
+| `--to <id>` | Target concept ID | - |
+| `--from-label <text>` | Source concept (search by label) | - |
+| `--to-label <text>` | Target concept (search by label) | - |
+| `--type <type>` | Relationship type (e.g., IMPLIES, SUPPORTS) | - |
+| `--category <cat>` | Relationship category (auto-inferred if omitted) | - |
+| `--confidence <n>` | Confidence score 0-1 (default: 1.0) | `"1.0"` |
+| `--create-vocab` | Create vocabulary term if it does not exist | - |
+| `--json` | Output as JSON | - |
+| `-i, --interactive` | Guided wizard mode | - |
+| `-y, --yes` | Skip confirmation prompts | - |
+
+### delete
+
+Delete an edge by its composite key (from, type, to).
+
+**Usage:**
+```bash
+kg delete <from> <type> <to>
+```
+
+**Arguments:**
+
+- `<from>` - Source concept ID
+- `<type>` - Relationship type
+- `<to>` - Target concept ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation | - |
+| `--json` | Output as JSON | - |
+
+
+## batch (b)
+
+Batch operations for creating concepts and edges in a single transaction. Import JSON files that define concepts and their relationships. All operations are atomic - if any item fails, the entire batch is rolled back.
+
+**Usage:**
+```bash
+kg batch [options]
+```
+
+**Subcommands:**
+
+- `create` - Import a batch JSON file to create concepts and edges atomically. The JSON must contain ontology, concepts array, and optional edges array. All operations succeed or all are rolled back.
+- `template` - Output a template batch JSON file to stdout. Redirect to a file to customize.
+
+---
+
+### create
+
+Import a batch JSON file to create concepts and edges atomically. The JSON must contain ontology, concepts array, and optional edges array. All operations succeed or all are rolled back.
+
+**Usage:**
+```bash
+kg create <file>
+```
+
+**Arguments:**
+
+- `<file>` - Path to batch JSON file
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output result as JSON | - |
+| `--dry-run` | Validate without creating (not yet implemented) | - |
+
+### template
+
+Output a template batch JSON file to stdout. Redirect to a file to customize.
+
+**Usage:**
+```bash
+kg template [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--with-edges` | Include example edges in template | - |
+
+
+## admin
+
+System administration and management - health monitoring, backup/restore, database operations, user/RBAC management, AI model configuration (requires authentication for destructive operations)
+
+**Usage:**
+```bash
+kg admin [options]
+```
+
+**Subcommands:**
+
+- `status` - Show comprehensive system health status (Docker containers, database connections, environment configuration, job scheduler)
+- `backup` - Create database backup (ADR-036) - full system or per-ontology, in restorable JSON or Gephi GEXF format
+- `list-backups` - List available backup files from configured directory
+- `restore` - Restore a database backup (uses OAuth authentication)
+- `scheduler` - Job scheduler management (ADR-014 job queue) - monitor worker status, cleanup stale jobs
+- `workers` - Worker lane management (ADR-100) - monitor slot utilization, queue depth, active jobs
+- `user` - User management commands (admin only)
+- `rbac` - Manage roles, permissions, and access control (ADR-028)
+- `embedding` - Manage embedding profiles (text + image model configuration)
+- `extraction` - Manage AI extraction model configuration (ADR-041)
+- `keys` - Manage API keys for AI providers (ADR-031, ADR-041)
+
+---
+
+### status
+
+Show comprehensive system health status (Docker containers, database connections, environment configuration, job scheduler)
+
+**Usage:**
+```bash
+kg status [options]
+```
+
+### backup
+
+Create database backup (ADR-036) - full system or per-ontology, in restorable JSON or Gephi GEXF format
+
+**Usage:**
+```bash
+kg backup [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--type <type>` | Backup type: "full" (entire graph) or "ontology" (single namespace) | - |
+| `--ontology <name>` | Ontology name (required if --type ontology) | - |
+| `--output <filename>` | Custom output filename (auto-generated if not specified) | - |
+| `--format <format>` | Export format: "archive" (tar.gz with documents, default), "json" (graph only), or "gexf" (Gephi visualization) | `"archive"` |
+
+### list-backups
+
+List available backup files from configured directory
+
+**Usage:**
+```bash
+kg list-backups [options]
+```
+
+### restore
+
+Restore a database backup (uses OAuth authentication)
+
+**Usage:**
+```bash
+kg restore [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--file <name>` | Backup filename (from configured directory) | - |
+| `--path <path>` | Custom backup file path (overrides configured directory) | - |
+| `--merge` | Merge into existing ontology if it exists (default: error if ontology exists) | `false` |
+| `--deps <action>` | How to handle external dependencies: prune, stitch, defer | `"prune"` |
+| `--confirm` | Confirm restore operation (required for non-interactive use) | `false` |
+
+### scheduler
+
+Job scheduler management (ADR-014 job queue) - monitor worker status, cleanup stale jobs
+
+**Usage:**
+```bash
+kg scheduler [options]
+```
+
+**Subcommands:**
+
+- `status` - Show job scheduler status and configuration
+- `cleanup` - Manually trigger scheduler cleanup (cancels expired jobs, deletes old jobs)
+
+---
+
+#### status
+
+Show job scheduler status and configuration
+
+**Usage:**
+```bash
+kg status [options]
+```
+
+#### cleanup
+
+Manually trigger scheduler cleanup (cancels expired jobs, deletes old jobs)
+
+**Usage:**
+```bash
+kg cleanup [options]
+```
+
+### workers
+
+Worker lane management (ADR-100) - monitor slot utilization, queue depth, active jobs
+
+**Usage:**
+```bash
+kg workers [options]
+```
+
+**Subcommands:**
+
+- `lanes` - Show worker lane configuration and utilization
+
+---
+
+#### lanes
+
+Show worker lane configuration and utilization
+
+**Usage:**
+```bash
+kg lanes [options]
+```
+
+### user
+
+User management commands (admin only)
+
+**Usage:**
+```bash
+kg user [options]
+```
+
+**Subcommands:**
+
+- `list` - List all users
+- `get` - Get user details by ID
+- `create` - Create new user
+- `update` - Update user details
+- `delete` - Delete user (requires re-authentication)
+
+---
+
+#### list
+
+List all users
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--role <role>` | Filter by role (read_only, contributor, curator, admin) | - |
+| `--skip <n>` | Skip first N users (pagination) | `"0"` |
+| `--limit <n>` | Limit results (default: 50) | `"50"` |
+
+#### get
+
+Get user details by ID
+
+**Usage:**
+```bash
+kg get <user_id>
+```
+
+**Arguments:**
+
+- `<user_id>` - Required
+
+#### create
+
+Create new user
+
+**Usage:**
+```bash
+kg create <username>
+```
+
+**Arguments:**
+
+- `<username>` - Required
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--role <role>` | User role (read_only, contributor, curator, admin) | - |
+| `-p, --password <password>` | Password (prompts if not provided) | - |
+
+#### update
+
+Update user details
+
+**Usage:**
+```bash
+kg update <user_id>
+```
+
+**Arguments:**
+
+- `<user_id>` - Required
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--role <role>` | Change user role | - |
+| `-p, --password [password]` | Change password (prompts if no value provided) | - |
+| `--disable` | Disable user account | - |
+| `--enable` | Enable user account | - |
+
+#### delete
+
+Delete user (requires re-authentication)
+
+**Usage:**
+```bash
+kg delete <user_id>
+```
+
+**Arguments:**
+
+- `<user_id>` - Required
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--yes` | Skip confirmation prompt | - |
+
+### rbac
+
+Manage roles, permissions, and access control (ADR-028)
+
+**Usage:**
+```bash
+kg rbac [options]
+```
+
+**Subcommands:**
+
+- `resource` (`resources`, `res`) - Manage resource types
+- `role` (`roles`) - Manage roles
+- `permission` (`permissions`, `perm`) - Manage permissions
+- `assign` - Assign roles to users
+
+---
+
+#### resource (resources, res)
+
+Manage resource types
+
+**Usage:**
+```bash
+kg resource [options]
+```
+
+**Subcommands:**
+
+- `list` - List all registered resource types
+- `create` - Register a new resource type
+
+---
+
+##### list
+
+List all registered resource types
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+##### create
+
+Register a new resource type
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Resource type name | - |
+| `-a, --actions <actions...>` | Available actions (space-separated) | - |
+| `-d, --description <desc>` | Resource description | - |
+| `-p, --parent <parent>` | Parent resource type | - |
+| `-s, --scoping` | Enable instance scoping | `false` |
+
+#### role (roles)
+
+Manage roles
+
+**Usage:**
+```bash
+kg role [options]
+```
+
+**Subcommands:**
+
+- `list` - List all roles
+- `show` - Show role details
+- `create` - Create a new role
+- `delete` - Delete a role
+
+---
+
+##### list
+
+List all roles
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--all` | Include inactive roles | `false` |
+
+##### show
+
+Show role details
+
+**Usage:**
+```bash
+kg show <role>
+```
+
+**Arguments:**
+
+- `<role>` - Required
+
+##### create
+
+Create a new role
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name <name>` | Role name (e.g., data_scientist) | - |
+| `-d, --display <display>` | Display name | - |
+| `--description <desc>` | Role description | - |
+| `-p, --parent <parent>` | Parent role to inherit from | - |
+
+##### delete
+
+Delete a role
+
+**Usage:**
+```bash
+kg delete <role>
+```
+
+**Arguments:**
+
+- `<role>` - Required
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force` | Skip confirmation | `false` |
+
+#### permission (permissions, perm)
+
+Manage permissions
+
+**Usage:**
+```bash
+kg permission [options]
+```
+
+**Subcommands:**
+
+- `list` - List permissions
+- `grant` - Grant a permission to a role
+- `revoke` - Revoke a permission (use permission ID from list)
+
+---
+
+##### list
+
+List permissions
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-r, --role <role>` | Filter by role name | - |
+| `-t, --resource-type <type>` | Filter by resource type | - |
+
+##### grant
+
+Grant a permission to a role
+
+**Usage:**
+```bash
+kg grant [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-r, --role <role>` | Role name | - |
+| `-t, --resource-type <type>` | Resource type | - |
+| `-a, --action <action>` | Action (read, write, delete, etc.) | - |
+| `-s, --scope <scope>` | Scope type (global, instance, filter) | `"global"` |
+| `--scope-id <id>` | Scope ID for instance scoping | - |
+| `--deny` | Create explicit deny (default is grant) | `false` |
+
+##### revoke
+
+Revoke a permission (use permission ID from list)
+
+**Usage:**
+```bash
+kg revoke <permission-id>
+```
+
+**Arguments:**
+
+- `<permission-id>` - Required
+
+#### assign
+
+Assign roles to users
+
+**Usage:**
+```bash
+kg assign [options]
+```
+
+**Subcommands:**
+
+- `list` - List role assignments for a user
+- `add` - Assign a role to a user
+- `remove` - Remove a role assignment (use assignment ID from list)
+
+---
+
+##### list
+
+List role assignments for a user
+
+**Usage:**
+```bash
+kg list <user-id>
+```
+
+**Arguments:**
+
+- `<user-id>` - Required
+
+##### add
+
+Assign a role to a user
+
+**Usage:**
+```bash
+kg add [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-u, --user-id <id>` | User ID | - |
+| `-r, --role <role>` | Role name | - |
+| `-s, --scope <scope>` | Scope type (global, workspace, ontology, etc.) | `"global"` |
+| `--scope-id <id>` | Scope ID (e.g., workspace ID) | - |
+
+##### remove
+
+Remove a role assignment (use assignment ID from list)
+
+**Usage:**
+```bash
+kg remove <assignment-id>
+```
+
+**Arguments:**
+
+- `<assignment-id>` - Required
+
+### embedding
+
+Manage embedding profiles (text + image model configuration)
+
+**Usage:**
+```bash
+kg embedding [options]
+```
+
+**Subcommands:**
+
+- `list` - List all embedding profiles
+- `create` - Create a new embedding profile (inactive)
+- `export` - Export an embedding profile as JSON
+- `activate` - Activate an embedding profile (with automatic protection)
+- `reload` - Hot reload embedding model (zero-downtime)
+- `protect` - Enable protection flags on an embedding profile
+- `unprotect` - Disable protection flags on an embedding profile
+- `delete` - Delete an embedding profile
+- `status` - Show comprehensive embedding coverage across all graph text entities with hash verification
+- `regenerate` - Regenerate vector embeddings for all graph text entities: concepts, sources, vocabulary (ADR-068 Phase 4) - useful after changing embedding model or repairing missing embeddings
+
+---
+
+#### list
+
+List all embedding profiles
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+#### create
+
+Create a new embedding profile (inactive)
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name <name>` | Profile name | - |
+| `--vector-space <tag>` | Vector space compatibility tag | - |
+| `--multimodal` | Text model handles both text and image | `false` |
+| `--provider <provider>` | Text provider: local or openai (shorthand for --text-provider) | - |
+| `--model <model>` | Text model name (shorthand for --text-model) | - |
+| `--dimensions <dims>` | Text embedding dimensions (shorthand for --text-dimensions) | - |
+| `--precision <precision>` | Text precision: float16 or float32 | - |
+| `--text-provider <provider>` | Text provider: local or openai | - |
+| `--text-model <model>` | Text model name | - |
+| `--text-dimensions <dims>` | Text embedding dimensions | - |
+| `--text-loader <loader>` | Text loader: sentence-transformers, transformers, api | - |
+| `--text-revision <rev>` | Text model revision/commit hash | - |
+| `--text-trust-remote-code` | Trust remote code for text model | `false` |
+| `--image-provider <provider>` | Image provider | - |
+| `--image-model <model>` | Image model name | - |
+| `--image-dimensions <dims>` | Image embedding dimensions | - |
+| `--image-loader <loader>` | Image loader: sentence-transformers, transformers, api | - |
+| `--image-revision <rev>` | Image model revision/commit hash | - |
+| `--image-trust-remote-code` | Trust remote code for image model | `false` |
+| `--text-query-prefix <prefix>` | Text prefix for search queries (e.g. "search_query: ") | - |
+| `--text-document-prefix <prefix>` | Text prefix for document ingestion (e.g. "search_document: ") | - |
+| `--device <device>` | Device: cpu, cuda, mps | - |
+| `--memory <mb>` | Max memory in MB | - |
+| `--threads <n>` | Number of threads | - |
+| `--batch-size <n>` | Batch size | - |
+| `--from-json <file>` | Import profile from JSON file | - |
+
+#### export
+
+Export an embedding profile as JSON
+
+**Usage:**
+```bash
+kg export <profile-id>
+```
+
+**Arguments:**
+
+- `<profile-id>` - Profile ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--profile-only` | Strip metadata (id, timestamps) | `false` |
+
+#### activate
+
+Activate an embedding profile (with automatic protection)
+
+**Usage:**
+```bash
+kg activate <config-id>
+```
+
+**Arguments:**
+
+- `<config-id>` - Profile ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force` | Force activation even with dimension mismatch (dangerous!) | - |
+
+#### reload
+
+Hot reload embedding model (zero-downtime)
+
+**Usage:**
+```bash
+kg reload [options]
+```
+
+#### protect
+
+Enable protection flags on an embedding profile
+
+**Usage:**
+```bash
+kg protect <config-id>
+```
+
+**Arguments:**
+
+- `<config-id>` - Profile ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--delete` | Enable delete protection | - |
+| `--change` | Enable change protection | - |
+
+#### unprotect
+
+Disable protection flags on an embedding profile
+
+**Usage:**
+```bash
+kg unprotect <config-id>
+```
+
+**Arguments:**
+
+- `<config-id>` - Profile ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--delete` | Disable delete protection | - |
+| `--change` | Disable change protection | - |
+
+#### delete
+
+Delete an embedding profile
+
+**Usage:**
+```bash
+kg delete <config-id>
+```
+
+**Arguments:**
+
+- `<config-id>` - Profile ID
+
+#### status
+
+Show comprehensive embedding coverage across all graph text entities with hash verification
+
+**Usage:**
+```bash
+kg status [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ontology <name>` | Limit status to specific ontology namespace | - |
+
+#### regenerate
+
+Regenerate vector embeddings for all graph text entities: concepts, sources, vocabulary (ADR-068 Phase 4) - useful after changing embedding model or repairing missing embeddings
+
+**Usage:**
+```bash
+kg regenerate [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--type <type>` | Type of embeddings to regenerate: concept, source, vocabulary, all | - |
+| `--only-missing` | Only generate for entities without embeddings (skip existing) - applies to concept and source types | `false` |
+| `--only-incompatible` | Only regenerate embeddings with mismatched model/dimensions (for model migrations) | `false` |
+| `--ontology <name>` | Limit regeneration to specific ontology namespace - applies to concept and source types | - |
+| `--limit <n>` | Maximum number of entities to process (useful for testing/batching) | - |
+| `--status` | Show embedding status before regeneration (diagnostic mode) | `false` |
+
+### extraction
+
+Manage AI extraction model configuration (ADR-041)
+
+**Usage:**
+```bash
+kg extraction [options]
+```
+
+**Subcommands:**
+
+- `config` - Show current AI extraction configuration
+- `set` - Update AI extraction configuration
+
+---
+
+#### config
+
+Show current AI extraction configuration
+
+**Usage:**
+```bash
+kg config [options]
+```
+
+#### set
+
+Update AI extraction configuration
+
+**Usage:**
+```bash
+kg set [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--provider <provider>` | Provider: openai, anthropic, ollama, or vllm | - |
+| `--model <model>` | Model name (e.g., gpt-4o, mistral:7b-instruct) | - |
+| `--vision` | Enable vision support | - |
+| `--no-vision` | Disable vision support | - |
+| `--json-mode` | Enable JSON mode | - |
+| `--no-json-mode` | Disable JSON mode | - |
+| `--max-tokens <n>` | Max tokens | - |
+| `--base-url <url>` | Base URL for local providers (e.g., http://localhost:11434) | - |
+| `--temperature <n>` | Sampling temperature 0.0-1.0 (default: 0.1) | - |
+| `--top-p <n>` | Nucleus sampling threshold 0.0-1.0 (default: 0.9) | - |
+| `--gpu-layers <n>` | GPU layers: -1=auto, 0=CPU only, >0=specific count | - |
+| `--num-threads <n>` | CPU threads for inference (default: 4) | - |
+| `--thinking-mode <mode>` | Thinking mode: off, low, medium, high (Ollama 0.12.x+) | - |
+
+### keys
+
+Manage API keys for AI providers (ADR-031, ADR-041)
+
+**Usage:**
+```bash
+kg keys [options]
+```
+
+**Subcommands:**
+
+- `list` - List API keys with validation status
+- `set` - Set API key for a provider (validates before storing)
+- `delete` - Delete API key for a provider
+
+---
+
+#### list
+
+List API keys with validation status
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+#### set
+
+Set API key for a provider (validates before storing)
+
+**Usage:**
+```bash
+kg set <provider>
+```
+
+**Arguments:**
+
+- `<provider>` - Provider name (openai or anthropic)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--key <key>` | API key (will prompt if not provided) | - |
+
+#### delete
+
+Delete API key for a provider
+
+**Usage:**
+```bash
+kg delete <provider>
+```
+
+**Arguments:**
+
+- `<provider>` - Provider name (openai or anthropic)
+
+
+## polarity
+
+Analyze bidirectional semantic dimensions between concept poles
+
+**Usage:**
+```bash
+kg polarity [options]
+```
+
+**Subcommands:**
+
+- `analyze` - Project concepts onto axis formed by two opposing poles (e.g., Modern ↔ Traditional)
+
+---
+
+### analyze
+
+Project concepts onto axis formed by two opposing poles (e.g., Modern ↔ Traditional)
+
+**Usage:**
+```bash
+kg analyze [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--positive <concept-id>` | Positive pole concept ID | - |
+| `--negative <concept-id>` | Negative pole concept ID | - |
+| `--candidates <ids...>` | Specific concept IDs to project (space-separated) | - |
+| `--no-auto-discover` | Disable auto-discovery of related concepts | - |
+| `--max-candidates <number>` | Maximum candidates for auto-discovery | `"20"` |
+| `--max-hops <number>` | Maximum graph hops for auto-discovery (1-3) | `"1"` |
+| `--discovery-mode <mode>` | Discovery strategy: conservative (pure degree), balanced (80/20 - DEFAULT), novelty (pure random) | `"balanced"` |
+| `--discovery-pct <number>` | Custom discovery percentage (0.0-1.0, overrides --discovery-mode) | - |
+| `--max-workers <number>` | Maximum parallel workers for 2-hop queries | `"8"` |
+| `--chunk-size <number>` | Concepts per worker chunk | `"20"` |
+| `--timeout <number>` | Wall-clock timeout in seconds | `"120"` |
+| `--save-artifact` | Save result as persistent artifact (uses async job) | - |
+| `--json` | Output raw JSON instead of formatted text | - |
+
+
+## projection (proj)
+
+Manage t-SNE/UMAP projections of concept embeddings. Projections reduce high-dimensional embeddings to 3D coordinates for the Embedding Landscape Explorer visualization. Use this to compute, view, and manage projection datasets.
+
+**Usage:**
+```bash
+kg projection [options]
+```
+
+**Subcommands:**
+
+- `list` - List projection status for all ontologies. Shows which ontologies have cached projections and their statistics.
+- `info` - Get detailed projection info for an ontology
+- `regenerate` - Compute or recompute projection for an ontology
+- `invalidate` - Delete cached projection for an ontology
+- `data` - Get full projection data as JSON (for visualization pipelines)
+- `algorithms` - List available projection algorithms
+
+---
+
+### list
+
+List projection status for all ontologies. Shows which ontologies have cached projections and their statistics.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+### info
+
+Get detailed projection info for an ontology
+
+**Usage:**
+```bash
+kg info <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name
+
+### regenerate
+
+Compute or recompute projection for an ontology
+
+**Usage:**
+```bash
+kg regenerate <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name, "all" (each separately), or "global" (all together)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Force recomputation even if cached | - |
+| `-a, --algorithm <algo>` | Algorithm: tsne or umap | `"tsne"` |
+| `-p, --perplexity <n>` | t-SNE perplexity (5-100) | `"30"` |
+| `--center` | Center embeddings before projection (fixes meatball artifact, default: true) | - |
+| `--no-center` | Disable embedding centering | - |
+| `--grounding` | Include grounding strength | - |
+| `--diversity` | Include diversity scores (slower) | - |
+| `--save-artifact` | Save result as persistent artifact (ADR-083) | - |
+
+### invalidate
+
+Delete cached projection for an ontology
+
+**Usage:**
+```bash
+kg invalidate <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name
+
+### data
+
+Get full projection data as JSON (for visualization pipelines)
+
+**Usage:**
+```bash
+kg data <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --output <file>` | Write to file instead of stdout | - |
+| `--pretty` | Pretty-print JSON output | - |
+
+### algorithms
+
+List available projection algorithms
+
+**Usage:**
+```bash
+kg algorithms [options]
+```
+
+
+## artifact (art)
+
+Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Artifacts support multi-tier storage: small payloads inline in PostgreSQL, large payloads in Garage S3. Each artifact tracks its graph_epoch for freshness detection.
+
+**Usage:**
+```bash
+kg artifact [options]
+```
+
+**Subcommands:**
+
+- `list` - List your artifacts. Shows metadata without payloads for efficiency. Filter by type, representation, or ontology.
+- `show` - Show artifact metadata by ID. Does not include the payload - use "payload" command for that.
+- `payload` - Get artifact with full payload. For large artifacts stored in Garage, this fetches from object storage.
+- `create` - Create a test artifact (for API validation). Creates a simple artifact with provided parameters.
+- `delete` - Delete an artifact. Removes both database record and any Garage-stored payload.
+
+---
+
+### list
+
+List your artifacts. Shows metadata without payloads for efficiency. Filter by type, representation, or ontology.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Filter by artifact type (polarity_analysis, projection, etc.) | - |
+| `-r, --representation <rep>` | Filter by representation/source (cli, polarity_explorer, etc.) | - |
+| `-o, --ontology <name>` | Filter by ontology | - |
+| `-l, --limit <n>` | Maximum artifacts to return | `"20"` |
+| `--offset <n>` | Skip N artifacts (for pagination) | `"0"` |
+| `-j, --json` | Output raw JSON instead of formatted table | - |
+
+### show
+
+Show artifact metadata by ID. Does not include the payload - use "payload" command for that.
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+### payload
+
+Get artifact with full payload. For large artifacts stored in Garage, this fetches from object storage.
+
+**Usage:**
+```bash
+kg payload <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-j, --json` | Output raw JSON payload only | - |
+
+### create
+
+Create a test artifact (for API validation). Creates a simple artifact with provided parameters.
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Artifact type (polarity_analysis, projection, query_result, etc.) | - |
+| `-n, --name <name>` | Human-readable name | - |
+| `-o, --ontology <name>` | Associated ontology | - |
+| `--payload <json>` | JSON payload (default: simple test payload) | `"{\"test\": true, \"created_via\": \"cli\"}"` |
+
+### delete
+
+Delete an artifact. Removes both database record and any Garage-stored payload.
+
+**Usage:**
+```bash
+kg delete <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation prompt | - |
+
+
+## group (grp)
+
+Manage groups for collaborative access control. Groups allow sharing resources with multiple users. System groups (public, admins) are managed by the platform.
+
+**Usage:**
+```bash
+kg group [options]
+```
+
+**Subcommands:**
+
+- `list` - List all groups
+- `members` - List members of a group
+- `create` - Create a new group (admin only)
+- `add-member` - Add a user to a group (admin only)
+- `remove-member` - Remove a user from a group (admin only)
+
+---
+
+### list
+
+List all groups
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--no-system` | Exclude system groups (public, admins) | - |
+
+### members
+
+List members of a group
+
+**Usage:**
+```bash
+kg members <group-id>
+```
+
+**Arguments:**
+
+- `<group-id>` - Group ID
+
+### create
+
+Create a new group (admin only)
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name <name>` | Group name (unique identifier) | - |
+| `-d, --display <name>` | Display name | - |
+| `--description <text>` | Group description | - |
+
+### add-member
+
+Add a user to a group (admin only)
+
+**Usage:**
+```bash
+kg add-member <group-id> <user-id>
+```
+
+**Arguments:**
+
+- `<group-id>` - Group ID
+- `<user-id>` - User ID to add
+
+### remove-member
+
+Remove a user from a group (admin only)
+
+**Usage:**
+```bash
+kg remove-member <group-id> <user-id>
+```
+
+**Arguments:**
+
+- `<group-id>` - Group ID
+- `<user-id>` - User ID to remove
+
+
+## query-def (qd)
+
+Manage saved query definitions - recipes that can be re-executed to generate artifacts. Supports block diagrams, cypher queries, searches, polarity analyses, and connection paths.
+
+**Usage:**
+```bash
+kg query-def [options]
+```
+
+**Subcommands:**
+
+- `list` - List query definitions
+- `show` - Show a query definition
+- `create` - Create a query definition
+- `delete` - Delete a query definition
+
+---
+
+### list
+
+List query definitions
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Filter by type (block_diagram, cypher, search, polarity, connection) | - |
+| `-l, --limit <n>` | Maximum to return | `"20"` |
+
+### show
+
+Show a query definition
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Definition ID
+
+### create
+
+Create a query definition
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name <name>` | Definition name | - |
+| `-t, --type <type>` | Type: block_diagram, cypher, search, polarity, connection | - |
+| `-d, --definition <json>` | Definition as JSON | - |
+
+### delete
+
+Delete a query definition
+
+**Usage:**
+```bash
+kg delete <id>
+```
+
+**Arguments:**
+
+- `<id>` - Definition ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation | - |
+
+
+## program (prog)
+
+Validate, store, and retrieve GraphProgram ASTs (ADR-500). Programs are notarized server-side to ensure safety before execution.
+
+**Usage:**
+```bash
+kg program [options]
+```
+
+**Subcommands:**
+
+- `validate` - Validate a program without storing it (dry run)
+- `create` - Notarize and store a program
+- `show` - Show a notarized program
+- `execute` - Execute a program server-side
+
+---
+
+### validate
+
+Validate a program without storing it (dry run)
+
+**Usage:**
+```bash
+kg validate <file>
+```
+
+**Arguments:**
+
+- `<file>` - JSON file path (use - for stdin)
+
+### create
+
+Notarize and store a program
+
+**Usage:**
+```bash
+kg create <file>
+```
+
+**Arguments:**
+
+- `<file>` - JSON file path (use - for stdin)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name <name>` | Program name | - |
+
+### show
+
+Show a notarized program
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Program ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output raw JSON | - |
+
+### execute
+
+Execute a program server-side
+
+**Usage:**
+```bash
+kg execute <source>
+```
+
+**Arguments:**
+
+- `<source>` - Program ID (number) or JSON file path (use - for stdin)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output raw JSON | - |
+| `--log-only` | Show only the execution log, not the graph | - |
+
+
+## storage
+
+Read-only diagnostics for S3-compatible object storage. List objects, inspect metadata, verify integrity after cascade deletes, and view retention policies. Useful for integration testing and debugging storage behavior.
+
+**Usage:**
+```bash
+kg storage [options]
+```
+
+**Subcommands:**
+
+- `health` - Check storage backend connectivity and bucket accessibility
+- `stats` - Show storage usage statistics by category (sources, images, projections, artifacts)
+- `list` - List objects in storage with optional prefix filter. Examples: kg storage list --prefix sources/ --limit 20
+- `inspect` - Inspect metadata for a single object without downloading content. Use the full S3 key from "kg storage list".
+- `integrity` - Cross-reference S3 objects against graph nodes. Finds orphaned objects (in S3 but not graph) and missing objects (in graph but not S3). Essential for verifying cascade deletes.
+- `retention` - Show current retention policy configuration for each storage category
+
+---
+
+### health
+
+Check storage backend connectivity and bucket accessibility
+
+**Usage:**
+```bash
+kg health [options]
+```
+
+### stats
+
+Show storage usage statistics by category (sources, images, projections, artifacts)
+
+**Usage:**
+```bash
+kg stats [options]
+```
+
+### list
+
+List objects in storage with optional prefix filter. Examples: kg storage list --prefix sources/ --limit 20
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-p, --prefix <prefix>` | S3 key prefix filter (e.g. sources/, images/My_Ontology/) | - |
+| `-l, --limit <n>` | Maximum objects to return | `50` |
+| `-o, --offset <n>` | Number of objects to skip | `0` |
+
+### inspect
+
+Inspect metadata for a single object without downloading content. Use the full S3 key from "kg storage list".
+
+**Usage:**
+```bash
+kg inspect <key>
+```
+
+**Arguments:**
+
+- `<key>` - S3 object key (e.g. sources/My_Ontology/abc123.md)
+
+### integrity
+
+Cross-reference S3 objects against graph nodes. Finds orphaned objects (in S3 but not graph) and missing objects (in graph but not S3). Essential for verifying cascade deletes.
+
+**Usage:**
+```bash
+kg integrity [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ontology <name>` | Scope check to a specific ontology | - |
+| `--category <type>` | Storage category: sources, images | `"sources"` |
+
+### retention
+
+Show current retention policy configuration for each storage category
+
+**Usage:**
+```bash
+kg retention [options]
+```
+
+
+## catalog
+
+Deterministic, filesystem-like browse of what is stored in the knowledge graph. Walk from ontologies down to documents and concepts, filter by name fragment, and inspect single nodes. Distinct from "kg search" (semantic) and "kg storage" (raw S3 admin). Add --json to any subcommand for machine-readable output.
+
+**Usage:**
+```bash
+kg catalog [options]
+```
+
+**Subcommands:**
+
+- `ls` - List children of a node, or root ontologies if no id given
+- `stat` - Show full metadata for a single catalog node
+
+---
+
+### ls
+
+List children of a node, or root ontologies if no id given
+
+**Usage:**
+```bash
+kg ls [id]
+```
+
+**Arguments:**
+
+- `<id>` - Parent node id (ontology or document). Omit to list ontologies.
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-k, --kind <kind>` | Parent kind hint (ontology|document) if id is ambiguous | - |
+| `-q, --query <fragment>` | Filter children by case-insensitive name fragment | - |
+| `-s, --sort <field>` | Sort: name | child_count | created | `"name"` |
+| `-l, --limit <n>` | Max results | `"100"` |
+| `-o, --offset <n>` | Pagination offset | `"0"` |
+| `--json` | Output raw JSON instead of formatted text for scripting | - |
+
+### stat
+
+Show full metadata for a single catalog node
+
+**Usage:**
+```bash
+kg stat <id>
+```
+
+**Arguments:**
+
+- `<id>` - Node id (ontology_id, document_id, or concept_id)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-k, --kind <kind>` | Disambiguate kind if id collides across kinds | - |
+| `--json` | Output raw JSON instead of formatted text for scripting | - |
+
+
+## login
+
+Authenticate with username and password - creates personal OAuth client credentials (required for admin commands)
+
+**Usage:**
+```bash
+kg login [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-u, --username <username>` | Username (will prompt if not provided - can be saved for future logins) | - |
+| `-p, --password <password>` | Password (will prompt if not provided - for scripted/non-interactive use) | - |
+| `-f, --force` | Replace existing credentials (use after platform redeploy) | - |
+| `--remember-username` | Save username for future logins (default in non-interactive mode) | - |
+| `--no-remember-username` | Do not save username | - |
+
+
+## logout
+
+End authentication session - revokes OAuth client and clears credentials (use --forget to also clear saved username)
+
+**Usage:**
+```bash
+kg logout [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--forget` | Also forget saved username (requires username prompt on next login) | - |
+
+
+## oauth
+
+Manage OAuth clients (list, create for MCP, revoke)
+
+**Usage:**
+```bash
+kg oauth [options]
+```
+
+**Subcommands:**
+
+- `clients` (`list`) - List your personal OAuth clients
+- `create` - Create OAuth client for external tools (MCP, FUSE, scripts)
+- `create-mcp` - Create OAuth client for MCP server (alias for: create --for mcp)
+- `revoke` - Revoke an OAuth client
+
+---
+
+### clients (list)
+
+List your personal OAuth clients
+
+**Usage:**
+```bash
+kg clients [options]
+```
+
+### create
+
+Create OAuth client for external tools (MCP, FUSE, scripts)
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name <name>` | Custom client name | - |
+| `--for <target>` | Target: mcp, fuse, or generic (shows appropriate setup instructions) | - |
+
+### create-mcp
+
+Create OAuth client for MCP server (alias for: create --for mcp)
+
+**Usage:**
+```bash
+kg create-mcp [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name <name>` | Custom client name | - |
+
+### revoke
+
+Revoke an OAuth client
+
+**Usage:**
+```bash
+kg revoke <client-id>
+```
+
+**Arguments:**
+
+- `<client-id>` - Required
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--force` | Force revocation even if it's your current CLI client | - |
 

--- a/docs/reference/cli/commands/admin.md
+++ b/docs/reference/cli/commands/admin.md
@@ -14,14 +14,14 @@ kg admin [options]
 **Subcommands:**
 
 - `status` - Show comprehensive system health status (Docker containers, database connections, environment configuration, job scheduler)
-- `backup` - Create database backup (ADR-036) - full system or per-ontology, in restorable archive/JSON or Gephi GEXF format
+- `backup` - Create database backup (ADR-036) - full system or per-ontology, in restorable JSON or Gephi GEXF format
 - `list-backups` - List available backup files from configured directory
 - `restore` - Restore a database backup (uses OAuth authentication)
 - `scheduler` - Job scheduler management (ADR-014 job queue) - monitor worker status, cleanup stale jobs
 - `workers` - Worker lane management (ADR-100) - monitor slot utilization, queue depth, active jobs
 - `user` - User management commands (admin only)
 - `rbac` - Manage roles, permissions, and access control (ADR-028)
-- `embedding` - Manage embedding model configuration (ADR-039)
+- `embedding` - Manage embedding profiles (text + image model configuration)
 - `extraction` - Manage AI extraction model configuration (ADR-041)
 - `keys` - Manage API keys for AI providers (ADR-031, ADR-041)
 
@@ -52,7 +52,7 @@ kg backup [options]
 | `--type <type>` | Backup type: "full" (entire graph) or "ontology" (single namespace) | - |
 | `--ontology <name>` | Ontology name (required if --type ontology) | - |
 | `--output <filename>` | Custom output filename (auto-generated if not specified) | - |
-| `--format <format>` | Export format: "archive" (tar.gz with documents, default), "json" (graph only), or "gexf" (Gephi visualization - not restorable) | `"archive"` |
+| `--format <format>` | Export format: "archive" (tar.gz with documents, default), "json" (graph only), or "gexf" (Gephi visualization) | `"archive"` |
 
 ### list-backups
 
@@ -118,18 +118,16 @@ kg cleanup [options]
 
 ### workers
 
-Worker lane management (ADR-100) - monitor slot utilization, queue depth, active jobs.
-Running `kg admin workers` shows the current worker status (slots, lanes, active jobs,
-queue depth).
+Worker lane management (ADR-100) - monitor slot utilization, queue depth, active jobs
 
 **Usage:**
 ```bash
-kg admin workers [subcommand]
+kg workers [options]
 ```
 
 **Subcommands:**
 
-- `lanes` - Show detailed worker lane configuration (job types, slots, poll interval, stale timeout)
+- `lanes` - Show worker lane configuration and utilization
 
 ---
 
@@ -139,7 +137,7 @@ Show worker lane configuration and utilization
 
 **Usage:**
 ```bash
-kg admin workers lanes
+kg lanes [options]
 ```
 
 ### user
@@ -526,7 +524,7 @@ kg remove <assignment-id>
 
 ### embedding
 
-Manage embedding profiles (text + image model configuration) (ADR-039)
+Manage embedding profiles (text + image model configuration)
 
 **Usage:**
 ```bash
@@ -550,7 +548,7 @@ kg embedding [options]
 
 #### list
 
-List all embedding configurations
+List all embedding profiles
 
 **Usage:**
 ```bash
@@ -603,8 +601,12 @@ Export an embedding profile as JSON
 
 **Usage:**
 ```bash
-kg export <config-id> [options]
+kg export <profile-id>
 ```
+
+**Arguments:**
+
+- `<profile-id>` - Profile ID
 
 **Options:**
 
@@ -623,7 +625,7 @@ kg activate <config-id>
 
 **Arguments:**
 
-- `<config-id>` - Configuration ID
+- `<config-id>` - Profile ID
 
 **Options:**
 
@@ -642,7 +644,7 @@ kg reload [options]
 
 #### protect
 
-Enable protection flags on an embedding configuration
+Enable protection flags on an embedding profile
 
 **Usage:**
 ```bash
@@ -651,7 +653,7 @@ kg protect <config-id>
 
 **Arguments:**
 
-- `<config-id>` - Configuration ID
+- `<config-id>` - Profile ID
 
 **Options:**
 
@@ -662,7 +664,7 @@ kg protect <config-id>
 
 #### unprotect
 
-Disable protection flags on an embedding configuration
+Disable protection flags on an embedding profile
 
 **Usage:**
 ```bash
@@ -671,7 +673,7 @@ kg unprotect <config-id>
 
 **Arguments:**
 
-- `<config-id>` - Configuration ID
+- `<config-id>` - Profile ID
 
 **Options:**
 
@@ -682,7 +684,7 @@ kg unprotect <config-id>
 
 #### delete
 
-Delete an embedding configuration
+Delete an embedding profile
 
 **Usage:**
 ```bash
@@ -691,7 +693,7 @@ kg delete <config-id>
 
 **Arguments:**
 
-- `<config-id>` - Configuration ID
+- `<config-id>` - Profile ID
 
 #### status
 

--- a/docs/reference/cli/commands/artifact.md
+++ b/docs/reference/cli/commands/artifact.md
@@ -1,0 +1,111 @@
+# kg artifact
+
+> Auto-generated
+
+## artifact (art)
+
+Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Artifacts support multi-tier storage: small payloads inline in PostgreSQL, large payloads in Garage S3. Each artifact tracks its graph_epoch for freshness detection.
+
+**Usage:**
+```bash
+kg artifact [options]
+```
+
+**Subcommands:**
+
+- `list` - List your artifacts. Shows metadata without payloads for efficiency. Filter by type, representation, or ontology.
+- `show` - Show artifact metadata by ID. Does not include the payload - use "payload" command for that.
+- `payload` - Get artifact with full payload. For large artifacts stored in Garage, this fetches from object storage.
+- `create` - Create a test artifact (for API validation). Creates a simple artifact with provided parameters.
+- `delete` - Delete an artifact. Removes both database record and any Garage-stored payload.
+
+---
+
+### list
+
+List your artifacts. Shows metadata without payloads for efficiency. Filter by type, representation, or ontology.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Filter by artifact type (polarity_analysis, projection, etc.) | - |
+| `-r, --representation <rep>` | Filter by representation/source (cli, polarity_explorer, etc.) | - |
+| `-o, --ontology <name>` | Filter by ontology | - |
+| `-l, --limit <n>` | Maximum artifacts to return | `"20"` |
+| `--offset <n>` | Skip N artifacts (for pagination) | `"0"` |
+| `-j, --json` | Output raw JSON instead of formatted table | - |
+
+### show
+
+Show artifact metadata by ID. Does not include the payload - use "payload" command for that.
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+### payload
+
+Get artifact with full payload. For large artifacts stored in Garage, this fetches from object storage.
+
+**Usage:**
+```bash
+kg payload <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-j, --json` | Output raw JSON payload only | - |
+
+### create
+
+Create a test artifact (for API validation). Creates a simple artifact with provided parameters.
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Artifact type (polarity_analysis, projection, query_result, etc.) | - |
+| `-n, --name <name>` | Human-readable name | - |
+| `-o, --ontology <name>` | Associated ontology | - |
+| `--payload <json>` | JSON payload (default: simple test payload) | `"{\"test\": true, \"created_via\": \"cli\"}"` |
+
+### delete
+
+Delete an artifact. Removes both database record and any Garage-stored payload.
+
+**Usage:**
+```bash
+kg delete <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation prompt | - |

--- a/docs/reference/cli/commands/batch.md
+++ b/docs/reference/cli/commands/batch.md
@@ -1,0 +1,54 @@
+# kg batch
+
+> Auto-generated
+
+## batch (b)
+
+Batch operations for creating concepts and edges in a single transaction. Import JSON files that define concepts and their relationships. All operations are atomic - if any item fails, the entire batch is rolled back.
+
+**Usage:**
+```bash
+kg batch [options]
+```
+
+**Subcommands:**
+
+- `create` - Import a batch JSON file to create concepts and edges atomically. The JSON must contain ontology, concepts array, and optional edges array. All operations succeed or all are rolled back.
+- `template` - Output a template batch JSON file to stdout. Redirect to a file to customize.
+
+---
+
+### create
+
+Import a batch JSON file to create concepts and edges atomically. The JSON must contain ontology, concepts array, and optional edges array. All operations succeed or all are rolled back.
+
+**Usage:**
+```bash
+kg create <file>
+```
+
+**Arguments:**
+
+- `<file>` - Path to batch JSON file
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output result as JSON | - |
+| `--dry-run` | Validate without creating (not yet implemented) | - |
+
+### template
+
+Output a template batch JSON file to stdout. Redirect to a file to customize.
+
+**Usage:**
+```bash
+kg template [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--with-edges` | Include example edges in template | - |

--- a/docs/reference/cli/commands/catalog.md
+++ b/docs/reference/cli/commands/catalog.md
@@ -1,0 +1,63 @@
+# kg catalog
+
+> Auto-generated
+
+## catalog
+
+Deterministic, filesystem-like browse of what is stored in the knowledge graph. Walk from ontologies down to documents and concepts, filter by name fragment, and inspect single nodes. Distinct from "kg search" (semantic) and "kg storage" (raw S3 admin). Add --json to any subcommand for machine-readable output.
+
+**Usage:**
+```bash
+kg catalog [options]
+```
+
+**Subcommands:**
+
+- `ls` - List children of a node, or root ontologies if no id given
+- `stat` - Show full metadata for a single catalog node
+
+---
+
+### ls
+
+List children of a node, or root ontologies if no id given
+
+**Usage:**
+```bash
+kg ls [id]
+```
+
+**Arguments:**
+
+- `<id>` - Parent node id (ontology or document). Omit to list ontologies.
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-k, --kind <kind>` | Parent kind hint (ontology|document) if id is ambiguous | - |
+| `-q, --query <fragment>` | Filter children by case-insensitive name fragment | - |
+| `-s, --sort <field>` | Sort: name | child_count | created | `"name"` |
+| `-l, --limit <n>` | Max results | `"100"` |
+| `-o, --offset <n>` | Pagination offset | `"0"` |
+| `--json` | Output raw JSON instead of formatted text for scripting | - |
+
+### stat
+
+Show full metadata for a single catalog node
+
+**Usage:**
+```bash
+kg stat <id>
+```
+
+**Arguments:**
+
+- `<id>` - Node id (ontology_id, document_id, or concept_id)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-k, --kind <kind>` | Disambiguate kind if id collides across kinds | - |
+| `--json` | Output raw JSON instead of formatted text for scripting | - |

--- a/docs/reference/cli/commands/concept.md
+++ b/docs/reference/cli/commands/concept.md
@@ -1,0 +1,103 @@
+# kg concept
+
+> Auto-generated
+
+## concept (c)
+
+Create, list, show, and delete concepts. Concepts are the fundamental nodes in the knowledge graph. When creating concepts, the description is embedded and similarity-matched against existing concepts (same as automatic ingestion). Use matching modes to control duplicate handling.
+
+**Usage:**
+```bash
+kg concept [options]
+```
+
+**Subcommands:**
+
+- `list` - List concepts with optional filters. Shows concept ID, label, ontology, and creation method.
+- `show` - Show detailed information about a concept by ID.
+- `create` - Create a new concept. Description is embedded and similarity-matched against existing concepts.
+- `delete` - Delete a concept by ID. Requires --force flag or interactive confirmation.
+
+---
+
+### list
+
+List concepts with optional filters. Shows concept ID, label, ontology, and creation method.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ontology <name>` | Filter by ontology | - |
+| `--label <text>` | Filter by label (contains) | - |
+| `--creation-method <method>` | Filter by creation method (cli, mcp, api, llm_extraction, import) | - |
+| `--limit <n>` | Maximum results (default: 50) | `"50"` |
+| `--offset <n>` | Pagination offset | `"0"` |
+| `--json` | Output as JSON | - |
+
+### show
+
+Show detailed information about a concept by ID.
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Concept ID (e.g., c_abc123)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output as JSON | - |
+
+### create
+
+Create a new concept. Description is embedded and similarity-matched against existing concepts.
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--label <name>` | Concept label (required) | - |
+| `--ontology <name>` | Target ontology (required) | - |
+| `--description <text>` | Concept description (used for embedding match) | - |
+| `--search-terms <terms>` | Comma-separated search terms | - |
+| `--matching-mode <mode>` | auto|force_create|match_only (default: auto) | `"auto"` |
+| `--json` | Output as JSON | - |
+| `-i, --interactive` | Guided wizard mode | - |
+| `-y, --yes` | Skip confirmation prompts | - |
+
+### delete
+
+Delete a concept by ID. Requires --force flag or interactive confirmation.
+
+**Usage:**
+```bash
+kg delete <id>
+```
+
+**Arguments:**
+
+- `<id>` - Concept ID to delete
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--cascade` | Also delete orphaned synthetic sources | - |
+| `-f, --force` | Skip confirmation | - |
+| `--json` | Output as JSON | - |

--- a/docs/reference/cli/commands/document.md
+++ b/docs/reference/cli/commands/document.md
@@ -1,0 +1,102 @@
+# kg document
+
+> Auto-generated
+
+## document (doc)
+
+Search for documents using semantic similarity and retrieve their content from Garage storage. Documents are aggregated from source chunks, ranked by their best matching chunk similarity (ADR-084).
+
+**Usage:**
+```bash
+kg document [options]
+```
+
+**Subcommands:**
+
+- `search` - Find documents that match a query using semantic search. Results show documents ranked by their best matching chunk similarity. Use --details to show full concept information for the top result.
+- `list` - List all documents (DocumentMeta nodes) in the knowledge graph. Filter by ontology to see documents from specific collections.
+- `show` - Retrieve and display the full content of a document from Garage storage. Shows the original document text plus source chunks created during ingestion.
+- `concepts` - Show all concepts extracted from a specific document. Displays concept names, IDs, and the source chunks where they appear. Use --details for full concept information including evidence and relationships.
+
+---
+
+### search
+
+Find documents that match a query using semantic search. Results show documents ranked by their best matching chunk similarity. Use --details to show full concept information for the top result.
+
+**Usage:**
+```bash
+kg search <query>
+```
+
+**Arguments:**
+
+- `<query>` - Search query (natural language)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --ontology <name>` | Filter by ontology name | - |
+| `-s, --min-similarity <n>` | Minimum similarity threshold (0-1) | `"0.5"` |
+| `-l, --limit <n>` | Maximum results | `"20"` |
+| `-d, --details` | Show full concept details for top result | - |
+| `-j, --json` | Output raw JSON | - |
+
+### list
+
+List all documents (DocumentMeta nodes) in the knowledge graph. Filter by ontology to see documents from specific collections.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --ontology <name>` | Filter by ontology name (partial match) | - |
+| `-l, --limit <n>` | Maximum documents to return | `"50"` |
+| `--offset <n>` | Skip N documents (pagination) | `"0"` |
+| `-j, --json` | Output raw JSON | - |
+
+### show
+
+Retrieve and display the full content of a document from Garage storage. Shows the original document text plus source chunks created during ingestion.
+
+**Usage:**
+```bash
+kg show <document-id>
+```
+
+**Arguments:**
+
+- `<document-id>` - Document ID (e.g., sha256:abc123...)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-c, --chunks` | Show source chunks instead of full document | - |
+| `-j, --json` | Output raw JSON | - |
+
+### concepts
+
+Show all concepts extracted from a specific document. Displays concept names, IDs, and the source chunks where they appear. Use --details for full concept information including evidence and relationships.
+
+**Usage:**
+```bash
+kg concepts <document-id>
+```
+
+**Arguments:**
+
+- `<document-id>` - Document ID (e.g., sha256:abc123...)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-d, --details` | Show full concept details (evidence, relationships, grounding) | - |
+| `-j, --json` | Output raw JSON | - |

--- a/docs/reference/cli/commands/edge.md
+++ b/docs/reference/cli/commands/edge.md
@@ -1,0 +1,88 @@
+# kg edge
+
+> Auto-generated
+
+## edge (e)
+
+Create, list, and delete edges between concepts. Edges represent relationships like IMPLIES, SUPPORTS, CONTRADICTS, etc. Use --from/--to with concept IDs or --from-label/--to-label for semantic lookup by label.
+
+**Usage:**
+```bash
+kg edge [options]
+```
+
+**Subcommands:**
+
+- `list` - List edges with optional filters.
+- `create` - Create an edge between two concepts.
+- `delete` - Delete an edge by its composite key (from, type, to).
+
+---
+
+### list
+
+List edges with optional filters.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--from <id>` | Filter by source concept ID | - |
+| `--to <id>` | Filter by target concept ID | - |
+| `--type <type>` | Filter by relationship type | - |
+| `--category <cat>` | Filter by category | - |
+| `--limit <n>` | Maximum results (default: 50) | `"50"` |
+| `--offset <n>` | Pagination offset | `"0"` |
+| `--json` | Output as JSON | - |
+
+### create
+
+Create an edge between two concepts.
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--from <id>` | Source concept ID | - |
+| `--to <id>` | Target concept ID | - |
+| `--from-label <text>` | Source concept (search by label) | - |
+| `--to-label <text>` | Target concept (search by label) | - |
+| `--type <type>` | Relationship type (e.g., IMPLIES, SUPPORTS) | - |
+| `--category <cat>` | Relationship category (auto-inferred if omitted) | - |
+| `--confidence <n>` | Confidence score 0-1 (default: 1.0) | `"1.0"` |
+| `--create-vocab` | Create vocabulary term if it does not exist | - |
+| `--json` | Output as JSON | - |
+| `-i, --interactive` | Guided wizard mode | - |
+| `-y, --yes` | Skip confirmation prompts | - |
+
+### delete
+
+Delete an edge by its composite key (from, type, to).
+
+**Usage:**
+```bash
+kg delete <from> <type> <to>
+```
+
+**Arguments:**
+
+- `<from>` - Source concept ID
+- `<type>` - Relationship type
+- `<to>` - Target concept ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation | - |
+| `--json` | Output as JSON | - |

--- a/docs/reference/cli/commands/group.md
+++ b/docs/reference/cli/commands/group.md
@@ -1,0 +1,95 @@
+# kg group
+
+> Auto-generated
+
+## group (grp)
+
+Manage groups for collaborative access control. Groups allow sharing resources with multiple users. System groups (public, admins) are managed by the platform.
+
+**Usage:**
+```bash
+kg group [options]
+```
+
+**Subcommands:**
+
+- `list` - List all groups
+- `members` - List members of a group
+- `create` - Create a new group (admin only)
+- `add-member` - Add a user to a group (admin only)
+- `remove-member` - Remove a user from a group (admin only)
+
+---
+
+### list
+
+List all groups
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--no-system` | Exclude system groups (public, admins) | - |
+
+### members
+
+List members of a group
+
+**Usage:**
+```bash
+kg members <group-id>
+```
+
+**Arguments:**
+
+- `<group-id>` - Group ID
+
+### create
+
+Create a new group (admin only)
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name <name>` | Group name (unique identifier) | - |
+| `-d, --display <name>` | Display name | - |
+| `--description <text>` | Group description | - |
+
+### add-member
+
+Add a user to a group (admin only)
+
+**Usage:**
+```bash
+kg add-member <group-id> <user-id>
+```
+
+**Arguments:**
+
+- `<group-id>` - Group ID
+- `<user-id>` - User ID to add
+
+### remove-member
+
+Remove a user from a group (admin only)
+
+**Usage:**
+```bash
+kg remove-member <group-id> <user-id>
+```
+
+**Arguments:**
+
+- `<group-id>` - Group ID
+- `<user-id>` - User ID to remove

--- a/docs/reference/cli/commands/mcp-config.md
+++ b/docs/reference/cli/commands/mcp-config.md
@@ -1,0 +1,165 @@
+# kg mcp-config
+
+> Auto-generated
+
+## mcp-config
+
+Manage path allowlist for secure file/directory ingestion from MCP server.
+
+Security Model (ADR-062):
+- Fail-secure validation (blocked patterns checked first)
+- Explicit allowlist (no access without configuration)
+- CLI-only management (agent can read, not write)
+- Path resolution prevents traversal attacks
+
+Configuration stored in: ~/.config/kg/mcp-allowed-paths.json
+
+**Usage:**
+```bash
+kg mcp-config [options]
+```
+
+**Subcommands:**
+
+- `init-allowlist` - Initialize allowlist with safe defaults
+- `allow-dir` - Add allowed directory
+- `remove-dir` - Remove allowed directory
+- `allow-pattern` - Add allowed file pattern
+- `remove-pattern` - Remove allowed file pattern
+- `block-pattern` - Add blocked file pattern (security)
+- `unblock-pattern` - Remove blocked file pattern
+- `show-allowlist` - Show current allowlist configuration
+- `test-path` - Test if a path would be allowed
+- `oauth` - Create OAuth client for MCP server
+
+---
+
+### init-allowlist
+
+Initialize allowlist with safe defaults
+
+**Usage:**
+```bash
+kg init-allowlist [options]
+```
+
+### allow-dir
+
+Add allowed directory
+
+**Usage:**
+```bash
+kg allow-dir <directory>
+```
+
+**Arguments:**
+
+- `<directory>` - Directory path (supports ~ and glob patterns like ~/Projects/*/docs)
+
+### remove-dir
+
+Remove allowed directory
+
+**Usage:**
+```bash
+kg remove-dir <directory>
+```
+
+**Arguments:**
+
+- `<directory>` - Directory path to remove
+
+### allow-pattern
+
+Add allowed file pattern
+
+**Usage:**
+```bash
+kg allow-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Glob pattern (e.g., "**/*.md", "**/*.png")
+
+### remove-pattern
+
+Remove allowed file pattern
+
+**Usage:**
+```bash
+kg remove-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Pattern to remove
+
+### block-pattern
+
+Add blocked file pattern (security)
+
+**Usage:**
+```bash
+kg block-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Glob pattern to block (e.g., "**/.env*", "**/*.key")
+
+### unblock-pattern
+
+Remove blocked file pattern
+
+**Usage:**
+```bash
+kg unblock-pattern <pattern>
+```
+
+**Arguments:**
+
+- `<pattern>` - Pattern to unblock
+
+### show-allowlist
+
+Show current allowlist configuration
+
+**Usage:**
+```bash
+kg show-allowlist [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output as JSON | - |
+
+### test-path
+
+Test if a path would be allowed
+
+**Usage:**
+```bash
+kg test-path <path>
+```
+
+**Arguments:**
+
+- `<path>` - File or directory path to test
+
+### oauth
+
+Create OAuth client for MCP server
+
+**Usage:**
+```bash
+kg oauth [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--name <name>` | Custom client name | - |

--- a/docs/reference/cli/commands/polarity.md
+++ b/docs/reference/cli/commands/polarity.md
@@ -1,0 +1,45 @@
+# kg polarity
+
+> Auto-generated
+
+## polarity
+
+Analyze bidirectional semantic dimensions between concept poles
+
+**Usage:**
+```bash
+kg polarity [options]
+```
+
+**Subcommands:**
+
+- `analyze` - Project concepts onto axis formed by two opposing poles (e.g., Modern ↔ Traditional)
+
+---
+
+### analyze
+
+Project concepts onto axis formed by two opposing poles (e.g., Modern ↔ Traditional)
+
+**Usage:**
+```bash
+kg analyze [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--positive <concept-id>` | Positive pole concept ID | - |
+| `--negative <concept-id>` | Negative pole concept ID | - |
+| `--candidates <ids...>` | Specific concept IDs to project (space-separated) | - |
+| `--no-auto-discover` | Disable auto-discovery of related concepts | - |
+| `--max-candidates <number>` | Maximum candidates for auto-discovery | `"20"` |
+| `--max-hops <number>` | Maximum graph hops for auto-discovery (1-3) | `"1"` |
+| `--discovery-mode <mode>` | Discovery strategy: conservative (pure degree), balanced (80/20 - DEFAULT), novelty (pure random) | `"balanced"` |
+| `--discovery-pct <number>` | Custom discovery percentage (0.0-1.0, overrides --discovery-mode) | - |
+| `--max-workers <number>` | Maximum parallel workers for 2-hop queries | `"8"` |
+| `--chunk-size <number>` | Concepts per worker chunk | `"20"` |
+| `--timeout <number>` | Wall-clock timeout in seconds | `"120"` |
+| `--save-artifact` | Save result as persistent artifact (uses async job) | - |
+| `--json` | Output raw JSON instead of formatted text | - |

--- a/docs/reference/cli/commands/program.md
+++ b/docs/reference/cli/commands/program.md
@@ -1,0 +1,92 @@
+# kg program
+
+> Auto-generated
+
+## program (prog)
+
+Validate, store, and retrieve GraphProgram ASTs (ADR-500). Programs are notarized server-side to ensure safety before execution.
+
+**Usage:**
+```bash
+kg program [options]
+```
+
+**Subcommands:**
+
+- `validate` - Validate a program without storing it (dry run)
+- `create` - Notarize and store a program
+- `show` - Show a notarized program
+- `execute` - Execute a program server-side
+
+---
+
+### validate
+
+Validate a program without storing it (dry run)
+
+**Usage:**
+```bash
+kg validate <file>
+```
+
+**Arguments:**
+
+- `<file>` - JSON file path (use - for stdin)
+
+### create
+
+Notarize and store a program
+
+**Usage:**
+```bash
+kg create <file>
+```
+
+**Arguments:**
+
+- `<file>` - JSON file path (use - for stdin)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name <name>` | Program name | - |
+
+### show
+
+Show a notarized program
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Program ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output raw JSON | - |
+
+### execute
+
+Execute a program server-side
+
+**Usage:**
+```bash
+kg execute <source>
+```
+
+**Arguments:**
+
+- `<source>` - Program ID (number) or JSON file path (use - for stdin)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output raw JSON | - |
+| `--log-only` | Show only the execution log, not the graph | - |

--- a/docs/reference/cli/commands/projection.md
+++ b/docs/reference/cli/commands/projection.md
@@ -1,0 +1,113 @@
+# kg projection
+
+> Auto-generated
+
+## projection (proj)
+
+Manage t-SNE/UMAP projections of concept embeddings. Projections reduce high-dimensional embeddings to 3D coordinates for the Embedding Landscape Explorer visualization. Use this to compute, view, and manage projection datasets.
+
+**Usage:**
+```bash
+kg projection [options]
+```
+
+**Subcommands:**
+
+- `list` - List projection status for all ontologies. Shows which ontologies have cached projections and their statistics.
+- `info` - Get detailed projection info for an ontology
+- `regenerate` - Compute or recompute projection for an ontology
+- `invalidate` - Delete cached projection for an ontology
+- `data` - Get full projection data as JSON (for visualization pipelines)
+- `algorithms` - List available projection algorithms
+
+---
+
+### list
+
+List projection status for all ontologies. Shows which ontologies have cached projections and their statistics.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+### info
+
+Get detailed projection info for an ontology
+
+**Usage:**
+```bash
+kg info <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name
+
+### regenerate
+
+Compute or recompute projection for an ontology
+
+**Usage:**
+```bash
+kg regenerate <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name, "all" (each separately), or "global" (all together)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Force recomputation even if cached | - |
+| `-a, --algorithm <algo>` | Algorithm: tsne or umap | `"tsne"` |
+| `-p, --perplexity <n>` | t-SNE perplexity (5-100) | `"30"` |
+| `--center` | Center embeddings before projection (fixes meatball artifact, default: true) | - |
+| `--no-center` | Disable embedding centering | - |
+| `--grounding` | Include grounding strength | - |
+| `--diversity` | Include diversity scores (slower) | - |
+| `--save-artifact` | Save result as persistent artifact (ADR-083) | - |
+
+### invalidate
+
+Delete cached projection for an ontology
+
+**Usage:**
+```bash
+kg invalidate <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name
+
+### data
+
+Get full projection data as JSON (for visualization pipelines)
+
+**Usage:**
+```bash
+kg data <ontology>
+```
+
+**Arguments:**
+
+- `<ontology>` - Ontology name
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --output <file>` | Write to file instead of stdout | - |
+| `--pretty` | Pretty-print JSON output | - |
+
+### algorithms
+
+List available projection algorithms
+
+**Usage:**
+```bash
+kg algorithms [options]
+```

--- a/docs/reference/cli/commands/query-def.md
+++ b/docs/reference/cli/commands/query-def.md
@@ -1,0 +1,86 @@
+# kg query-def
+
+> Auto-generated
+
+## query-def (qd)
+
+Manage saved query definitions - recipes that can be re-executed to generate artifacts. Supports block diagrams, cypher queries, searches, polarity analyses, and connection paths.
+
+**Usage:**
+```bash
+kg query-def [options]
+```
+
+**Subcommands:**
+
+- `list` - List query definitions
+- `show` - Show a query definition
+- `create` - Create a query definition
+- `delete` - Delete a query definition
+
+---
+
+### list
+
+List query definitions
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Filter by type (block_diagram, cypher, search, polarity, connection) | - |
+| `-l, --limit <n>` | Maximum to return | `"20"` |
+
+### show
+
+Show a query definition
+
+**Usage:**
+```bash
+kg show <id>
+```
+
+**Arguments:**
+
+- `<id>` - Definition ID
+
+### create
+
+Create a query definition
+
+**Usage:**
+```bash
+kg create [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name <name>` | Definition name | - |
+| `-t, --type <type>` | Type: block_diagram, cypher, search, polarity, connection | - |
+| `-d, --definition <json>` | Definition as JSON | - |
+
+### delete
+
+Delete a query definition
+
+**Usage:**
+```bash
+kg delete <id>
+```
+
+**Arguments:**
+
+- `<id>` - Definition ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation | - |

--- a/docs/reference/cli/commands/source.md
+++ b/docs/reference/cli/commands/source.md
@@ -1,0 +1,71 @@
+# kg source
+
+> Auto-generated
+
+## source
+
+Retrieve and manage source documents stored in Garage. Source documents are the original files ingested into the knowledge graph, preserved for model evolution and re-extraction (ADR-081).
+
+**Usage:**
+```bash
+kg source [options]
+```
+
+**Subcommands:**
+
+- `list` - List source nodes (chunks) in the graph. Sources are chunks of ingested documents. Filter by ontology name to see sources from specific documents.
+- `get` - Download the original source document from Garage storage. This returns the complete document as it was before chunking, not individual chunks. Useful for verification, re-processing, or archival. Output goes to stdout by default (for piping) or to a file with -o.
+- `info` - Display metadata for a source node including document name, paragraph number, content type, garage_key, and embedding status.
+
+---
+
+### list
+
+List source nodes (chunks) in the graph. Sources are chunks of ingested documents. Filter by ontology name to see sources from specific documents.
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --ontology <name>` | Filter by ontology/document name (partial match) | - |
+| `-l, --limit <n>` | Maximum sources to return | `"50"` |
+| `--offset <n>` | Skip N sources (pagination) | `"0"` |
+| `-j, --json` | Output raw JSON | - |
+
+### get
+
+Download the original source document from Garage storage. This returns the complete document as it was before chunking, not individual chunks. Useful for verification, re-processing, or archival. Output goes to stdout by default (for piping) or to a file with -o.
+
+**Usage:**
+```bash
+kg get <source-id>
+```
+
+**Arguments:**
+
+- `<source-id>` - Source ID (e.g., sha256:abc123_chunk1)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-o, --output <file>` | Save to file instead of stdout | - |
+| `-m, --metadata` | Show source metadata instead of content | - |
+
+### info
+
+Display metadata for a source node including document name, paragraph number, content type, garage_key, and embedding status.
+
+**Usage:**
+```bash
+kg info <source-id>
+```
+
+**Arguments:**
+
+- `<source-id>` - Source ID

--- a/docs/reference/cli/commands/storage.md
+++ b/docs/reference/cli/commands/storage.md
@@ -1,0 +1,96 @@
+# kg storage
+
+> Auto-generated
+
+## storage
+
+Read-only diagnostics for S3-compatible object storage. List objects, inspect metadata, verify integrity after cascade deletes, and view retention policies. Useful for integration testing and debugging storage behavior.
+
+**Usage:**
+```bash
+kg storage [options]
+```
+
+**Subcommands:**
+
+- `health` - Check storage backend connectivity and bucket accessibility
+- `stats` - Show storage usage statistics by category (sources, images, projections, artifacts)
+- `list` - List objects in storage with optional prefix filter. Examples: kg storage list --prefix sources/ --limit 20
+- `inspect` - Inspect metadata for a single object without downloading content. Use the full S3 key from "kg storage list".
+- `integrity` - Cross-reference S3 objects against graph nodes. Finds orphaned objects (in S3 but not graph) and missing objects (in graph but not S3). Essential for verifying cascade deletes.
+- `retention` - Show current retention policy configuration for each storage category
+
+---
+
+### health
+
+Check storage backend connectivity and bucket accessibility
+
+**Usage:**
+```bash
+kg health [options]
+```
+
+### stats
+
+Show storage usage statistics by category (sources, images, projections, artifacts)
+
+**Usage:**
+```bash
+kg stats [options]
+```
+
+### list
+
+List objects in storage with optional prefix filter. Examples: kg storage list --prefix sources/ --limit 20
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-p, --prefix <prefix>` | S3 key prefix filter (e.g. sources/, images/My_Ontology/) | - |
+| `-l, --limit <n>` | Maximum objects to return | `50` |
+| `-o, --offset <n>` | Number of objects to skip | `0` |
+
+### inspect
+
+Inspect metadata for a single object without downloading content. Use the full S3 key from "kg storage list".
+
+**Usage:**
+```bash
+kg inspect <key>
+```
+
+**Arguments:**
+
+- `<key>` - S3 object key (e.g. sources/My_Ontology/abc123.md)
+
+### integrity
+
+Cross-reference S3 objects against graph nodes. Finds orphaned objects (in S3 but not graph) and missing objects (in graph but not S3). Essential for verifying cascade deletes.
+
+**Usage:**
+```bash
+kg integrity [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ontology <name>` | Scope check to a specific ontology | - |
+| `--category <type>` | Storage category: sources, images | `"sources"` |
+
+### retention
+
+Show current retention policy configuration for each storage category
+
+**Usage:**
+```bash
+kg retention [options]
+```

--- a/docs/reference/cli/commands/vocabulary.md
+++ b/docs/reference/cli/commands/vocabulary.md
@@ -13,27 +13,27 @@ kg vocabulary [options]
 
 **Subcommands:**
 
-- `status` - Show current vocabulary status including size, zone (GREEN/WATCH/DANGER/EMERGENCY per ADR-032), aggressiveness (growth above minimum), and thresholds. Shows breakdown of builtin types, custom types, and categories. Use this to monitor vocabulary health, check zone before consolidation, track growth over time, and trigger consolidation workflows when needed.
-- `list` - List all edge types with statistics, categories, and confidence scores (ADR-047). Shows TYPE (colored by semantic), CATEGORY (composition, causation, logical, etc.), CONF (confidence score with ⚠ for ambiguous), GROUNDING (epistemic status avg_grounding), EDGES (usage count), STATUS (active ✓), and [B] flag for builtin types. Use this for vocabulary overview, finding consolidation candidates, reviewing auto-categorization accuracy, identifying unused types, and auditing quality.
-- `consolidate` - AI-assisted vocabulary consolidation workflow (AITL - AI-in-the-loop, ADR-032). Analyzes vocabulary via embeddings, identifies similar pairs above threshold, presents merge recommendations with confidence, and executes or prompts based on mode. Workflow: 1) analyze vocabulary, 2) identify candidates, 3) present recommendations, 4) execute or prompt, 5) apply merges (deprecate source, redirect edges), 6) prune unused types (default). Modes: interactive (default, prompts each), dry-run (shows candidates without executing), AITL auto (auto-executes high confidence). Threshold guidelines: 0.95+ very conservative, 0.90-0.95 balanced AITL, 0.85-0.90 aggressive requires review, <0.85 very aggressive manual review.
-- `merge` - Manually merge one edge type into another for consolidation or correction. Validates both types exist, redirects all edges from deprecated type to target type, marks deprecated type as inactive, records audit trail (reason, user, timestamp), and preserves edge provenance. This is a non-destructive, atomic operation useful for manual consolidation, fixing misnamed types from extraction, bulk scripted operations, and targeted category cleanup. Safety: edges preserved, atomic transaction, audit trail for compliance, can be reviewed in inactive types list.
-- `generate-embeddings` - Generate vector embeddings for vocabulary types (required for consolidation and categorization). Identifies types without embeddings, generates embeddings using configured embedding model, stores embeddings for similarity comparison, and enables consolidation and auto-categorization. Use after fresh install (bootstrap vocabulary embeddings), after ingestion introduces new custom types, when switching embedding models (regenerate), or for inconsistency fixes (force regeneration if corrupted). Performance: ~100-200ms per embedding (OpenAI), ~20-50ms per embedding (local models), parallel generation (batches of 10).
-- `category-scores` - Show category similarity scores for a specific relationship type (ADR-047). Displays assigned category, confidence score (calculated as max_score/second_max_score * 100), ambiguous flag (set when runner-up within 20% of winner), runner-up category if ambiguous, and similarity to all category seeds (0-100%) sorted by similarity with visual bar chart. Use this to verify auto-categorization makes sense, debug low confidence assignments, understand why confidence is low, resolve ambiguity between close categories, and audit all types for misassignments.
-- `refresh-categories` - Refresh category assignments for vocabulary types using latest embeddings (ADR-047, ADR-053). As of ADR-053, new edge types are automatically categorized during ingestion, so this command is primarily needed when category seeds change. Use when category seed definitions are updated (seeds currently defined in code, future: database-configurable), after embedding model changes, or for migrating pre-ADR-053 uncategorized types. This is a non-destructive operation (doesn't affect edges), preserves manual assignments, and records audit trail per type.
-- `similar` - Find similar edge types via embedding similarity (ADR-053). Shows types with highest cosine similarity - useful for synonym detection and consolidation. Use --limit to control results (1-100, default 10). Similar types with high similarity (>0.90) are strong merge candidates for vocabulary consolidation (ADR-052).
-- `opposite` - Find opposite (least similar) edge types via embedding similarity (ADR-053). Shows types with lowest cosine similarity - useful for understanding semantic range and antonyms. Use --limit to control results (1-100, default 5).
-- `analyze` - Detailed analysis of vocabulary type for quality assurance (ADR-053). Shows category fit, similar types in same/other categories, and detects potential miscategorization. Use this to verify auto-categorization accuracy and identify types that may need reclassification.
-- `search` - Search for vocabulary terms by natural language query (useful when creating edges to find the best relationship type).
-- `config` - Show or update vocabulary configuration. No args: display config table. With args: update properties directly using database key names (e.g., "kg vocab config vocab_max 275 vocab_emergency 350"). Property names shown in config table.
-- `profiles` - Manage aggressiveness profiles (Bezier curves for consolidation behavior). Has nested subcommands: `list`, `show`, `create`, `delete`.
-- `epistemic-status` - Epistemic status classification for vocabulary types (ADR-065 Phase 2). Shows knowledge validation state based on grounding patterns: WELL_GROUNDED (avg >0.8, well-established), MIXED_GROUNDING (0.15-0.8, variable validation), WEAK_GROUNDING (0.0-0.15, emerging evidence), POORLY_GROUNDED (-0.5-0.0, uncertain), CONTRADICTED (<-0.5, refuted), HISTORICAL (temporal vocabulary), INSUFFICIENT_DATA (<3 measurements). Results are temporal measurements that change as graph evolves. Use for filtering relationships by epistemic reliability, identifying contested knowledge, tracking knowledge validation trends, and curating high-confidence vs exploratory subgraphs.
+- `status` - Show current vocabulary status including size, zone (GREEN/WATCH/DANGER/EMERGENCY per ADR-032), aggressiveness, and thresholds.
+- `list` - List all edge types with statistics, categories, and confidence scores (ADR-047).
+- `consolidate` - AI-assisted vocabulary consolidation workflow (AITL - AI-in-the-loop, ADR-032). Analyzes vocabulary via embeddings, identifies similar pairs above threshold, presents merge recommendations.
+- `merge` - Manually merge one edge type into another. Redirects all edges from deprecated type to target type.
+- `generate-embeddings` - Generate vector embeddings for vocabulary types (required for consolidation and categorization).
+- `category-scores` - Show category similarity scores for a specific relationship type (ADR-047).
+- `refresh-categories` - Refresh category assignments for vocabulary types using latest embeddings (ADR-047, ADR-053).
+- `search` - Search for vocabulary terms by natural language query. Useful when creating edges to find the best relationship type.
+- `similar` - Find similar edge types via embedding similarity (ADR-053). Shows types with highest cosine similarity - useful for synonym detection and consolidation.
+- `opposite` - Find opposite (least similar) edge types via embedding similarity (ADR-053). Shows types with lowest cosine similarity.
+- `analyze` - Detailed analysis of vocabulary type for quality assurance (ADR-053). Shows category fit and potential miscategorization.
+- `config` - Show or update vocabulary configuration. No args: display config. With args: update properties (e.g., "kg vocab config vocab_max 275").
+- `profiles` - Manage aggressiveness profiles (Bezier curves for consolidation behavior)
+- `epistemic-status` - Epistemic status classification for vocabulary types (ADR-065). Shows knowledge validation state based on grounding patterns.
 - `sync` - Sync missing edge types from graph to vocabulary (ADR-077). Discovers edge types used in the graph but not registered in vocabulary table/VocabType nodes. Use --dry-run first to preview, then --execute to sync.
 
 ---
 
 ### status
 
-Show current vocabulary status including size, zone (GREEN/WATCH/DANGER/EMERGENCY per ADR-032), aggressiveness (growth above minimum), and thresholds. Shows breakdown of builtin types, custom types, and categories. Use this to monitor vocabulary health, check zone before consolidation, track growth over time, and trigger consolidation workflows when needed.
+Show current vocabulary status including size, zone (GREEN/WATCH/DANGER/EMERGENCY per ADR-032), aggressiveness, and thresholds.
 
 **Usage:**
 ```bash
@@ -42,7 +42,7 @@ kg status [options]
 
 ### list
 
-List all edge types with statistics, categories, and confidence scores (ADR-047). Shows TYPE (colored by semantic), CATEGORY (composition, causation, logical, etc.), CONF (confidence score with ⚠ for ambiguous), GROUNDING (epistemic status avg_grounding), EDGES (usage count), STATUS (active ✓), and [B] flag for builtin types. Use this for vocabulary overview, finding consolidation candidates, reviewing auto-categorization accuracy, identifying unused types, and auditing quality.
+List all edge types with statistics, categories, and confidence scores (ADR-047).
 
 **Usage:**
 ```bash
@@ -55,12 +55,12 @@ kg list [options]
 |--------|-------------|---------|
 | `--inactive` | Include inactive/deprecated types | - |
 | `--no-builtin` | Exclude builtin types | - |
-| `--sort <fields>` | Sort by comma-separated fields: edges, type, conf, grounding, category, status (case-insensitive). Default: edges (descending) | - |
+| `--sort <fields>` | Sort by comma-separated fields: edges, type, conf, grounding, category, status (default: edges) | - |
 | `--json` | Output as JSON for programmatic use | - |
 
 ### consolidate
 
-AI-assisted vocabulary consolidation workflow (AITL - AI-in-the-loop, ADR-032). Analyzes vocabulary via embeddings, identifies similar pairs above threshold, presents merge recommendations with confidence, and executes or prompts based on mode. Workflow: 1) analyze vocabulary, 2) identify candidates, 3) present recommendations, 4) execute or prompt, 5) apply merges (deprecate source, redirect edges), 6) prune unused types (default). Modes: interactive (default, prompts each), dry-run (shows candidates without executing), AITL auto (auto-executes high confidence). Threshold guidelines: 0.95+ very conservative, 0.90-0.95 balanced AITL, 0.85-0.90 aggressive requires review, <0.85 very aggressive manual review.
+AI-assisted vocabulary consolidation workflow (AITL - AI-in-the-loop, ADR-032). Analyzes vocabulary via embeddings, identifies similar pairs above threshold, presents merge recommendations.
 
 **Usage:**
 ```bash
@@ -73,13 +73,12 @@ kg consolidate [options]
 |--------|-------------|---------|
 | `-t, --target <size>` | Target vocabulary size | `"90"` |
 | `--threshold <value>` | Auto-execute threshold (0.0-1.0) | `"0.90"` |
-| `--dry-run` | Evaluate candidates without executing merges | - |
-| `--auto` | Auto-execute high confidence merges (AITL mode) | - |
-| `--no-prune-unused` | Skip pruning vocabulary types with 0 uses (default: prune enabled) | - |
+| `--dry-run` | Preview candidates without executing (no merges, no pruning) | - |
+| `--no-prune-unused` | Skip pruning vocabulary types with 0 uses | - |
 
 ### merge
 
-Manually merge one edge type into another for consolidation or correction. Validates both types exist, redirects all edges from deprecated type to target type, marks deprecated type as inactive, records audit trail (reason, user, timestamp), and preserves edge provenance. This is a non-destructive, atomic operation useful for manual consolidation, fixing misnamed types from extraction, bulk scripted operations, and targeted category cleanup. Safety: edges preserved, atomic transaction, audit trail for compliance, can be reviewed in inactive types list.
+Manually merge one edge type into another. Redirects all edges from deprecated type to target type.
 
 **Usage:**
 ```bash
@@ -100,7 +99,7 @@ kg merge <deprecated-type> <target-type>
 
 ### generate-embeddings
 
-Generate vector embeddings for vocabulary types (required for consolidation and categorization). Identifies types without embeddings, generates embeddings using configured embedding model, stores embeddings for similarity comparison, and enables consolidation and auto-categorization. Use after fresh install (bootstrap vocabulary embeddings), after ingestion introduces new custom types, when switching embedding models (regenerate), or for inconsistency fixes (force regeneration if corrupted). Performance: ~100-200ms per embedding (OpenAI), ~20-50ms per embedding (local models), parallel generation (batches of 10).
+Generate vector embeddings for vocabulary types (required for consolidation and categorization).
 
 **Usage:**
 ```bash
@@ -116,7 +115,7 @@ kg generate-embeddings [options]
 
 ### category-scores
 
-Show category similarity scores for a specific relationship type (ADR-047). Displays assigned category, confidence score (calculated as max_score/second_max_score * 100), ambiguous flag (set when runner-up within 20% of winner), runner-up category if ambiguous, and similarity to all category seeds (0-100%) sorted by similarity with visual bar chart. Use this to verify auto-categorization makes sense, debug low confidence assignments, understand why confidence is low, resolve ambiguity between close categories, and audit all types for misassignments.
+Show category similarity scores for a specific relationship type (ADR-047).
 
 **Usage:**
 ```bash
@@ -129,7 +128,7 @@ kg category-scores <type>
 
 ### refresh-categories
 
-Refresh category assignments for vocabulary types using latest embeddings (ADR-047, ADR-053). As of ADR-053, new edge types are automatically categorized during ingestion, so this command is primarily needed when category seeds change. Use when category seed definitions are updated (seeds currently defined in code, future: database-configurable), after embedding model changes, or for migrating pre-ADR-053 uncategorized types. This is a non-destructive operation (doesn't affect edges), preserves manual assignments, and records audit trail per type.
+Refresh category assignments for vocabulary types using latest embeddings (ADR-047, ADR-053).
 
 **Usage:**
 ```bash
@@ -140,58 +139,7 @@ kg refresh-categories [options]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--computed-only` | Refresh only types with category_source=computed (excludes manual assignments) | - |
-
-### similar
-
-Find similar edge types via embedding similarity (ADR-053). Shows types with highest cosine similarity - useful for synonym detection and consolidation. Use --limit to control results (1-100, default 10). Similar types with high similarity (>0.90) are strong merge candidates for vocabulary consolidation (ADR-052).
-
-**Usage:**
-```bash
-kg similar <type>
-```
-
-**Arguments:**
-
-- `<type>` - Relationship type to analyze (e.g., IMPLIES)
-
-**Options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--limit <n>` | Number of results to return (1-100) | `"10"` |
-
-### opposite
-
-Find opposite (least similar) edge types via embedding similarity (ADR-053). Shows types with lowest cosine similarity - useful for understanding semantic range and antonyms. Use --limit to control results (1-100, default 5).
-
-**Usage:**
-```bash
-kg opposite <type>
-```
-
-**Arguments:**
-
-- `<type>` - Relationship type to analyze (e.g., IMPLIES)
-
-**Options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--limit <n>` | Number of results to return (1-100) | `"5"` |
-
-### analyze
-
-Detailed analysis of vocabulary type for quality assurance (ADR-053). Shows category fit, similar types in same/other categories, and detects potential miscategorization. Use this to verify auto-categorization accuracy and identify types that may need reclassification.
-
-**Usage:**
-```bash
-kg analyze <type>
-```
-
-**Arguments:**
-
-- `<type>` - Relationship type to analyze (e.g., STORES)
+| `--computed-only` | Refresh only types with category_source=computed | - |
 
 ### search
 
@@ -213,26 +161,77 @@ kg search <query>
 | `--limit <n>` | Number of results to return (1-20) | `"5"` |
 | `--json` | Output as JSON for scripting | - |
 
-### config
+### similar
 
-Show or update vocabulary configuration. No args: display config table. With args: update properties directly using database key names (e.g., "kg vocab config vocab_max 275 vocab_emergency 350"). Property names shown in config table.
+Find similar edge types via embedding similarity (ADR-053). Shows types with highest cosine similarity - useful for synonym detection and consolidation.
 
 **Usage:**
 ```bash
-kg config [properties...]
+kg similar <type>
 ```
 
 **Arguments:**
 
-- `<properties...>` - Property assignments: key value [key value...]
+- `<type>` - Relationship type to analyze (e.g., IMPLIES)
 
-### profiles
+**Options:**
 
-Manage aggressiveness profiles (Bezier curves for consolidation behavior).
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--limit <n>` | Number of results to return (1-100) | `"10"` |
+
+### opposite
+
+Find opposite (least similar) edge types via embedding similarity (ADR-053). Shows types with lowest cosine similarity.
 
 **Usage:**
 ```bash
-kg profiles [subcommand]
+kg opposite <type>
+```
+
+**Arguments:**
+
+- `<type>` - Relationship type to analyze (e.g., IMPLIES)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--limit <n>` | Number of results to return (1-100) | `"5"` |
+
+### analyze
+
+Detailed analysis of vocabulary type for quality assurance (ADR-053). Shows category fit and potential miscategorization.
+
+**Usage:**
+```bash
+kg analyze <type>
+```
+
+**Arguments:**
+
+- `<type>` - Relationship type to analyze (e.g., STORES)
+
+### config
+
+Show or update vocabulary configuration. No args: display config. With args: update properties (e.g., "kg vocab config vocab_max 275").
+
+**Usage:**
+```bash
+kg config [properties]
+```
+
+**Arguments:**
+
+- `<properties>` - Property assignments: key value [key value...]
+
+### profiles
+
+Manage aggressiveness profiles (Bezier curves for consolidation behavior)
+
+**Usage:**
+```bash
+kg profiles [options]
 ```
 
 **Subcommands:**
@@ -246,11 +245,11 @@ kg profiles [subcommand]
 
 #### list
 
-List all aggressiveness profiles including builtin (8 predefined) and custom profiles.
+List all aggressiveness profiles including builtin (8 predefined) and custom profiles. Shows profile name, control points, description, and builtin flag.
 
 **Usage:**
 ```bash
-kg vocab profiles list
+kg list [options]
 ```
 
 #### show
@@ -259,7 +258,7 @@ Show details for a specific aggressiveness profile including Bezier parameters a
 
 **Usage:**
 ```bash
-kg vocab profiles show <name>
+kg show <name>
 ```
 
 **Arguments:**
@@ -272,7 +271,7 @@ Create a custom aggressiveness profile with Bezier curve parameters.
 
 **Usage:**
 ```bash
-kg vocab profiles create [options]
+kg create [options]
 ```
 
 **Options:**
@@ -292,7 +291,7 @@ Delete a custom aggressiveness profile. Cannot delete builtin profiles.
 
 **Usage:**
 ```bash
-kg vocab profiles delete <name>
+kg delete <name>
 ```
 
 **Arguments:**
@@ -301,7 +300,7 @@ kg vocab profiles delete <name>
 
 ### epistemic-status
 
-Epistemic status classification for vocabulary types (ADR-065 Phase 2). Shows knowledge validation state based on grounding patterns: WELL_GROUNDED (avg >0.8, well-established), MIXED_GROUNDING (0.15-0.8, variable validation), WEAK_GROUNDING (0.0-0.15, emerging evidence), POORLY_GROUNDED (-0.5-0.0, uncertain), CONTRADICTED (<-0.5, refuted), HISTORICAL (temporal vocabulary), INSUFFICIENT_DATA (<3 measurements). Results are temporal measurements that change as graph evolves. Use for filtering relationships by epistemic reliability, identifying contested knowledge, tracking knowledge validation trends, and curating high-confidence vs exploratory subgraphs.
+Epistemic status classification for vocabulary types (ADR-065). Shows knowledge validation state based on grounding patterns.
 
 **Usage:**
 ```bash
@@ -310,15 +309,15 @@ kg epistemic-status [options]
 
 **Subcommands:**
 
-- `list` - List all vocabulary types with their epistemic status classifications and statistics. Shows TYPE, STATUS (color-coded), AVG GROUNDING (reliability score), SAMPLED (edges analyzed), and MEASURED AT (timestamp). Filter by status using --status flag. Sorted by highest grounding first. Use for overview of epistemic landscape, finding high-confidence types for critical queries, identifying contested/contradictory types needing review, and tracking temporal evolution of knowledge validation.
-- `show` - Show detailed epistemic status for a specific vocabulary type including full grounding statistics, measurement timestamp, and rationale. Displays classification (WELL_GROUNDED/MIXED_GROUNDING/etc.), average grounding (reliability), standard deviation (consistency), min/max range (outliers), sample sizes (measurement scope), total edges (population), and measurement timestamp (temporal context). Use for deep-diving on specific types, understanding classification rationale, verifying measurement quality, and tracking individual type evolution.
-- `measure` - Run epistemic status measurement for all vocabulary types (ADR-065 Phase 2). Samples edges (default 100 per type), calculates grounding dynamically for target concepts (bounded recursion), classifies epistemic patterns (AFFIRMATIVE/CONTESTED/CONTRADICTORY/HISTORICAL), and optionally stores results to VocabType nodes. Measurement is temporal and observer-dependent - results change as graph evolves. Use --sample-size to control precision vs speed (larger samples = more accurate but slower), --no-store for analysis without persistence, --verbose for detailed statistics. This enables Phase 2 query filtering via GraphQueryFacade.match_concept_relationships().
+- `list` - List all vocabulary types with their epistemic status classifications and statistics.
+- `show` - Show detailed epistemic status for a specific vocabulary type.
+- `measure` - Run epistemic status measurement for all vocabulary types (ADR-065).
 
 ---
 
 #### list
 
-List all vocabulary types with their epistemic status classifications and statistics. Shows TYPE, STATUS (color-coded), AVG GROUNDING (reliability score), SAMPLED (edges analyzed), and MEASURED AT (timestamp). Filter by status using --status flag. Sorted by highest grounding first. Use for overview of epistemic landscape, finding high-confidence types for critical queries, identifying contested/contradictory types needing review, and tracking temporal evolution of knowledge validation.
+List all vocabulary types with their epistemic status classifications and statistics.
 
 **Usage:**
 ```bash
@@ -333,7 +332,7 @@ kg list [options]
 
 #### show
 
-Show detailed epistemic status for a specific vocabulary type including full grounding statistics, measurement timestamp, and rationale. Displays classification (WELL_GROUNDED/MIXED_GROUNDING/etc.), average grounding (reliability), standard deviation (consistency), min/max range (outliers), sample sizes (measurement scope), total edges (population), and measurement timestamp (temporal context). Use for deep-diving on specific types, understanding classification rationale, verifying measurement quality, and tracking individual type evolution.
+Show detailed epistemic status for a specific vocabulary type.
 
 **Usage:**
 ```bash
@@ -346,7 +345,7 @@ kg show <type>
 
 #### measure
 
-Run epistemic status measurement for all vocabulary types (ADR-065 Phase 2). Samples edges (default 100 per type), calculates grounding dynamically for target concepts (bounded recursion), classifies epistemic patterns (AFFIRMATIVE/CONTESTED/CONTRADICTORY/HISTORICAL), and optionally stores results to VocabType nodes. Measurement is temporal and observer-dependent - results change as graph evolves. Use --sample-size to control precision vs speed (larger samples = more accurate but slower), --no-store for analysis without persistence, --verbose for detailed statistics. This enables Phase 2 query filtering via GraphQueryFacade.match_concept_relationships().
+Run epistemic status measurement for all vocabulary types (ADR-065).
 
 **Usage:**
 ```bash

--- a/fuse/kg_fuse/filesystem/read.py
+++ b/fuse/kg_fuse/filesystem/read.py
@@ -194,7 +194,7 @@ class ReadMixin:
             except Exception as e:
                 log.debug(f"Could not fetch concepts for document: {e}")
 
-        return self._format_document(data, concepts)
+        return self._format_document(data, concepts, entry.ontology)
 
     async def _read_concept(self, entry: InodeEntry) -> str:
         """Read and format a concept file."""
@@ -242,9 +242,9 @@ class ReadMixin:
 
         return format_job(data)
 
-    def _format_document(self, data: dict, concepts: list = None) -> str:
+    def _format_document(self, data: dict, concepts: list = None, ontology: str = None) -> str:
         """Format document data as markdown with optional YAML frontmatter."""
-        return format_document(data, concepts, self.tags_config)
+        return format_document(data, concepts, self.tags_config, ontology=ontology)
 
     def _format_concept(self, data: dict) -> str:
         """Format concept data as markdown with YAML frontmatter."""

--- a/fuse/kg_fuse/formatters.py
+++ b/fuse/kg_fuse/formatters.py
@@ -6,17 +6,29 @@ from .config import TagsConfig
 from .query_store import Query
 
 
-def format_document(data: dict, concepts: list = None, tags_config: TagsConfig = None) -> str:
-    """Format document data as markdown with optional YAML frontmatter."""
+def format_document(data: dict, concepts: list = None, tags_config: TagsConfig = None,
+                    ontology: str = None) -> str:
+    """Format document data as markdown with optional YAML frontmatter.
+
+    Args:
+        data: The /documents/{id}/content API response.
+        concepts: Concepts linked to the document (drives tag frontmatter).
+        tags_config: Controls whether YAML frontmatter/tags are emitted.
+        ontology: The ontology the document was browsed under. FUSE knows this
+            from the mount path; the content response does not carry it, so it
+            is passed in here rather than falling back to "unknown".
+    """
     concepts = concepts or []
     tags_config = tags_config or TagsConfig()
+    # Prefer the path-derived ontology FUSE knows over the (absent) API value.
+    ont = ontology or data.get("ontology") or "unknown"
     lines = []
 
     # Add YAML frontmatter if tags are enabled and we have concepts
     if tags_config.enabled and concepts:
         lines.append("---")
         lines.append(f"document_id: {data.get('document_id', 'unknown')}")
-        lines.append(f"ontology: {data.get('ontology', 'unknown')}")
+        lines.append(f"ontology: {ont}")
 
         # Add concept tags
         tags = []
@@ -35,7 +47,7 @@ def format_document(data: dict, concepts: list = None, tags_config: TagsConfig =
         lines.append("")
 
     lines.append(f"# {data.get('filename', 'Document')}\n")
-    lines.append(f"**Ontology:** {data.get('ontology', 'unknown')}\n")
+    lines.append(f"**Ontology:** {ont}\n")
     lines.append(f"**Document ID:** {data.get('document_id', 'unknown')}\n")
     lines.append("")
 

--- a/fuse/tests/test_formatters.py
+++ b/fuse/tests/test_formatters.py
@@ -1,0 +1,38 @@
+"""Tests for markdown formatters — focused on the ontology-source fix.
+
+Regression guard: the /documents/{id}/content response does not carry the
+ontology, so format_document must use the path-derived ontology FUSE passes in
+rather than rendering "unknown".
+"""
+
+from kg_fuse.config import TagsConfig
+from kg_fuse.formatters import format_document
+
+
+def _doc():
+    return {"document_id": "sha256:abc", "filename": "doc.md", "chunks": []}
+
+
+def test_ontology_arg_used_in_frontmatter_and_body():
+    tags = TagsConfig(enabled=True)
+    concepts = [{"name": "Convivial Tool"}]
+    out = format_document(_doc(), concepts, tags, ontology="Conviviality of Knowledge Graphs")
+    assert "ontology: Conviviality of Knowledge Graphs" in out
+    assert "**Ontology:** Conviviality of Knowledge Graphs" in out
+    assert "ontology: unknown" not in out
+
+
+def test_ontology_arg_overrides_content_value():
+    # Path-derived ontology wins even if the API response carried one.
+    data = {**_doc(), "ontology": "stale-value"}
+    out = format_document(data, [{"name": "X"}], TagsConfig(enabled=True), ontology="real-ontology")
+    assert "ontology: real-ontology" in out
+    assert "stale-value" not in out
+
+
+def test_falls_back_to_data_then_unknown_when_no_arg():
+    # No ontology arg: use data's value, else "unknown" (preserves old behavior).
+    assert "ontology: from-data" in format_document(
+        {**_doc(), "ontology": "from-data"}, [{"name": "X"}], TagsConfig(enabled=True)
+    )
+    assert "**Ontology:** unknown" in format_document(_doc(), [], TagsConfig(enabled=True))


### PR DESCRIPTION
Two fixes for issues found while verifying the v0.14.0 release through the FUSE mount.

## 1. CLI doc generator drove from a stale hardcoded list (`fix(cli)`)
`cli/scripts/simple-doc-gen.mjs` kept its own hardcoded 12-module list that had drifted from the real CLI registry — the generated index listed only **10 of 26** commands and omitted `catalog` (ADR-501) entirely.

- Hoisted the `subcommands` array to a module-level **`documentedCommands`** export in `commands.ts` (single source of truth the CLI registers from; includes the 3 auth commands).
- `simple-doc-gen.mjs` now maps over that registry — **cannot silently drop commands again**.
- Regenerated `docs/reference/cli/` → all **26** commands + 14 previously-missing per-command files.
- ✅ 46/46 CLI tests pass; registration refactor verified.

## 2. FUSE document frontmatter showed `ontology: unknown` (`fix(fuse)`)
The `/documents/{id}/content` API response doesn't carry the ontology, so `format_document` fell back to `"unknown"` — visible when reading a doc through the mount, even though FUSE knows the ontology from the browse path.

- Thread `entry.ontology` → `_read_document` → `_format_document` → `format_document`, preferring it over the absent API value.
- Added `fuse/tests/test_formatters.py` (3 tests) to guard it.
- ✅ 267/267 FUSE tests pass.

## Release impact
- The CLI fix is repo-docs + build tooling only — **no npm republish needed** (0.13.0 stands).
- The FUSE fix needs a **`kg-fuse` 0.12.1** PyPI patch to reach installed drivers (follow-up after merge).