### PR TITLE
refactor(vision): collapse parallel vision provider hierarchy into AIProvider (#457)

### DIFF
--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -214,6 +214,23 @@ def _load_api_key(provider: str, explicit_key: Optional[str] = None, env_var: Op
     return None
 
 
+def _openai_token_usage(response: Any) -> Dict[str, int]:
+    """Normalize an OpenAI/OpenRouter chat usage object to the describe_image
+    token shape ({input_tokens, output_tokens, total_tokens}). Zeros when the
+    SDK omits usage.  @verified ff971ab5"""
+    usage = getattr(response, "usage", None)
+    if not usage:
+        return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    prompt = getattr(usage, "prompt_tokens", 0) or 0
+    completion = getattr(usage, "completion_tokens", 0) or 0
+    total = getattr(usage, "total_tokens", 0) or (prompt + completion)
+    return {
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "total_tokens": total,
+    }
+
+
 def _anthropic_drops_sampling_params(model_id: str) -> bool:
     """True if the model rejects temperature/top_p/top_k (Opus 4.7 family).
 
@@ -418,20 +435,44 @@ class AIProvider(ABC):
         pass
 
     @abstractmethod
-    def describe_image(self, image_data: bytes, prompt: str) -> Dict[str, Any]:
+    def describe_image(
+        self,
+        image_data: bytes,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        detail: Optional[str] = "high",
+        temperature: float = 0.3,
+    ) -> Dict[str, Any]:
         """
-        Generate detailed description of an image using multimodal AI.
+        Generate detailed description of an image using multimodal AI (ADR-057).
 
-        Used for ingesting visual content (slides, diagrams, charts) into the
-        knowledge graph by converting them to text descriptions that can be
-        processed by the normal concept extraction pipeline.
+        The single image->prose capability for the whole system — both the
+        synchronous ingest route (`routes/ingest.py`) and the async image
+        worker (`workers/ingestion_worker.py`, the ADR-057-validated path)
+        call this method. The defaults reproduce the route's historical
+        behaviour; the worker passes explicit args to reproduce the literal
+        transcription path (ADR-057): LITERAL prompt, no high-detail, temp 0.1.
 
         Args:
             image_data: Raw image bytes (PNG, JPEG, etc.)
-            prompt: Description prompt (e.g., "Describe this slide in detail")
+            prompt: Description prompt (e.g. IMAGE_DESCRIPTION_PROMPT or the
+                worker's LITERAL_DESCRIPTION_PROMPT). Required — no hidden
+                default, so each call site declares its intent.
+            model: Vision model id. None resolves it from the catalog (ADR-800
+                /801); an explicit id is used as-is. Threading an explicit id is
+                what lets the vision capability slot resolve independently of
+                the extraction model (ADR-802 §2) without re-slaving vision to
+                extraction.
+            detail: OpenAI/OpenRouter image ``detail`` hint. None omits the key
+                (provider "auto"); "high"/"low"/"auto" set it. Ignored by
+                providers without a detail concept (Anthropic, Ollama).
+            temperature: Sampling temperature. Anthropic models in the
+                no-sampling family (Opus 4.7) drop it automatically.
 
         Returns:
-            Dict with 'text' (description) and 'tokens' (usage info)
+            Dict with 'text' (description), 'tokens'
+            ({input_tokens, output_tokens, total_tokens}), 'model', 'provider'.
         """
         pass
 
@@ -789,11 +830,20 @@ class OpenAIProvider(AIProvider):
         except Exception as e:
             raise Exception(f"OpenAI code translation failed: {e}") from e
 
-    def describe_image(self, image_data: bytes, prompt: str) -> Dict[str, Any]:
+    def describe_image(
+        self,
+        image_data: bytes,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        detail: Optional[str] = "high",
+        temperature: float = 0.3,
+    ) -> Dict[str, Any]:
         """
-        Describe an image using GPT-4o vision capabilities.
+        Describe an image using GPT-4o vision capabilities.  @verified ff971ab5
 
-        Returns dict with 'text' (description) and 'tokens' (usage info)
+        See AIProvider.describe_image for the full contract. ``detail=None``
+        omits the key (OpenAI "auto"); the worker's literal path passes None.
         """
         import base64
 
@@ -801,9 +851,15 @@ class OpenAIProvider(AIProvider):
             # Encode image to base64
             image_base64 = base64.b64encode(image_data).decode('utf-8')
 
-            vision_model = _resolve_provider_model_id(
+            vision_model = model or _resolve_provider_model_id(
                 "openai", "vision", env_var="VISION_MODEL"
             )
+
+            image_url: Dict[str, Any] = {
+                "url": f"data:image/png;base64,{image_base64}"
+            }
+            if detail is not None:
+                image_url["detail"] = detail
 
             response = self.client.chat.completions.create(
                 model=vision_model,
@@ -812,18 +868,12 @@ class OpenAIProvider(AIProvider):
                         "role": "user",
                         "content": [
                             {"type": "text", "text": prompt},
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:image/png;base64,{image_base64}",
-                                    "detail": "high"  # High detail for better extraction
-                                }
-                            }
+                            {"type": "image_url", "image_url": image_url}
                         ]
                     }
                 ],
                 max_tokens=8192,
-                temperature=0.3   # Lower for consistency
+                temperature=temperature
             )
 
             choice = response.choices[0]
@@ -835,14 +885,11 @@ class OpenAIProvider(AIProvider):
                 )
             description = choice.message.content.strip()
 
-            # Extract token usage
-            tokens = 0
-            if hasattr(response, 'usage') and response.usage:
-                tokens = response.usage.total_tokens
-
             return {
                 "text": description,
-                "tokens": tokens
+                "tokens": _openai_token_usage(response),
+                "model": vision_model,
+                "provider": "openai",
             }
 
         except Exception as e:
@@ -1088,7 +1135,15 @@ class LocalEmbeddingProvider(AIProvider):
             "Use OpenAI or Anthropic for translation."
         )
 
-    def describe_image(self, image_data: bytes, prompt: str) -> Dict[str, Any]:
+    def describe_image(
+        self,
+        image_data: bytes,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        detail: Optional[str] = "high",
+        temperature: float = 0.3,
+    ) -> Dict[str, Any]:
         """LocalEmbeddingProvider doesn't support image description (requires multimodal LLM)"""
         raise NotImplementedError(
             "LocalEmbeddingProvider only supports embeddings, not image description. "
@@ -1388,15 +1443,22 @@ class AnthropicProvider(AIProvider):
         except Exception as e:
             raise Exception(f"Anthropic code translation failed: {e}") from e
 
-    def describe_image(self, image_data: bytes, prompt: str) -> Dict[str, Any]:
+    def describe_image(
+        self,
+        image_data: bytes,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        detail: Optional[str] = "high",
+        temperature: float = 0.3,
+    ) -> Dict[str, Any]:
         """
-        Describe an image using the configured Anthropic vision model.
+        Describe an image using the configured Anthropic vision model.  @verified ff971ab5
 
-        The vision model resolves via catalog → VISION_MODEL env → ValueError
-        (no literal fallback). The prior hardcoded "claude-3-5-sonnet-20241022"
-        was retired Oct 28, 2025 and ignored any configured vision model.
-
-        Returns dict with 'text' (description) and 'tokens' (usage info).
+        See AIProvider.describe_image for the full contract. ``detail`` has no
+        Anthropic equivalent and is accepted (ignored) for a uniform signature;
+        the vision model resolves via ``model`` → catalog → VISION_MODEL env →
+        ValueError (no literal fallback).
         """
         import base64
 
@@ -1413,7 +1475,7 @@ class AnthropicProvider(AIProvider):
             elif image_data[:4] == b'RIFF' and image_data[8:12] == b'WEBP':
                 image_type = "image/webp"
 
-            vision_model = _resolve_provider_model_id(
+            vision_model = model or _resolve_provider_model_id(
                 "anthropic", "vision", env_var="VISION_MODEL"
             )
 
@@ -1437,7 +1499,7 @@ class AnthropicProvider(AIProvider):
                 }],
             }
             if not _anthropic_drops_sampling_params(vision_model):
-                request_kwargs["temperature"] = 0.3
+                request_kwargs["temperature"] = temperature
 
             message = self.client.messages.create(**request_kwargs)
 
@@ -1459,14 +1521,18 @@ class AnthropicProvider(AIProvider):
                 )
             description = text_block.text.strip()
 
-            # Extract token usage
-            tokens = 0
-            if hasattr(message, 'usage') and message.usage:
-                tokens = message.usage.input_tokens + message.usage.output_tokens
+            usage = getattr(message, "usage", None)
+            tokens = {
+                "input_tokens": getattr(usage, "input_tokens", 0) if usage else 0,
+                "output_tokens": getattr(usage, "output_tokens", 0) if usage else 0,
+            }
+            tokens["total_tokens"] = tokens["input_tokens"] + tokens["output_tokens"]
 
             return {
                 "text": description,
-                "tokens": tokens
+                "tokens": tokens,
+                "model": vision_model,
+                "provider": "anthropic",
             }
 
         except Exception as e:
@@ -1839,8 +1905,21 @@ class OpenRouterProvider(AIProvider):
         except Exception as e:
             raise Exception(f"OpenRouter code translation failed: {e}") from e
 
-    def describe_image(self, image_data: bytes, prompt: str) -> Dict[str, Any]:
-        """Describe an image using a vision-capable model via OpenRouter."""
+    def describe_image(
+        self,
+        image_data: bytes,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        detail: Optional[str] = "high",
+        temperature: float = 0.3,
+    ) -> Dict[str, Any]:
+        """Describe an image using a vision-capable model via OpenRouter.  @verified ff971ab5
+
+        See AIProvider.describe_image. ``model`` defaults to the configured
+        extraction model (OpenRouter routes a single model for both); pass an
+        explicit vision model id to override.
+        """
         import base64
 
         try:
@@ -1855,8 +1934,15 @@ class OpenRouterProvider(AIProvider):
             elif image_data[:4] == b"RIFF" and image_data[8:12] == b"WEBP":
                 mime_type = "image/webp"
 
-            # Use the extraction model if it supports vision, otherwise default
-            vision_model = self.extraction_model
+            # Use the explicit vision model when threaded through; otherwise the
+            # configured extraction model (OpenRouter routes one model per call).
+            vision_model = model or self.extraction_model
+
+            image_url: Dict[str, Any] = {
+                "url": f"data:{mime_type};base64,{image_base64}"
+            }
+            if detail is not None:
+                image_url["detail"] = detail
 
             response = self.client.chat.completions.create(
                 model=vision_model,
@@ -1865,18 +1951,12 @@ class OpenRouterProvider(AIProvider):
                         "role": "user",
                         "content": [
                             {"type": "text", "text": prompt},
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:{mime_type};base64,{image_base64}",
-                                    "detail": "high",
-                                },
-                            },
+                            {"type": "image_url", "image_url": image_url},
                         ],
                     }
                 ],
                 max_tokens=8192,
