### PR TITLE
feat: modality embedding architecture + vision config exposure (ADR-803, closes #325 #454)

### DIFF
--- a/api/app/lib/embedding_config.py
+++ b/api/app/lib/embedding_config.py
@@ -707,6 +707,9 @@ def export_embedding_profile(profile_id: int) -> Optional[Dict[str, Any]]:
             "dimensions": config["image_dimensions"],
             "precision": config.get("image_precision"),
             "trust_remote_code": config.get("image_trust_remote_code", False),
+            # ADR-803: the image index's own vector_space, independent of the
+            # profile-level (text) vector_space and never compared to it.
+            "vector_space": config.get("image_vector_space"),
         }
 
     return result

--- a/api/app/lib/embedding_config.py
+++ b/api/app/lib/embedding_config.py
@@ -21,7 +21,8 @@ _PROFILE_COLUMNS = """
     max_seq_length, normalize_embeddings,
     active, delete_protected, change_protected,
     created_at, updated_at, updated_by,
-    text_query_prefix, text_document_prefix
+    text_query_prefix, text_document_prefix,
+    image_vector_space
 """
 
 
@@ -60,6 +61,7 @@ def _row_to_dict(row) -> Dict[str, Any]:
         "updated_by": row[29],
         "text_query_prefix": row[30],
         "text_document_prefix": row[31],
+        "image_vector_space": row[32],  # ADR-803: independent image index space
         # Backward-compat aliases used by model manager and routes
         "provider": row[4],            # text_provider
         "model_name": row[5],          # text_model_name
