### PR TITLE
feat(vision): vision capability slot under the uniform provider contract (ADR-802, #378)

### DIFF
--- a/api/app/lib/ai_vision_config.py
+++ b/api/app/lib/ai_vision_config.py
@@ -1,0 +1,186 @@
+"""
+AI Vision Configuration Management
+
+Loads and saves the active vision (image->prose) provider selection from/to
+the database, mirroring ai_extraction_config (ADR-041) under the ADR-802
+decision that vision is a first-class provider capability resolved
+independently like embedding.
+
+This module is SELECTION-ONLY: it persists which provider/model is active for
+vision and its reasoning controls. Connectivity (base_url, API keys) is reused
+from the existing per-provider mechanisms (encrypted key store + env / provider
+config) — a provider's endpoint is the same whether it serves extraction or
+vision, so it is not duplicated here.  @verified b4106aac
+"""
+
+import logging
+from typing import Optional, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+
+def load_active_vision_config() -> Optional[Dict[str, Any]]:
+    """Load the active vision provider config row, or None if no provider is
+    active for vision.
+
+    A None result is normal, not an error: with no active vision config the
+    resolver falls to the ADR-802 §2 default (the active extraction provider
+    when it has a supports_vision catalog model).  @verified b4106aac
+    """
+    from .age_client import AGEClient
+
+    try:
+        client = AGEClient()
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT id, provider, model_name, max_tokens, temperature,
+                           created_at, updated_at, updated_by, active
+                    FROM kg_api.ai_vision_config
+                    WHERE active = TRUE
+                    LIMIT 1
+                """)
+                row = cur.fetchone()
+                if not row:
+                    logger.info("📍 No active vision config in database")
+                    return None
+                return _row_to_config(row)
+        finally:
+            client.pool.putconn(conn)
+    except Exception as e:
+        logger.error(f"Failed to load active vision config: {e}")
+        return None
+
+
+def load_vision_provider_config(provider: str) -> Optional[Dict[str, Any]]:
+    """Load a specific provider's saved vision config row regardless of whether
+    it is the active vision provider (parallel to
+    ai_extraction_config.load_provider_config).  @verified b4106aac
+    """
+    from .age_client import AGEClient
+
+    try:
+        client = AGEClient()
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT id, provider, model_name, max_tokens, temperature,
+                           created_at, updated_at, updated_by, active
+                    FROM kg_api.ai_vision_config
+                    WHERE provider = %s
+                    LIMIT 1
+                """, (provider,))
+                row = cur.fetchone()
+                return _row_to_config(row) if row else None
+        finally:
+            client.pool.putconn(conn)
+    except Exception as e:
+        logger.error(f"Failed to load vision provider config for {provider}: {e}")
+        return None
+
+
+def save_vision_config(config: Dict[str, Any], updated_by: str = "api") -> bool:
+    """Upsert one provider's vision config (per-provider row, UNIQUE(provider)).
+
+    Carries the ADR-801 §3 send-only-what-changed invariant: ON CONFLICT
+    (provider) every optional field is COALESCEd against the stored value, so a
+    partial save never nulls the rest of the row. `model_name` uses
+    NULLIF(EXCLUDED.model_name,'') so the empty-string sentinel of a brand-new
+    row never overwrites a real stored model.
+
+    `config['active']` (default True) controls the active pointer only: True
+    activates this provider and deactivates the others; False persists config
+    without changing which vision provider is active.
+
+    Args:
+        config: dict; `provider` required. Optional: model_name, max_tokens,
+            temperature, active.
+        updated_by: who made the change.
+
+    Returns:
+        True on success, False otherwise.  @verified b4106aac
+    """
+    from .age_client import AGEClient
+
+    try:
+        client = AGEClient()
+        conn = client.pool.getconn()
+        try:
+            activate = config.get('active', True)
+            with conn.cursor() as cur:
+                cur.execute("BEGIN")
+
+                if activate:
+                    cur.execute("""
+                        UPDATE kg_api.ai_vision_config
+                        SET active = FALSE
+                        WHERE active = TRUE AND provider <> %s
+                    """, (config['provider'],))
+
+                # Partial-save safety: absent optional fields are passed as NULL
+                # and COALESCEd against the stored value (or fall to column
+                # defaults on a brand-new row). model_name '' never overwrites a
+                # real model (NULLIF). See ai_extraction_config.save_extraction_config.
+                cur.execute("""
+                    INSERT INTO kg_api.ai_vision_config (
+                        provider, model_name, max_tokens, temperature,
+                        updated_by, active
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (provider) DO UPDATE SET
+                        model_name = COALESCE(
+                            NULLIF(EXCLUDED.model_name, ''),
+                            kg_api.ai_vision_config.model_name),
+                        max_tokens = COALESCE(
+                            EXCLUDED.max_tokens,
+                            kg_api.ai_vision_config.max_tokens),
+                        temperature = COALESCE(
+                            EXCLUDED.temperature,
+                            kg_api.ai_vision_config.temperature),
+                        updated_by = EXCLUDED.updated_by,
+                        active = CASE WHEN %s THEN TRUE
+                                      ELSE kg_api.ai_vision_config.active END,
+                        updated_at = NOW()
+                """, (
+                    config['provider'],
+                    config.get('model_name', ''),
+                    config.get('max_tokens'),
+                    config.get('temperature'),
+                    updated_by,
+                    activate,
+                    activate,
+                ))
+
+                cur.execute("COMMIT")
+                logger.info(
+                    f"✅ Saved vision config: {config['provider']} / "
+                    f"{config.get('model_name') or '(catalog)'} (active={activate})"
+                )
+                return True
+        except Exception as e:
+            try:
+                cur.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise e
+        finally:
+            client.pool.putconn(conn)
+    except Exception as e:
+        logger.error(f"Failed to save vision config: {e}")
+        return False
+
+
+def _row_to_config(row) -> Dict[str, Any]:
+    """Map an ai_vision_config row tuple to a config dict.  @verified b4106aac"""
+    return {
+        "id": row[0],
+        "provider": row[1],
+        "model_name": row[2],
+        "max_tokens": row[3],
+        "temperature": row[4],
+        "created_at": row[5],
+        "updated_at": row[6],
+        "updated_by": row[7],
+        "active": row[8],
+    }