-                temperature=0.3,
+                temperature=temperature,
             )
 
             choice = response.choices[0]
@@ -1887,11 +1967,13 @@ class OpenRouterProvider(AIProvider):
                     "would receive partial text. Split the image or raise the cap."
                 )
             description = choice.message.content.strip()
-            tokens = 0
-            if hasattr(response, "usage") and response.usage:
-                tokens = response.usage.total_tokens
 
-            return {"text": description, "tokens": tokens}
+            return {
+                "text": description,
+                "tokens": _openai_token_usage(response),
+                "model": vision_model,
+                "provider": "openrouter",
+            }
 
         except Exception as e:
             raise Exception(f"OpenRouter image description failed: {e}") from e
@@ -2442,13 +2524,27 @@ class OllamaProvider(AIProvider):
         except Exception as e:
             raise Exception(f"Ollama code translation failed: {e}") from e
 
-    def describe_image(self, image_data: bytes, prompt: str) -> Dict[str, Any]:
+    def describe_image(
+        self,
+        image_data: bytes,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        detail: Optional[str] = "high",
+        temperature: float = 0.3,
+    ) -> Dict[str, Any]:
         """
-        Describe an image using Ollama vision model (e.g., llava, bakllava).
+        Describe an image using Ollama vision model (e.g., llava, bakllava).  @verified ff971ab5
 
-        Returns dict with 'text' (description) and 'tokens' (always 0 for local).
+        See AIProvider.describe_image. ``detail`` has no Ollama equivalent and
+        is accepted (ignored) for a uniform signature. Local inference reports
+        no token usage, so 'tokens' is always zeros.
 
-        Note: Requires a vision-capable model like llava:7b, llava:13b, or bakllava.
+        Note: Ollama vision is the OPTIONAL / unvalidated path (ADR-057 found it
+        inconsistent); this method is kept functional behind the unified
+        contract but is not golden-tested.
+
+        Requires a vision-capable model like llava:7b, llava:13b, or bakllava.
         """
         import requests
         import base64
@@ -2457,8 +2553,9 @@ class OllamaProvider(AIProvider):
             # Encode image to base64
             image_base64 = base64.b64encode(image_data).decode('utf-8')
 
-            # Use vision model (override extraction model if it's not vision-capable)
-            vision_model = self.extraction_model
+            # Use the explicit vision model when threaded through (ADR-802 §2);
+            # otherwise the configured extraction model.
+            vision_model = model or self.extraction_model
             if "llava" not in vision_model.lower() and "bakllava" not in vision_model.lower():
                 logger.warning(
                     f"Model '{vision_model}' may not support vision. "
@@ -2476,9 +2573,12 @@ class OllamaProvider(AIProvider):
                         "images": [image_base64],
                         "stream": False,
                         "options": {
-                            "temperature": 0.3,  # Lower for consistency
+                            "temperature": temperature,
                             "top_p": self.top_p,
-                            "num_predict": 2000
+                            # Match the cloud paths' 8192 cap so dense literal
+                            # descriptions aren't silently truncated (the old
+                            # 2000 cap could clip a full-page transcription).
+                            "num_predict": 8192
                         }
                     },
                     timeout=180  # 3 minute timeout for vision
@@ -2492,7 +2592,9 @@ class OllamaProvider(AIProvider):
 
             return {
                 "text": description,
-                "tokens": 0  # No token costs for local inference
+                "tokens": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "model": vision_model,
+                "provider": "ollama",
             }
 
         except Exception as e:

