### PR TITLE
docs(adr): amend ADR-802 §4 — facade collapse is de-dup, not rewrite (#457)

### DIFF
--- a/docs/architecture/ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md
+++ b/docs/architecture/ai-embeddings/ADR-802-unify-vision-providers-under-the-uniform-provider-contract.md
@@ -165,6 +165,23 @@ the migration path retires `get_vision_provider`'s parallel validation and
 config-loading in favour of the ADR-801 surfaces, capability by capability,
 behind the existing factory signature.
 
+> **Amendment (2026-05-31, post-ADR-803):** A scoping investigation found the
+> collapse is *thinner* than "§4 / Alternatives" originally framed it. `AIProvider`
+> **already declares `describe_image()`** (`ai_providers.py:421`) and
+> OpenAI/Anthropic/OpenRouter/Mock already implement it; `routes/ingest.py`
+> already calls `get_provider().describe_image()`. `_load_api_key` is 100%
+> duplicated and the catalog helpers ~80% duplicated between the two modules.
+> So the remaining work is **de-duplication + one call-site migration**
+> (`ingestion_worker.py`), not a rewrite. The genuine risk is *behavioral
+> fidelity*, not size: the ingestion `describe_image` is research-validated
+> (ADR-057 — `LITERAL_DESCRIPTION_PROMPT`, OpenAI `detail="high"`, temp 0.1) and
+> differs from the `ai_providers` one (different prompt, no high-detail, temp
+> 0.3, simpler return shape), and `OllamaProvider.describe_image` is not yet
+> implemented. A collapse must parameterize prompt/detail/temp, unify the
+> return shape, port Ollama vision, and golden-compare ingestion output. The
+> "Rejected: high-risk rewrite" alternative below is **superseded** by this
+> assessment. Tracked in issue #457.
+
 ## Consequences
 
 ### Positive


### PR DESCRIPTION
## Summary

Amends ADR-802 §4 with the finding from the post-ADR-803 scoping investigation: the vision-provider facade collapse is **de-duplication + one call-site migration**, not the "high-risk rewrite" the original §4/Alternatives framed it as.

- `AIProvider` already declares `describe_image()` and OpenAI/Anthropic/OpenRouter/Mock implement it; `routes/ingest.py` already uses `get_provider().describe_image()`.
- `_load_api_key` is 100% duplicated; catalog helpers ~80%.
- The genuine risk is **behavioral fidelity** (preserving ADR-057-validated ingestion vision settings) and the unimplemented `OllamaProvider.describe_image`, not size.

The §4 "high-risk rewrite" alternative is marked superseded. Full plan tracked in #457.

Doc-only; lint clean.

Refs #457, ADR-803.