@@ -162,8 +164,11 @@ def save_embedding_config(config: Dict[str, Any], updated_by: str = "api", force
     image_dimensions = config.get('image_dimensions')
     image_precision = config.get('image_precision', 'float16')
     image_trust_remote_code = config.get('image_trust_remote_code', False)
+    # ADR-803: the image index has its OWN vector_space, independent of the text
+    # space (never compared to it). Optional; NULL for text-only/multimodal.
+    image_vector_space = config.get('image_vector_space')
 
-    # Multimodal: clear image fields
+    # Multimodal: clear image fields (text model serves both roles)
     if multimodal:
         image_provider = None
         image_model_name = None
@@ -172,6 +177,7 @@ def save_embedding_config(config: Dict[str, Any], updated_by: str = "api", force
         image_dimensions = None
         image_precision = None
         image_trust_remote_code = False
+        image_vector_space = None
 
     try:
         client = AGEClient()
@@ -191,6 +197,7 @@ def save_embedding_config(config: Dict[str, Any], updated_by: str = "api", force
                         device, max_memory_mb, num_threads, batch_size,
                         max_seq_length, normalize_embeddings,
                         text_query_prefix, text_document_prefix,
+                        image_vector_space,
                         updated_by, active
                     ) VALUES (
                         %s, %s, %s,
@@ -201,6 +208,7 @@ def save_embedding_config(config: Dict[str, Any], updated_by: str = "api", force
                         %s, %s, %s, %s,
                         %s, %s,
                         %s, %s,
+                        %s,
                         %s, FALSE
                     )
                     RETURNING id
@@ -214,6 +222,7 @@ def save_embedding_config(config: Dict[str, Any], updated_by: str = "api", force
                     config.get('num_threads'), config.get('batch_size', 8),
                     config.get('max_seq_length'), config.get('normalize_embeddings', True),
                     config.get('text_query_prefix'), config.get('text_document_prefix'),
+                    image_vector_space,
                     updated_by
                 ))
 
@@ -512,12 +521,12 @@ def activate_embedding_config(config_id: int, updated_by: str = "api", force_dim
 
                 target_id, target_provider, target_model, target_dims, target_multimodal, target_img_dims = target_row
 
-                # Validate image/text dimension consistency for non-multimodal profiles
-                if not target_multimodal and target_img_dims is not None and target_dims != target_img_dims:
-                    cur.execute("ROLLBACK")
-                    return (False,
-                        f"Profile {config_id} has mismatched text ({target_dims}D) and image ({target_img_dims}D) dimensions. "
-                        "Text and image dimensions must match for non-multimodal profiles.")
+                # ADR-803: the image slot is an INDEPENDENT same-modality index,
+                # never compared to the text/prose space — its dimensions need
+                # NOT match the text model's. The former "text and image
+                # dimensions must match" guard (and chk_image_dimensions_match,
+                # dropped in migration 075) was a co-spatiality assumption the
+                # system never uses. No image/text dimension check on activate.
 
                 # Get currently active profile
                 cur.execute("""

--- a/api/app/models/embedding.py
+++ b/api/app/models/embedding.py
@@ -100,6 +100,8 @@ class EmbeddingProfileDetail(BaseModel):
     image_dimensions: Optional[int] = None
     image_precision: Optional[str] = None
     image_trust_remote_code: bool = False
+    # ADR-803: the image index's own vector_space, independent of text
+    image_vector_space: Optional[str] = None
 
     # Resources
     device: Optional[str] = None
@@ -158,9 +160,10 @@ class EmbeddingProfileCreateRequest(BaseModel):
     image_model_name: Optional[str] = Field(None, description="Image model")
     image_loader: Optional[str] = Field(None, description="Image loader")
     image_revision: Optional[str] = Field(None, description="Image model revision")
-    image_dimensions: Optional[int] = Field(None, description="Image embedding dimensions")
+    image_dimensions: Optional[int] = Field(None, description="Image embedding dimensions (independent of text dims, ADR-803)")
     image_precision: Optional[str] = Field('float16', description="Image precision")
     image_trust_remote_code: bool = Field(False, description="Trust remote code for image model")
+    image_vector_space: Optional[str] = Field(None, description="Independent vector_space of the image index (ADR-803); never compared to the text space")
 
     # Shorthand (maps to text slot for backward compat)
     provider: Optional[str] = Field(None, description="Shorthand for text_provider")

--- a/api/app/routes/embedding.py
+++ b/api/app/routes/embedding.py
@@ -170,14 +170,12 @@ async def create_embedding_config(
                 detail="multimodal=true: image fields must be absent (text model serves both roles)"
             )
 
-        # Validate dimension match for non-multimodal with image
-        if not request.multimodal and request.image_dimensions:
-            text_dims = request.text_dimensions or request.embedding_dimensions
-            if text_dims and text_dims != request.image_dimensions:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Dimension mismatch: text={text_dims}, image={request.image_dimensions}. Must match for non-multimodal profiles."
-                )
+        # ADR-803: the image slot is an INDEPENDENT same-modality index, never
+        # compared to the text/prose space — so its dimensions need NOT match
+        # the text model's. The old "dimension mismatch" rejection (and the
+        # chk_image_dimensions_match constraint, dropped in migration 075) was a
+        # co-spatiality assumption the system never uses. No dimension-match
+        # check here by design.
 
         # Validate precision
         text_precision = request.text_precision

--- a/api/app/routes/ingest_image.py
+++ b/api/app/routes/ingest_image.py
@@ -178,7 +178,11 @@ async def ingest_image(
     **Visual Embeddings:**
     - Nomic Embed Vision v1.5 (768-dim, local via transformers)
     - 0.847 clustering quality (27% better than CLIP)
-    - Same vector space as text embeddings
+    - Independent same-modality index for image search (ADR-803): stored on the
+      Source, never compared to the text/concept space. The prose (step 3-5),
+      not this vector, is what joins the image to the graph. (Historically
+      described as "same vector space as text"; that co-spatiality is neither
+      required nor used — corrected per ADR-803.)
 
     **Workflow (ADR-014):**
     1. Submit image → Job created with status `pending`

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -1934,6 +1934,38 @@ export class KnowledgeGraphClient {
   }
 
   /**
+   * Get effective vision provider/model summary (ADR-802; public endpoint)
+   */
+  async getVisionConfig(): Promise<any> {
+    const response = await this.client.get('/vision/config');
+    return response.data;
+  }
+
+  /**
+   * Get active vision config row + effective resolution (admin endpoint)
+   */
+  async getVisionConfigDetail(): Promise<any> {
+    const response = await this.client.get('/admin/vision/config');
+    return response.data;
+  }
+
+  /**
+   * Set/activate the vision provider (admin endpoint, ADR-802)
+   */
+  async updateVisionConfig(config: any): Promise<any> {
+    const response = await this.client.post('/admin/vision/config', config);
+    return response.data;
+  }
+
+  /**
+   * Per-provider vision-capability metadata from the catalog (admin endpoint)
+   */
+  async getVisionProviders(): Promise<{ providers: Array<{ provider: string; supports_vision: boolean; vision_models: string[] }> }> {
+    const response = await this.client.get('/admin/vision/providers');
+    return response.data;
+  }
+
+  /**
    * List API keys with validation status (admin endpoint)
    */
   async listApiKeys(): Promise<any[]> {

--- a/cli/src/cli/admin/index.ts
+++ b/cli/src/cli/admin/index.ts
@@ -8,7 +8,7 @@ import { createClientFromEnv } from '../../api/client';
 import { setCommandHelp, configureColoredHelp } from '../help-formatter';
 import { registerAuthAdminCommand } from '../auth-admin';
 import { createRbacCommand } from '../rbac';
-import { createEmbeddingCommand, createExtractionCommand, createKeysCommand } from '../ai-config';
+import { createEmbeddingCommand, createExtractionCommand, createVisionCommand, createKeysCommand } from '../ai-config';
 
 // Import split command modules
 import { createStatusCommand } from './status';
@@ -48,17 +48,20 @@ const rbacCommand = createRbacCommand(client);
 configureColoredHelp(rbacCommand);
 adminCommand.addCommand(rbacCommand);
 
-// ADR-039, ADR-041: Register AI configuration commands
+// ADR-039, ADR-041, ADR-802: Register AI configuration commands
 const embeddingCommand = createEmbeddingCommand(client);
 const extractionCommand = createExtractionCommand(client);
+const visionCommand = createVisionCommand(client);
 const keysCommand = createKeysCommand(client);
 
 configureColoredHelp(embeddingCommand);
 configureColoredHelp(extractionCommand);
+configureColoredHelp(visionCommand);
 configureColoredHelp(keysCommand);
 
 adminCommand.addCommand(embeddingCommand);
 adminCommand.addCommand(extractionCommand);
+adminCommand.addCommand(visionCommand);
 adminCommand.addCommand(keysCommand);
 
 // Configure colored help for all admin commands

--- a/cli/src/cli/ai-config/index.ts
+++ b/cli/src/cli/ai-config/index.ts
@@ -18,4 +18,5 @@
 
 export { createEmbeddingCommand } from './embedding';
 export { createExtractionCommand } from './extraction';
+export { createVisionCommand } from './vision';
 export { createKeysCommand } from './keys';

--- a/cli/src/cli/ai-config/vision.ts
+++ b/cli/src/cli/ai-config/vision.ts
@@ -1,0 +1,140 @@
+/**
+ * Vision Commands (ADR-802)
+ * Manages the active vision (image->prose) provider selection — the reasoning
+ * capability that backs multimodal image ingestion. Mirrors the extraction
+ * command shape; vision is resolved independently (active vision config →
+ * active extraction provider if vision-capable → fail loud).
+ */
+
+import { Command } from 'commander';
+import { KnowledgeGraphClient } from '../../api/client';
+import * as colors from '../colors';
+import { separator } from '../colors';
+
+/**
+ * Show the effective vision configuration
+ */
+function createVisionConfigCommand(client: KnowledgeGraphClient): Command {
+  return new Command('config')
+    .description('Show the effective vision (image->prose) provider/model')
+    .action(async () => {
+      try {
+        console.log('\n' + separator());
+        console.log(colors.ui.title('👁  Vision Configuration'));
+        console.log(separator());
+
+        const detail = await client.getVisionConfigDetail();
+        const eff = detail.effective || {};
+        const row = detail.config;
+
+        console.log(`\n  ${colors.ui.key('Effective Provider:')} ${eff.provider ? colors.ui.value(eff.provider) : colors.status.error('unresolved')}`);
+        console.log(`  ${colors.ui.key('Effective Model:')} ${colors.ui.value(eff.model || '(catalog default)')}`);
+        console.log(`  ${colors.ui.key('Source:')} ${colors.ui.value(eff.source)}`);
+
+        if (eff.source === 'extraction_default') {
+          console.log(`\n  ${colors.status.dim('No explicit vision provider set — inheriting the active extraction provider (it has a vision-capable model).')}`);
+        } else if (eff.source === 'unresolved') {
+          console.log(`\n  ${colors.status.warning('⚠️  No vision provider resolves. Set one with `kg admin vision set --provider <p>`, or ensure the active extraction provider has a supports_vision model.')}`);
+        }
+
+        if (row) {
+          console.log(`\n  ${colors.ui.header('Active vision config row:')}`);
+          console.log(`    ${colors.ui.key('Provider:')} ${colors.ui.value(row.provider)}`);
+          console.log(`    ${colors.ui.key('Model:')} ${colors.ui.value(row.model_name || '(catalog)')}`);
+          if (row.max_tokens != null) console.log(`    ${colors.ui.key('Max Tokens:')} ${colors.ui.value(row.max_tokens)}`);
+          if (row.temperature != null) console.log(`    ${colors.ui.key('Temperature:')} ${colors.ui.value(row.temperature)}`);
+        }
+
+        console.log('\n' + separator() + '\n');
+      } catch (error: any) {
+        console.error(colors.status.error('✗ Failed to get vision configuration'));
+        console.error(colors.status.error(error.response?.data?.detail || error.message));
+        process.exit(1);
+      }
+    });
+}
+
+/**
+ * List providers and their vision capability (catalog-driven)
+ */
+function createVisionProvidersCommand(client: KnowledgeGraphClient): Command {
+  return new Command('providers')
+    .description('List providers and whether they have a vision-capable catalog model')
+    .action(async () => {
+      try {
+        console.log('\n' + separator());
+        console.log(colors.ui.title('👁  Vision-Capable Providers'));
+        console.log(separator() + '\n');
+
+        const { providers } = await client.getVisionProviders();
+        for (const p of providers) {
+          const mark = p.supports_vision ? colors.status.success('✓') : colors.status.dim('✗');
+          const models = p.vision_models.length ? colors.status.dim(`(${p.vision_models.join(', ')})`) : colors.status.dim('(no vision model in catalog)');
+          console.log(`  ${mark} ${colors.ui.value(p.provider)} ${models}`);
+        }
+        console.log('\n' + colors.status.dim('  ✓ = can be activated for vision without an explicit model.'));
+        console.log('\n' + separator() + '\n');
+      } catch (error: any) {
+        console.error(colors.status.error('✗ Failed to list vision providers'));
+        console.error(colors.status.error(error.response?.data?.detail || error.message));
+        process.exit(1);
+      }
+    });
+}
+
+/**
+ * Set / activate the vision provider
+ */
+function createVisionSetCommand(client: KnowledgeGraphClient): Command {
+  return new Command('set')
+    .description('Set/activate the vision (image->prose) provider')
+    .option('--provider <provider>', 'Provider: openai, anthropic, ollama, openrouter, llamacpp')
+    .option('--model <model>', 'Vision model id (optional; resolved from the catalog when omitted)')
+    .option('--max-tokens <n>', 'Max output tokens for image description', parseInt)
+    .option('--temperature <n>', 'Sampling temperature 0.0-1.0', parseFloat)
+    .option('--no-activate', 'Persist the provider config without making it the active vision provider')
+    .action(async (options) => {
+      try {
+        console.log('\n' + separator());
+        console.log(colors.ui.title('👁  Update Vision Configuration'));
+        console.log(separator());
+
+        if (!options.provider) {
+          console.error(colors.status.error('\n✗ --provider is required'));
+          console.log(colors.status.dim('  Example: kg admin vision set --provider anthropic\n'));
+          process.exit(1);
+        }
+
+        const config: any = { provider: options.provider, active: options.activate !== false };
+        if (options.model) config.model_name = options.model;
+        if (options.maxTokens) config.max_tokens = options.maxTokens;
+        if (options.temperature !== undefined) config.temperature = options.temperature;
+
+        const result = await client.updateVisionConfig(config);
+        const eff = result.effective || {};
+
+        console.log('\n' + colors.status.success('✓ Vision configuration updated'));
+        console.log(`\n  ${colors.ui.key('Effective Provider:')} ${colors.ui.value(eff.provider)}`);
+        console.log(`  ${colors.ui.key('Effective Model:')} ${colors.ui.value(eff.model || '(catalog default)')}`);
+        console.log('\n' + separator() + '\n');
+      } catch (error: any) {
+        console.error(colors.status.error('✗ Failed to update vision configuration'));
+        console.error(colors.status.error(error.response?.data?.detail || error.message));
+        process.exit(1);
+      }
+    });
+}
+
+/**
+ * Vision command group
+ */
+export function createVisionCommand(client: KnowledgeGraphClient): Command {
+  const visionCommand = new Command('vision')
+    .description('Manage the vision (image->prose) provider (ADR-802)');
+
+  visionCommand.addCommand(createVisionConfigCommand(client));
+  visionCommand.addCommand(createVisionProvidersCommand(client));
+  visionCommand.addCommand(createVisionSetCommand(client));
+
+  return visionCommand;
+}

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -163,6 +163,7 @@ _Providers, extraction, convergence, prompts_
 | [ADR-800](./ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md) | Dynamic Model Catalog and OpenRouter Support | Accepted |
 | [ADR-801](./ai-embeddings/ADR-801-uniform-provider-configuration-contract.md) | Uniform Provider Configuration Contract | Draft |
 | [ADR-802](./ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md) | Unify Vision Providers Under the Uniform Provider Contract | Accepted |
+| [ADR-803](./ai-embeddings/ADR-803-modality-embedding-architecture-universal-text-space-and-independent-per-modality-embedders.md) | Modality Embedding Architecture — Universal Text Space and Independent Per-Modality Embedders | Proposed |
 
 ## Meta/Process
 _Documentation, workflow, access models, ADR system_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -163,7 +163,7 @@ _Providers, extraction, convergence, prompts_
 | [ADR-800](./ai-embeddings/ADR-800-dynamic-model-catalog-and-openrouter-support.md) | Dynamic Model Catalog and OpenRouter Support | Accepted |
 | [ADR-801](./ai-embeddings/ADR-801-uniform-provider-configuration-contract.md) | Uniform Provider Configuration Contract | Draft |
 | [ADR-802](./ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md) | Unify Vision Providers Under the Uniform Provider Contract | Accepted |
-| [ADR-803](./ai-embeddings/ADR-803-modality-embedding-architecture-universal-text-space-and-independent-per-modality-embedders.md) | Modality Embedding Architecture — Universal Text Space and Independent Per-Modality Embedders | Proposed |
+| [ADR-803](./ai-embeddings/ADR-803-modality-embedding-architecture-universal-text-space-and-independent-per-modality-embedders.md) | Modality Embedding Architecture — Universal Text Space and Independent Per-Modality Embedders | Accepted |
 
 ## Meta/Process
 _Documentation, workflow, access models, ADR system_

--- a/docs/architecture/ai-embeddings/ADR-803-modality-embedding-architecture-universal-text-space-and-independent-per-modality-embedders.md
+++ b/docs/architecture/ai-embeddings/ADR-803-modality-embedding-architecture-universal-text-space-and-independent-per-modality-embedders.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 date: 2026-05-31
 deciders:
   - aaronsb

--- a/docs/architecture/ai-embeddings/ADR-803-modality-embedding-architecture-universal-text-space-and-independent-per-modality-embedders.md
+++ b/docs/architecture/ai-embeddings/ADR-803-modality-embedding-architecture-universal-text-space-and-independent-per-modality-embedders.md
@@ -1,0 +1,174 @@
+---
+status: Proposed
+date: 2026-05-31
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-802
+  - ADR-800
+  - ADR-801
+  - ADR-057
+  - ADR-039
+  - ADR-045
+---
+
+# ADR-803: Modality Embedding Architecture — Universal Text Space and Independent Per-Modality Embedders
+
+## Context
+
+ADR-802 established vision as a first-class *reasoning* capability (image→prose)
+resolved independently like embedding. Implementing the embedding side surfaced
+a modality-general question about **embedding spaces** that ADR-057 and its
+schema (migration 055, `kg_api.embedding_profile`) answered implicitly — and
+incorrectly.
+
+Migration 055 models an embedding profile as **two co-spatial slots**: a text
+model and an image model sharing one `vector_space`, with
+`chk_image_dimensions_match` forcing `text_dimensions = image_dimensions` and a
+`multimodal` flag for "one model serves both." The implicit premise is that
+image and text embeddings must be **comparable** — an image vector and a concept
+vector in the same space, matched cross-modally.
+
+Inspection of the running system contradicts that premise:
+
+- The image embedding (`visual_embedding`, 768-dim) is **stored on Source nodes
+  and exposed only as a `has_visual_embedding` presence flag**
+  (`routes/sources.py`). There is **no `vector_search` over it**, and **nothing
+  compares an image embedding to a Concept/text embedding.**
+- The concept graph is built **entirely from prose**: image ingestion is a
+  hairpin — `image → describe_image() → prose → text pipeline → concepts`
+  (`workers/ingestion_worker.py`, ADR-057). Every semantic operation
+  (extraction, vector-match/merge, edges) runs on **text** embeddings.
+
+So the cross-modal co-spatiality the schema enforces is never exercised. It does
+no work except to **forbid otherwise-valid configurations** (e.g. a 768-dim text
+embedder with a 1024-dim image embedder). The coupling was a category error.
+
+This is not a push to build new modalities. It is about keeping the architecture
+**sane and non-locking** — so that it does not bake in the assumption that all
+content must be reduced to one comparable vector space, and does not preclude
+modality-native embedders (or reasoners) if they ever become useful.
+
+**Why prose is privileged (grounding, not arbitrary).** Modality-native
+symbolic relationships are real: one can mark two lines on wood and *see*,
+wordlessly, that one is longer. But to make that relation **communicable and
+relational** — to enter a *shared* knowledge graph — it must be rendered in
+symbolic representation ("line", "mark", "longer"/"shorter", "wood"). A knowledge
+graph arises precisely from the **unification of symbolic representation with the
+sensory/format modalities** (visual, spatial, motion, auditory). Prose is not
+privileged by fiat; it is the symbolic medium through which any modality's
+content becomes relational knowledge. That is why every modality joins the graph
+through prose, while its raw perceptual embedding stays an independent index.
+
+## Decision
+
+**The knowledge graph has exactly one semantic embedding space — the text/prose
+space. Content joins it through prose; a modality's native embedding, if any, is
+an independent same-modality search index that is never compared to the graph.**
+
+### 1. One universal text/prose space
+
+All graph semantics live in a single embedding space produced by the **text/prose
+embedder**: concepts, edges, documents/sources, **and the prose description of
+any non-text artifact**. It is the only space the graph reasons or matches in.
+Exactly **one** embedder is semantically global.
+
+### 2. Prose is the bridge into the graph (the hairpin)
+
+A non-text artifact joins the graph by being **described into prose**, which is
+embedded in the universal text space and extracted like any other text:
+
+```
+artifact → describe → prose → text space → concepts
+```
+
+The describe step is a *reasoning* capability (ADR-802); the embedding step is
+the universal text embedder. The artifact needs no representation comparable to
+concepts, because its **prose** is what reaches the graph.
+
+### 3. A modality's native embedding is an independent index
+
+Where a native embedding exists (the image vector today), it lives in its **own**
+space, sized by its own model, used **only** for same-modality similarity search.
+It is **not** co-spatial with the text space and is **never** compared to it.
+Modalities are decoupled from text and from each other by construction.
+
+A single multimodal model that *can* embed text and image into one space does
+**not** change this: we treat its image output as an independent index and let
+prose do the graph work. Co-spatiality is an optional property of a model, never
+an architectural requirement.
+
+### 4. The real invariant is text-space consistency
+
+The risk worth guarding is **not** "text and image embedders differ" — that is
+the design. It is **changing the active text/prose embedder**, which changes the
+universal space and invalidates *every* existing text embedding (concepts, edges,
+docs, image-prose), requiring a re-embed. That change must warn and prompt
+re-embedding. Choosing a different (or absent) modality embedder carries no such
+consequence.
+
+### 5. Schema correction (incremental, non-committal)
+
+Migration 055's co-spatiality constraints are relaxed: `chk_image_dimensions_match`
+is dropped and the image slot may hold its **own** `vector_space` and dimensions,
+independent of the text slot. This removes the over-constraint without committing
+to any particular future shape — the architecture *permits* additional
+independent per-modality embedders but this ADR does **not** design or schedule
+them. We are not building the future here; we are not locking it out.
+
+## Consequences
+
+### Positive
+
+- The cross-modal embedding-space problem **dissolves**: nothing must be
+  co-spatial because nothing is compared across modalities. Prose is the only
+  bridge, and it is already in the universal space.
+- Configurations the old constraint forbade (independent image dims/space) become
+  valid; the operator is no longer asked to match image and text embedders for a
+  comparison that never happens.
+- The warning surface points at the **real** risk (text-embedder change ⇒
+  re-embed) instead of a non-issue (text≠image embedders).
+- The architecture is not locked into "all content reduces to one vector space,"
+  so future modality-native embedders are neither required nor precluded.
+
+### Negative
+
+- ADR-057 / migration 055 carried the co-spatiality assumption; relaxing it is a
+  correction future readers must understand (hence this ADR supersedes that
+  aspect). Code/docstrings asserting "image embeddings share the text vector
+  space" (e.g. `routes/ingest_image.py`) must be corrected so the wrong premise
+  is not re-propagated.
+
+### Neutral
+
+- Image-by-vector search is not yet wired (the native index is currently
+  write-only/presence-flagged); this ADR defines the space it will search in when
+  built, without requiring it now.
+- **Forward note, not a decision:** prose is today the unification substrate for
+  *reasoning* as well as embedding — all reasoning currently routes through text.
+  Nothing here precludes modality-native reasoners (visual, auditory, motion)
+  later, with prose remaining the common logical-reasoning substrate that ties
+  them together. We are not building that; we are only keeping the door open.
+- A multimodal embedder remains usable — it fills the text role and, optionally,
+  an independent modality role; its cross-modal capability is simply not relied
+  upon.
+
+## Alternatives Considered
+
+- **Keep co-spatiality (migration 055 as-is).** Rejected: it enforces a property
+  the system never uses, forbids valid configurations, and points operator
+  attention at a non-problem. The code shows no cross-modal comparison exists.
+- **Require a single multimodal model for both text and image.** Rejected:
+  couples the universal text space to image-model availability for no benefit —
+  prose already bridges the modality, and forcing one model restricts provider
+  choice (counter to ADR-801).
+- **Re-architect now into a general text-embedder + N-modality registry.**
+  Rejected for this ADR as over-building: the principle does not require a
+  speculative registry, and the goal is a non-locking architecture, not a
+  forward roadmap. The minimal constraint relaxation is sufficient; a richer
+  shape can be designed if and when a real second modality arrives.
+- **Compare image embeddings to concepts directly (a real cross-modal graph).**
+  Rejected (analysed in the ADR-802 session): a raw image vector is a noisier
+  query than its prose, and the prose is produced anyway — cross-modal adds cost
+  and noise for no gain over the hairpin.

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -2212,6 +2212,7 @@ kg admin [options]
 - `rbac` - Manage roles, permissions, and access control (ADR-028)
 - `embedding` - Manage embedding profiles (text + image model configuration)
 - `extraction` - Manage AI extraction model configuration (ADR-041)
+- `vision` - Manage the vision (image->prose) provider (ADR-802)
 - `keys` - Manage API keys for AI providers (ADR-031, ADR-041)
 
 ---
@@ -2970,6 +2971,60 @@ kg set [options]
 | `--gpu-layers <n>` | GPU layers: -1=auto, 0=CPU only, >0=specific count | - |
 | `--num-threads <n>` | CPU threads for inference (default: 4) | - |
 | `--thinking-mode <mode>` | Thinking mode: off, low, medium, high (Ollama 0.12.x+) | - |
+
+### vision
+
+Manage the vision (image->prose) provider (ADR-802)
+
+**Usage:**
+```bash
+kg vision [options]
+```
+
+**Subcommands:**
+
+- `config` - Show the effective vision (image->prose) provider/model
+- `providers` - List providers and whether they have a vision-capable catalog model
+- `set` - Set/activate the vision (image->prose) provider
+
+---
+
+#### config
+
+Show the effective vision (image->prose) provider/model
+
+**Usage:**
+```bash
+kg config [options]
+```
+
+#### providers
+
+List providers and whether they have a vision-capable catalog model
+
+**Usage:**
+```bash
+kg providers [options]
+```
+
+#### set
+
+Set/activate the vision (image->prose) provider
+
+**Usage:**
+```bash
+kg set [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--provider <provider>` | Provider: openai, anthropic, ollama, openrouter, llamacpp | - |
+| `--model <model>` | Vision model id (optional; resolved from the catalog when omitted) | - |
+| `--max-tokens <n>` | Max output tokens for image description | - |
+| `--temperature <n>` | Sampling temperature 0.0-1.0 | - |
+| `--no-activate` | Persist the provider config without making it the active vision provider | - |
 
 ### keys
 

--- a/docs/reference/cli/commands/admin.md
+++ b/docs/reference/cli/commands/admin.md
@@ -23,6 +23,7 @@ kg admin [options]
 - `rbac` - Manage roles, permissions, and access control (ADR-028)
 - `embedding` - Manage embedding profiles (text + image model configuration)
 - `extraction` - Manage AI extraction model configuration (ADR-041)
+- `vision` - Manage the vision (image->prose) provider (ADR-802)
 - `keys` - Manage API keys for AI providers (ADR-031, ADR-041)
 
 ---
@@ -781,6 +782,60 @@ kg set [options]
 | `--gpu-layers <n>` | GPU layers: -1=auto, 0=CPU only, >0=specific count | - |
 | `--num-threads <n>` | CPU threads for inference (default: 4) | - |
 | `--thinking-mode <mode>` | Thinking mode: off, low, medium, high (Ollama 0.12.x+) | - |
+
+### vision
+
+Manage the vision (image->prose) provider (ADR-802)
+
+**Usage:**
+```bash
+kg vision [options]
+```
+
+**Subcommands:**
+
+- `config` - Show the effective vision (image->prose) provider/model
+- `providers` - List providers and whether they have a vision-capable catalog model
+- `set` - Set/activate the vision (image->prose) provider
+
+---
+
+#### config
+
+Show the effective vision (image->prose) provider/model
+
+**Usage:**
+```bash
+kg config [options]
+```
+
+#### providers
+
+List providers and whether they have a vision-capable catalog model
+
+**Usage:**
+```bash
+kg providers [options]
+```
+
+#### set
+
+Set/activate the vision (image->prose) provider
+
+**Usage:**
+```bash
+kg set [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--provider <provider>` | Provider: openai, anthropic, ollama, openrouter, llamacpp | - |
+| `--model <model>` | Vision model id (optional; resolved from the catalog when omitted) | - |
+| `--max-tokens <n>` | Max output tokens for image description | - |
+| `--temperature <n>` | Sampling temperature 0.0-1.0 | - |
+| `--no-activate` | Persist the provider config without making it the active vision provider | - |
 
 ### keys
 

--- a/schema/migrations/075_decouple_image_embedding_space.sql
+++ b/schema/migrations/075_decouple_image_embedding_space.sql
@@ -1,0 +1,49 @@
+-- Migration 075: decouple the image embedding slot from the text vector space
+-- (ADR-803). Corrects the migration-055 category error.
+--
+-- Migration 055 modelled the embedding profile as two CO-SPATIAL slots: a text
+-- model and an image model sharing one `vector_space`, with
+-- chk_image_dimensions_match forcing text_dimensions = image_dimensions. The
+-- implicit premise was that image and text embeddings are comparable
+-- (cross-modal matching). They are not: the image embedding is stored on Source
+-- nodes and never vector-searched or compared to Concept/text embeddings — the
+-- concept graph is built entirely from PROSE (the hairpin, ADR-057). The
+-- constraint therefore enforces a property the system never uses and forbids
+-- otherwise-valid configurations (e.g. a 768-dim text embedder + a 1024-dim
+-- image embedder).
+--
+-- ADR-803: the graph has ONE universal text/prose embedding space; a modality's
+-- native embedding (the image vector) is an INDEPENDENT same-modality search
+-- index with its own space and dimensions, never compared to the text space.
+-- This migration makes the schema express that independence. It does NOT design
+-- a general N-modality registry (that is a deferred, non-committal follow-up).
+
+BEGIN;
+
+-- 1. Drop the co-spatiality dimension constraint: the image slot may now have
+--    its own dimensions, independent of the text slot.
+ALTER TABLE kg_api.embedding_profile
+    DROP CONSTRAINT IF EXISTS chk_image_dimensions_match;
+
+-- 2. Give the image slot its own vector_space compatibility key, independent of
+--    the profile's text `vector_space`. Nullable: text-only profiles and
+--    multimodal profiles (image served by the text model) leave it NULL. This
+--    is the image index's OWN space tag, used for same-modality search only —
+--    never compared to the text vector_space.
+ALTER TABLE kg_api.embedding_profile
+    ADD COLUMN IF NOT EXISTS image_vector_space VARCHAR(100);
+
+COMMENT ON COLUMN kg_api.embedding_profile.image_vector_space IS
+    'Independent vector_space of the image (modality) embedding index (ADR-803). '
+    'NULL for text-only / multimodal profiles. Never compared to text vector_space.';
+
+COMMENT ON COLUMN kg_api.embedding_profile.vector_space IS
+    'Compatibility key for the universal TEXT/prose space (concepts, edges, docs, '
+    'image-prose). Profiles with the same text vector_space produce comparable '
+    'text embeddings. Image embeddings are independent — see image_vector_space (ADR-803).';
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (75, 'decouple_image_embedding_space')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/tests/api/test_embedding_independent_image.py
+++ b/tests/api/test_embedding_independent_image.py
@@ -1,0 +1,70 @@
+"""
+Regression tests for ADR-803: the image embedding slot is an INDEPENDENT
+same-modality index, not co-spatial with the text/prose space.
+
+Migration 075 dropped chk_image_dimensions_match and the route/activate
+dimension-match guards. A non-multimodal profile may now pair a text model and
+an image model of DIFFERENT dimensions, with the image index carrying its own
+vector_space. These tests lock that relaxation so the co-spatiality assumption
+is not silently reintroduced.
+
+Created profiles are inactive and cleaned up by id (no active-profile churn).
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def allow_admin_permissions(monkeypatch):
+    def always_admin(user, resource_type, action,
+                     resource_id=None, resource_context=None):
+        return user.role == "admin"
+    monkeypatch.setattr(
+        "api.app.dependencies.auth.check_permission", always_admin)
+
+
+@pytest.fixture
+def cleanup_profiles():
+    """Delete any embedding profiles created during the test (by id)."""
+    created: list[int] = []
+    yield created
+    from api.app.lib.embedding_config import delete_embedding_config
+    for cid in created:
+        try:
+            delete_embedding_config(cid)
+        except Exception:
+            pass
+
+
+class TestIndependentImageDimensions:
+    def test_create_allows_mismatched_text_image_dims_and_image_vector_space(
+            self, api_client, mock_oauth_validation, auth_headers_admin, cleanup_profiles):
+        # text=768, image=1024 — previously rejected ("Dimension mismatch ...
+        # must match for non-multimodal profiles"). ADR-803: now valid.
+        resp = api_client.post(
+            "/admin/embedding/config", headers=auth_headers_admin,
+            json={
+                "name": "adr803-independent-dims-test",
+                "vector_space": "test-text-768",
+                "multimodal": False,
+                "text_provider": "local",
+                "text_model_name": "test/text-768",
+                "text_loader": "sentence-transformers",
+                "text_dimensions": 768,
+                "image_provider": "local",
+                "image_model_name": "test/image-1024",
+                "image_loader": "transformers",
+                "image_dimensions": 1024,
+                "image_vector_space": "test-image-1024",
+            })
+        assert resp.status_code == 200, resp.text
+        config_id = resp.json()["config_id"]
+        cleanup_profiles.append(config_id)
+
+        # Round-trip: the independent image dims + image_vector_space persist.
+        configs = api_client.get("/admin/embedding/configs",
+                                 headers=auth_headers_admin).json()
+        prof = next(c for c in configs if c["id"] == config_id)
+        assert prof["text_dimensions"] == 768
+        assert prof["image_dimensions"] == 1024          # independent of text
+        assert prof["image_vector_space"] == "test-image-1024"

--- a/tests/api/test_embedding_independent_image.py
+++ b/tests/api/test_embedding_independent_image.py
@@ -68,3 +68,74 @@ class TestIndependentImageDimensions:
         assert prof["text_dimensions"] == 768
         assert prof["image_dimensions"] == 1024          # independent of text
         assert prof["image_vector_space"] == "test-image-1024"
+
+    def test_multimodal_profile_clears_image_vector_space(
+            self, api_client, mock_oauth_validation, auth_headers_admin, cleanup_profiles):
+        # ADR-803: a multimodal profile (text model serves both roles) must NOT
+        # carry an independent image_vector_space — it is cleared on save even
+        # if passed. Locks the multimodal-clear branch.
+        resp = api_client.post(
+            "/admin/embedding/config", headers=auth_headers_admin,
+            json={
+                "name": "adr803-multimodal-test",
+                "vector_space": "test-mm-768",
+                "multimodal": True,
+                "text_provider": "local",
+                "text_model_name": "test/multimodal-768",
+                "text_loader": "transformers",
+                "text_dimensions": 768,
+                # Attempt to set image_vector_space — must be ignored/cleared.
+                "image_vector_space": "should-be-cleared",
+            })
+        assert resp.status_code == 200, resp.text
+        config_id = resp.json()["config_id"]
+        cleanup_profiles.append(config_id)
+
+        prof = next(c for c in api_client.get(
+            "/admin/embedding/configs", headers=auth_headers_admin).json()
+            if c["id"] == config_id)
+        assert prof["multimodal"] is True
+        assert prof["image_vector_space"] is None
+
+
+class TestTextSpaceInvariantPreserved:
+    """ADR-803 §4: relaxing the image co-spatiality guard must NOT relax the
+    text-space invariant — changing the active profile's text dimensions still
+    requires --force (it invalidates all existing text embeddings)."""
+
+    def test_activate_rejects_text_dimension_change_without_force(self):
+        # Non-mutating: we only attempt a NON-forced activation that the guard
+        # must REJECT — so the real active profile is never actually switched
+        # (no embeddings marked stale on the shared dev DB). We pick a target
+        # whose text_dimensions differ from whatever is currently active.
+        from api.app.lib.embedding_config import (
+            load_active_embedding_config, save_embedding_config,
+            activate_embedding_config, delete_embedding_config,
+        )
+
+        active = load_active_embedding_config()
+        if not active:
+            import pytest
+            pytest.skip("no active embedding profile to guard against")
+        active_dims = active.get("text_dimensions") or 768
+        target_dims = active_dims + 256  # guaranteed different
+
+        ok, _, target_id = save_embedding_config(
+            {"name": "adr803-dimguard-target", "vector_space": "dimguard-target",
+             "text_provider": "local", "text_model_name": "t/dimguard",
+             "text_loader": "sentence-transformers", "text_dimensions": target_dims},
+            updated_by="test")
+        assert ok
+        try:
+            # active_dims -> target_dims without force must fail loud, leaving
+            # the real active profile untouched.
+            success, err = activate_embedding_config(target_id, updated_by="test")
+            assert success is False
+            assert "dimension" in (err or "").lower()
+            # The original profile is still the active one (no switch happened).
+            assert (load_active_embedding_config() or {}).get("id") == active.get("id")
+        finally:
+            try:
+                delete_embedding_config(target_id)
+            except Exception:
+                pass

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1277,9 +1277,47 @@ class APIClient {
       provider: string;
       requires_key: boolean;
       is_local: boolean;
+      supports_vision?: boolean;
     }>;
   }> {
     const response = await this.client.get('/admin/providers');
+    return response.data;
+  }
+
+  /**
+   * Vision (image->prose) provider config — active row + effective resolution
+   * (ADR-802). `config` is null when no explicit vision provider is set; in
+   * that case `effective.source === 'extraction_default'`.
+   */
+  async getVisionConfigDetail(): Promise<{
+    config: { provider: string; model_name: string; max_tokens: number | null; temperature: number | null; active: boolean } | null;
+    effective: { provider: string | null; model: string | null; source: string };
+  }> {
+    const response = await this.client.get('/admin/vision/config');
+    return response.data;
+  }
+
+  /**
+   * Set/activate the vision provider (ADR-802).
+   */
+  async updateVisionConfig(config: {
+    provider: string;
+    model_name?: string;
+    max_tokens?: number;
+    temperature?: number;
+    active?: boolean;
+  }): Promise<{ status: string; provider: string; effective: { provider: string | null; model: string | null; source: string } }> {
+    const response = await this.client.post('/admin/vision/config', config);
+    return response.data;
+  }
+
+  /**
+   * Per-provider vision-capability metadata (catalog-driven, ADR-802).
+   */
+  async getVisionProviders(): Promise<{
+    providers: Array<{ provider: string; supports_vision: boolean; vision_models: string[] }>;
+  }> {
+    const response = await this.client.get('/admin/vision/providers');
     return response.data;
   }
 

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -30,6 +30,7 @@ import {
 } from 'lucide-react';
 import { apiClient, API_BASE_URL } from '../../api/client';
 import { Section, StatusBadge } from './components';
+import { VisionProviderCard } from './VisionProviderCard';
 import type { SystemStatus, EmbeddingConfig, ExtractionConfig, ApiKeyInfo, SchedulerStatus, WorkerStatus } from './types';
 
 interface SystemTabProps {
@@ -1160,6 +1161,10 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
           </div>
         )}
       </Section>
+
+      {/* ADR-802: vision (image->prose) provider selection, resolved like a
+          first-class capability alongside extraction. Self-contained card. */}
+      <VisionProviderCard onError={onError} />
     </>
   );
 };