--- a/api/app/lib/ai_providers.py
+++ b/api/app/lib/ai_providers.py
@@ -214,6 +214,22 @@ def _load_api_key(provider: str, explicit_key: Optional[str] = None, env_var: Op
     return None
 
 
+def _detect_image_mime(image_data: bytes) -> str:
+    """Detect image MIME type from magic bytes, defaulting to image/png.
+
+    Shared by the describe_image paths so the data-URL / media_type a model
+    receives matches the actual bytes (PNG/JPEG/GIF/WebP). Mislabeling a JPEG
+    as PNG is usually tolerated by providers that sniff the bytes, but sending
+    the right type is correct and keeps the paths consistent.  @verified ff971ab5"""
+    if image_data[:2] == b"\xff\xd8":
+        return "image/jpeg"
+    if image_data[:4] == b"GIF8":
+        return "image/gif"
+    if image_data[:4] == b"RIFF" and image_data[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/png"
+
+
 def _openai_token_usage(response: Any) -> Dict[str, int]:
     """Normalize an OpenAI/OpenRouter chat usage object to the describe_image
     token shape ({input_tokens, output_tokens, total_tokens}). Zeros when the
@@ -855,8 +871,9 @@ class OpenAIProvider(AIProvider):
                 "openai", "vision", env_var="VISION_MODEL"
             )
 
+            mime_type = _detect_image_mime(image_data)
             image_url: Dict[str, Any] = {
-                "url": f"data:image/png;base64,{image_base64}"
+                "url": f"data:{mime_type};base64,{image_base64}"
             }
             if detail is not None:
                 image_url["detail"] = detail

--- a/api/app/lib/mock_ai_provider.py
+++ b/api/app/lib/mock_ai_provider.py
@@ -259,23 +259,39 @@ class MockAIProvider(AIProvider):
             "tokens": self._calculate_mock_tokens(prompt + code)
         }
 
-    def describe_image(self, image_data: bytes, prompt: str) -> Dict[str, Any]:
+    def describe_image(
+        self,
+        image_data: bytes,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        detail: Optional[str] = "high",
+        temperature: float = 0.3,
+    ) -> Dict[str, Any]:
         """
         Mock image description.
 
-        Returns deterministic description based on image data size.
+        Returns deterministic description based on image data size. Mirrors the
+        unified describe_image contract (AIProvider.describe_image): a 'tokens'
+        dict plus 'model'/'provider'.
 
         Args:
             image_data: Raw image bytes
             prompt: Description prompt
+            model: Optional vision model override (echoed back as the model id)
+            detail: Accepted (ignored) for signature uniformity
+            temperature: Accepted (ignored) for signature uniformity
 
         Returns:
-            Dict with 'text' (description) and 'tokens' (usage info)
+            Dict with 'text', 'tokens' (dict), 'model', 'provider'
         """
         description = f"Mock image description ({len(image_data)} bytes). Prompt: {prompt[:100]}"
+        total = self._calculate_mock_tokens(prompt)
         return {
             "text": description,
-            "tokens": self._calculate_mock_tokens(prompt)
+            "tokens": {"input_tokens": total, "output_tokens": 0, "total_tokens": total},
+            "model": model or "mock-vision",
+            "provider": "mock",
         }
 
     def call_with_tools(

--- a/api/app/lib/vision_providers.py
+++ b/api/app/lib/vision_providers.py
@@ -1,28 +1,32 @@
 """
-Vision Provider abstraction layer for image-to-prose conversion.
+Vision capability policy: which provider/model performs image → prose.
 
-Supports multiple providers (OpenAI GPT-4o, Anthropic Claude, Ollama) with
-configurable models for converting images to literal text descriptions.
+This module is the **vision capability slot policy** (ADR-802 §2), not a
+provider hierarchy. The image → prose call itself runs through the single
+`AIProvider.describe_image` contract in `ai_providers.py` — the parallel
+`VisionProvider` classes were collapsed into it (#457). What lives here is
+only the catalog-driven *selection* policy plus the research-validated literal
+prompt:
+
+- `resolve_vision_selection()` — resolve the active vision provider/model
+  independently of extraction (ADR-802 §2 / #378), fail-loud at the end.
+- `_resolve_vision_model()` / `_catalog_vision_model_ids()` — catalog-driven
+  vision model resolution by the per-row `supports_vision` flag (ADR-800/801).
+- `LITERAL_DESCRIPTION_PROMPT` — the ADR-057-validated literal transcription
+  prompt the ingestion worker passes to `describe_image`.
 
 Research Findings (ADR-057, Nov 2025):
 - Primary: GPT-4o Vision (100% reliable, excellent literal descriptions)
-- Alternate: Claude 3.5 Sonnet Vision (similar quality to GPT-4o)
-- Optional: Ollama (Granite, LLaVA) - inconsistent quality, use only when cloud unavailable
+- Alternate: Claude Sonnet Vision (similar quality to GPT-4o)
+- Optional: Ollama (Granite, LLaVA) — inconsistent quality, use only when
+  cloud unavailable
 
 See docs/research/vision-testing/ for comprehensive findings.
-
-API Key Loading (ADR-031):
-- First tries encrypted key store (system_api_keys table)
-- Falls back to environment variables (.env or direct)
-- Maintains backward compatibility
 """
 
 import os
 import logging
-import base64
-from typing import Dict, Any, Optional
-from abc import ABC, abstractmethod
-from io import BytesIO
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -122,16 +126,17 @@ def resolve_vision_selection(
          provider literal.
       4. Otherwise raise — no silent fallback to a hardcoded provider.
 
-    Note this resolves only the provider *name* (and optionally a model).
-    The model is still resolved/validated against the catalog by
-    ``_resolve_vision_model`` inside the provider constructor, which is the
-    fail-loud point when a provider has no vision-capable model.
+    Note this resolves only the provider *name* (and optionally a model). The
+    caller passes the (provider, model) pair to ``get_provider(name)`` +
+    ``describe_image(..., model=model)`` (ADR-802 §4 / #457). When ``model`` is
+    None, ``describe_image`` resolves/validates it against the catalog, which
+    is the fail-loud point when a provider has no vision-capable model.
 
     Returns:
         (provider_name, model_or_None)
 
     Raises:
-        ValueError: when no vision provider can be resolved.  @verified b4106aac
+        ValueError: when no vision provider can be resolved.  @verified ff971ab5
     """
     # 1. Explicit override (param or dev-mode env), parallel to AI_PROVIDER.
     explicit = provider or os.getenv("VISION_PROVIDER")
@@ -143,8 +148,8 @@ def resolve_vision_selection(
     #    provider chose it, and the POST /admin/vision/config guard already
     #    rejected activation without a usable model. If the catalog later loses
     #    that model, we still honour the explicit choice and fail loud at
-    #    _resolve_vision_model — a named, diagnosable error — rather than
-    #    silently overriding the operator's selection with a different provider.
+    #    describe_image's model resolution — a named, diagnosable error —
+    #    rather than silently overriding the operator's selection.
     try:
         from .ai_vision_config import load_active_vision_config
         vc = load_active_vision_config()
@@ -177,7 +182,8 @@ def resolve_vision_selection(
     )
 
 
-# Literal description prompt (validated in research, Nov 2025)
+# Literal description prompt (validated in research, Nov 2025).
+# Passed by the ingestion worker to AIProvider.describe_image (ADR-057).
 # See docs/research/vision-testing/FINDINGS.md
 LITERAL_DESCRIPTION_PROMPT = """
 Describe everything visible in this image literally and exhaustively.
@@ -194,606 +200,3 @@ Instead, describe:
 
 Be thorough and literal. If you see text, transcribe it exactly. If you see a box with an arrow pointing to another box, describe that precisely.
 """.strip()
-
-
-def _load_api_key(provider: str, explicit_key: Optional[str] = None, env_var: Optional[str] = None, service_token: Optional[str] = None) -> Optional[str]:
-    """
-    Load API key with fallback chain (ADR-031).
-
-    Priority order:
-    1. Explicit key provided as parameter
-    2. Encrypted key from database (system_api_keys table) - requires service token
-    3. Environment variable
-    4. None (will raise error in provider __init__)
-
-    Args:
-        provider: Provider name ('openai', 'anthropic', etc.)
-        explicit_key: API key passed explicitly to constructor
-        env_var: Environment variable name (e.g., 'OPENAI_API_KEY')
-        service_token: Internal service authorization token (for encrypted key access)
-
-    Returns:
-        API key if found, None otherwise
-    """
-    # 1. Explicit key takes precedence
-    if explicit_key:
-        logger.debug(f"Using explicit API key for {provider}")
-        return explicit_key
-
-    # 2. Try encrypted key store (requires service token)
-    try:
-        from .encrypted_keys import get_system_api_key
-        from .age_client import AGEClient
-        from .secrets import get_internal_key_service_secret
-
-        try:
-            client = AGEClient()
-            conn = client.pool.getconn()
-            try:
-                # Load service token if not provided
-                if service_token is None:
-                    service_token = get_internal_key_service_secret()
-
-                key = get_system_api_key(conn, provider, service_token)
-                if key:
-                    logger.debug(f"Loaded encrypted API key for {provider} from database")
-                    return key
-            finally:
-                client.pool.putconn(conn)
-        except ValueError as e:
-            # ValueError is raised for missing/invalid token or missing key
-            logger.debug(f"Could not load encrypted key for {provider}: {e}")
-        except Exception as e:
-            logger.debug(f"Could not load encrypted key for {provider}: {e}")
-    except ImportError:
-        logger.debug("Encrypted key store not available")
-
-    # 3. Fall back to environment variable
-    if env_var:
-        key = os.getenv(env_var)
-        if key:
-            logger.debug(f"Loaded API key for {provider} from environment variable: {env_var}")
-            return key
-
-    logger.debug(f"No API key found for {provider}")
-    return None
-
-
-class VisionProvider(ABC):
-    """Abstract base class for vision providers (image → text)"""
-
-    @abstractmethod
-    def describe_image(self, image_bytes: bytes, prompt: Optional[str] = None) -> Dict[str, Any]:
-        """
-        Convert image to prose description.
-
-        Args:
-            image_bytes: Raw image bytes (PNG, JPEG, etc.)
-            prompt: Description prompt (defaults to LITERAL_DESCRIPTION_PROMPT)
-
-        Returns:
-            Dict with:
-            - 'text': The prose description
-            - 'tokens': Token usage info (input_tokens, output_tokens, total_tokens)
-            - 'model': Model name used
-            - 'provider': Provider name
-        """
-        pass
-
-    @abstractmethod
-    def get_provider_name(self) -> str:
-        """Get the name of this provider"""
-        pass
-
-    @abstractmethod
-    def get_model_name(self) -> str:
-        """Get the model name used for vision"""
-        pass
-
-    @abstractmethod
-    def validate_api_key(self) -> bool:
-        """Validate that the API key works"""
-        pass
-
-    @abstractmethod
-    def list_available_models(self) -> list[str]:
-        """List available vision models for this provider"""
-        pass
-
-
-class OpenAIVisionProvider(VisionProvider):
-    """
-    OpenAI GPT-4o Vision provider (PRIMARY - validated in research).
-
-    Research shows:
-    - 100% reliable (no random refusals)
-    - Excellent literal descriptions (3,017 chars avg)
-    - Fast (~5s per image)
-    - Cost: ~$0.01/image
-
-    See docs/research/vision-testing/FINDINGS.md
-    """
-
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        model: Optional[str] = None
-    ):
-        from openai import OpenAI
-
-        # Load API key with fallback chain (ADR-031)
-        self.api_key = _load_api_key("openai", api_key, "OPENAI_API_KEY")
-        if not self.api_key:
-            raise ValueError(
-                "OpenAI API key not found. Either:\n"
-                "  1. Configure via admin API: POST /admin/keys/openai\n"
-                "  2. Set OPENAI_API_KEY environment variable\n"
-                "  3. Add to .env file (development only)"
-            )
-
-        # Configure retry behavior
-        from .rate_limiter import get_provider_max_retries
-        max_retries = get_provider_max_retries("openai")
-
-        self.client = OpenAI(
-            api_key=self.api_key,
-            max_retries=max_retries,
-            timeout=120.0  # 2 minute timeout for vision requests
-        )
-        logger.info(f"OpenAI Vision client configured with max_retries={max_retries}")
-
-        # Catalog-resolved — see _resolve_vision_model.
-        self.model = _resolve_vision_model("openai", model)
-
-    def describe_image(self, image_bytes: bytes, prompt: Optional[str] = None) -> Dict[str, Any]:
-        """
-        Describe image using GPT-4o Vision.
-
-        Args:
-            image_bytes: Raw image bytes
-            prompt: Description prompt (defaults to LITERAL_DESCRIPTION_PROMPT)
-
-        Returns:
-            Dict with 'text', 'tokens', 'model', 'provider'
-        """
-        # Use literal prompt by default
-        if prompt is None:
-            prompt = LITERAL_DESCRIPTION_PROMPT
-
-        # Encode image to base64
-        image_b64 = base64.b64encode(image_bytes).decode('utf-8')
-
-        # Detect mime type (simplified - assumes JPEG if not PNG)
-        if image_bytes.startswith(b'\x89PNG'):
-            mime_type = 'image/png'
-        else:
-            mime_type = 'image/jpeg'
-
-        try:
-            response = self.client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": prompt},
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:{mime_type};base64,{image_b64}"
-                                }
-                            }
-                        ]
-                    }
-                ],
-                max_tokens=8192,
-                temperature=0.1  # Low temperature for consistent literal descriptions
-            )
-
-            choice = response.choices[0]
-            if choice.finish_reason == "length":
-                raise Exception(
-                    f"OpenAI vision description truncated at max_tokens=8192 "
-                    f"(model={self.model}). Downstream concept extraction would "
-                    "receive partial text. Split the image or raise the cap."
-                )
-            description = choice.message.content
-
-            # Extract token usage
-            usage = response.usage
-            tokens = {
-                "input_tokens": usage.prompt_tokens,
-                "output_tokens": usage.completion_tokens,
-                "total_tokens": usage.total_tokens
-            }
-
-            logger.info(
-                f"OpenAI Vision described image: {len(description)} chars, "
-                f"{tokens['total_tokens']} tokens"
-            )
-
-            return {
-                "text": description,
-                "tokens": tokens,
-                "model": self.model,
-                "provider": "openai"
-            }
-
-        except Exception as e:
-            logger.error(f"OpenAI Vision error: {e}")
-            raise
-
-    def get_provider_name(self) -> str:
-        return "openai"
-
-    def get_model_name(self) -> str:
-        return self.model
-
-    def validate_api_key(self) -> bool:
-        """Validate API key by making a minimal API call"""
-        try:
-            # Simple test: describe a tiny 1x1 black pixel PNG
-            test_image = base64.b64decode(
-                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-            )
-            result = self.describe_image(test_image, "What color is this pixel?")
-            return bool(result.get("text"))
-        except Exception as e:
-            logger.error(f"OpenAI Vision API key validation failed: {e}")
-            return False
-
-    def list_available_models(self) -> list[str]:
-        """List available OpenAI vision models from the catalog (ADR-801)."""
-        return _catalog_vision_model_ids("openai")
-
-
-class AnthropicVisionProvider(VisionProvider):
-    """
-    Anthropic Claude 3.5 Sonnet Vision provider (ALTERNATE).
-
-    Similar quality to GPT-4o, slightly higher cost.
-    Cost: ~$0.015/image, Speed: ~5s/image
-
-    See docs/research/vision-testing/ (not tested yet, but expected similar quality).
-    """
-
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        model: Optional[str] = None
-    ):
-        from anthropic import Anthropic
-
-        # Load API key with fallback chain (ADR-031)
-        self.api_key = _load_api_key("anthropic", api_key, "ANTHROPIC_API_KEY")
-        if not self.api_key:
-            raise ValueError(
-                "Anthropic API key not found. Either:\n"
-                "  1. Configure via admin API: POST /admin/keys/anthropic\n"
-                "  2. Set ANTHROPIC_API_KEY environment variable\n"
-                "  3. Add to .env file (development only)"
-            )
-
-        # Configure retry behavior
-        from .rate_limiter import get_provider_max_retries
-        max_retries = get_provider_max_retries("anthropic")
-
-        self.client = Anthropic(
-            api_key=self.api_key,
-            max_retries=max_retries,
-            timeout=120.0
-        )
-        logger.info(f"Anthropic Vision client configured with max_retries={max_retries}")
-
-        # Catalog-resolved — see _resolve_vision_model.
-        self.model = _resolve_vision_model("anthropic", model)
-
-    def describe_image(self, image_bytes: bytes, prompt: Optional[str] = None) -> Dict[str, Any]:
-        """
-        Describe image using Claude Vision.
-
-        Args:
-            image_bytes: Raw image bytes
-            prompt: Description prompt (defaults to LITERAL_DESCRIPTION_PROMPT)
-
-        Returns:
-            Dict with 'text', 'tokens', 'model', 'provider'
-        """
-        # Use literal prompt by default
-        if prompt is None:
-            prompt = LITERAL_DESCRIPTION_PROMPT
-
-        # Encode image to base64
-        image_b64 = base64.b64encode(image_bytes).decode('utf-8')
-
-        # Detect mime type
-        if image_bytes.startswith(b'\x89PNG'):
-            mime_type = 'image/png'
-        else:
-            mime_type = 'image/jpeg'
-
-        # Opus 4.7 removes sampling params; sending temperature 400s.
-        # Other Claude 4.x models still accept it for description consistency.
-        request_kwargs: Dict[str, Any] = {
-            "model": self.model,
-            "max_tokens": 8192,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "media_type": mime_type,
-                                "data": image_b64,
-                            },
-                        },
-                        {"type": "text", "text": prompt},
-                    ],
-                }
-            ],
-        }
-        from .ai_providers import _anthropic_drops_sampling_params
-        if not _anthropic_drops_sampling_params(self.model):
-            request_kwargs["temperature"] = 0.1
-
-        try:
-            response = self.client.messages.create(**request_kwargs)
-
-            if response.stop_reason == "max_tokens":
-                raise Exception(
-                    f"Anthropic vision description truncated at max_tokens=8192 "
-                    f"(model={self.model}). The image is dense enough that the "
-                    "literal description exceeds the cap — downstream concept "
-                    "extraction would receive partial text. Split the image or "
-                    "raise the cap."
-                )
-
-            text_block = next(
-                (b for b in response.content if getattr(b, "type", None) == "text"),
-                None,
-            )
-            if text_block is None:
-                raise Exception(
-                    f"Anthropic vision returned no text block "
-                    f"(stop_reason={response.stop_reason}, model={self.model})."
-                )
-            description = text_block.text
-
-            # Extract token usage
-            tokens = {
-                "input_tokens": response.usage.input_tokens,
-                "output_tokens": response.usage.output_tokens,
-                "total_tokens": response.usage.input_tokens + response.usage.output_tokens
-            }
-
-            logger.info(
-                f"Anthropic Vision described image: {len(description)} chars, "
-                f"{tokens['total_tokens']} tokens"
-            )
-
-            return {
-                "text": description,
-                "tokens": tokens,
-                "model": self.model,
-                "provider": "anthropic"
-            }
-
-        except Exception as e:
-            logger.error(f"Anthropic Vision error: {e}")
-            raise
-
-    def get_provider_name(self) -> str:
-        return "anthropic"
-
-    def get_model_name(self) -> str:
-        return self.model
-
-    def validate_api_key(self) -> bool:
-        """Validate API key by making a minimal API call"""
-        try:
-            # Simple test: describe a tiny 1x1 black pixel PNG
-            test_image = base64.b64decode(
-                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-            )
-            result = self.describe_image(test_image, "What color is this pixel?")
-            return bool(result.get("text"))
-        except Exception as e:
-            logger.error(f"Anthropic Vision API key validation failed: {e}")
-            return False
-
-    def list_available_models(self) -> list[str]:
-        """List available Anthropic vision models from the catalog (ADR-801)."""
-        return _catalog_vision_model_ids("anthropic")
-
-
-class OllamaVisionProvider(VisionProvider):
-    """
-    Ollama Vision provider (OPTIONAL - pattern in place, not recommended).
-
-    Research shows:
-    - Inconsistent quality (works on some images, refuses on others)
-    - Random refusals with "text is not fully visible" errors
-    - Slower than cloud (~15s per image)
-    - Cost: $0 (local)
-
-    Use only when cloud APIs unavailable.
-
-    See docs/research/vision-testing/FINDINGS.md for details.
-    """
-
-    def __init__(
-        self,
-        base_url: Optional[str] = None,
-        model: Optional[str] = None
-    ):
-        """
-        Initialize Ollama Vision provider.
-
-        Args:
-            base_url: Ollama API base URL (defaults to OLLAMA_BASE_URL env or http://localhost:11434)
-            model: Vision model id — resolved via catalog → VISION_MODEL env if omitted (ADR-801).
-        """
-        self.base_url = base_url or os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
-        self.model = _resolve_vision_model("ollama", model)
-
-        logger.warning(
-            f"Using Ollama Vision ({self.model}). Research shows inconsistent quality. "
-            "See docs/research/vision-testing/FINDINGS.md"
-        )
-
-    def describe_image(self, image_bytes: bytes, prompt: Optional[str] = None) -> Dict[str, Any]:
-        """
-        Describe image using Ollama vision model.
-
-        Args:
-            image_bytes: Raw image bytes
-            prompt: Description prompt (defaults to LITERAL_DESCRIPTION_PROMPT)
-
-        Returns:
-            Dict with 'text', 'tokens', 'model', 'provider'
-
-        Note: May fail with random refusals on some images.
-        """
-        import requests
-
-        # Use literal prompt by default
-        if prompt is None:
-            prompt = LITERAL_DESCRIPTION_PROMPT
-
-        # Encode image to base64
-        image_b64 = base64.b64encode(image_bytes).decode('utf-8')
-
-        try:
-            response = requests.post(
-                f"{self.base_url}/api/generate",
-                json={
-                    "model": self.model,
-                    "prompt": prompt,
-                    "images": [image_b64],
-                    "stream": False
-                },
-                timeout=120.0
-            )
-            response.raise_for_status()
-
-            result = response.json()
-            description = result.get("response", "")
-
-            # Ollama doesn't provide detailed token counts
-            tokens = {
-                "input_tokens": 0,  # Not available
-                "output_tokens": 0,  # Not available
-                "total_tokens": 0
-            }
-
-            logger.info(
-                f"Ollama Vision described image: {len(description)} chars "
-                f"(model: {self.model})"
-            )
-
-            return {
-                "text": description,
-                "tokens": tokens,
-                "model": self.model,
-                "provider": "ollama"
-            }
-
-        except Exception as e:
-            logger.error(f"Ollama Vision error: {e}")
-            raise
-
-    def get_provider_name(self) -> str:
-        return "ollama"
-
-    def get_model_name(self) -> str:
-        return self.model
-
-    def validate_api_key(self) -> bool:
-        """Validate Ollama connection (no API key needed)"""
-        import requests
-        try:
-            response = requests.get(f"{self.base_url}/api/tags", timeout=5.0)
-            response.raise_for_status()
-            return True
-        except Exception as e:
-            logger.error(f"Ollama connection validation failed: {e}")
-            return False
-
-    def list_available_models(self) -> list[str]:
-        """List vision models from the catalog (ADR-801); live Ollama query
-        as fallback when the catalog has no vision rows for ollama yet."""
-        catalog = _catalog_vision_model_ids("ollama")
-        if catalog:
-            return catalog
-        import requests
-        try:
-            response = requests.get(f"{self.base_url}/api/tags", timeout=5.0)
-            response.raise_for_status()
-
-            models = response.json().get("models", [])
-            # Filter for vision models (contains "vision" or "llava" in name)
-            vision_models = [
-                m["name"] for m in models
-                if "vision" in m["name"].lower() or "llava" in m["name"].lower()
-            ]
-            return vision_models if vision_models else ["No vision models found"]
-        except Exception as e:
-            logger.error(f"Failed to list Ollama models: {e}")
-            return []
-
-
-def get_vision_provider(
-    provider: Optional[str] = None,
-    api_key: Optional[str] = None,
-    model: Optional[str] = None
-) -> VisionProvider:
-    """
-    Factory function to get vision provider instance.
-
-    Args:
-        provider: Provider name ('openai', 'anthropic', 'ollama'). When None,
-                 it is resolved via resolve_vision_selection (ADR-802 §2):
-                 active vision config → active extraction provider if
-                 vision-capable → ValueError. No hardcoded 'openai' default.
-        api_key: API key (optional, will use env vars if not provided)
-        model: Model name (optional, will use env vars or provider defaults)
-
-    Returns:
-        VisionProvider instance
-
-    Raises:
-        ValueError: If no provider can be resolved, the provider is not
-            recognized, or the configuration is invalid.
-
-    Examples:
-        # Resolve the configured/active vision provider (ADR-802 §2)
-        provider = get_vision_provider()
-
-        # Use specific provider
-        provider = get_vision_provider(provider="anthropic")
-
-        # Override model
-        provider = get_vision_provider(provider="openai", model="gpt-4o-mini")
-    """
-    # ADR-802 §2 / #378: resolve the provider through the defined chain rather
-    # than defaulting to a hardcoded 'openai'. An explicit `provider` arg is
-    # honoured as-is; None triggers config/catalog-aware resolution.
-    provider, model = resolve_vision_selection(provider=provider, model=model)
-
-    logger.info(f"Initializing vision provider: {provider}")
-
-    if provider == "openai":
-        return OpenAIVisionProvider(api_key=api_key, model=model)
-    elif provider == "anthropic":
-        return AnthropicVisionProvider(api_key=api_key, model=model)
-    elif provider == "ollama":
-        # Ollama doesn't use API keys
-        base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
-        return OllamaVisionProvider(base_url=base_url, model=model)
-    else:
-        raise ValueError(
-            f"Unknown vision provider: {provider}. "
-            f"Supported: openai (recommended), anthropic, ollama"
-        )