--- a/api/app/lib/ingestion.py
+++ b/api/app/lib/ingestion.py
@@ -49,8 +49,17 @@ def _retrieve_candidate_concepts(
     failure (empty graph, embedding worker down) — candidate retrieval is an
     optimisation, never a hard dependency of ingestion. Degrades silently so a
     retrieval hiccup never fails an ingest; the graph-adjacency seed still
-    provides context.  @verified b4106aac
+    provides context.
+
+    Cost: without pgvector, ``vector_search`` is a Python-side full scan over
+    all embedded concepts (see age_client.query.vector_search). This adds one
+    such scan per chunk, on top of the per-extracted-concept matching scans
+    already in the concept loop. Set ``EXTRACTION_CANDIDATE_K=0`` to disable
+    retrieval entirely (kill switch for very large graphs without pgvector).
+    @verified b4106aac
     """
+    if limit <= 0:
+        return []  # kill switch — skip the per-chunk full scan
     try:
         worker = get_embedding_worker()
         if worker is None:

--- a/api/app/lib/ingestion.py
+++ b/api/app/lib/ingestion.py
@@ -22,6 +22,68 @@ from api.app.lib.ai_providers import get_provider
 from api.app.services.embedding_worker import get_embedding_worker
 
 
+# --- Reasoner context: global candidate-concept retrieval (#453) -----------
+# The reasoner is seeded with existing concepts so it reuses them instead of
+# coining near-duplicates. The graph-adjacency seed (get_document_concepts,
+# ontology-scoped, arbitrary cap) is blind to the globally-similar concepts
+# the post-extraction merge (vector_search, global) will actually fold into —
+# so duplicates that fall just under the merge threshold fragment the graph.
+# We retrieve the top-K concepts most similar to the chunk embedding (the same
+# global space the merge uses) and prioritise them as candidates, bounded by K
+# to cap prompt size. Tunable so the relevance/over-merge trade-off can be
+# dialled per deployment (showing more candidates biases toward reuse, which at
+# the extreme over-merges similar-but-distinct concepts).
+CANDIDATE_CONCEPT_K = int(os.getenv("EXTRACTION_CANDIDATE_K", "30"))
+CANDIDATE_CONCEPT_THRESHOLD = float(os.getenv("EXTRACTION_CANDIDATE_THRESHOLD", "0.5"))
+
+
+def _retrieve_candidate_concepts(
+    age_client: AGEClient,
+    text: str,
+    limit: int = CANDIDATE_CONCEPT_K,
+    threshold: float = CANDIDATE_CONCEPT_THRESHOLD,
+) -> List[Dict[str, Any]]:
+    """Top-K existing concepts most similar to ``text`` (global, #453).
+
+    Returns [{concept_id, label}] ranked by embedding similarity, or [] on any
+    failure (empty graph, embedding worker down) — candidate retrieval is an
+    optimisation, never a hard dependency of ingestion. Degrades silently so a
+    retrieval hiccup never fails an ingest; the graph-adjacency seed still
+    provides context.  @verified b4106aac
+    """
+    try:
+        worker = get_embedding_worker()
+        if worker is None:
+            return []
+        embedding = worker.generate_concept_embedding(text)["embedding"]
+        matches = age_client.vector_search(
+            embedding=embedding, threshold=threshold, top_k=limit)
+        return [{"concept_id": m["concept_id"], "label": m["label"]} for m in matches]
+    except Exception as e:
+        logger.debug(f"Candidate-concept retrieval failed (non-fatal): {e}",
+                     exc_info=True)
+        return []
+
+
+def _merge_context_concepts(
+    candidates: List[Dict[str, Any]],
+    existing: List[Dict[str, Any]],
+    limit: int = CANDIDATE_CONCEPT_K,
+) -> List[Dict[str, Any]]:
+    """Merge relevance-ranked candidates with the ontology seed, dedup by
+    concept_id, candidates first, bounded by ``limit``.  @verified b4106aac"""
+    seen: set = set()
+    merged: List[Dict[str, Any]] = []
+    for c in list(candidates) + list(existing):
+        cid = c.get("concept_id")
+        if cid and cid not in seen:
+            seen.add(cid)
+            merged.append(c)
+        if len(merged) >= limit:
+            break
+    return merged
+
+
 class ChunkedIngestionStats:
     """Track ingestion statistics for chunked processing."""
 
@@ -274,12 +336,24 @@ def process_chunk(
         logger.debug(f"  Source embedding error details:", exc_info=True)
         # Continue with ingestion - embeddings can be regenerated later
 
-    # Step 2: Extract concepts via LLM (with context from recent concepts)
+    # #453: build the reasoner context. Retrieve the concepts most similar to
+    # this chunk (global, the same space the post-extraction merge uses) and
+    # prioritise them over the ontology-adjacency seed, so the reasoner sees —
+    # and can reuse — exactly the concepts its output might merge into, instead
+    # of only an arbitrary same-ontology slice. Bounded by K to cap prompt size.
+    candidate_concepts = _retrieve_candidate_concepts(age_client, chunk.text)
+    context_concepts = _merge_context_concepts(candidate_concepts, existing_concepts)
+    if candidate_concepts:
+        logger.info(
+            f"  🔎 {len(candidate_concepts)} candidate concept(s) retrieved; "
+            f"{len(context_concepts)} in reasoner context")
+
+    # Step 2: Extract concepts via LLM (with context from relevant concepts)
     try:
         extraction_response = extract_concepts(
             text=chunk.text,
             source_id=source_id,
-            existing_concepts=existing_concepts,
+            existing_concepts=context_concepts,
             age_client=age_client  # ADR-049: Pass client for dynamic direction examples
         )
         extraction = extraction_response["result"]
@@ -309,8 +383,9 @@ def process_chunk(
     # Map LLM concept_ids to actual concept_ids for relationship processing
     concept_id_map = {}
 
-    # Pre-populate with existing concepts so LLM can reference them in relationships
-    for existing in existing_concepts:
+    # Pre-populate with the same context concepts shown to the reasoner so it
+    # can reference them in relationships (#453: candidates + ontology seed).
+    for existing in context_concepts:
         # Existing concepts already have their actual IDs
         concept_id_map[existing["concept_id"]] = existing["concept_id"]
 

--- a/api/app/lib/vision_providers.py
+++ b/api/app/lib/vision_providers.py
@@ -98,6 +98,79 @@ def _resolve_vision_model(provider: str, model: Optional[str] = None) -> str:
     )
 
 
+# --- Active vision provider resolution (ADR-802 §2, #378) ------------------
+# Vision is a first-class provider capability resolved independently like
+# embedding. The provider is no longer a hardcoded "openai" literal: it
+# resolves through a defined chain, and a chosen provider with no usable
+# vision model fails loud rather than silently misrouting image->prose.
+
+def resolve_vision_selection(
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+) -> tuple[str, Optional[str]]:
+    """Resolve which provider/model performs image->prose (ADR-802 §2).
+
+    Resolution order, fail-loud at the end:
+      1. Explicit override (per-job ``vision_provider`` / ``VISION_PROVIDER``
+         env) — unchanged behaviour for callers that name a provider.
+      2. The configured **active vision provider** (its own pointer in
+         ``kg_api.ai_vision_config``), and its stored model if the caller
+         gave none.
+      3. Default: the **active extraction provider**, but only when its
+         catalog has a ``supports_vision`` model — so single-provider
+         deployments need zero vision config, without re-introducing a bare
+         provider literal.
+      4. Otherwise raise — no silent fallback to a hardcoded provider.
+
+    Note this resolves only the provider *name* (and optionally a model).
+    The model is still resolved/validated against the catalog by
+    ``_resolve_vision_model`` inside the provider constructor, which is the
+    fail-loud point when a provider has no vision-capable model.
+
+    Returns:
+        (provider_name, model_or_None)
+
+    Raises:
+        ValueError: when no vision provider can be resolved.  @verified b4106aac
+    """
+    # 1. Explicit override (param or dev-mode env), parallel to AI_PROVIDER.
+    explicit = provider or os.getenv("VISION_PROVIDER")
+    if explicit:
+        return explicit.lower(), model
+
+    # 2. Active vision config pointer.
+    try:
+        from .ai_vision_config import load_active_vision_config
+        vc = load_active_vision_config()
+        if vc and vc.get("provider"):
+            return vc["provider"].lower(), (model or (vc.get("model_name") or None))
+    except Exception:
+        logger.debug("Active vision config lookup failed; trying extraction default",
+                     exc_info=True)
+
+    # 3. Default to the active extraction provider iff it is vision-capable.
+    try:
+        from .ai_extraction_config import load_active_extraction_config
+        ec = load_active_extraction_config()
+        ep = ec.get("provider") if ec else None
+        if ep and _catalog_vision_model_ids(ep):
+            logger.info(
+                "Vision provider unset; defaulting to active extraction "
+                f"provider '{ep}' (has a supports_vision catalog model)")
+            return ep.lower(), model
+    except Exception:
+        logger.debug("Extraction-default vision resolution failed", exc_info=True)
+
+    # 4. Fail loud — no hardcoded provider literal (the #378 bug).
+    raise ValueError(
+        "No vision provider could be resolved (ADR-802 §2): no explicit "
+        "override, no active vision config, and the active extraction provider "
+        "has no vision-capable model in the catalog. Configure a vision "
+        "provider (POST /admin/vision/config) or run the provider's 'Get "
+        "models' admin action so a supports_vision model is in the catalog."
+    )
+
+
 # Literal description prompt (validated in research, Nov 2025)
 # See docs/research/vision-testing/FINDINGS.md
 LITERAL_DESCRIPTION_PROMPT = """
@@ -674,8 +747,10 @@ def get_vision_provider(
     Factory function to get vision provider instance.
 
     Args:
-        provider: Provider name ('openai', 'anthropic', 'ollama')
-                 Defaults to VISION_PROVIDER env var or 'openai'
+        provider: Provider name ('openai', 'anthropic', 'ollama'). When None,
+                 it is resolved via resolve_vision_selection (ADR-802 §2):
+                 active vision config → active extraction provider if
+                 vision-capable → ValueError. No hardcoded 'openai' default.
         api_key: API key (optional, will use env vars if not provided)
         model: Model name (optional, will use env vars or provider defaults)
 
@@ -683,10 +758,11 @@ def get_vision_provider(
         VisionProvider instance
 
     Raises:
-        ValueError: If provider not recognized or configuration invalid
+        ValueError: If no provider can be resolved, the provider is not
+            recognized, or the configuration is invalid.
 
     Examples:
-        # Use default provider (OpenAI GPT-4o)
+        # Resolve the configured/active vision provider (ADR-802 §2)
         provider = get_vision_provider()
 
         # Use specific provider
@@ -695,8 +771,10 @@ def get_vision_provider(
         # Override model
         provider = get_vision_provider(provider="openai", model="gpt-4o-mini")
     """
-    provider = provider or os.getenv("VISION_PROVIDER", "openai")
-    provider = provider.lower()
+    # ADR-802 §2 / #378: resolve the provider through the defined chain rather
+    # than defaulting to a hardcoded 'openai'. An explicit `provider` arg is
+    # honoured as-is; None triggers config/catalog-aware resolution.
+    provider, model = resolve_vision_selection(provider=provider, model=model)
 
     logger.info(f"Initializing vision provider: {provider}")
 

--- a/api/app/lib/vision_providers.py
+++ b/api/app/lib/vision_providers.py
@@ -138,7 +138,13 @@ def resolve_vision_selection(
     if explicit:
         return explicit.lower(), model
 
-    # 2. Active vision config pointer.
+    # 2. Active vision config pointer. Deliberately NO _catalog_vision_model_ids
+    #    check here (unlike step 3): an operator who explicitly activated this
+    #    provider chose it, and the POST /admin/vision/config guard already
+    #    rejected activation without a usable model. If the catalog later loses
+    #    that model, we still honour the explicit choice and fail loud at
+    #    _resolve_vision_model — a named, diagnosable error — rather than
+    #    silently overriding the operator's selection with a different provider.
     try:
         from .ai_vision_config import load_active_vision_config
         vc = load_active_vision_config()

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -31,7 +31,7 @@ from .services.scheduled_jobs_manager import JobScheduler as ScheduledJobsManage
 from .services.worker_registry import register_all_workers, get_all_job_types, validate_lane_uniqueness
 from .services.lane_manager import LaneManager
 from .launchers import CategoryRefreshLauncher, VocabConsolidationLauncher, EpistemicRemeasurementLauncher, VocabEmbeddingLauncher, ProjectionLauncher, ArtifactCleanupLauncher, AnnealingLauncher
-from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, oauth, sources, projection, artifacts, grants, query_definitions, documents, concepts, edges, graph, storage_admin, programs, admin_workers, models, epochs, catalog
+from .routes import ingest, ingest_image, jobs, queries, database, ontology, admin, auth, rbac, vocabulary, vocabulary_config, embedding, extraction, vision, oauth, sources, projection, artifacts, grants, query_definitions, documents, concepts, edges, graph, storage_admin, programs, admin_workers, models, epochs, catalog
 from .services.embedding_worker import get_embedding_worker
 from .lib.age_client import AGEClient
 from .lib.ai_providers import get_provider
@@ -517,6 +517,8 @@ app.include_router(embedding.public_router)  # ADR-039: Public embedding config
 app.include_router(embedding.admin_router)  # ADR-039: Admin embedding management
 app.include_router(extraction.public_router)  # ADR-041: Public extraction config
 app.include_router(extraction.admin_router)  # ADR-041: Admin extraction management
+app.include_router(vision.public_router)  # ADR-802: Public vision provider config
+app.include_router(vision.admin_router)  # ADR-802: Admin vision provider management
 app.include_router(projection.router)  # ADR-078: Embedding landscape projections
 app.include_router(artifacts.router)  # ADR-083: Artifact persistence
 app.include_router(grants.router)  # ADR-082: Groups and resource grants

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -690,11 +690,18 @@ async def list_providers(
     # in get_provider() yet — don't surface a card that can't function.
     unimplemented = {"vllm"}
 
+    # ADR-802: vision is a catalog-described capability. `supports_vision` is
+    # true when the provider has a supports_vision model in the catalog, so the
+    # UI can data-drive a vision selector without hardcoding which providers
+    # can do image->prose.
+    from ..lib.vision_providers import _catalog_vision_model_ids
+
     providers = [
         {
             "provider": name,
             "requires_key": name in API_KEY_PROVIDERS,
             "is_local": name in LOCAL_PROVIDERS,
+            "supports_vision": bool(_catalog_vision_model_ids(name)),
         }
         for name in sorted(EXTRACTION_PROVIDERS)
         if name not in unimplemented

--- a/api/app/routes/ingest_image.py
+++ b/api/app/routes/ingest_image.py
@@ -151,7 +151,7 @@ async def ingest_image(
     force: bool = Form(False, description="Force re-ingestion even if duplicate"),
     auto_approve: bool = Form(False, description="Auto-approve job (skip approval step)"),
     processing_mode: str = Form("serial", description="Processing mode: serial or parallel"),
-    vision_provider: Optional[str] = Form(None, description="Vision provider: openai (default), anthropic, ollama"),
+    vision_provider: Optional[str] = Form(None, description="Vision provider override (openai/anthropic/ollama); unset resolves the active/default vision provider per ADR-802"),
     vision_model: Optional[str] = Form(None, description="Vision model name (optional, uses provider default)"),
     # ADR-051: Source metadata (optional)
     source_type: Optional[str] = Form(None, description="Source type: file, mcp, api"),
@@ -282,8 +282,10 @@ async def ingest_image(
         "content_type": "image",  # Mark as image for worker routing
         "original_filename": file.filename,
         "image_size_bytes": len(content),
-        # Vision config (worker will use these)
-        "vision_provider": vision_provider or "openai",
+        # Vision config (worker will use these). Pass the override through as-is
+        # (may be None) so the worker resolves the active/default vision
+        # provider per ADR-802 §2 / #378 — no hardcoded 'openai' here.
+        "vision_provider": vision_provider,
         "vision_model": vision_model,
         "uploaded_by": current_user.username,
     }

--- a/api/app/routes/vision.py
+++ b/api/app/routes/vision.py
@@ -1,0 +1,183 @@
+"""
+Vision Provider Configuration Routes (ADR-802 / #378)
+
+Vision is a first-class provider capability resolved independently like
+embedding. These endpoints expose the active vision-provider selection that
+backs the ADR-802 §2 resolution chain (explicit override → active vision
+config → active extraction provider if vision-capable → fail loud).
+
+Public endpoints:
+- GET  /vision/config        - active vision provider/model summary
+
+Admin endpoints:
+- GET  /admin/vision/config  - active vision config detail (or null)
+- POST /admin/vision/config  - set/activate the vision provider
+- GET  /admin/vision/providers - which providers are vision-capable (catalog)
+
+Authorization reuses the `extraction_config` RBAC resource: configuring the
+vision provider is the same class of admin operation as configuring the
+extraction provider, so no new RBAC resource/migration is introduced.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from ..dependencies.auth import CurrentUser, require_permission
+from ..constants import EXTRACTION_PROVIDERS
+from ..lib.ai_vision_config import (
+    load_active_vision_config,
+    load_vision_provider_config,
+    save_vision_config,
+)
+from ..lib.vision_providers import (
+    _catalog_vision_model_ids,
+    _resolve_vision_model,
+    resolve_vision_selection,
+)
+
+logger = logging.getLogger(__name__)
+
+public_router = APIRouter(prefix="/vision", tags=["vision"])
+admin_router = APIRouter(prefix="/admin/vision", tags=["admin", "vision"])
+
+# vllm is an EXTRACTION_PROVIDERS placeholder with no connector — never a card.
+_UNIMPLEMENTED = {"vllm"}
+
+
+class UpdateVisionConfigRequest(BaseModel):
+    """Set/activate the vision provider. Only `provider` is required; an empty
+    `model_name` resolves from the catalog's supports_vision rows."""
+    provider: str
+    model_name: Optional[str] = None
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    active: bool = True
+    updated_by: str = "api"
+
+
+def _vision_summary() -> dict:
+    """Resolve the effective vision provider/model for client display.
+
+    Mirrors the resolution the worker uses, so clients see what an image
+    ingest would actually use — including the extraction-provider default —
+    rather than only an explicitly-saved row. Returns provider=None when
+    nothing resolves (a misconfiguration the operator must fix).  @verified b4106aac
+    """
+    try:
+        provider, model = resolve_vision_selection()
+    except Exception:
+        return {"provider": None, "model": None, "source": "unresolved"}
+    # Resolve the effective model (catalog → env) so the summary shows what an
+    # ingest would actually use; None if the provider has no usable model.
+    try:
+        model = _resolve_vision_model(provider, model)
+    except Exception:
+        model = None
+    active = load_active_vision_config()
+    source = "vision_config" if (active and active.get("provider") == provider) else "extraction_default"
+    return {"provider": provider, "model": model, "source": source}
+
+
+@public_router.get("/config")
+async def get_vision_config():
+    """Effective vision provider/model summary (public, no auth)."""
+    return _vision_summary()
+
+
+@admin_router.get("/config")
+async def get_vision_config_detail(
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("extraction_config", "read")),
+):
+    """Active vision config row (or null), plus the effective resolution.
+
+    `config` is null when no vision provider has been explicitly activated —
+    in that case `effective` shows the ADR-802 §2 default (the active
+    extraction provider when vision-capable).
+
+    **Authorization:** Requires `extraction_config:read` permission
+    """
+    return {"config": load_active_vision_config(), "effective": _vision_summary()}
+
+
+@admin_router.post("/config")
+async def update_vision_config(
+    request: UpdateVisionConfigRequest,
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("extraction_config", "write")),
+):
+    """Set/activate the vision provider (ADR-802 §2).
+
+    Validates the provider against the supported set and, when activating,
+    that the provider has a vision-capable catalog model (or an explicit
+    model is supplied) — so we never activate a provider that would fail
+    loud at the first image. Partial saves preserve other fields (COALESCE).
+
+    **Authorization:** Requires `extraction_config:write` permission
+    """
+    provider = request.provider.lower()
+    if provider in _UNIMPLEMENTED or provider not in EXTRACTION_PROVIDERS:
+        valid = ", ".join(f"'{p}'" for p in sorted(EXTRACTION_PROVIDERS - _UNIMPLEMENTED))
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid vision provider: {request.provider}. Must be one of: {valid}",
+        )
+
+    # Don't activate a provider that has no usable vision model: that would
+    # only surface as a fail-loud error on the next image ingest.
+    if request.active and not request.model_name and not _catalog_vision_model_ids(provider):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Provider '{provider}' has no vision-capable model in the catalog. "
+                "Run the provider's 'Get models' admin action first, or pass an "
+                "explicit model_name."
+            ),
+        )
+
+    ok = save_vision_config(
+        {
+            "provider": provider,
+            "model_name": request.model_name or "",
+            "max_tokens": request.max_tokens,
+            "temperature": request.temperature,
+            "active": request.active,
+        },
+        updated_by=request.updated_by,
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save vision configuration",
+        )
+    logger.info(f"✅ Vision config updated: {provider} (active={request.active})")
+    return {"status": "success", "provider": provider, "effective": _vision_summary()}
+
+
+@admin_router.get("/providers")
+async def list_vision_providers(
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("api_keys", "read")),
+):
+    """Vision-capability metadata per provider (data-driven UI, ADR-801 style).
+
+    `supports_vision` is true when the provider has at least one
+    `supports_vision` model in the catalog — i.e. it can be activated for
+    vision without an explicit model. `vision_models` lists those ids.
+
+    **Authorization:** Requires `api_keys:read` permission
+    """
+    providers = []
+    for name in sorted(EXTRACTION_PROVIDERS - _UNIMPLEMENTED):
+        model_ids = _catalog_vision_model_ids(name)
+        providers.append(
+            {
+                "provider": name,
+                "supports_vision": bool(model_ids),
+                "vision_models": model_ids,
+            }
+        )
+    return {"providers": providers}

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -228,7 +228,10 @@ def run_ingestion_worker(
         logger.info("Converting image to prose with vision AI...")
         from api.app.lib.vision_providers import get_vision_provider, LITERAL_DESCRIPTION_PROMPT
         try:
-            vision_provider_name = job_data.get("vision_provider", "openai")
+            # ADR-802 §2 / #378: pass the per-job override through (may be None);
+            # get_vision_provider resolves the active/default provider when unset
+            # rather than defaulting to a hardcoded 'openai'.
+            vision_provider_name = job_data.get("vision_provider")
             vision_model_name = job_data.get("vision_model")
 
             vision_provider = get_vision_provider(

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -162,7 +162,7 @@ _Providers, extraction, convergence, prompts_
 | [ADR-070](./ai-embeddings/ADR-070-polarity-axis-analysis.md) | Polarity Axis Analysis for Bidirectional Semantic Dimensions | Accepted |
 | [ADR-800](./ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md) | Dynamic Model Catalog and OpenRouter Support | Accepted |
 | [ADR-801](./ai-embeddings/ADR-801-uniform-provider-configuration-contract.md) | Uniform Provider Configuration Contract | Draft |
-| [ADR-802](./ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md) | Unify Vision Providers Under the Uniform Provider Contract | Proposed |
+| [ADR-802](./ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md) | Unify Vision Providers Under the Uniform Provider Contract | Accepted |
 
 ## Meta/Process
 _Documentation, workflow, access models, ADR system_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -162,6 +162,7 @@ _Providers, extraction, convergence, prompts_
 | [ADR-070](./ai-embeddings/ADR-070-polarity-axis-analysis.md) | Polarity Axis Analysis for Bidirectional Semantic Dimensions | Accepted |
 | [ADR-800](./ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md) | Dynamic Model Catalog and OpenRouter Support | Accepted |
 | [ADR-801](./ai-embeddings/ADR-801-uniform-provider-configuration-contract.md) | Uniform Provider Configuration Contract | Draft |
+| [ADR-802](./ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md) | Unify Vision Providers Under the Uniform Provider Contract | Proposed |
 
 ## Meta/Process
 _Documentation, workflow, access models, ADR system_

--- a/docs/architecture/ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md
+++ b/docs/architecture/ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 date: 2026-05-30
 deciders:
   - aaronsb

--- a/docs/architecture/ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md
+++ b/docs/architecture/ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md
@@ -1,0 +1,222 @@
+---
+status: Proposed
+date: 2026-05-30
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-800
+  - ADR-801
+  - ADR-039
+  - ADR-045
+  - ADR-041
+---
+
+# ADR-802: Unify Vision Providers Under the Uniform Provider Contract
+
+## Context
+
+ADR-800 made *which models exist* catalog-driven; ADR-801 made *how a
+reasoning provider is configured and selected* a uniform four-surface
+contract (validate / enumerate / reasoning controls / persisted per-provider
+config, with a per-provider config row decoupled from a single `active`
+pointer). The catalog-driven vision work (task #13,
+`feat/adr-801-catalog-driven-vision-selection`) made vision selection of
+*which model* catalog-driven via the per-row `supports_vision` flag, but
+deliberately stopped there. Two gaps remain, filed as #378 and #379:
+
+- **#378 — vision provider default is a bare hardcoded policy.**
+  `ingestion_worker.py` resolves the vision provider as
+  `job_data.get("vision_provider", "openai")`. The default is `"openai"`
+  independent of what is configured or active. A deployment running only
+  Anthropic or only a local model still sends image→prose to OpenAI unless
+  every job explicitly overrides it.
+
+- **#379 — vision is a parallel hierarchy, not a unified one.**
+  `api/app/lib/vision_providers.py` duplicates the reasoning hierarchy in
+  `api/app/lib/ai_providers.py`: separate `VisionProvider` ABC, separate
+  per-provider classes (OpenAI / Anthropic / Ollama), separate
+  `describe_image()` interface, separate `get_vision_provider` factory,
+  separate validation and enumeration. Task #13 made the two share the
+  **model catalog** only; they do **not** share the ADR-801 four-surface
+  contract, and there is no vision equivalent of the
+  per-provider-config-plus-active-pointer resolution that extraction has.
+
+The system already runs **two** decoupled provider capabilities, not one:
+
+- **Reasoning/extraction** resolves its active provider from
+  `kg_api.ai_extraction_config` via `load_active_extraction_config()` — a
+  per-provider row plus a single `active` flag (ADR-801 §2).
+- **Embedding** resolves *independently* via `get_embedding_provider()`
+  (ADR-039/045). A local multimodal model can serve embeddings regardless of
+  which cloud provider does extraction. As the code states: "the embedder
+  stays separate (delegated), as with every reasoning provider."
+
+Vision is the third capability, but it was never given this treatment — it
+was left as a hardcoded default over a parallel hierarchy.
+
+## Decision
+
+**Vision is a first-class provider capability, resolved independently like
+embedding, under the ADR-801 uniform contract.** Concretely:
+
+### 1. Three capability slots, one contract
+
+A deployment selects an active provider per **capability** — reasoning,
+embedding, vision — independently. All three speak the ADR-801 four-surface
+contract (validate / enumerate / reasoning controls / persisted per-provider
+config) and draw their model lists from the ADR-800 catalog. A provider's
+*capabilities* are catalog-described: a model row's `supports_vision` flag
+declares it can serve the vision slot, exactly as it already gates vision
+model selection.
+
+This mirrors the established reasoning-vs-embedding split rather than
+inventing a new abstraction. Vision is decoupled from extraction the same
+way embedding is: choosing OpenAI for extraction does not force OpenAI for
+vision, and a locally hosted multimodal model can serve the vision slot
+while a cloud provider does extraction.
+
+**Independent does not mean different.** The slots are configured
+independently but may freely **coincide on one model**. Reasoning is the
+higher-capability operation and is realistically cloud here
+(OpenAI / Anthropic / OpenRouter) — local hardware on this machine is not
+expected to host a reasoning-grade model. Within that, three shapes are all
+first-class and expressible by the same mechanism:
+
+- **One model, both slots** — a multimodal cloud model whose catalog row has
+  `supports_vision` true serves *both* the reasoning and vision slots. No
+  second configuration is needed; the single model's capability flags decide
+  it.
+- **Two models, one provider** — vision→prose handled by a vision-capable
+  model and reasoning by a stronger text model, both from the same provider.
+- **Two providers** — e.g. a local multimodal model for vision→prose, a
+  cloud provider for reasoning.
+
+The per-model `supports_vision` catalog flag is precisely what lets a single
+model satisfy both slots without special-casing: the vision slot resolves to
+"a model that can do vision," which may be the very model the reasoning slot
+already points at.
+
+### 2. Vision resolves an active provider — never a hardcoded literal
+
+`get_vision_provider()` resolves the provider the way extraction does:
+
+1. Explicit per-job override (`job_data["vision_provider"]`) — unchanged.
+2. Otherwise the **configured active vision provider** (its own pointer,
+   parallel to extraction's `active`).
+3. The chosen provider must have a `supports_vision` catalog model; if it
+   does not, resolution **fails loud** with a diagnosable error naming the
+   provider and the admin action that populates the catalog — consistent
+   with the existing `_resolve_vision_model` "no literal fallback" stance.
+
+The hardcoded `"openai"` default at `ingestion_worker.py` is removed. This
+closes #378: the default is no longer a bare provider literal independent of
+configuration, behaviour is defined when the chosen provider has no
+vision-capable model, and the resolution policy is testable.
+
+### 3. Scope boundary — vision-reasoning is decoupled; visual *embedding* is not
+
+This ADR governs the **vision-reasoning** capability (image→prose,
+`describe_image()`), and *only* that. The image ingestion path is a hairpin:
+`image → prose → concepts` (`routes/ingest_image.py`). The vision slot can be
+any vision-capable provider precisely **because its output is prose** — a
+model-agnostic text string that rides the existing text-embedding path. By
+the time anything is embedded, it is text; no cross-modal vector comparison
+occurs. This is why the vision slot may be chosen as freely as the embedding
+slot is chosen relative to reasoning.
+
+The system *also* generates a **direct visual embedding** (currently Nomic
+Vision v1.5, 768-dim) stored alongside the prose-derived concepts and
+explicitly placed in the **same vector space as the text embeddings**. That
+co-spatiality is mandatory: an image vector is only comparable to a concept
+vector if both embedders share one space. The text and image embedders are
+therefore **a matched pair, not independently selectable** — either one
+multimodal model serves both (a multimodal profile), or a co-trained pair
+(e.g. Nomic text-v1.5 ↔ vision-v1.5) whose alignment *is* the guarantee.
+Mixing unrelated embedders (e.g. OpenAI `text-embedding-3` text + Nomic
+vision images) puts the vectors in different spaces and makes cross-modal
+similarity meaningless.
+
+This coupling is **out of scope here** — it belongs to the embedding
+**profile** abstraction (`kg_api.embedding_profile`, migration 055) and its
+pending decision record (issues #321, #325). The boundary is the point:
+
+> Independence between capability slots is permitted exactly where their
+> outputs later **converge** to a common representation (reasoning and vision
+> both converge to prose/concepts). Coupling is mandatory where the outputs
+> **are themselves the comparison surface** (text and visual embeddings are
+> compared directly as vectors, with no later convergence step).
+
+ADR-802 sits on the "converge to prose" side; the embedding-profile decision
+owns the "vectors must be co-spatial" side. Conflating them — e.g. trying to
+make the visual embedder independently selectable the way the vision slot is
+— reintroduces the cross-modal mismatch this boundary exists to prevent.
+
+### 4. Convergence of the parallel hierarchy is incremental, not a rewrite
+
+Unification is a direction, not a big-bang merge. The vision and reasoning
+hierarchies converge on the **shared surfaces** they can share now — the
+catalog (already shared), validation, enumeration, and per-provider config
+persistence — while `describe_image()` remains a distinct capability method
+(image→prose has a genuinely different request shape from text extraction,
+and that distinction is intentional, not accidental drift). The end state is
+one provider abstraction whose methods are capability-gated by the catalog;
+the migration path retires `get_vision_provider`'s parallel validation and
+config-loading in favour of the ADR-801 surfaces, capability by capability,
+behind the existing factory signature.
+
+## Consequences
+
+### Positive
+
+- Closes #378 and answers #379 with a single coherent model: vision is the
+  third capability slot, decoupled and catalog-described.
+- A local multimodal model can serve vision independently of the cloud
+  extraction provider — the same flexibility embedding already has.
+- No deployment silently routes image→prose to OpenAI; mis-selection fails
+  loud with a diagnosable error instead of an invisible default.
+- Adding a vision-capable provider becomes a connector + catalog flag, not a
+  new parallel branch — the ADR-801 "connector + metadata, not surgery"
+  property extends to vision.
+
+### Negative
+
+- A new active-vision pointer (and its admin surface) is configuration that
+  did not exist before; operators now have a third capability to set,
+  although it can sensibly default to "the active extraction provider if it
+  has a vision model" for zero-config single-provider deployments.
+- Incremental convergence means the codebase carries *both* the unified
+  surfaces and the soon-to-be-retired parallel ones during migration; the
+  transitional state must be clearly flagged so it is not mistaken for the
+  end state.
+
+### Neutral
+
+- `describe_image()` stays a distinct capability method; unification is at
+  the configuration/contract layer, not a forced collapse of request shapes.
+- The per-job `vision_provider` override is preserved unchanged — the
+  decision only changes the *default* resolution, not explicit selection.
+- The vision active pointer can reuse the `ai_extraction_config` decoupled
+  pattern or a parallel table; the exact schema shape is an implementation
+  detail settled during #378, not by this ADR.
+
+## Alternatives Considered
+
+- **Vision inherits the active extraction provider** (no independent
+  pointer). Rejected as the *primary* model: it couples image→prose to the
+  text provider and forbids the local-multimodal-for-vision +
+  cloud-for-extraction split that embedding already enjoys. Retained only as
+  a sensible *default* for the vision pointer when unset.
+- **Keep the parallel hierarchy, just make the default catalog-aware**
+  (pick the first provider with a `supports_vision` model). Rejected: it
+  patches #378 without answering #379, leaves two drifting hierarchies, and
+  makes provider selection implicit/order-dependent rather than configured.
+- **Big-bang merge of `vision_providers.py` into `ai_providers.py`.**
+  Rejected: high-risk rewrite of the working extraction path for no
+  immediate user benefit; the four-surface contract can be adopted
+  incrementally behind the existing factory.
+- **Leave the hardcoded `"openai"` default and document it.** Rejected:
+  silently wrong on Anthropic-only / local-only deployments, the exact bug
+  class ADR-801 §2–3 exists to eliminate.
+</content>
+</invoke>

--- a/schema/migrations/074_ai_vision_config.sql
+++ b/schema/migrations/074_ai_vision_config.sql
@@ -1,0 +1,87 @@
+-- Migration 074: ai_vision_config — active vision provider selection (ADR-802 / #378)
+--
+-- ADR-802 makes vision a first-class provider capability resolved independently
+-- like embedding, under the ADR-801 uniform contract. Vision previously had no
+-- persisted selection at all: the worker resolved the provider as a bare
+-- hardcoded `"openai"` (ingestion_worker.py) / `VISION_PROVIDER` env default
+-- (vision_providers.py), independent of what was configured or active (#378).
+--
+-- This table is the vision capability's active pointer, mirroring
+-- ai_extraction_config's per-provider-row + single-`active`-flag pattern
+-- (migration 062, ADR-801 §2). It is SELECTION-ONLY: connectivity (base_url,
+-- API keys) is NOT duplicated here — it is reused from the existing
+-- per-provider mechanisms (encrypted key store + env / provider config), since
+-- a provider's endpoint is the same whether it serves extraction or vision.
+-- The only vision-specific state is which provider/model is active and its
+-- reasoning controls.
+--
+-- model_name defaults to '' (the not-yet-chosen sentinel): an empty model is
+-- resolved from the dynamic model catalog's supports_vision rows at request
+-- time (vision_providers._resolve_vision_model), exactly as extraction does.
+--
+-- NO seed row is inserted. With no active vision config, resolution falls to
+-- the sensible default defined in ADR-802 §2 — the active EXTRACTION provider
+-- when its catalog has a supports_vision model — so single-provider
+-- deployments need zero vision configuration, and we do not re-introduce a
+-- hardcoded provider literal in seed data.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS kg_api.ai_vision_config (
+    id SERIAL PRIMARY KEY,
+
+    -- Which provider performs image->prose. Same provider set as extraction
+    -- (vllm excluded: placeholder, no connector). Connectivity is shared with
+    -- that provider's existing config; this row only selects it for vision.
+    provider VARCHAR(50) NOT NULL
+        CHECK (provider IN ('openai', 'anthropic', 'ollama', 'openrouter', 'llamacpp')),
+
+    -- Vision model id. '' = resolve from the catalog's supports_vision rows.
+    model_name VARCHAR(200) NOT NULL DEFAULT '',
+
+    -- Reasoning controls (ADR-801 surface 3), optional, applied to describe_image.
+    max_tokens INTEGER,
+    temperature DOUBLE PRECISION
+        CHECK (temperature IS NULL OR (temperature >= 0.0 AND temperature <= 1.0)),
+
+    -- Metadata
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_by VARCHAR(100),
+
+    -- The single live vision provider (ADR-801 §2: active pointer decoupled
+    -- from provider identity). Per-provider rows persist independently; only
+    -- one is active at a time (enforced by the partial unique index below).
+    active BOOLEAN DEFAULT TRUE,
+
+    CONSTRAINT ai_vision_config_provider_key UNIQUE (provider)
+);
+
+-- Only one active vision config at a time (PostgreSQL partial unique index;
+-- same construct as ai_extraction_config's active guard).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_vision_config_unique_active
+ON kg_api.ai_vision_config(active) WHERE active = TRUE;
+
+COMMENT ON TABLE kg_api.ai_vision_config IS 'Active vision (image->prose) provider selection — ADR-802 / #378. Selection-only; connectivity reused from per-provider config.';
+COMMENT ON COLUMN kg_api.ai_vision_config.provider IS 'Provider performing image->prose description';
+COMMENT ON COLUMN kg_api.ai_vision_config.model_name IS 'Vision model id; '''' resolves from the catalog supports_vision rows';
+COMMENT ON COLUMN kg_api.ai_vision_config.active IS 'Only one vision config active at a time (enforced by partial unique index)';
+
+-- Reuse the same updated_at trigger function created in migration 004.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger WHERE tgname = 'ai_vision_config_update_timestamp'
+    ) THEN
+        CREATE TRIGGER ai_vision_config_update_timestamp
+            BEFORE UPDATE ON kg_api.ai_vision_config
+            FOR EACH ROW
+            EXECUTE FUNCTION kg_api.update_ai_extraction_config_timestamp();
+    END IF;
+END $$;
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (74, 'ai_vision_config')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/tests/api/test_vision_routes.py
+++ b/tests/api/test_vision_routes.py
@@ -1,0 +1,118 @@
+"""
+Route + persistence tests for the vision provider config contract (ADR-802 / #378).
+
+Locks the HTTP surface the vision capability slot depends on:
+
+- GET  /vision/config           — effective provider/model (public)
+- GET  /admin/vision/config     — active row + effective resolution
+- POST /admin/vision/config     — set/activate, with vision-capable guard
+- GET  /admin/vision/providers  — per-provider supports_vision metadata
+
+DB-mutating tests snapshot-restore kg_api.ai_vision_config so the shared dev
+DB is left untouched (mirrors test_providers_routes.py).
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_admin_permissions(monkeypatch):
+    """Admin token passes RBAC; mirrors test_providers_routes.py."""
+    def always_admin(user, resource_type, action,
+                     resource_id=None, resource_context=None):
+        return user.role == "admin"
+    monkeypatch.setattr(
+        "api.app.dependencies.auth.check_permission", always_admin)
+
+
+@pytest.fixture
+def restore_vision_config():
+    """Snapshot/restore kg_api.ai_vision_config around a mutating test."""
+    from api.app.lib.age_client import AGEClient
+    client = AGEClient()
+    conn = client.pool.getconn()
+    cols = "provider, model_name, max_tokens, temperature, updated_by, active"
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT {cols} FROM kg_api.ai_vision_config")
+            snapshot = cur.fetchall()
+        conn.commit()
+        yield
+    finally:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM kg_api.ai_vision_config")
+                if snapshot:
+                    ph = "(" + ",".join(["%s"] * 6) + ")"
+                    cur.execute(
+                        f"INSERT INTO kg_api.ai_vision_config ({cols}) "
+                        f"VALUES {','.join([ph] * len(snapshot))}",
+                        [v for row in snapshot for v in row],
+                    )
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+
+
+class TestVisionProvidersMetadata:
+    def test_should_require_authentication(self, api_client, mock_oauth_validation):
+        assert api_client.get("/admin/vision/providers").status_code == 401
+
+    def test_should_report_supports_vision_per_provider(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        resp = api_client.get("/admin/vision/providers", headers=auth_headers_admin)
+        assert resp.status_code == 200
+        providers = {p["provider"]: p for p in resp.json()["providers"]}
+        # vllm is a placeholder with no connector — never surfaced.
+        assert "vllm" not in providers
+        # Every entry carries the data-driven capability flag + model list.
+        for p in providers.values():
+            assert isinstance(p["supports_vision"], bool)
+            assert isinstance(p["vision_models"], list)
+
+
+@pytest.mark.usefixtures("restore_vision_config")
+class TestVisionConfigRoundTrip:
+    def test_should_set_activate_and_reflect_in_effective(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        # Activate openai for vision with an explicit model (bypasses the
+        # catalog guard so the test doesn't depend on catalog state).
+        save = api_client.post(
+            "/admin/vision/config", headers=auth_headers_admin,
+            json={"provider": "openai", "model_name": "gpt-4o", "active": True})
+        assert save.status_code == 200, save.text
+        eff = save.json()["effective"]
+        assert eff["provider"] == "openai"
+        assert eff["source"] == "vision_config"
+
+        got = api_client.get("/admin/vision/config", headers=auth_headers_admin).json()
+        assert got["config"]["provider"] == "openai"
+        assert got["config"]["model_name"] == "gpt-4o"
+        assert got["config"]["active"] is True
+
+    def test_partial_save_does_not_wipe_model(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        api_client.post("/admin/vision/config", headers=auth_headers_admin,
+                        json={"provider": "openai", "model_name": "gpt-4o", "active": True})
+        # Re-save without model_name (only temperature) — model must survive.
+        api_client.post("/admin/vision/config", headers=auth_headers_admin,
+                        json={"provider": "openai", "temperature": 0.2, "active": True})
+        cfg = api_client.get("/admin/vision/config", headers=auth_headers_admin).json()["config"]
+        assert cfg["model_name"] == "gpt-4o"
+        assert cfg["temperature"] == 0.2
+
+    def test_should_reject_unsupported_provider(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        resp = api_client.post("/admin/vision/config", headers=auth_headers_admin,
+                               json={"provider": "vllm", "model_name": "x"})
+        assert resp.status_code == 400
+
+    def test_should_reject_activation_without_vision_capable_model(
+            self, api_client, mock_oauth_validation, auth_headers_admin, monkeypatch):
+        # No explicit model + no catalog vision model → 400, not a silent
+        # activation that fails loud at the first image.
+        monkeypatch.setattr(
+            "api.app.routes.vision._catalog_vision_model_ids", lambda p: [])
+        resp = api_client.post("/admin/vision/config", headers=auth_headers_admin,
+                               json={"provider": "ollama", "active": True})
+        assert resp.status_code == 400

--- a/tests/api/test_vision_routes.py
+++ b/tests/api/test_vision_routes.py
@@ -116,3 +116,13 @@ class TestVisionConfigRoundTrip:
         resp = api_client.post("/admin/vision/config", headers=auth_headers_admin,
                                json={"provider": "ollama", "active": True})
         assert resp.status_code == 400
+
+    def test_effective_source_is_extraction_default_when_no_vision_config(
+            self, api_client, mock_oauth_validation, auth_headers_admin):
+        # Zero-config deployment story: with no explicit vision row, the
+        # effective provider comes from the active extraction provider (when
+        # vision-capable) — source must report that, not 'vision_config'.
+        # restore_vision_config guarantees the table is empty here.
+        got = api_client.get("/admin/vision/config", headers=auth_headers_admin).json()
+        assert got["config"] is None
+        assert got["effective"]["source"] in ("extraction_default", "unresolved")

--- a/tests/unit/lib/test_candidate_concepts.py
+++ b/tests/unit/lib/test_candidate_concepts.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for global candidate-concept retrieval (#453).
+
+The reasoner context is seeded with concepts most similar to the chunk (the
+same global space the post-extraction merge uses), prioritised over the
+ontology-adjacency seed and bounded by K. The embedding worker / DB boundary
+is mocked (no network/DB).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from api.app.lib import ingestion as ing
+
+
+class TestMergeContextConcepts:
+    def test_candidates_come_first_then_existing(self):
+        cand = [{"concept_id": "c1", "label": "A"}]
+        existing = [{"concept_id": "e1", "label": "B"}]
+        merged = ing._merge_context_concepts(cand, existing, limit=10)
+        assert [m["concept_id"] for m in merged] == ["c1", "e1"]
+
+    def test_dedup_by_concept_id_keeps_candidate(self):
+        cand = [{"concept_id": "x", "label": "from-candidate"}]
+        existing = [{"concept_id": "x", "label": "from-existing"},
+                    {"concept_id": "y", "label": "Y"}]
+        merged = ing._merge_context_concepts(cand, existing, limit=10)
+        ids = [m["concept_id"] for m in merged]
+        assert ids == ["x", "y"]
+        assert merged[0]["label"] == "from-candidate"  # candidate wins the dup
+
+    def test_bounded_by_limit(self):
+        cand = [{"concept_id": f"c{i}", "label": str(i)} for i in range(50)]
+        merged = ing._merge_context_concepts(cand, [], limit=30)
+        assert len(merged) == 30
+
+    def test_skips_entries_without_concept_id(self):
+        merged = ing._merge_context_concepts(
+            [{"label": "no-id"}], [{"concept_id": "ok", "label": "ok"}], limit=10)
+        assert [m["concept_id"] for m in merged] == ["ok"]
+
+
+class TestRetrieveCandidateConcepts:
+    def test_maps_vector_search_results_to_id_label(self):
+        client = MagicMock()
+        client.vector_search.return_value = [
+            {"concept_id": "c1", "label": "A", "description": "d", "similarity": 0.9},
+            {"concept_id": "c2", "label": "B", "description": "d", "similarity": 0.7},
+        ]
+        worker = MagicMock()
+        worker.generate_concept_embedding.return_value = {"embedding": [0.1, 0.2]}
+        with patch.object(ing, "get_embedding_worker", return_value=worker):
+            out = ing._retrieve_candidate_concepts(client, "some chunk", limit=5, threshold=0.5)
+        assert out == [{"concept_id": "c1", "label": "A"},
+                       {"concept_id": "c2", "label": "B"}]
+        client.vector_search.assert_called_once_with(
+            embedding=[0.1, 0.2], threshold=0.5, top_k=5)
+
+    def test_returns_empty_when_worker_unavailable(self):
+        with patch.object(ing, "get_embedding_worker", return_value=None):
+            assert ing._retrieve_candidate_concepts(MagicMock(), "t") == []
+
+    def test_degrades_to_empty_on_error(self):
+        # Retrieval is an optimisation: any failure must not raise (would fail
+        # the whole ingest), just yields no candidates.
+        worker = MagicMock()
+        worker.generate_concept_embedding.side_effect = Exception("embed down")
+        with patch.object(ing, "get_embedding_worker", return_value=worker):
+            assert ing._retrieve_candidate_concepts(MagicMock(), "t") == []

--- a/tests/unit/lib/test_vision_provider_catalog.py
+++ b/tests/unit/lib/test_vision_provider_catalog.py
@@ -162,3 +162,12 @@ class TestResolveVisionSelection:
              patch("api.app.lib.ai_extraction_config.load_active_extraction_config", return_value=None):
             with pytest.raises(ValueError, match="No vision provider could be resolved"):
                 vp.resolve_vision_selection()
+
+    def test_get_vision_provider_propagates_resolver_error(self):
+        # The headline #378 fix: get_vision_provider() with no explicit provider
+        # no longer defaults to 'openai' — it resolves, and an unresolvable
+        # config raises rather than silently picking a hardcoded provider.
+        with patch.object(vp, "resolve_vision_selection",
+                          side_effect=ValueError("No vision provider could be resolved")):
+            with pytest.raises(ValueError, match="No vision provider could be resolved"):
+                vp.get_vision_provider()

--- a/tests/unit/lib/test_vision_provider_catalog.py
+++ b/tests/unit/lib/test_vision_provider_catalog.py
@@ -104,3 +104,61 @@ class TestOpenAIVisionHeuristic:
         assert cat["gpt-5-preview"]["supports_vision"] is True
         # gpt-3.5 is genuinely not vision-capable.
         assert cat["gpt-3.5-turbo"]["supports_vision"] is False
+
+
+# ===========================================================================
+# resolve_vision_selection — ADR-802 §2 / #378
+# explicit → active vision config → vision-capable extraction default → raise
+# (no hardcoded 'openai' literal)
+# ===========================================================================
+
+class TestResolveVisionSelection:
+    @pytest.fixture(autouse=True)
+    def _no_env(self, monkeypatch):
+        # Default: no VISION_PROVIDER env so the config/default chain is exercised.
+        monkeypatch.delenv("VISION_PROVIDER", raising=False)
+
+    def test_explicit_override_is_honored_and_short_circuits(self):
+        # Explicit provider wins without consulting config/catalog at all.
+        with patch("api.app.lib.ai_vision_config.load_active_vision_config") as lv, \
+             patch("api.app.lib.ai_extraction_config.load_active_extraction_config") as le:
+            assert vp.resolve_vision_selection(provider="Anthropic", model="m") == ("anthropic", "m")
+            lv.assert_not_called()
+            le.assert_not_called()
+
+    def test_vision_provider_env_used_when_no_param(self, monkeypatch):
+        monkeypatch.setenv("VISION_PROVIDER", "ollama")
+        assert vp.resolve_vision_selection() == ("ollama", None)
+
+    def test_active_vision_config_used_when_present(self):
+        with patch("api.app.lib.ai_vision_config.load_active_vision_config",
+                   return_value={"provider": "openai", "model_name": "gpt-4o"}):
+            assert vp.resolve_vision_selection() == ("openai", "gpt-4o")
+
+    def test_explicit_model_overrides_vision_config_model(self):
+        with patch("api.app.lib.ai_vision_config.load_active_vision_config",
+                   return_value={"provider": "openai", "model_name": "gpt-4o"}):
+            assert vp.resolve_vision_selection(model="gpt-4o-mini") == ("openai", "gpt-4o-mini")
+
+    def test_defaults_to_extraction_provider_when_vision_capable(self):
+        with patch("api.app.lib.ai_vision_config.load_active_vision_config", return_value=None), \
+             patch("api.app.lib.ai_extraction_config.load_active_extraction_config",
+                   return_value={"provider": "anthropic"}), \
+             patch.object(vp, "_catalog_vision_model_ids", return_value=["claude-x"]):
+            assert vp.resolve_vision_selection() == ("anthropic", None)
+
+    def test_does_not_default_to_extraction_provider_without_vision_model(self):
+        # Extraction provider has no supports_vision catalog model → fail loud,
+        # rather than picking a provider that would error at the first image.
+        with patch("api.app.lib.ai_vision_config.load_active_vision_config", return_value=None), \
+             patch("api.app.lib.ai_extraction_config.load_active_extraction_config",
+                   return_value={"provider": "ollama"}), \
+             patch.object(vp, "_catalog_vision_model_ids", return_value=[]):
+            with pytest.raises(ValueError, match="No vision provider could be resolved"):
+                vp.resolve_vision_selection()
+
+    def test_raises_when_nothing_resolves(self):
+        with patch("api.app.lib.ai_vision_config.load_active_vision_config", return_value=None), \
+             patch("api.app.lib.ai_extraction_config.load_active_extraction_config", return_value=None):
+            with pytest.raises(ValueError, match="No vision provider could be resolved"):
+                vp.resolve_vision_selection()


### PR DESCRIPTION
## Summary

Makes **vision a first-class provider capability** resolved independently like embedding, under the ADR-801 uniform contract — closing #378 and recording the #379 decision (ADR-802). Also harmonizes the reasoning flow both text and image ingestion share (#453).

Per ADR-802 §4, the full collapse of `vision_providers.py` into `ai_providers.py` is **deliberately deferred** to incremental follow-up — this PR adopts shared surfaces (catalog, validation, config pattern) without the high-risk rewrite.

## What's here

**ADR-802 (Accepted)** — vision/embedding/reasoning are three independently-selectable capability slots, all catalog-described. Includes the boundary note that vision-reasoning (image→prose) is freely decoupled because its output converges to prose, while visual *embedding* must stay co-spatial with text embeddings (owned by the embedding-profile decision, #321/#325).

**#378 — active vision-provider slot** (closes #378)
- `migration 074`: `kg_api.ai_vision_config` (per-provider row + single active pointer, mirrors `ai_extraction_config`; selection-only — connectivity reused from existing per-provider mechanisms)
- `ai_vision_config.py`: load/save with the ADR-801 §3 COALESCE partial-save invariant
- `resolve_vision_selection`: explicit override → active vision config → active extraction provider iff vision-capable → **fail loud** (no hardcoded `"openai"`). Wired through `get_vision_provider`, the worker, and the image route; per-job override preserved
- routes: `GET /vision/config`, `GET/POST /admin/vision/config`, `GET /admin/vision/providers`; `/admin/providers` gains a data-driven `supports_vision` flag

**#453 — global candidate-concept retrieval** (closes #453)
- Reasoner now seeded with the top-K concepts most similar to the chunk (the same global space the post-extraction merge uses), prioritised over the ontology-adjacency seed and bounded by K. Aligns seeding with the already-global merge so the reasoner can reuse concepts its output would otherwise duplicate
- Tunable via `EXTRACTION_CANDIDATE_K` (30) / `EXTRACTION_CANDIDATE_THRESHOLD` (0.5)

## Verification

- New tests: vision resolution policy (unit), vision route/persistence round-trip incl. partial-save + activation guard, candidate-concept dedup/bound/priority + degradation
- Regression: **368 passed, 1 skipped** across `tests/unit/lib` + provider/ingest/vision/health route tests
- Over-merge safety verified on the live graph: the 0.5 candidate floor surfaces relevant context while the 0.85 merge floor sits well above it — seeding never forces a merge

## Deferred (follow-ups filed)
- #454 — web vision provider selector card (backend usable via API; `SystemTab.tsx` already >800 lines, deserves a shared provider-card extraction)
- ADR-802 §4 — incremental collapse of the parallel vision hierarchy

Closes #378, #453. Refs #379, #321, #325, ADR-801.