--- a/web/src/components/admin/VisionProviderCard.tsx
+++ b/web/src/components/admin/VisionProviderCard.tsx
@@ -1,0 +1,173 @@
+/**
+ * Vision Provider Card (ADR-802)
+ *
+ * Manages the active vision (image->prose) provider — the reasoning capability
+ * behind multimodal image ingestion. Self-contained: fetches its own vision
+ * config + capability metadata so it can drop into the System tab without
+ * growing it. Data-driven from /admin/vision/providers (no hardcoded provider
+ * list); vision is resolved independently (active vision config → active
+ * extraction provider if vision-capable → fail loud).
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Eye, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import { apiClient } from '../../api/client';
+import { Section } from './components';
+
+interface VisionProviderMeta {
+  provider: string;
+  supports_vision: boolean;
+  vision_models: string[];
+}
+
+interface VisionEffective {
+  provider: string | null;
+  model: string | null;
+  source: string;
+}
+
+export const VisionProviderCard: React.FC<{ onError?: (msg: string) => void }> = ({ onError }) => {
+  const [loading, setLoading] = useState(true);
+  const [providers, setProviders] = useState<VisionProviderMeta[]>([]);
+  const [effective, setEffective] = useState<VisionEffective | null>(null);
+  const [activeProvider, setActiveProvider] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const [provResp, detail] = await Promise.all([
+        apiClient.getVisionProviders(),
+        apiClient.getVisionConfigDetail(),
+      ]);
+      setProviders(provResp.providers);
+      setEffective(detail.effective);
+      setActiveProvider(detail.config?.provider ?? null);
+      // Seed each provider's model draft with its currently-selected/first model.
+      setDrafts((prev) => {
+        const next = { ...prev };
+        for (const p of provResp.providers) {
+          if (next[p.provider] === undefined) {
+            next[p.provider] =
+              (detail.config?.provider === p.provider ? detail.config?.model_name : '') ||
+              p.vision_models[0] || '';
+          }
+        }
+        return next;
+      });
+    } catch (err: any) {
+      onError?.(err?.response?.data?.detail || err?.message || 'Failed to load vision config');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleActivate = async (provider: string) => {
+    setSaving(provider);
+    try {
+      const model = drafts[provider] || undefined;
+      await apiClient.updateVisionConfig({ provider, model_name: model, active: true });
+      await load();
+    } catch (err: any) {
+      onError?.(err?.response?.data?.detail || err?.message || 'Failed to set vision provider');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <Section title="Vision (Image → Prose)" icon={<Eye className="w-5 h-5" />}>
+      <p className="text-sm text-muted-foreground mb-4">
+        The vision provider converts images to literal prose, which is then
+        extracted into concepts like any other text (the hairpin). Resolved
+        independently of extraction; if unset it inherits the active extraction
+        provider when that provider has a vision-capable model.
+      </p>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="w-6 h-6 text-primary animate-spin" />
+        </div>
+      ) : (
+        <>
+          {/* Effective resolution banner */}
+          <div className="mb-4 p-3 rounded-lg bg-muted/50 border border-border text-sm">
+            {effective?.provider ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Effective:</span>
+                <span className="font-medium text-foreground capitalize">{effective.provider}</span>
+                <span className="font-mono text-xs text-muted-foreground">{effective.model || '(catalog default)'}</span>
+                <span className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground">{effective.source}</span>
+              </div>
+            ) : (
+              <span className="flex items-center gap-1 text-status-warning">
+                <AlertCircle className="w-4 h-4" /> No vision provider resolves — set one below or configure a vision-capable extraction provider.
+              </span>
+            )}
+            {effective?.source === 'extraction_default' && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                No explicit vision provider set — inheriting the active extraction provider.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            {providers.map((p) => {
+              const isActive = activeProvider === p.provider;
+              const capable = p.supports_vision;
+              return (
+                <div
+                  key={p.provider}
+                  className={`p-4 rounded-lg border ${isActive ? 'border-status-active bg-status-active/5' : 'border-border bg-muted/50'}`}
+                >
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="font-medium text-foreground capitalize">{p.provider}</span>
+                    {isActive ? (
+                      <span className="flex items-center gap-1 text-status-active text-xs font-medium">
+                        <CheckCircle className="w-4 h-4" /> Active for vision
+                      </span>
+                    ) : !capable ? (
+                      <span className="text-xs text-muted-foreground">No vision model in catalog</span>
+                    ) : null}
+                  </div>
+
+                  <div className="flex items-center justify-between gap-3">
+                    <select
+                      className="flex-1 min-w-0 px-2 py-1 text-sm bg-background border border-border rounded text-foreground disabled:opacity-50"
+                      value={drafts[p.provider] ?? ''}
+                      disabled={!capable || saving === p.provider}
+                      onChange={(e) => setDrafts((d) => ({ ...d, [p.provider]: e.target.value }))}
+                    >
+                      {p.vision_models.length === 0 ? (
+                        <option value="">(no vision model — run Get models)</option>
+                      ) : (
+                        p.vision_models.map((m) => (
+                          <option key={m} value={m}>{m}</option>
+                        ))
+                      )}
+                    </select>
+                    <button
+                      onClick={() => handleActivate(p.provider)}
+                      disabled={!capable || saving === p.provider}
+                      title={capable ? `Use ${p.provider} for vision` : 'No vision-capable model in the catalog'}
+                      className="px-3 py-1 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+                    >
+                      {saving === p.provider ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : isActive ? 'Re-apply' : 'Activate'}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </Section>
+  );
+};

--- a/web/src/components/admin/VisionProviderCard.tsx
+++ b/web/src/components/admin/VisionProviderCard.tsx
@@ -43,14 +43,17 @@ export const VisionProviderCard: React.FC<{ onError?: (msg: string) => void }> =
       setProviders(provResp.providers);
       setEffective(detail.effective);
       setActiveProvider(detail.config?.provider ?? null);
-      // Seed each provider's model draft with its currently-selected/first model.
+      // Seed each provider's model draft. Always re-sync the ACTIVE provider's
+      // draft to what's persisted (the server may resolve/normalize the model
+      // id); leave untouched drafts for inactive providers alone.
       setDrafts((prev) => {
         const next = { ...prev };
         for (const p of provResp.providers) {
-          if (next[p.provider] === undefined) {
-            next[p.provider] =
-              (detail.config?.provider === p.provider ? detail.config?.model_name : '') ||
-              p.vision_models[0] || '';
+          const isActive = detail.config?.provider === p.provider;
+          if (isActive && detail.config?.model_name) {
+            next[p.provider] = detail.config.model_name;
+          } else if (next[p.provider] === undefined) {
+            next[p.provider] = p.vision_models[0] || '';
           }
         }
         return next;
@@ -144,7 +147,7 @@ export const VisionProviderCard: React.FC<{ onError?: (msg: string) => void }> =
                       onChange={(e) => setDrafts((d) => ({ ...d, [p.provider]: e.target.value }))}
                     >
                       {p.vision_models.length === 0 ? (
-                        <option value="">(no vision model — run Get models)</option>
+                        <option value="">(no vision model in catalog — add one via AI Providers)</option>
                       ) : (
                         p.vision_models.map((m) => (
                           <option key={m} value={m}>{m}</option>


### PR DESCRIPTION
## Summary

Two related decisions, landed together:

- **ADR-803 (Accepted) — modality embedding architecture.** The knowledge graph has **one** universal text/prose embedding space (concepts, edges, docs, *and* image-prose); a modality's native embedding (the image vector) is an **independent same-modality index**, never compared to the text space. This corrects migration 055's category error, which forced text/image co-spatiality (`chk_image_dimensions_match` + shared `vector_space`) for a comparison the system never performs — the graph is built entirely from prose (the hairpin). Prose is privileged because symbolic representation is what makes any modality's content relational. Non-locking: doesn't preclude future modality-native embedders/reasoners; doesn't build them.
- **ADR-802 exposure follow-up** — surfaces the vision capability slot in the **CLI and web**, completing #454.

## What's here

**ADR-803 — decouple image index from text space** (closes #325)
- `migration 075`: drop `chk_image_dimensions_match`; add independent `image_vector_space` column
- relax the dimension-match guards in the create route **and** the activate path; wire `image_vector_space` through create / load / models / detail
- correct the stale "same vector space as text" docstring in `ingest_image.py`
- **kept intact:** the text dimension-*change* guard (changing the active text embedder invalidates text embeddings → needs `--force` + regenerate). ADR-803 §4 relaxes cross-modal co-spatiality, never text-space consistency.

**Vision config exposure** (closes #454)
- `kg admin vision config | providers | set` — parity with the embedding/extraction CLI
- web `VisionProviderCard` (new self-contained component — keeps the 1167-line SystemTab from growing), data-driven from `/admin/vision/providers`, shows the effective resolution incl. the `extraction_default` zero-config story

## Verification
- New tests: independent image dims accepted; multimodal clears `image_vector_space`; **text dimension-change guard still fires** (non-mutating — only attempts a rejected activation, live active profile untouched)
- Regression: **369 passed, 1 skipped**
- CLI verified live (`vision providers`/`config`); web **browser-verified** (System tab renders the card with effective = Anthropic/claude-sonnet-4-6/extraction_default, capable vs non-capable providers correct)
- Code-reviewed; S1–S3 + N4–N5 addressed

## Deferred
- ADR-802 §4 facade collapse (unchanged stance — incremental follow-up)
- A general text-embedder + N-modality registry (ADR-803 names it non-committally; not built — no second modality exists yet)

Closes #325, #454. Refs ADR-802, ADR-057, #321.