--- a/api/app/routes/ingest.py
+++ b/api/app/routes/ingest.py
@@ -212,7 +212,9 @@ async def ingest_document(
                 # Replace image bytes with text description
                 original_size = len(content)
                 content = description_response["text"].encode('utf-8')
-                vision_tokens = description_response.get("tokens", 0)
+                # describe_image returns a normalized token dict
+                # ({input,output,total}); fall back gracefully if absent.
+                vision_tokens = (description_response.get("tokens") or {}).get("total_tokens", 0)
 
                 logger.info(
                     f"Image described successfully: {original_size} bytes → "

--- a/api/app/routes/ingest_image.py
+++ b/api/app/routes/ingest_image.py
@@ -222,6 +222,15 @@ async def ingest_image(
     age_client = AGEClient()
     hasher = ContentHasher(queue, age_client)
 
+    # ADR-200 Phase 2: Frozen ontologies reject ingestion. The image route had
+    # drifted from the prose route (routes/ingest.py) and was missing this
+    # guard — align them so image ingestion respects lifecycle state too.
+    if age_client.is_ontology_frozen(ontology):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Ontology '{ontology}' is frozen (read-only). Set lifecycle state to 'active' before ingesting."
+        )
+
     # Read image content
     content = await file.read()
 
@@ -255,6 +264,15 @@ async def ingest_image(
                 content=duplicate_info
             )
 
+    # #402 Defect B1: Record whether the target ontology existed at submit time
+    # (same as the prose route, routes/ingest.py). The worker uses this to tell
+    # "first ingest into a brand-new ontology, create it" apart from "ontology
+    # vanished between queue and execution." Without it the worker defaulted to
+    # existed_at_submit=True, so EVERY image ingest into a NEW ontology tripped
+    # the missing-target anomaly guard — the image route had simply never set
+    # this key. Aligning the two routes fixes it.
+    existed_at_submit = age_client.get_ontology_node(ontology) is not None
+
     # Step 2: Prepare job data with raw image bytes
     # Heavy work (embedding, vision, MinIO upload) happens in worker
     use_filename = filename or file.filename or "uploaded_image"
@@ -269,6 +287,7 @@ async def ingest_image(
         "image_bytes": base64.b64encode(content).decode('utf-8'),  # Store raw image
         "content_hash": content_hash,
         "ontology": ontology,
+        "ontology_existed_at_submit": existed_at_submit,  # #402 Defect B1 (see above)
         "filename": use_filename,
         "user_id": current_user.id,  # Track job owner (user ID from kg_auth.users)
         "processing_mode": processing_mode,

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -224,24 +224,36 @@ def run_ingestion_worker(
             logger.error(f"Failed to generate visual embedding: {e}")
             raise Exception(f"Visual embedding generation failed: {str(e)}")
 
-        # Step 2: Convert image to prose description (Vision Provider)
+        # Step 2: Convert image to prose description (ADR-057 literal path).
+        #
+        # The vision capability slot resolves INDEPENDENTLY of extraction
+        # (ADR-802 §2 / #378): resolve_vision_selection picks the provider/model
+        # (per-job override → active vision config → vision-capable extraction
+        # default → fail loud), then we build that provider and call the unified
+        # describe_image. We deliberately do NOT call get_provider() bare —
+        # that returns the *extraction* provider and would re-slave vision to
+        # extraction. The explicit args reproduce the research-validated literal
+        # settings: LITERAL prompt, detail=None (OpenAI "auto"), temperature 0.1.
         logger.info("Converting image to prose with vision AI...")
-        from api.app.lib.vision_providers import get_vision_provider, LITERAL_DESCRIPTION_PROMPT
+        # NOTE: get_provider is already imported at module level (top of file).
+        # Do NOT re-import it locally here — a function-local `from ... import
+        # get_provider` would make get_provider a local for the WHOLE function,
+        # so the text-extraction path's get_provider() call (later in this same
+        # function) would hit UnboundLocalError on non-image code paths.
+        from api.app.lib.vision_providers import resolve_vision_selection, LITERAL_DESCRIPTION_PROMPT
         try:
-            # ADR-802 §2 / #378: pass the per-job override through (may be None);
-            # get_vision_provider resolves the active/default provider when unset
-            # rather than defaulting to a hardcoded 'openai'.
-            vision_provider_name = job_data.get("vision_provider")
-            vision_model_name = job_data.get("vision_model")
-
-            vision_provider = get_vision_provider(
-                provider=vision_provider_name,
-                model=vision_model_name
+            vision_provider_name, vision_model_name = resolve_vision_selection(
+                provider=job_data.get("vision_provider"),
+                model=job_data.get("vision_model"),
             )
 
+            vision_provider = get_provider(vision_provider_name)
             description_response = vision_provider.describe_image(
-                image_bytes=image_bytes,
-                prompt=LITERAL_DESCRIPTION_PROMPT
+                image_bytes,
+                LITERAL_DESCRIPTION_PROMPT,
+                model=vision_model_name,
+                detail=None,
+                temperature=0.1,
             )
 
             prose_description = description_response["text"]
@@ -297,8 +309,13 @@ def run_ingestion_worker(
         job_data["storage_key"] = storage_key
         job_data["visual_embedding"] = visual_embedding
         job_data["vision_metadata"] = {
-            "provider": vision_provider.get_provider_name(),
-            "model": vision_provider.get_model_name(),
+            # Record the provider/model that actually performed image->prose,
+            # straight from the describe_image response (#457). The collapsed
+            # AIProvider has no get_model_name(), and its get_provider_name()
+            # is capitalized; the response carries the real lowercase provider
+            # + resolved vision model, which is what we want stored.
+            "provider": description_response.get("provider"),
+            "model": description_response.get("model"),
             "vision_tokens": vision_tokens,
             "visual_embedding_model": visual_model_name,
             "visual_embedding_dimension": visual_model_dim,

--- a/scripts/development/diagnostics/golden_describe_image.py
+++ b/scripts/development/diagnostics/golden_describe_image.py
@@ -1,0 +1,187 @@
+"""
+Golden fidelity check for the #457 vision facade collapse (ADR-802 §4, ADR-057).
+
+LLM output at temperature 0.1 is near-deterministic but NOT byte-identical
+run-to-run, so a text diff would be noisy even comparing old-vs-old. The
+deterministic, meaningful fidelity proof is the REQUEST PAYLOAD the provider
+SDK receives: if the collapsed AIProvider.describe_image sends the same request
+the old vision_providers path sent, image->prose behaviour is preserved (modulo
+provider nondeterminism, which is out of our control).
+
+Part 1 (deterministic): capture the new path's outgoing Anthropic request and
+assert it equals the reconstructed old vision_providers request, for the same
+(image, prompt, model, temperature, detail=None) the ingestion worker uses.
+
+Part 2 (live, optional): run the real worker path (resolve_vision_selection →
+get_provider → describe_image) against the configured Anthropic provider on a
+real ADR-057 research image, and print the description so quality is eyeballable.
+
+Run inside the API container:
+    docker exec kg-api-dev python scripts/development/diagnostics/golden_describe_image.py
+"""
+
+import base64
+import copy
+import sys
+from unittest.mock import MagicMock
+
+from api.app.lib.ai_providers import AnthropicProvider, _anthropic_drops_sampling_params
+from api.app.lib.vision_providers import LITERAL_DESCRIPTION_PROMPT, resolve_vision_selection
+
+import os
+# Default to an ADR-057 research image; override with GOLDEN_IMAGE for an
+# ad-hoc article (e.g. the Old Town Wichita cowtown photos).
+IMAGE_PATH = os.getenv("GOLDEN_IMAGE", "docs/research/vision-testing/test-images/old_western_town_scene.jpg")
+MODEL = "claude-sonnet-4-6"  # representative active vision model
+
+
+def _old_vision_providers_anthropic_request(image_bytes, prompt, model):
+    """Reconstruct EXACTLY the request the deleted
+    vision_providers.AnthropicVisionProvider.describe_image built, for a
+    png/jpeg image (the ADR-057-validated formats)."""
+    image_b64 = base64.b64encode(image_bytes).decode("utf-8")
+    mime_type = "image/png" if image_bytes.startswith(b"\x89PNG") else "image/jpeg"
+    request_kwargs = {
+        "model": model,
+        "max_tokens": 8192,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": mime_type,
+                            "data": image_b64,
+                        },
+                    },
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    }
+    if not _anthropic_drops_sampling_params(model):
+        request_kwargs["temperature"] = 0.1
+    return request_kwargs
+
+
+def _capture_new_request(image_bytes, prompt, model):
+    """Capture the request the NEW AIProvider.describe_image sends, using the
+    worker's exact args (model threaded, detail=None, temperature=0.1)."""
+    p = object.__new__(AnthropicProvider)
+    p.client = MagicMock()
+    captured = {}
+
+    def _record(**kwargs):
+        captured.update(kwargs)
+        msg = MagicMock()
+        msg.stop_reason = "end_turn"
+        block = MagicMock()
+        block.type = "text"
+        block.text = "ok"
+        msg.content = [block]
+        msg.usage.input_tokens = 1
+        msg.usage.output_tokens = 1
+        return msg
+
+    p.client.messages.create.side_effect = _record
+    p.describe_image(image_bytes, prompt, model=model, detail=None, temperature=0.1)
+    return captured
+
+
+def part1_request_equivalence(image_bytes):
+    old = _old_vision_providers_anthropic_request(image_bytes, LITERAL_DESCRIPTION_PROMPT, MODEL)
+    new = _capture_new_request(image_bytes, LITERAL_DESCRIPTION_PROMPT, MODEL)
+    # Compare the SDK-facing payloads.
+    if copy.deepcopy(old) == copy.deepcopy(new):
+        print("✅ PART 1 — request payloads IDENTICAL (old vision_providers ≡ new AIProvider)")
+        print(f"   model={new['model']} max_tokens={new['max_tokens']} "
+              f"temperature={new.get('temperature')} "
+              f"content_order={[c['type'] for c in new['messages'][0]['content']]} "
+              f"media_type={new['messages'][0]['content'][0]['source']['media_type']}")
+        return True
+    print("❌ PART 1 — request payloads DIFFER")
+    for k in sorted(set(old) | set(new)):
+        if old.get(k) != new.get(k):
+            # Don't dump the base64 image; summarize.
+            if k == "messages":
+                print(f"   messages differ (content structure / media_type / order)")
+            else:
+                print(f"   {k}: old={old.get(k)!r} new={new.get(k)!r}")
+    return False
+
+
+async def _ensure_embedding_manager():
+    """Initialize the embedding model manager singleton.
+
+    get_embedding_provider() builds a LocalEmbeddingProvider, which needs the
+    manager the API server initializes at startup. A bare script doesn't have
+    it, so get_provider() would wrongly fail with "requires an embedding
+    provider" — a harness artifact, not a real regression. Initialize it here
+    so PART 2 reproduces the actual worker runtime.
+    """
+    from api.app.lib.embedding_model_manager import init_embedding_model_manager
+    await init_embedding_model_manager()
+
+
+def part2_live(image_bytes, label):
+    import asyncio
+    print(f"\n--- PART 2 — live worker path (real provider call) [{label}] ---")
+    try:
+        asyncio.run(_ensure_embedding_manager())
+    except Exception as e:
+        print(f"   ⚠️  embedding manager init failed (live call may fail): {e}")
+    try:
+        provider_name, vision_model = resolve_vision_selection()
+        print(f"   resolved vision slot: provider={provider_name} model={vision_model}")
+    except Exception as e:
+        print(f"   ⚠️  resolve_vision_selection failed: {e}")
+        return
+    try:
+        from api.app.lib.ai_providers import get_provider
+        provider = get_provider(provider_name)
+        out = provider.describe_image(
+            image_bytes, LITERAL_DESCRIPTION_PROMPT,
+            model=vision_model, detail=None, temperature=0.1,
+        )
+        text = out["text"]
+        print(f"   ✅ described: {len(text)} chars, tokens={out['tokens']}, "
+              f"model={out['model']}, provider={out['provider']}")
+        print("   --- first 400 chars ---")
+        print("   " + text[:400].replace("\n", "\n   "))
+    except Exception as e:
+        print(f"   ⚠️  live call failed: {e}")
+
+
+def _iter_images(path):
+    """Yield (label, bytes) for a file or every image in a directory."""
+    if os.path.isdir(path):
+        names = sorted(
+            n for n in os.listdir(path)
+            if n.lower().endswith((".png", ".jpg", ".jpeg"))
+        )
+        for n in names:
+            with open(os.path.join(path, n), "rb") as f:
+                yield n, f.read()
+    else:
+        with open(path, "rb") as f:
+            yield os.path.basename(path), f.read()
+
+
+def main():
+    # PART1_ONLY skips the live (token-spending) calls — useful to prove
+    # request-payload equivalence across a whole image set for free.
+    part1_only = os.getenv("GOLDEN_PART1_ONLY") == "1"
+    all_ok = True
+    for label, image_bytes in _iter_images(IMAGE_PATH):
+        print(f"\n========== {label} ({len(image_bytes)} bytes) ==========")
+        ok = part1_request_equivalence(image_bytes)
+        all_ok = all_ok and ok
+        if not part1_only:
+            part2_live(image_bytes, label)
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/lib/test_describe_image_contract.py
+++ b/tests/unit/lib/test_describe_image_contract.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for the unified AIProvider.describe_image contract (#457, ADR-802 §4).
+
+The parallel VisionProvider hierarchy was collapsed into AIProvider.describe_image.
+This pins the behavioural-fidelity contract the collapse had to preserve (ADR-057):
+
+- The signature is parameterized: ``model`` / ``detail`` / ``temperature``.
+- ``detail=None`` omits the OpenAI ``detail`` key (provider "auto") — exactly
+  how the ingestion worker reproduces the research-validated literal path; the
+  route keeps ``detail="high"`` via the default.
+- ``temperature`` and an explicit vision ``model`` thread through to the request.
+- The return shape is unified: {text, tokens:{...}, model, provider}.
+
+The provider SDK client is mocked — no network.
+"""
+
+from unittest.mock import MagicMock
+
+from api.app.lib.ai_providers import OpenAIProvider, AnthropicProvider
+
+
+def _openai_response(text="described", finish_reason="stop"):
+    """Build a mock OpenAI chat-completions response with usage."""
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].finish_reason = finish_reason
+    resp.choices[0].message.content = text
+    resp.usage.prompt_tokens = 100
+    resp.usage.completion_tokens = 40
+    resp.usage.total_tokens = 140
+    return resp
+
+
+def _make_openai():
+    """OpenAIProvider with a mocked client (bypasses __init__/key loading)."""
+    p = object.__new__(OpenAIProvider)
+    p.client = MagicMock()
+    p.client.chat.completions.create.return_value = _openai_response()
+    return p
+
+
+class TestOpenAIDescribeImageContract:
+    def test_default_detail_high_is_sent(self):
+        # The route (ingest.py) path: defaults reproduce historical behaviour.
+        p = _make_openai()
+        p.describe_image(b"\x89PNGfake", "prompt", model="gpt-4o")
+        kwargs = p.client.chat.completions.create.call_args.kwargs
+        image_part = kwargs["messages"][0]["content"][1]["image_url"]
+        assert image_part.get("detail") == "high"
+        assert kwargs["temperature"] == 0.3
+
+    def test_detail_none_omits_key(self):
+        # The ingestion-worker literal path passes detail=None → key omitted
+        # (OpenAI "auto"), reproducing the old vision_providers behaviour.
+        p = _make_openai()
+        p.describe_image(b"\x89PNGfake", "prompt", model="gpt-4o",
+                         detail=None, temperature=0.1)
+        kwargs = p.client.chat.completions.create.call_args.kwargs
+        image_part = kwargs["messages"][0]["content"][1]["image_url"]
+        assert "detail" not in image_part
+        assert kwargs["temperature"] == 0.1
+
+    def test_explicit_model_threads_through(self):
+        p = _make_openai()
+        p.describe_image(b"\x89PNGfake", "prompt", model="gpt-4o-mini")
+        assert p.client.chat.completions.create.call_args.kwargs["model"] == "gpt-4o-mini"
+
+    def test_unified_return_shape(self):
+        p = _make_openai()
+        out = p.describe_image(b"\x89PNGfake", "prompt", model="gpt-4o")
+        assert out["text"] == "described"
+        assert out["provider"] == "openai"
+        assert out["model"] == "gpt-4o"
+        assert out["tokens"] == {
+            "input_tokens": 100, "output_tokens": 40, "total_tokens": 140,
+        }
+
+    def test_truncation_raises(self):
+        p = _make_openai()
+        p.client.chat.completions.create.return_value = _openai_response(
+            finish_reason="length")
+        try:
+            p.describe_image(b"\x89PNGfake", "prompt", model="gpt-4o")
+            assert False, "expected truncation to raise"
+        except Exception as e:
+            assert "truncated" in str(e)
+
+
+def _make_anthropic():
+    p = object.__new__(AnthropicProvider)
+    p.client = MagicMock()
+    msg = MagicMock()
+    msg.stop_reason = "end_turn"
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = "described"
+    msg.content = [text_block]
+    msg.usage.input_tokens = 80
+    msg.usage.output_tokens = 20
+    p.client.messages.create.return_value = msg
+    return p
+
+
+class TestAnthropicDescribeImageContract:
+    def test_temperature_and_model_thread_through(self):
+        # claude-sonnet keeps sampling params (not the Opus 4.7 no-sampling family).
+        p = _make_anthropic()
+        p.describe_image(b"\xff\xd8jpegfake", "prompt",
+                         model="claude-sonnet-4-6", temperature=0.1)
+        kwargs = p.client.messages.create.call_args.kwargs
+        assert kwargs["model"] == "claude-sonnet-4-6"
+        assert kwargs["temperature"] == 0.1
+
+    def test_unified_return_shape(self):
+        p = _make_anthropic()
+        out = p.describe_image(b"\xff\xd8jpegfake", "prompt",
+                               model="claude-sonnet-4-6")
+        assert out["text"] == "described"
+        assert out["provider"] == "anthropic"
+        assert out["model"] == "claude-sonnet-4-6"
+        assert out["tokens"] == {
+            "input_tokens": 80, "output_tokens": 20, "total_tokens": 100,
+        }

--- a/tests/unit/lib/test_describe_image_contract.py
+++ b/tests/unit/lib/test_describe_image_contract.py
@@ -65,6 +65,23 @@ class TestOpenAIDescribeImageContract:
         p.describe_image(b"\x89PNGfake", "prompt", model="gpt-4o-mini")
         assert p.client.chat.completions.create.call_args.kwargs["model"] == "gpt-4o-mini"
 
+    def test_mime_detected_from_magic_bytes(self):
+        # Regression for the data-URL MIME: a JPEG must be labelled image/jpeg,
+        # not hardcoded image/png. The old vision path detected this; the
+        # collapsed path must too (PR #457 review item).
+        p = _make_openai()
+        p.describe_image(b"\xff\xd8\xff\xe0jpegfake", "prompt", model="gpt-4o")
+        url = p.client.chat.completions.create.call_args.kwargs[
+            "messages"][0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,")
+
+    def test_png_mime_default(self):
+        p = _make_openai()
+        p.describe_image(b"\x89PNG\r\n\x1a\n", "prompt", model="gpt-4o")
+        url = p.client.chat.completions.create.call_args.kwargs[
+            "messages"][0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+
     def test_unified_return_shape(self):
         p = _make_openai()
         out = p.describe_image(b"\x89PNGfake", "prompt", model="gpt-4o")

--- a/tests/unit/lib/test_vision_provider_catalog.py
+++ b/tests/unit/lib/test_vision_provider_catalog.py
@@ -60,26 +60,28 @@ class TestResolveVisionModel:
 
 
 # ===========================================================================
-# list_available_models — catalog-driven, no hardcoded fallback
+# _catalog_vision_model_ids — catalog-driven vision model enumeration
+# (the admin /vision/providers surface; no hardcoded fallback).
+#
+# #457: the parallel VisionProvider classes that wrapped this as
+# list_available_models() were collapsed into the AIProvider contract; the
+# enumeration policy survives here as the catalog helper the routes call.
 # ===========================================================================
 
-class TestListAvailableModelsCatalogOnly:
-    def test_openai_should_return_catalog_vision_ids_when_present(self):
-        p = object.__new__(vp.OpenAIVisionProvider)
-        with patch.object(vp, "_catalog_vision_model_ids",
-                          return_value=["gpt-4o", "o3"]):
-            assert p.list_available_models() == ["gpt-4o", "o3"]
+class TestCatalogVisionModelIds:
+    def test_should_return_catalog_vision_ids_when_present(self):
+        rows = [{"model_id": "gpt-4o"}, {"model_id": "o3"}]
+        with patch.object(vp, "_catalog_vision_models", return_value=rows):
+            assert vp._catalog_vision_model_ids("openai") == ["gpt-4o", "o3"]
 
-    def test_openai_should_return_empty_when_catalog_empty(self):
-        p = object.__new__(vp.OpenAIVisionProvider)
-        with patch.object(vp, "_catalog_vision_model_ids", return_value=[]):
-            assert p.list_available_models() == []
+    def test_should_return_empty_when_catalog_empty(self):
+        with patch.object(vp, "_catalog_vision_models", return_value=[]):
+            assert vp._catalog_vision_model_ids("openai") == []
 
-    def test_anthropic_should_prefer_catalog(self):
-        p = object.__new__(vp.AnthropicVisionProvider)
-        with patch.object(vp, "_catalog_vision_model_ids",
-                          return_value=["claude-sonnet-4-20250514"]):
-            assert p.list_available_models() == ["claude-sonnet-4-20250514"]
+    def test_should_map_anthropic_catalog_rows_to_ids(self):
+        rows = [{"model_id": "claude-sonnet-4-20250514"}]
+        with patch.object(vp, "_catalog_vision_models", return_value=rows):
+            assert vp._catalog_vision_model_ids("anthropic") == ["claude-sonnet-4-20250514"]
 
 
 # ===========================================================================
@@ -158,16 +160,13 @@ class TestResolveVisionSelection:
                 vp.resolve_vision_selection()
 
     def test_raises_when_nothing_resolves(self):
+        # The headline #378 fix, now the surviving guarantee after #457 collapsed
+        # the get_vision_provider() factory into the AIProvider contract: with no
+        # explicit provider, no active vision config, and no vision-capable
+        # extraction default, resolution RAISES rather than silently defaulting
+        # to a hardcoded 'openai'. The ingestion worker then never reaches
+        # get_provider()/describe_image with a bogus provider.
         with patch("api.app.lib.ai_vision_config.load_active_vision_config", return_value=None), \
              patch("api.app.lib.ai_extraction_config.load_active_extraction_config", return_value=None):
             with pytest.raises(ValueError, match="No vision provider could be resolved"):
                 vp.resolve_vision_selection()
-
-    def test_get_vision_provider_propagates_resolver_error(self):
-        # The headline #378 fix: get_vision_provider() with no explicit provider
-        # no longer defaults to 'openai' — it resolves, and an unresolvable
-        # config raises rather than silently picking a hardcoded provider.
-        with patch.object(vp, "resolve_vision_selection",
-                          side_effect=ValueError("No vision provider could be resolved")):
-            with pytest.raises(ValueError, match="No vision provider could be resolved"):
-                vp.get_vision_provider()


### PR DESCRIPTION
Closes #457. Implements ADR-802 §4 (and its 2026-05-31 amendment): vision is no longer a parallel provider hierarchy — it speaks the one `AIProvider` contract.

## What & why

`vision_providers.py` was a parallel fork of `ai_providers.py` (its own `VisionProvider` ABC, per-provider classes, `get_vision_provider` factory, a 100%-duplicated `_load_api_key`). The unified contract already existed (`AIProvider.describe_image` + `routes/ingest.py` used it), so this is **de-duplication + one call-site migration, not a rewrite** — exactly as the ADR-802 §4 amendment predicted.

## Changes

- **Unify `AIProvider.describe_image`** across OpenAI / Anthropic / OpenRouter / Ollama / LocalEmbedding / Mock: parameterized `(model, detail, temperature)`, unified return shape `{text, tokens:{input,output,total}, model, provider}`. Defaults reproduce the prose route's historical behavior byte-for-byte.
  - `detail=None` omits the OpenAI `detail` key (provider "auto"); `model` threads an explicit vision model so the **vision slot resolves independently of extraction** (ADR-802 §2). New `_openai_token_usage()` normalizes token shape.
- **Migrate `workers/ingestion_worker.py`** off `get_vision_provider()` to `resolve_vision_selection() → get_provider(name) → describe_image(..., detail=None, temperature=0.1)`, preserving the ADR-057 literal path exactly.
- **Reduce `vision_providers.py` 799 → 230 lines**: only the selection policy remains (`resolve_vision_selection`, catalog helpers, `LITERAL_DESCRIPTION_PROMPT`).

## Bundled fix (separate commit)

`fix(ingest): align image route ontology handling with prose route` — the dedicated image route had drifted from the prose route: missing the frozen-ontology guard and never setting `ontology_existed_at_submit`, so the #402 anomaly guard tripped on **every image ingest into a new ontology**. Same parallel-fork-drift class; pre-existing; bundled because it blocked end-to-end validation.

## Verification

- **Golden fidelity** (`scripts/development/diagnostics/golden_describe_image.py`): request payloads **byte-identical old-vs-new across 10 images**; live Anthropic descriptions are correct literal transcriptions.
- **Live front-door run** (`kg ingest image` → worker → graph): real images ingested into a new ontology, concepts created. This is the integration coverage for the worker (which isn't unit-tested) and is how three bugs were caught (two migration, one pre-existing drift) — all now fixed.
- **Full suite green**: 1236 passed, 16 skipped. New `test_describe_image_contract.py` (7 tests) pins the parameterization/return-shape; `test_vision_provider_catalog.py` updated for the collapsed surface.

Refs ADR-802 §4, ADR-803, ADR-057. Follow-up design idea filed as #459 (primordial/default ontology fallback).