### PR TITLE
ADR-207: Uniform freshness contract for materialized graph derivations

### DIFF
--- a/api/app/lib/age_client/grounding.py
+++ b/api/app/lib/age_client/grounding.py
@@ -42,7 +42,12 @@ import numpy as np
 from psycopg2 import extras
 
 from api.app.constants import BATCH_CHUNK_SIZE
-from .graph_generation import get_graph_generation
+from api.app.lib.freshness import (
+    Budget,
+    CollectionDerivation,
+    read_committed_epoch,
+    register_derivation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -269,25 +274,19 @@ class GroundingMixin:
         """
         global _grounding_cache, _grounding_cache_generation
 
-        # Warm-cache short-circuit (ADR-201 Phase 5f #278) — see the longer
-        # comment on calculate_grounding_strength_batch for the soundness
-        # rationale. Per-concept callers benefit even more from this:
-        # rendering a search result page typically calls this method
-        # serially per concept, so the bulk of repeat queries land here.
-        with _grounding_cache_lock:
-            cached_gen = _grounding_cache_generation
-            if cached_gen is not None:
-                cache_hit = _grounding_cache.get((concept_id, cached_gen))
-                if cache_hit is not None:
-                    return cache_hit
-
         conn = self.pool.getconn()
         try:
             with conn.cursor(cursor_factory=extras.RealDictCursor) as cur:
                 # ---- Tier 2 cache check: per-concept grounding ----
-                # Read graph generation from graph_accel if available,
-                # otherwise fall back to a simple counter.
-                graph_gen = get_graph_generation(cur)
+                # ADR-207 D2: read the canonical freshness clock (the committed-
+                # epoch tick) on EVERY call. The previous connection-free warm-
+                # path short-circuit skipped this re-read, leaving staleness
+                # unbounded in wall-clock time (#422). The cache still saves the
+                # expensive edge fetch + projection — it just no longer skips the
+                # clock read. graph_gen here is the universal tick, not
+                # graph_accel.generation (which co-advances with it as a
+                # sub-counter, ADR-207 D1).
+                graph_gen = read_committed_epoch(cur)
 
                 # Evict entire cache if graph generation changed
                 with _grounding_cache_lock:
@@ -437,45 +436,17 @@ class GroundingMixin:
 
         result = {cid: 0.0 for cid in concept_ids}
 
-        # --- Phase 0: warm-cache short-circuit (ADR-201 Phase 5f #278) ---
-        # If every requested concept is in the cache at the last-known graph
-        # generation, return without acquiring a pool connection. Saves one
-        # round-trip per call when callers are reading the same neighborhood
-        # repeatedly (search-then-render, paginated UIs, etc.).
-        #
-        # Soundness trade-off: skipping the get_graph_generation() probe
-        # means staleness is bounded by the next cold-path call in this
-        # process, NOT by wall-clock time. A workload that keeps hitting
-        # the same warm working set will keep returning pre-mutation values
-        # until something else (a different concept set, an unrelated
-        # endpoint, the API restart) takes the cold path and re-reads the
-        # generation. For the read-heavy steady state this targets that's
-        # the right trade — but callers needing linearizable freshness
-        # should opt out of the cache entirely. Worth it
-        # for the read-heavy steady state.
-        with _grounding_cache_lock:
-            cached_gen = _grounding_cache_generation
-            if cached_gen is not None:
-                cached_values = {}
-                for cid in concept_ids:
-                    cache_entry = _grounding_cache.get((cid, cached_gen))
-                    if cache_entry is None:
-                        cached_values = None
-                        break
-                    cached_values[cid] = cache_entry
-                if cached_values is not None:
-                    logger.debug(
-                        f"Grounding batch: warm-cache short-circuit, "
-                        f"{len(concept_ids)} concepts served without "
-                        f"acquiring a pool connection"
-                    )
-                    return cached_values
-
-        # --- Phase 1: cache check + polarity axis (one connection) ---
+        # --- Cache check + polarity axis (one connection) ---
+        # ADR-207 D2: read the canonical freshness clock on EVERY call. An
+        # earlier connection-free "Phase 0" warm-cache short-circuit served the
+        # whole batch from cache WITHOUT re-reading the generation, leaving
+        # staleness unbounded in wall-clock time (#422). The single clock read +
+        # connection per batch is cheap and amortizes across all concept_ids; the
+        # cache still saves the expensive per-concept edge fetch + projection.
         conn = self.pool.getconn()
         try:
             with conn.cursor(cursor_factory=extras.RealDictCursor) as cur:
-                graph_gen = get_graph_generation(cur)
+                graph_gen = read_committed_epoch(cur)
 
                 misses = []
                 with _grounding_cache_lock:
@@ -658,3 +629,104 @@ class GroundingMixin:
         )
 
         return result
+
+
+# ---------------------------------------------------------------------------
+# ADR-207 freshness-contract registration
+#
+# The grounding cluster is TWO derivations on two different clocks (ADR-207 D3),
+# so they register separately rather than being forced behind one interface. The
+# on-read detection and cache live in GroundingMixin above; these objects expose
+# each tier to the freshness registry — for the conformance test (CI catches a
+# tier that forgets the contract) and the operator surface (list / show
+# freshness / reconcile). Each is constructed with an AGEClient for its clock
+# read; the cache state itself is process-global (above).
+# ---------------------------------------------------------------------------
+
+
+@register_derivation
+class GroundingCacheDerivation(CollectionDerivation):
+    """Tier 2 — per-concept grounding cache (ADR-207 CollectionDerivation).
+
+    Whole-tier stamp: one generation covers every cached concept, and reconcile
+    clears the lot (a graph mutation may have changed any concept's edges). Its
+    clock is the **universal committed-epoch tick** — #386 makes that advance for
+    every mutation kind, so the tier invalidates on ingestion, edits, and
+    annealing alike. graph_accel.generation co-advances with the tick as a
+    sub-counter (ADR-207 D1); this derivation reads the tick, not the sub-counter.
+    """
+
+    name = "grounding_cache"
+    budget = Budget.strict()
+
+    def __init__(self, client):
+        """Store the AGE client for the clock read; cache state is module-global."""
+        self.client = client
+
+    def version_stamp(self):
+        """The committed-epoch tick the cache was last filled at (None if cold)."""
+        return _grounding_cache_generation
+
+    def current_version(self) -> int:
+        """The canonical clock now: the committed-epoch tick."""
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=extras.RealDictCursor) as cur:
+                v = read_committed_epoch(cur)
+            conn.rollback()
+            return v
+        finally:
+            self.client.pool.putconn(conn)
+
+    def reconcile(self) -> None:
+        """Invalidate the whole tier; it refills lazily on the next read."""
+        global _grounding_cache, _grounding_cache_generation
+        with _grounding_cache_lock:
+            _grounding_cache.clear()
+            _grounding_cache_generation = None
+
+
+@register_derivation
+class PolarityAxisDerivation(CollectionDerivation):
+    """Tier 1 — polarity-axis cache (ADR-207 CollectionDerivation).
+
+    Distinct clock from the graph tick: the axis is derived from VOCABULARY
+    embeddings, so its source-of-truth is `vocabulary_embedding_generation_counter`
+    (migration 069) — a declared sub-counter that changes only on embedding
+    (re)generation, far more rarely than the graph. Tracking the graph tick here
+    would needlessly recompute the axis on every concept edit.
+    """
+
+    name = "polarity_axis"
+    budget = Budget.strict()
+
+    def __init__(self, client):
+        """Store the AGE client for the clock read; cache state is module-global."""
+        self.client = client
+
+    def version_stamp(self):
+        """The vocab-embedding generation the axis was built at (None if cold)."""
+        cached = _polarity_axis_cache
+        return cached[0] if cached is not None else None
+
+    def current_version(self) -> int:
+        """The polarity axis's clock: vocabulary_embedding_generation_counter."""
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=extras.RealDictCursor) as cur:
+                cur.execute(
+                    "SELECT counter FROM graph_metrics "
+                    "WHERE metric_name = 'vocabulary_embedding_generation_counter'"
+                )
+                row = cur.fetchone()
+                v = int(row["counter"]) if row else 0
+            conn.rollback()
+            return v
+        finally:
+            self.client.pool.putconn(conn)
+
+    def reconcile(self) -> None:
+        """Invalidate the axis; it recomputes lazily on the next grounding call."""
+        global _polarity_axis_cache
+        with _polarity_axis_cache_lock:
+            _polarity_axis_cache = None

--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -123,6 +123,47 @@ class IngestionMixin:
                 exc_info=True,
             )
 
+    def record_mutation(
+        self,
+        kind: str,
+        actor: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[int]:
+        """Announce an already-committed atomic graph mutation (ADR-207, #386).
+
+        The universal freshness tick (kg_api.graph_epochs.event_id) only advances
+        when application code records an epoch event — AGE Cypher bypasses
+        PostgreSQL triggers, so there is no automatic backstop. Every path that
+        mutates the graph must call this (or, for long-running jobs, the
+        record_epoch/complete_epoch pair) or its changes are invisible to
+        freshness and every derivation serves stale data for them.
+
+        This does the two things that must co-advance, from one place:
+          1. records a *completed* epoch event of `kind` (advances the tick), and
+          2. invalidates the graph_accel sub-counter (+ its pg_notify),
+        so event_id and graph_accel.generation move together by construction.
+
+        For atomic, synchronous mutations (edit routes, proposal execution). Long
+        jobs that need to tag nodes with the event_id mid-run use record_epoch()
+        at the start and complete_epoch() at the end instead.
+
+        Returns the event_id, or None if the epoch could not be recorded.
+        """
+        event_id = self.record_epoch(kind, actor=actor, metadata=metadata)
+        if event_id is not None:
+            self.complete_epoch(event_id, "completed")
+        # Co-advance the in-memory accelerator's sub-counter. Non-fatal: the
+        # extension may not be loaded on this connection.
+        try:
+            self.graph.invalidate()
+        except Exception:
+            pass
+        # Keep the graph_change_counter snapshot fresh too — FUSE and other
+        # pollers read it (this subsumes the bare refresh_epoch() that mutation
+        # paths used to call).
+        self.refresh_epoch()
+        return event_id
+
     def create_source_node(
         self,
         source_id: str,

--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -87,6 +87,42 @@ class IngestionMixin:
             )
             return None
 
+    def complete_epoch(self, event_id: int, status: str = "completed") -> None:
+        """
+        Resolve an epoch event recorded by record_epoch().
+
+        ADR-207/#384: record_epoch() inserts the event as `in_progress`. Call
+        this with `completed` when the mutation transaction commits, or `failed`
+        when it aborts/rolls back. Until resolved, the event holds the committed
+        watermark (kg_api.get_committed_epoch()) just below its event_id, so
+        every materialized derivation correctly reads stale until the job lands.
+
+        Best-effort, like record_epoch(): a failure here is logged at ERROR (a
+        steady-state rate means the watermark can stall on a phantom in-flight
+        event and should be investigated) but never masks the job's own outcome.
+
+        Grep target: `complete_epoch failed`.
+        """
+        if event_id is None:
+            return
+        try:
+            conn = self.pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT kg_api.complete_graph_epoch(%s::bigint, %s::text)",
+                        (event_id, status),
+                    )
+            finally:
+                conn.commit()
+                self.pool.putconn(conn)
+        except Exception as e:
+            logger.error(
+                "complete_epoch failed (event_id=%s, status=%s): %s",
+                event_id, status, e,
+                exc_info=True,
+            )
+
     def create_source_node(
         self,
         source_id: str,

--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -60,32 +60,40 @@ class IngestionMixin:
 
         Grep target: `record_epoch failed`.
         """
+        conn = None
         try:
             conn = self.pool.getconn()
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        "SELECT kg_api.record_graph_epoch(%s::text, %s::text, %s::jsonb)",
-                        (
-                            kind,
-                            str(actor) if actor is not None else None,
-                            json.dumps(metadata or {}),
-                        ),
-                    )
-                    row = cur.fetchone()
-                    return row[0] if row else None
-            finally:
-                conn.commit()
-                self.pool.putconn(conn)
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT kg_api.record_graph_epoch(%s::text, %s::text, %s::jsonb)",
+                    (
+                        kind,
+                        str(actor) if actor is not None else None,
+                        json.dumps(metadata or {}),
+                    ),
+                )
+                row = cur.fetchone()
+            conn.commit()
+            return row[0] if row else None
         except Exception as e:
             # ERROR (not WARNING) — see docstring. Any non-zero rate of
             # this in a healthy install indicates a real problem.
+            if conn is not None:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
             logger.error(
                 "record_epoch failed (kind=%s, actor=%s): %s",
                 kind, actor, e,
                 exc_info=True,
             )
             return None
+        finally:
+            # Always return the connection — even if commit/rollback raised — so
+            # a steady failure rate cannot slowly exhaust the pool (review S1).
+            if conn is not None:
+                self.pool.putconn(conn)
 
     def complete_epoch(self, event_id: int, status: str = "completed") -> None:
         """
@@ -105,23 +113,30 @@ class IngestionMixin:
         """
         if event_id is None:
             return
+        conn = None
         try:
             conn = self.pool.getconn()
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        "SELECT kg_api.complete_graph_epoch(%s::bigint, %s::text)",
-                        (event_id, status),
-                    )
-            finally:
-                conn.commit()
-                self.pool.putconn(conn)
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT kg_api.complete_graph_epoch(%s::bigint, %s::text)",
+                    (event_id, status),
+                )
+            conn.commit()
         except Exception as e:
+            if conn is not None:
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
             logger.error(
                 "complete_epoch failed (event_id=%s, status=%s): %s",
                 event_id, status, e,
                 exc_info=True,
             )
+        finally:
+            # Always return the connection (review S1).
+            if conn is not None:
+                self.pool.putconn(conn)
 
     def record_mutation(
         self,

--- a/api/app/lib/artifact_freshness.py
+++ b/api/app/lib/artifact_freshness.py
@@ -1,0 +1,113 @@
+"""
+Artifact freshness as an ADR-207 InstanceDerivation.
+
+Saved artifacts (polarity analyses, projections, query results) are the platform's
+one *instance-level* materialized derivation: unlike the catalog index or the
+grounding cache — which have a single stamp for the whole derivation — each
+artifact row carries its own `graph_epoch` stamp and reconciles (regenerates)
+independently from its stored parameters. That is exactly the ADR-207 D3
+`InstanceDerivation` shape.
+
+The freshness stamp is the committed-epoch tick (the universal clock, ADR-207
+D1): an artifact is fresh while the tick it was computed at still equals the
+current tick. `reconcile(id)` regenerates the artifact — an async job, the same
+one `POST /artifacts/{id}/regenerate` dispatches.
+"""
+
+import logging
+from typing import Optional
+
+from .freshness import Budget, InstanceDerivation, register_derivation
+
+logger = logging.getLogger(__name__)
+
+# Artifact types that can be regenerated, mapped to their job type. Mirrors the
+# map in routes/artifacts.py:regenerate_artifact — keep them in sync.
+_REGENERATABLE = {
+    "polarity_analysis": "polarity",
+    "projection": "projection",
+}
+
+
+@register_derivation
+class ArtifactDerivation(InstanceDerivation):
+    """Saved artifacts under the ADR-207 freshness contract (per-row).
+
+    Reads/writes go through psycopg2 connections from the auth dependency's
+    pool (the same source the artifact routes use); imports are deferred to call
+    time to avoid an import cycle with the routes/dependencies layer.
+    """
+
+    name = "artifacts"
+    budget = Budget.strict()
+
+    def version_stamp(self, item_id) -> Optional[int]:
+        """The committed-epoch tick artifact `item_id` was computed at (None if
+        the artifact does not exist)."""
+        from api.app.dependencies.auth import get_db_connection
+        conn = get_db_connection()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT graph_epoch FROM kg_api.artifacts WHERE id = %s",
+                    (item_id,),
+                )
+                row = cur.fetchone()
+            return int(row[0]) if row and row[0] is not None else None
+        finally:
+            conn.close()
+
+    def current_version(self) -> int:
+        """The canonical clock now: the committed-epoch tick."""
+        from api.app.dependencies.auth import get_db_connection
+        conn = get_db_connection()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT kg_api.get_committed_epoch()")
+                return int(cur.fetchone()[0] or 0)
+        finally:
+            conn.close()
+
+    def reconcile(self, item_id) -> None:
+        """Regenerate one artifact from its stored parameters (async job).
+
+        System-triggered (no requesting user) — mirrors the enqueue in
+        `routes/artifacts.py:regenerate_artifact`, which is the user-facing,
+        auth-checked entry point. Raises ValueError if the artifact is missing
+        or its type does not support regeneration.
+        """
+        from api.app.dependencies.auth import get_db_connection
+        from api.app.services.job_queue import get_job_queue
+
+        conn = get_db_connection()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT artifact_type, parameters, ontology "
+                    "FROM kg_api.artifacts WHERE id = %s",
+                    (item_id,),
+                )
+                row = cur.fetchone()
+            if not row:
+                raise ValueError(f"artifact not found: {item_id}")
+            artifact_type, parameters, ontology = row
+            job_type = _REGENERATABLE.get(artifact_type)
+            if not job_type:
+                raise ValueError(
+                    f"artifact type '{artifact_type}' does not support regeneration"
+                )
+
+            job_data = dict(parameters) if parameters else {}
+            job_data["create_artifact"] = True
+            if ontology:
+                job_data["ontology"] = ontology
+            job_data["description"] = (
+                f"Reconcile (regenerate) stale artifact {item_id} ({artifact_type})"
+            )
+
+            queue = get_job_queue()
+            job_id = queue.enqueue(job_type=job_type, job_data=job_data)
+            queue.update_job(job_id, {"status": "approved", "approved_by": "freshness_reconcile"})
+            logger.info(f"Artifact {item_id} reconcile → regeneration job {job_id}")
+        finally:
+            conn.close()

--- a/api/app/lib/catalog_facade.py
+++ b/api/app/lib/catalog_facade.py
@@ -4,7 +4,9 @@ Catalog Facade (ADR-501)
 Read surface for hierarchical browse of the ontology -> document -> concept
 hierarchy. The AGE graph is the source of truth; this facade maintains a
 materialized index (kg_api.catalog_node + kg_api.catalog_edge) that is rebuilt
-whenever the graph epoch (graph_change_counter) advances.
+whenever the committed-epoch watermark (kg_api.get_committed_epoch(), ADR-207)
+advances. It is a CollectionDerivation under the ADR-207 freshness contract and
+the contract's reference implementation.
 
 Membership is always derived from the graph's CANONICAL edges — never from the
 denormalized Source.document string, which lags during annealing reassignment
@@ -27,6 +29,13 @@ from typing import List, Dict, Any, Optional, Tuple
 
 from psycopg2.extras import RealDictCursor
 
+from .freshness import (
+    Budget,
+    CollectionDerivation,
+    read_committed_epoch,
+    register_derivation,
+)
+
 logger = logging.getLogger(__name__)
 
 # Advisory-lock key for serializing rebuilds across workers. Arbitrary constant,
@@ -43,13 +52,25 @@ _SORT_SQL = {
 }
 
 
-class CatalogFacade:
+@register_derivation
+class CatalogFacade(CollectionDerivation):
     """Materialized-index read surface for catalog browse (ADR-501).
 
     Constructed with an AGEClient; reuses its connection pool. Browse reads come
     from the relational index; the index is rebuilt from the graph on epoch
     advance via ensure_fresh().
+
+    A `CollectionDerivation` (ADR-207): one stamp for the whole index, reconcile
+    rebuilds the lot. It resolves freshness against the committed-epoch watermark
+    (`get_committed_epoch()`), not the graph_change_counter — and serves as the
+    contract's reference implementation, since its deferred / on-read /
+    serve-stale-under-lock behavior already matches the target shape.
     """
+
+    #: Registry name / operator label (ADR-207).
+    name = "catalog_index"
+    #: Strict freshness: the browse index must reflect the committed graph.
+    budget = Budget.strict()
 
     def __init__(self, client):
         """Store the AGE client and reuse its connection pool."""
@@ -58,14 +79,12 @@ class CatalogFacade:
     # ------------------------------------------------------------------ epochs
 
     def _current_epoch(self, cur) -> int:
-        """Current graph_change_counter — the same freshness signal artifacts use."""
-        cur.execute("SELECT kg_api.get_graph_epoch()")
-        row = cur.fetchone()
-        # RealDictCursor returns a dict; plain cursor a tuple.
-        if row is None:
-            return 0
-        val = list(row.values())[0] if isinstance(row, dict) else row[0]
-        return int(val) if val is not None else 0
+        """Canonical freshness clock: the committed-epoch watermark (ADR-207).
+
+        Was graph_change_counter (get_graph_epoch); migrated to the watermark so
+        the index stamps against a monotonic, false-FRESH-safe signal.
+        """
+        return read_committed_epoch(cur)
 
     def _index_epoch(self, cur) -> Optional[int]:
         """Epoch the index was last built at, or None if never built."""
@@ -130,6 +149,41 @@ class CatalogFacade:
             return (True, 0)
         finally:
             self.client.pool.putconn(conn)
+
+    # ------------------------------------------------ FreshnessContract surface
+
+    # ensure_fresh() above is the optimized combined detect+reconcile (single
+    # connection, advisory-locked, serve-stale-under-contention). The three
+    # methods below expose the same behavior through the ADR-207 contract so the
+    # catalog is enumerable/uniform with the other derivations; is_fresh() is
+    # inherited from CollectionDerivation.
+
+    def version_stamp(self) -> Optional[int]:
+        """The watermark the index was last built at (ADR-207). None if empty."""
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                stamp = self._index_epoch(cur)
+            conn.rollback()
+            return stamp
+        finally:
+            self.client.pool.putconn(conn)
+
+    def current_version(self) -> int:
+        """The canonical clock now: the committed-epoch watermark (ADR-207)."""
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                current = self._current_epoch(cur)
+            conn.rollback()
+            return current
+        finally:
+            self.client.pool.putconn(conn)
+
+    def reconcile(self) -> None:
+        """Rebuild the index if it lags the watermark (delegates to ensure_fresh,
+        which rebuilds under the advisory lock and is a no-op when fresh)."""
+        self.ensure_fresh()
 
     # ----------------------------------------------------------------- rebuild
 

--- a/api/app/lib/freshness.py
+++ b/api/app/lib/freshness.py
@@ -106,10 +106,15 @@ class FreshnessContract(ABC):
 
     @abstractmethod
     def current_version(self) -> int:
-        """The canonical clock now. Implementations open a connection (their own
-        pool/cursor) and return `read_committed_epoch(cur)` — the shared helper
-        keeps the SQL in exactly one place so no derivation drifts onto a
-        different signal."""
+        """The monotonic version this derivation tracks, read now.
+
+        Graph-topology derivations return `read_committed_epoch(cur)` — the
+        shared helper keeps the canonical-clock SQL in one place so no
+        graph-derived surface drifts onto a different signal. A derivation whose
+        source-of-truth is a narrower scope returns *that* monotonic sub-counter
+        instead (e.g. the polarity axis is derived from vocabulary embeddings, so
+        it tracks `vocabulary_embedding_generation_counter`, not the graph tick).
+        Either way it must be monotonic and advance when the source changes."""
         raise NotImplementedError
 
 

--- a/api/app/lib/freshness.py
+++ b/api/app/lib/freshness.py
@@ -1,0 +1,182 @@
+"""
+Materialized-derivation freshness contract (ADR-207).
+
+The platform maintains several *materialized derivations* of the graph — caches
+of a graph computation that must track the graph as it mutates: the catalog
+index, the grounding/polarity cache tiers, and saved artifacts. Each one answers
+the same four questions — what version was I built at? what is the version now?
+am I stale? what do I do when I am? — and historically each answered them
+ad-hoc, against different (and sometimes unsound) version signals.
+
+This module is the one place those answers live:
+
+- `read_committed_epoch(cur)` — THE canonical freshness clock (ADR-207 D1): the
+  committed-prefix watermark over the ADR-203 epoch event log. Every derivation
+  resolves freshness against this and nothing else. Never use
+  `kg_api.get_graph_epoch()` (the graph_change_counter) for a freshness
+  decision — it is a non-injective count checksum (ADR-203) and can read
+  false-FRESH; it is a one-directional dirty-hint only.
+
+- `Budget` — a derivation's declared staleness tolerance. Default is strict
+  (must be at the current version). A derivation opts into bounded staleness
+  explicitly.
+
+- `CollectionDerivation` / `InstanceDerivation` — the two contract shapes. A
+  collection derivation has ONE stamp for the whole thing and reconciles by
+  rebuilding/invalidating the lot (catalog index, a grounding cache tier). An
+  instance derivation is per-row: each item carries its own stamp and reconciles
+  independently (artifacts). Forcing both behind one interface was an ISP/LSP
+  leak (ADR-207 D3), hence two shapes over a shared base.
+
+- the registry — derivations register their class so a conformance test can
+  assert every one implements the contract (CI catches a new derivation that
+  forgets on-read detection), and an operator surface can enumerate them.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional, Type
+
+__all__ = [
+    "read_committed_epoch",
+    "Budget",
+    "FreshnessContract",
+    "CollectionDerivation",
+    "InstanceDerivation",
+    "register_derivation",
+    "registered_derivations",
+]
+
+
+def read_committed_epoch(cur) -> int:
+    """Read the canonical freshness clock: kg_api.get_committed_epoch().
+
+    ADR-207 D1: the committed-prefix watermark over the ADR-203 epoch sequence —
+    monotonic, gap-tolerant, and out-of-order-completion safe. This is the ONLY
+    sanctioned freshness signal; `cur` is any open cursor (RealDict or plain).
+    """
+    cur.execute("SELECT kg_api.get_committed_epoch()")
+    row = cur.fetchone()
+    if row is None:
+        return 0
+    val = list(row.values())[0] if isinstance(row, dict) else row[0]
+    return int(val) if val is not None else 0
+
+
+@dataclass(frozen=True)
+class Budget:
+    """A derivation's declared staleness tolerance (ADR-207 D2).
+
+    `versions` is how many clock-versions behind the derivation may serve before
+    it must reconcile. The default (0) is strict: the derivation must reflect the
+    current committed watermark. A wall-clock axis (stale_ok_ms) is reserved for
+    later — it needs per-derivation build timestamps and is not yet enforced.
+    """
+
+    versions: int = 0
+
+    @classmethod
+    def strict(cls) -> "Budget":
+        """Zero tolerance — the derivation must be at the current version."""
+        return cls(versions=0)
+
+    def tolerates(self, stamp: int, current: int) -> bool:
+        """True if a derivation built at `stamp` is fresh enough against `current`.
+
+        On the monotonic watermark a stamp can never exceed `current`, so strict
+        (versions=0) is exactly `stamp == current`; a positive budget permits
+        being that many versions behind.
+        """
+        return (current - stamp) <= self.versions
+
+
+class FreshnessContract(ABC):
+    """Shared base for every materialized derivation (ADR-207 D3).
+
+    Subclasses do not inherit this directly — they implement one of the two
+    shapes below. The base pins what is common: a registry `name`, a declared
+    staleness `budget`, and resolution against the one canonical clock.
+    """
+
+    #: Stable registry key, also the operator-facing label.
+    name: str = ""
+
+    #: Declared staleness tolerance; strict by default.
+    budget: Budget = Budget.strict()
+
+    @abstractmethod
+    def current_version(self) -> int:
+        """The canonical clock now. Implementations open a connection (their own
+        pool/cursor) and return `read_committed_epoch(cur)` — the shared helper
+        keeps the SQL in exactly one place so no derivation drifts onto a
+        different signal."""
+        raise NotImplementedError
+
+
+class CollectionDerivation(FreshnessContract):
+    """A whole-derivation materialized view: one stamp for the entire thing,
+    reconcile rebuilds/invalidates the lot (catalog index, a grounding tier)."""
+
+    @abstractmethod
+    def version_stamp(self) -> Optional[int]:
+        """The clock value the derivation was last built at, or None if never
+        built (which reads as stale)."""
+        raise NotImplementedError
+
+    def is_fresh(self) -> bool:
+        """Deferred, on-read freshness, honoring the declared budget. Never a
+        warm-path short-circuit that skips reading current_version() — that is
+        the #422 defect the contract forbids."""
+        stamp = self.version_stamp()
+        if stamp is None:
+            return False
+        return self.budget.tolerates(stamp, self.current_version())
+
+    @abstractmethod
+    def reconcile(self) -> None:
+        """Make the derivation reflect current_version() (rebuild or invalidate).
+        Idempotent: a no-op when already fresh."""
+        raise NotImplementedError
+
+
+class InstanceDerivation(FreshnessContract):
+    """A per-row materialized view: each item carries its own stamp and
+    reconciles independently from its stored parameters (artifacts)."""
+
+    @abstractmethod
+    def version_stamp(self, item_id) -> Optional[int]:
+        """The clock value `item_id` was built at, or None if absent."""
+        raise NotImplementedError
+
+    def is_fresh(self, item_id) -> bool:
+        """Deferred, on-read freshness for one item, honoring the budget."""
+        stamp = self.version_stamp(item_id)
+        if stamp is None:
+            return False
+        return self.budget.tolerates(stamp, self.current_version())
+
+    @abstractmethod
+    def reconcile(self, item_id) -> None:
+        """Regenerate one item so it reflects current_version()."""
+        raise NotImplementedError
+
+
+# --------------------------------------------------------------------- registry
+
+_DERIVATION_CLASSES: List[Type[FreshnessContract]] = []
+
+
+def register_derivation(cls: Type[FreshnessContract]) -> Type[FreshnessContract]:
+    """Register a derivation class (usable as a class decorator).
+
+    Registration buys the conformance test (every registered derivation must
+    implement a contract shape) and the operator surface (enumerate derivations,
+    show freshness, trigger reconcile)."""
+    if cls not in _DERIVATION_CLASSES:
+        _DERIVATION_CLASSES.append(cls)
+    return cls
+
+
+def registered_derivations() -> List[Type[FreshnessContract]]:
+    """All registered derivation classes (for conformance tests / operator UI)."""
+    return list(_DERIVATION_CLASSES)

--- a/api/app/routes/artifacts.py
+++ b/api/app/routes/artifacts.py
@@ -22,6 +22,8 @@ from ..models.artifact import (
 from ..models.auth import UserInDB
 from ..dependencies.auth import get_current_active_user, get_db_connection
 from ..lib.garage import get_artifact_storage
+# Registers ArtifactDerivation in the ADR-207 freshness registry on import.
+from ..lib.artifact_freshness import ArtifactDerivation  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +31,15 @@ router = APIRouter(prefix="/artifacts", tags=["artifacts"])
 
 
 def _get_current_epoch(conn) -> int:
-    """Get current graph epoch for freshness tracking."""
+    """Get the canonical freshness clock (ADR-207): the committed-epoch tick.
+
+    Was get_graph_epoch() (the non-injective graph_change_counter). Repointed to
+    get_committed_epoch() so artifact freshness uses the same universal tick as
+    every other materialized derivation; artifacts stamp this at creation and
+    compare against it for is_fresh.
+    """
     with conn.cursor() as cur:
-        cur.execute("SELECT kg_api.get_graph_epoch()")
+        cur.execute("SELECT kg_api.get_committed_epoch()")
         return cur.fetchone()[0] or 0
 
 

--- a/api/app/routes/concepts.py
+++ b/api/app/routes/concepts.py
@@ -83,8 +83,9 @@ async def create_concept(
             outcome="success"
         )
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        age_client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        age_client.record_mutation("edit")
 
         return result
     except ValueError as e:
@@ -259,8 +260,9 @@ async def delete_concept(
     try:
         await service.delete_concept(concept_id=concept_id, cascade=cascade)
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        age_client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        age_client.record_mutation("edit")
 
         return None  # 204 No Content
     except ValueError as e:
@@ -378,7 +380,9 @@ async def add_evidence(
             outcome="success"
         )
 
-        age_client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        age_client.record_mutation("edit")
 
         return result
     except ValueError as e:

--- a/api/app/routes/documents.py
+++ b/api/app/routes/documents.py
@@ -1158,8 +1158,9 @@ async def delete_document(
             f"{sources_deleted} sources, {orphaned_count} orphaned concepts"
         )
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        client.record_mutation("edit")
 
         return DocumentDeleteResponse(
             document_id=document_id,

--- a/api/app/routes/edges.py
+++ b/api/app/routes/edges.py
@@ -87,8 +87,9 @@ async def create_edge(
             outcome="success"
         )
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        age_client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        age_client.record_mutation("edit")
 
         return result
     except ValueError as e:
@@ -238,8 +239,9 @@ async def delete_edge(
             relationship_type=relationship_type
         )
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        age_client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        age_client.record_mutation("edit")
 
         return None  # 204 No Content
     except ValueError as e:

--- a/api/app/routes/graph.py
+++ b/api/app/routes/graph.py
@@ -91,11 +91,16 @@ async def create_batch(
                 }
             )
 
-        # ADR-201: Invalidate graph_accel cache after graph mutations
+        # ADR-207/#386: announce the mutation so the universal freshness tick
+        # advances (record_mutation also invalidates graph_accel, co-advancing
+        # the sub-counter). Non-fatal — never fail the edit on a bookkeeping miss.
         try:
-            service.age_client.graph.invalidate()
+            service.age_client.record_mutation(
+                "edit",
+                actor=str(current_user.id) if current_user else None,
+            )
         except Exception:
-            pass  # Non-fatal — extension may not be installed
+            pass
 
         return response
 

--- a/api/app/routes/ontology.py
+++ b/api/app/routes/ontology.py
@@ -236,8 +236,9 @@ async def create_ontology(
         except Exception as e:
             logger.warning(f"Failed to generate embedding for new ontology '{request.name}': {e}")
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        client.record_mutation("edit")
 
         return OntologyNodeResponse(
             ontology_id=node.get('ontology_id', ontology_id),
@@ -1450,8 +1451,9 @@ async def delete_ontology(
         if jobs_deleted > 0:
             logger.info(f"Deleted {jobs_deleted} job records for ontology '{ontology_name}'")
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        client.record_mutation("edit")
 
         return OntologyDeleteResponse(
             ontology=ontology_name,
@@ -1866,8 +1868,9 @@ async def create_ontology_edge(
             source="manual",
         )
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        client.record_mutation("edit")
 
         return OntologyEdge(
             from_ontology=ontology_name,
@@ -1925,8 +1928,9 @@ async def delete_ontology_edge(
                 detail=f"No {edge_type} edge found from '{ontology_name}' to '{to_ontology}'",
             )
 
-        # Refresh graph epoch so caches (FUSE, etc.) detect the change
-        client.refresh_epoch()
+        # ADR-207/#386: announce the mutation — advances the universal freshness
+        # tick (event_id), invalidates graph_accel, and refreshes the counter.
+        client.record_mutation("edit")
 
         return {"deleted": deleted, "from_ontology": ontology_name,
                 "to_ontology": to_ontology, "edge_type": edge_type}
@@ -1975,11 +1979,16 @@ async def reassign_sources(
             else:
                 raise HTTPException(status_code=500, detail=error)
 
-        # ADR-201: Invalidate graph_accel cache after SCOPED_BY edge changes
+        # ADR-207/#386: SCOPED_BY edge changes alter the catalog hierarchy —
+        # announce the mutation so the freshness tick advances (record_mutation
+        # also invalidates graph_accel). Non-fatal.
         try:
-            client.graph.invalidate()
+            client.record_mutation(
+                "edit",
+                actor=getattr(current_user, "username", None),
+            )
         except Exception:
-            pass  # Non-fatal — extension may not be installed
+            pass
 
         return ReassignResponse(
             from_ontology=ontology_name,
@@ -2073,11 +2082,16 @@ async def dissolve_ontology(
             else:
                 raise HTTPException(status_code=500, detail=error)
 
-        # ADR-201: Invalidate graph_accel cache after ontology dissolution
+        # ADR-207/#386: dissolution restructures the catalog hierarchy —
+        # announce the mutation so the freshness tick advances (record_mutation
+        # also invalidates graph_accel). Non-fatal.
         try:
-            client.graph.invalidate()
+            client.record_mutation(
+                "edit",
+                actor=getattr(current_user, "username", None),
+            )
         except Exception:
-            pass  # Non-fatal — extension may not be installed
+            pass
 
         return DissolveResponse(
             dissolved_ontology=ontology_name,

--- a/api/app/services/confidence_analyzer.py
+++ b/api/app/services/confidence_analyzer.py
@@ -43,7 +43,12 @@ _confidence_cache: Dict[Tuple[str, int], Dict[str, Any]] = {}
 _confidence_cache_generation: Optional[int] = None
 
 from api.app.constants import BATCH_CHUNK_SIZE
-from api.app.lib.age_client.graph_generation import get_graph_generation
+from api.app.lib.freshness import (
+    Budget,
+    CollectionDerivation,
+    read_committed_epoch,
+    register_derivation,
+)
 
 
 # Confidence level thresholds
@@ -188,17 +193,18 @@ class ConfidenceAnalyzer:
 
     def _read_graph_generation_with_pool_conn(self) -> int:
         """
-        Acquire a pool connection just to read graph generation.
+        Acquire a pool connection just to read the canonical freshness clock.
 
-        Thin wrapper around `get_graph_generation` for callers that don't
-        already hold a cursor. Batch callers should use `get_graph_generation`
-        directly on the cursor they already have — avoid double-acquiring.
+        ADR-207: the confidence cache keys on the committed-epoch tick (the
+        universal clock), not graph_accel.generation. Thin wrapper around
+        `read_committed_epoch` for callers that don't already hold a cursor;
+        batch callers read it directly on their own cursor.
         """
         from psycopg2 import extras
         conn = self.client.pool.getconn()
         try:
             with conn.cursor(cursor_factory=extras.RealDictCursor) as cur:
-                return get_graph_generation(cur, savepoint_name="conf_gen_check")
+                return read_committed_epoch(cur)
         finally:
             self.client.pool.putconn(conn)
 
@@ -252,50 +258,17 @@ class ConfidenceAnalyzer:
 
         from psycopg2 import extras as pg_extras
 
-        # --- Phase 0: warm-cache short-circuit (ADR-201 Phase 5f #278) ---
-        # Mirror of the grounding-batch optimization in grounding.py — same
-        # staleness bound: bounded by the next cold-path call in this
-        # process, NOT by wall-clock time. See the long comment on
-        # grounding.py:calculate_grounding_strength_batch for the full
-        # rationale; the trade-off applies identically here.
-        #
-        # Caveat specific to confidence: grounding_display is recomputed
-        # even on a warm hit because it depends on the caller's current
-        # grounding_map (which can change call-to-call independently of
-        # the graph generation).
-        with _confidence_cache_lock:
-            cached_gen = _confidence_cache_generation
-            if cached_gen is not None:
-                cached_entries = {}
-                for cid in concept_ids:
-                    entry = _confidence_cache.get((cid, cached_gen))
-                    if entry is None:
-                        cached_entries = None
-                        break
-                    cached_entries[cid] = entry
-                if cached_entries is not None:
-                    # Replace grounding_display per current grounding_map
-                    refreshed = {}
-                    for cid, entry in cached_entries.items():
-                        refreshed_entry = dict(entry)
-                        refreshed_entry['grounding_display'] = (
-                            self._get_grounding_display(
-                                grounding_map.get(cid), entry.get('level')
-                            )
-                        )
-                        refreshed[cid] = refreshed_entry
-                    logger.debug(
-                        f"Confidence batch: warm-cache short-circuit, "
-                        f"{len(concept_ids)} concepts served without "
-                        f"acquiring a pool connection"
-                    )
-                    return refreshed
-
-        # --- Phase 1: cache check (one connection) ---
+        # --- Cache check (one connection) ---
+        # ADR-207 D2: read the canonical freshness clock on EVERY call. An
+        # earlier connection-free "Phase 0" warm short-circuit served the batch
+        # from cache WITHOUT re-reading the generation, leaving staleness
+        # unbounded in wall-clock time (#422). The single clock read + connection
+        # per batch is cheap and amortizes across all concept_ids; the cache
+        # still saves the expensive per-concept confidence computation.
         conn = self.client.pool.getconn()
         try:
             with conn.cursor(cursor_factory=pg_extras.RealDictCursor) as cur:
-                graph_gen = get_graph_generation(cur, savepoint_name="conf_gen_check_batch")
+                graph_gen = read_committed_epoch(cur)
 
                 misses = []
                 with _confidence_cache_lock:
@@ -723,3 +696,49 @@ class ConfidenceAnalyzer:
         }
 
         return display_matrix.get((grounding_cat, confidence), "Unknown")
+
+
+# ---------------------------------------------------------------------------
+# ADR-207 freshness-contract registration
+# ---------------------------------------------------------------------------
+
+
+@register_derivation
+class ConfidenceCacheDerivation(CollectionDerivation):
+    """Per-concept confidence cache as an ADR-207 CollectionDerivation.
+
+    Same shape as the grounding cache (Tier 2): a whole-tier stamp on the
+    universal committed-epoch tick, reconcile clears the lot. On-read detection
+    and the cache itself live in ConfidenceAnalyzer above; this exposes the tier
+    to the freshness registry (conformance test + operator reconcile).
+    """
+
+    name = "confidence_cache"
+    budget = Budget.strict()
+
+    def __init__(self, client):
+        """Store the AGE client for the clock read; cache state is module-global."""
+        self.client = client
+
+    def version_stamp(self):
+        """The committed-epoch tick the cache was last filled at (None if cold)."""
+        return _confidence_cache_generation
+
+    def current_version(self) -> int:
+        """The canonical clock now: the committed-epoch tick."""
+        from psycopg2 import extras
+        conn = self.client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=extras.RealDictCursor) as cur:
+                v = read_committed_epoch(cur)
+            conn.rollback()
+            return v
+        finally:
+            self.client.pool.putconn(conn)
+
+    def reconcile(self) -> None:
+        """Invalidate the whole tier; it refills lazily on the next read."""
+        global _confidence_cache, _confidence_cache_generation
+        with _confidence_cache_lock:
+            _confidence_cache.clear()
+            _confidence_cache_generation = None

--- a/api/app/workers/ingestion_worker.py
+++ b/api/app/workers/ingestion_worker.py
@@ -404,6 +404,14 @@ def run_ingestion_worker(
         tmp.write(content)
         tmp_path = tmp.name
 
+    # ADR-207/#384: the epoch event recorded mid-run (below) must be resolved on
+    # every exit path — success, cancel, or failure — or it stays in_progress
+    # and holds the committed watermark (kg_api.get_committed_epoch()) behind a
+    # phantom in-flight job, freezing freshness for every derivation.
+    event_id = None
+    age_client = None
+    epoch_resolved = False
+
     try:
         # Load text
         with open(tmp_path, 'r', encoding='utf-8') as f:
@@ -544,6 +552,10 @@ def run_ingestion_worker(
             # ADR-100: Check for cancellation at chunk boundary
             if job_queue.is_job_cancelled(job_id):
                 logger.info(f"Job {job_id} cancelled at chunk {i}/{len(chunks)}")
+                # ADR-207: resolve the epoch (counts toward the watermark either
+                # way — partial per-chunk commits are real graph changes).
+                age_client.complete_epoch(event_id, "failed")
+                epoch_resolved = True
                 return {
                     "status": "cancelled",
                     "chunks_processed": i - 1,
@@ -703,6 +715,12 @@ def run_ingestion_worker(
         except Exception as e:
             logger.warning(f"[{job_id}] Annealing launcher check failed: {e}")
 
+        # ADR-207: graph mutations for this ingestion are committed — resolve
+        # the epoch so the committed watermark advances past it. Done before
+        # close()/cost-calc so the connection pool is still open.
+        age_client.complete_epoch(event_id, "completed")
+        epoch_resolved = True
+
         # ADR-201: Invalidate graph_accel cache after graph mutations
         try:
             age_client.graph.invalidate()
@@ -732,6 +750,14 @@ def run_ingestion_worker(
             "filename": filename,
             "chunks_processed": len(chunks)
         }
+
+    except Exception:
+        # ADR-207: a crashed run must resolve its epoch as failed so it stops
+        # holding the committed watermark behind a phantom in-flight event.
+        # (Failed still counts toward the watermark — partial commits are real.)
+        if age_client is not None and not epoch_resolved:
+            age_client.complete_epoch(event_id, "failed")
+        raise
 
     finally:
         # Clean up temp file

--- a/api/app/workers/proposal_execution_worker.py
+++ b/api/app/workers/proposal_execution_worker.py
@@ -127,6 +127,20 @@ def run_proposal_execution_worker(
                 f"Proposal {proposal_id} ({proposal['proposal_type']}) "
                 f"executed successfully"
             )
+            # ADR-207/#386: annealing's graph mutations land here. Announce them
+            # so the universal freshness tick (event_id) advances and graph_accel
+            # co-invalidates — otherwise the catalog and grounding caches go
+            # silently stale after annealing. Control-only proposal types change
+            # no graph topology, so they don't tick.
+            if proposal["proposal_type"] not in ("NO_ACTION", "ESCALATE", "ADJUST_CONTROL"):
+                age_client.record_mutation(
+                    "annealing",
+                    actor="annealing",
+                    metadata={
+                        "proposal_id": proposal_id,
+                        "proposal_type": proposal["proposal_type"],
+                    },
+                )
         elif result.get("retry_later"):
             # #402 PR-404 review (finding #2 / advisor): revert the claim
             # so the proposal stays available for the next cycle. Without

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -161,21 +161,27 @@ def run_restore_worker(
             }
         })
 
-        # Refresh graph metrics after restore (ADR-079: cache invalidation)
-        # This is critical after restore since the entire graph may have changed
+        # ADR-207/#386: a restore wholesale replaces the graph — the single
+        # largest possible mutation. Announce it via record_mutation so the
+        # universal freshness tick (get_committed_epoch) advances past every
+        # derivation's stamp; otherwise the catalog index and the grounding /
+        # confidence / artifact caches keep serving pre-restore data as "fresh".
+        # record_mutation records a completed epoch event (advances the tick),
+        # invalidates graph_accel, AND refreshes the graph_change_counter
+        # snapshot — subsuming the bare refresh_graph_metrics() this replaced.
         try:
             metrics_client = AGEClient()
-            conn = metrics_client.pool.getconn()
             try:
-                with conn.cursor() as cur:
-                    cur.execute("SELECT refresh_graph_metrics()")
-                conn.commit()
-                logger.info(f"[{job_id}] Refreshed graph metrics after restore")
+                metrics_client.record_mutation(
+                    "ingestion",
+                    actor="restore",
+                    metadata={"restore": True, "job_id": job_id},
+                )
+                logger.info(f"[{job_id}] Recorded restore as a graph mutation (freshness tick advanced)")
             finally:
-                metrics_client.pool.putconn(conn)
                 metrics_client.close()
         except Exception as e:
-            logger.warning(f"[{job_id}] Failed to refresh graph metrics: {e}")
+            logger.warning(f"[{job_id}] Failed to record restore mutation: {e}")
 
         # Success: Delete checkpoint
         if checkpoint_path and checkpoint_path.exists():

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -52,7 +52,7 @@ _Apache AGE, migrations, schema design, PostgreSQL_
 | [ADR-204](./database-schema/ADR-204-node-type-and-abstract-property-representation-for-concept-nodes.md) | Node Type and Abstract Property Representation for Concept Nodes | Draft |
 | [ADR-205](./database-schema/ADR-205-postgresql-18-migration.md) | PostgreSQL 18 Migration | Draft |
 | [ADR-206](./database-schema/ADR-206-closed-vocabulary-annealing-actions-with-tiered-escalation-and-epistemic-ledger.md) | Closed-Vocabulary Annealing Actions with Tiered Escalation and Epistemic Ledger | Draft |
-| [ADR-207](./database-schema/ADR-207-derived-state-freshness-contract.md) | A Uniform Freshness Contract for Materialized Graph Derivations | Proposed |
+| [ADR-207](./database-schema/ADR-207-derived-state-freshness-contract.md) | A Uniform Freshness Contract for Materialized Graph Derivations | Accepted |
 
 ## Ingestion
 _Content processing, jobs, extraction, deduplication_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -52,6 +52,7 @@ _Apache AGE, migrations, schema design, PostgreSQL_
 | [ADR-204](./database-schema/ADR-204-node-type-and-abstract-property-representation-for-concept-nodes.md) | Node Type and Abstract Property Representation for Concept Nodes | Draft |
 | [ADR-205](./database-schema/ADR-205-postgresql-18-migration.md) | PostgreSQL 18 Migration | Draft |
 | [ADR-206](./database-schema/ADR-206-closed-vocabulary-annealing-actions-with-tiered-escalation-and-epistemic-ledger.md) | Closed-Vocabulary Annealing Actions with Tiered Escalation and Epistemic Ledger | Draft |
+| [ADR-207](./database-schema/ADR-207-derived-state-freshness-contract.md) | A Uniform Freshness Contract for Materialized Graph Derivations | Proposed |
 
 ## Ingestion
 _Content processing, jobs, extraction, deduplication_

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 date: 2026-05-31
 deciders:
   - aaronsb

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -34,8 +34,9 @@ clocks were rejected on the merits, not deferred.
 
 Several read-heavy surfaces in the platform are not primary state — they are
 **caches of a graph computation**, persisted in some tier and expected to track
-the graph as it mutates. Three exist today, each built independently at a
-different time, for a different subsystem:
+the graph as it mutates. At least four exist today (the grounding row below is
+itself two cache tiers — see [Scope / inventory](#scope--inventory)), each built
+independently at a different time, for a different subsystem:
 
 | Derivation | Storage tier | Version signal it reads | Tracking issue |
 |---|---|---|---|
@@ -123,12 +124,39 @@ borrow solutions instead of inventing them:
 
 ### Structural precedent inside this repo
 
-This is the same *shape* of problem the provider work just resolved. Vision was
-a **parallel provider hierarchy** that duplicated the extraction hierarchy
+This shares its *motivation* with the provider work — not its difficulty. Vision
+was a **parallel provider hierarchy** that duplicated the extraction hierarchy
 (#379); ADR-801 defined a uniform provider contract and ADR-802 collapsed vision
-onto it. Here, each derivation is a **parallel freshness hierarchy** — its own
-stamp, its own clock, its own ad-hoc reconcile. The remedy rhymes: one contract,
-one trustworthy signal, existing implementations migrated onto it.
+onto it. Each derivation here is likewise a **parallel freshness hierarchy** —
+its own stamp, its own clock, its own ad-hoc reconcile — and the remedy rhymes:
+one contract, one trustworthy signal, existing implementations brought onto it.
+But the provider collapse unified objects that were *already the same kind of
+thing* behind one call signature, whereas these derivations are genuinely
+**heterogeneous in tier and cardinality** (per-process in-memory dict vs.
+per-row persisted blob vs. materialized relational table). The shared *motive*
+holds; do not expect the same clean collapse — which is exactly why D3 is a small
+hierarchy, not one interface.
+
+### Scope / inventory
+
+The contract governs **graph-topology-derived, server-maintained read surfaces**.
+By that rule the inventory is:
+
+- **Catalog index** (`catalog_node`) — collection-level. *Reference implementation.*
+- **Grounding cache, per-concept tier** — collection-level; keyed on the graph
+  generation. (#422)
+- **Grounding cache, polarity-axis tier** — collection-level but keyed on the
+  **vocabulary-embedding generation**, not the graph epoch; it changes only on
+  embedding regeneration, so it is registered and invalidated separately.
+- **Artifacts** — instance-level (per-row, user-parameterized). (#233)
+- **`graph_accel` in-memory generation layer** — in scope *in principle* (it is a
+  materialized derivation) but its version signal is internal to the Rust
+  extension; brought under the contract or proven to co-advance as a separable
+  follow-up, not in the first pass.
+
+Deliberately **excluded**: caches not derived from graph topology — e.g. the
+model catalog (provider/model metadata) — which have their own invalidation
+lifecycles and no graph-epoch relationship.
 
 ## Problem statement
 
@@ -149,25 +177,38 @@ derivation, resolved against **one canonical logical clock**, with the catalog
 facade's deferred / on-read / serve-stale-under-lock behavior as the reference
 shape. Three concrete decisions:
 
-### D1 — The canonical clock is the ADR-203 epoch event-log sequence
+### D1 — The canonical clock is a committed-prefix watermark over the ADR-203 epoch sequence
 
-`kg_api.graph_epochs.event_id` is `BIGSERIAL PRIMARY KEY` — **monotonic and
-unique by construction**, therefore injective in both directions: a stored stamp
-equal to the current value *proves* freshness, and an unequal stamp *proves*
-staleness. This is the property cache coherence requires of a version signal and
-the property `graph_change_counter` provably lacks.
+`kg_api.graph_epochs.event_id` is `BIGSERIAL PRIMARY KEY` — monotonic and unique
+*as a column*. That gives us a **monotonic high-water freshness signal** (not, as
+an earlier draft claimed, a bidirectionally-injective one — see the watermark
+caveat below). It is the property cache coherence requires of a version signal,
+and the property `graph_change_counter` provably lacks.
 
-The contract resolves freshness against a **commit-gated accessor** over this
-sequence:
+The subtlety is that epoch rows are inserted at job **start** (ADR-203's
+deliberate design, so the `event_id` can tag Instances created during the run),
+while a job *commits* at its end — and jobs complete **out of order** (a long
+ingestion started at id 6 may finish after a short one at id 7). Therefore the
+naive accessor `MAX(event_id) WHERE status = 'completed'` is **not a safe
+progress cursor**: with 6 in-flight and 7 done it returns 7, and 6's eventual
+commit is never re-surfaced — re-introducing the very false-FRESH it is meant to
+kill. The contract instead resolves freshness against the **contiguous committed
+prefix**:
 
-```sql
--- returns the highest event_id whose mutation actually committed
-kg_api.get_committed_epoch() := MAX(event_id) WHERE status = 'completed'
+```text
+get_committed_epoch() := the highest N such that EVERY event_id <= N
+                         has status = 'completed'
+                         (i.e. the high-water mark below which no job is in flight)
 ```
 
-This makes **#384 (epoch `status` column) a hard prerequisite** — without it the
-sequence reflects *attempts*, not *commits*, and a derivation could stamp itself
-against a mutation that rolled back.
+This makes **#384 (epoch `status` column) a hard prerequisite** — without a
+commit/fail status the sequence reflects *attempts*, not *commits*. The watermark
+advances only past gap-free committed runs, so an in-flight job at id N holds the
+watermark at N-1 and every derivation correctly reads stale until it commits.
+
+**`graph_epoch` columns are typed `BIGINT`** to match the sequence — the existing
+`INTEGER` columns (`artifacts.graph_epoch`, `catalog_node.graph_epoch`) and the
+`get_graph_epoch()` return type are widened as part of this work.
 
 **`graph_change_counter` is demoted, not deleted.** It remains a sound
 *one-directional dirty hint* — `counter != stamp` reliably means "changed", so
@@ -179,8 +220,8 @@ migrated to store the committed event-log sequence.
 **`graph_accel.generation`** is the in-memory acceleration layer's *own*
 invalidation signal, internal to the `graph_accel` extension — itself a
 materialized derivation. It is not a competing system clock; it is brought under
-the same contract (Phase 4), resolving against `get_committed_epoch()` or proven
-to co-advance with it.
+the same contract as a separable follow-up, resolving against
+`get_committed_epoch()` or proven to co-advance with it.
 
 ### D2 — Mandatory maintenance discipline: deferred, on-read, bounded
 
@@ -197,25 +238,47 @@ to co-advance with it.
   but is explicitly **out of scope** for the initial contract — the catalog
   index's full rebuild is the baseline all three adopt first.
 
-### D3 — One uniform surface: a `MaterializedDerivation` contract + registry
+### D3 — A small contract hierarchy: collection- vs instance-level derivations
 
-Every derivation implements a single interface (Python ABC / Protocol), so the
-four steps stop being re-implemented per surface:
+A *single* interface does not honestly fit the surfaces (architectural review,
+PR #462): a materialized table or in-memory cache is **collection-level** (one
+stamp for the whole derivation, reconcile = rebuild/invalidate the lot), whereas
+an artifact is **instance-level** (each row carries its own stamp and reconciles
+— regenerate — independently, against its own stored parameters). Forcing both
+behind one `version_stamp() -> int` is an ISP/LSP leak. So the contract is a
+shared base specialized into two shapes:
 
-```
-MaterializedDerivation:
-    version_stamp() -> int          # the clock value this derivation was built at
+```text
+FreshnessContract (shared):
     current_version() -> int        # get_committed_epoch()
-    is_fresh() -> bool              # deferred, on-read; honors the staleness budget
-    reconcile(strategy) -> None     # rebuild | regenerate | invalidate
-    staleness_budget -> Budget      # declared; default strict
+    staleness_budget -> Budget      # declared; default strict (0 versions / 0 ms)
+
+CollectionDerivation(FreshnessContract):   # catalog index, each grounding cache tier
+    version_stamp() -> int          # the clock value the whole derivation was built at
+    is_fresh() -> bool              # deferred, on-read; honors the budget
+    reconcile() -> None             # rebuild | invalidate (whole derivation)
+
+InstanceDerivation(FreshnessContract):     # artifacts
+    version_stamp(id) -> int        # per-row stamp
+    is_fresh(id) -> bool            # deferred, on-read, per row
+    reconcile(id) -> None           # regenerate one instance from its stored parameters
 ```
+
+The grounding cache is **not one derivation** — it is (at least) two registered
+`CollectionDerivation`s on two different signals: the per-concept grounding tier
+and the polarity-axis tier, the latter keyed on the vocabulary-embedding
+generation rather than the graph epoch (see [inventory](#scope--inventory)).
+Registering them separately keeps each one's invalidation honest rather than
+over-invalidating the rarely-changing axis on every graph mutation.
 
 Derivations **register** themselves, which buys two things:
 
-1. A **conformance test** asserting every registered derivation implements the
-   contract (the freshness analogue of `docstring_coverage` / `lint_queries`) —
-   so a *new* derivation that forgets on-read detection fails CI, not production.
+1. A **conformance test** asserting every registered derivation implements its
+   contract and pins the comparison semantics (strict `==` on the monotonic
+   clock — *not* the catalog's legacy `>=`, which only existed to tolerate the
+   regressing counter). This is the freshness analogue of `docstring_coverage` /
+   `lint_queries`: a *new* derivation that forgets on-read detection fails CI,
+   not production.
 2. A **uniform reconcile surface** across CLI/MCP/operator: list derivations,
    show freshness, trigger reconcile. This subsumes #233's regenerate/cleanup
    exposure and storage-tier-hiding items as fallout of conformance rather than
@@ -223,46 +286,59 @@ Derivations **register** themselves, which buys two things:
 
 ## Execution plan
 
-This is one body of work, best delivered as a single PR whose commits read in
-order as a coherent narrative — not a multi-phase project. Only one ordering
-constraint is load-bearing: **the clock must be made trustworthy before any
-derivation migrates onto it**, or we re-stamp everything against sand. Beyond
-that, the sequence below is the natural narrative, not a gate sequence.
+**Clean-rebuild assumption.** The platform carries no production data that must
+be preserved: it is wiped and re-initialized as part of landing this. That
+removes the riskiest piece a freshness-clock change would normally carry — there
+is **no back-fill and no migration machinery** to map old `graph_change_counter`
+stamps (a different number space) onto the new clock, and **no rollback-of-data
+hazard**. Columns are simply defined `BIGINT` from the reset forward; every
+derivation builds fresh against the watermark on first read. (If the platform
+ever holds data worth preserving, this execution section must be revisited —
+back-filling stamps across the counter→event-sequence number-space gap has no
+sound automatic answer.)
 
-1. **Make the clock trustworthy.** Land the epoch `status` column, add
-   `kg_api.get_committed_epoch()`, and re-comment `graph_change_counter` as a
-   one-directional dirty-hint (with a lint note so it is never reintroduced as a
-   freshness signal). This closes **#384** and fixes the false-FRESH class on its
-   own merit, independent of the rest.
+Given that, this is one body of work, best delivered as a single PR whose commits
+read in order as a coherent narrative. Only one ordering constraint is
+load-bearing: **the clock must be trustworthy before any derivation reads it.**
+
+1. **Make the clock trustworthy.** Land the epoch `status` column and the
+   contiguous-committed-prefix `kg_api.get_committed_epoch()` (D1); widen the
+   `graph_epoch` columns and `get_graph_epoch()` to `BIGINT`; re-comment
+   `graph_change_counter` as a one-directional dirty-hint (with a lint note so it
+   is never reintroduced as a freshness signal). Closes **#384**. Note this fixes
+   false-FRESH only *with* the watermark semantics — the `status` column alone is
+   necessary but not sufficient.
 2. **Establish the contract against the surface that already obeys it.** Define
-   the `MaterializedDerivation` interface, registry, and conformance test, then
-   migrate the **catalog facade** first — it already behaves correctly, so it is
-   the lowest-risk way to prove the interface is right before reshaping anything
-   that isn't.
-3. **Bring the misbehaving derivations into conformance.** The grounding cache
-   gains on-read re-reads and a declared staleness budget (**#422**); artifacts
-   stamp against the committed sequence, expose `reconcile` via CLI/MCP, and hide
-   the storage tier behind `--verbose` (**#233**).
+   the `FreshnessContract` base + the two specializations + registry +
+   conformance test, then bring the **catalog facade** on first — it already
+   behaves correctly, so it is the lowest-risk way to prove the interface is
+   right before reshaping anything that isn't.
+3. **Bring the misbehaving derivations into conformance.** The two grounding
+   cache tiers gain on-read re-reads and declared staleness budgets, registered
+   separately (**#422**); artifacts implement `InstanceDerivation`, expose
+   `reconcile` via CLI/MCP, and hide the storage tier behind `--verbose`
+   (**#233**).
 4. **Follow-up, separable:** bring `graph_accel.generation` under the contract or
    prove co-advance, and revisit IVM where it is cheap. This can trail in its own
    PR without holding up the rest.
 
 The commits stand on their own in review — the clock fix is a correctness fix,
-the contract is an abstraction with a test, each migration closes a standing
-issue — while together they tell the single story this ADR names.
+the contract is an abstraction with a test, each conformance step closes a
+standing issue — while together they tell the single story this ADR names.
 
 ## Consequences
 
 - **Positive:** silent-staleness defects become **contract violations the
   conformance test catches**, not production incidents; the false-FRESH class is
-  eliminated at the root (D1); new derivations inherit correct freshness behavior
-  by implementing one interface; cross-surface snapshot skew becomes a declared,
-  reasoned property (D2) rather than an accident of which clock a subsystem
-  happened to read.
-- **Cost:** touches three subsystems plus a schema-level clock change; **the
-  clock-trustworthiness work (#384) must land first**; the `graph_epoch`-column
-  data migration (counter → committed sequence) must be planned with the existing
-  artifact and catalog-index rows.
+  eliminated at the root (D1's watermark); new derivations inherit correct
+  freshness behavior by implementing the contract for their cardinality;
+  cross-surface snapshot skew becomes a declared, reasoned property (D2) rather
+  than an accident of which clock a subsystem happened to read.
+- **Cost:** touches the grounding, artifact, and catalog subsystems plus a
+  schema-level clock change; **the clock-trustworthiness work (#384) must land
+  first**. The data-migration cost is avoided only by the clean-rebuild
+  assumption above — it is a real, unsolved cost the moment the platform holds
+  data worth preserving.
 - **Risk accepted:** IVM is deferred — derivations full-recompute on staleness,
   which is correct but not always cheapest. Acceptable: correctness first, the
   contract *permits* IVM later without re-litigation.
@@ -271,8 +347,8 @@ issue — while together they tell the single story this ADR names.
 
 ## Alternatives considered
 
-- **Repair `graph_change_counter` into a monotonic commit-bumped sequence
-  (decision-space A.2).** Rejected: ADR-203 already established the checksum is
+- **Repair `graph_change_counter` into a monotonic commit-bumped sequence.**
+  Rejected: ADR-203 already established the checksum is
   the wrong primitive, and a *second* monotonic sequence alongside the epoch log
   would be a redundant clock. The epoch `event_id` is already the monotonic
   sequence we need.

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -270,6 +270,19 @@ already committed partial changes, and excluding it would read false-FRESH. The
 exit path (success/cancel/exception) is what keeps a crashed job from freezing
 the watermark behind a phantom in-flight event. (Built and verified in step 1.)
 
+**Staleness bound (review S3).** Because the watermark holds at
+`MIN(in_flight) - 1`, a mutation committed *while a longer job is in flight* is
+not reflected until that job resolves. So the bound on detection latency is **the
+duration of the longest concurrent in-flight job**, not wall-clock. This is the
+deliberate price of the contiguous-prefix guarantee (no half-applied state ever
+shows as fresh), and it is acceptable because the dominant in-flight job is
+ingestion, after which a rebuild was going to happen anyway. An atomic edit's own
+`record_mutation` records a *completed* event, so in the common case (no long job
+running) it advances the tick immediately. The brief two-phase window inside
+`record_mutation` itself (record → complete) only *holds* the watermark at its
+prior value, never regresses it (S2), so it cannot surface stale-as-fresh — at
+worst a derivation rebuilt inside that window re-checks once the event completes.
+
 ### D2 — Mandatory maintenance discipline: deferred, on-read, bounded
 
 - **Deferred / on-read detection is the floor.** Every derivation re-reads the

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -177,68 +177,71 @@ derivation, resolved against **one canonical logical clock**, with the catalog
 facade's deferred / on-read / serve-stale-under-lock behavior as the reference
 shape. Three concrete decisions:
 
-### D1 — The canonical clock is a committed-prefix watermark over the ADR-203 epoch sequence
+### D1 — The canonical clock is one universal monotonic tick, with an eventual-consistency guarantee
 
-`kg_api.graph_epochs.event_id` is `BIGSERIAL PRIMARY KEY` — monotonic and unique
-*as a column*. That gives us a **monotonic high-water freshness signal** (not, as
-an earlier draft claimed, a bidirectionally-injective one — see the watermark
-caveat below). It is the property cache coherence requires of a version signal,
-and the property `graph_change_counter` provably lacks.
+The freshness clock is **one universal monotonic tick** that advances on every
+graph action. Sub-counters may exist for specialized cache scopes, but there is
+exactly one universal tick above them, and it is what every derivation stamps
+against.
 
-The subtlety is that epoch rows are inserted at job **start** (ADR-203's
-deliberate design, so the `event_id` can tag Instances created during the run),
-while a job *commits* at its end — and jobs complete **out of order** (a long
-ingestion started at id 6 may finish after a short one at id 7). Therefore the
-naive accessor `MAX(event_id) WHERE status = 'completed'` is **not a safe
-progress cursor**: with 6 in-flight and 7 done it returns 7, and 6's eventual
-commit is never re-surfaced — re-introducing the very false-FRESH it is meant to
-kill. The contract instead resolves freshness against the **contiguous resolved
-prefix**:
+**Why it is application-level, not a trigger.** The obvious implementation — a
+PostgreSQL trigger that bumps a sequence on every write — does not work here, and
+migration 033 already documents why: *Apache AGE's Cypher operations bypass
+PostgreSQL's trigger mechanism entirely* (AGE manipulates label tables via
+internal C functions that do not fire row-level triggers). That is the original
+reason `graph_change_counter` is a recomputed `COUNT(*)` checksum rather than a
+trigger counter — and the reason it is non-injective (ADR-203: delete one + add
+one leaves the sum unchanged). The universal tick therefore lives where it can
+actually see every mutation: the application choke point `refresh_epoch()` /
+`refresh_graph_metrics()`, which already declares the rule "every mutation path
+must call this, regardless of caller." The tick is a monotonic
+application-incremented counter (migration 033's "category B" pattern, already
+proven to survive AGE).
 
-```text
-get_committed_epoch() := MIN(event_id WHERE status = 'in_progress') - 1
-                         if any job is in flight, else
-                         MAX(event_id) over all resolved events
-                         (the high-water mark below which no job is in flight)
-```
+**Eventual consistency, guaranteed — not synchronous.** Because the tick is
+advanced out-of-band from the AGE write (not in the same trigger), there is a
+window where it lags the true graph state. We accept that and guarantee
+*convergence* instead of instantaneous accuracy:
 
-This makes **#384 (epoch `status` column) a hard prerequisite** — without a
-commit/fail status the sequence reflects *attempts*, not *commits*. An in-flight
-job at id N holds the watermark at N-1, so every derivation correctly reads stale
-until it resolves; sequence gaps (a `BIGSERIAL` rolled-back transaction) are
-tolerated because the watermark keys on the lowest in-flight id, not contiguity
-of values.
+- The periodic `refresh_graph_metrics()` background sync is the **backstop**: it
+  recomputes the snapshot and bumps the tick on any detected change, so a
+  count-changing mutation advances the tick within one interval **even if a
+  mutation path forgot the explicit call**. No mutation stays invisible forever.
+- **Count-preserving** AGE mutations (annealing edge re-scope, delete+add netting
+  zero) are invisible to a `COUNT` checksum and to triggers alike, so those paths
+  must **signal explicitly** — which is exactly what recording an epoch event for
+  every mutation kind buys (**#386**, now a prerequisite, not a follow-up). An
+  explicit signal bumps the tick directly.
+- This guarantee has interplay with the `graph_accel` pgrx extension, whose own
+  `generation` counter is advanced the same out-of-band way (`graph_accel_invalidate`).
+  It is a **sub-counter** under the universal tick with the same
+  eventual-consistency contract, not a competing clock.
 
-**Both `completed` and `failed` events count toward the watermark** — only
-`in_progress` blocks it. This is load-bearing, and it is *why the watermark is
-not `MAX(event_id WHERE completed)`*: ingestion commits **per-chunk**, so a job
-that aborted or was cancelled mid-run may have already committed partial graph
-changes. Excluding it would hide those commits and read false-FRESH. A cleanly-
-rolled-back failed event that committed nothing costs at most one benign no-op
-rebuild — the safe direction to err. The `completed`/`failed` distinction is
-therefore for *analytics* (#384's original motive: drop zero-instance jobs from
-hot/stale signals), **not** for this watermark. Correspondingly, the epoch must
-be resolved on **every** exit path of a mutation — success, cancel, *and*
-exception — or one crashed job holds the watermark behind a phantom in-flight
-event and freezes freshness platform-wide. (Verified end-to-end against the
-ingestion worker, the only epoch-recording path.)
+**Sub-counters stay subordinate.** `graph_accel.generation`,
+`vocabulary_change_counter`, and `vocabulary_embedding_generation_counter` remain
+for their narrower invalidation scopes (e.g. the polarity-axis tier keys on the
+vocab-embedding counter, which changes far more rarely than the graph). One
+universal tick above them; they do not substitute for it.
 
-**`graph_epoch` columns are typed `BIGINT`** to match the sequence — the existing
-`INTEGER` columns (`artifacts.graph_epoch`, `catalog_node.graph_epoch`) and the
-`get_graph_epoch()` return type are widened as part of this work.
+**`graph_change_counter` is demoted, not deleted.** The `COUNT` checksum keeps
+its statistics role and serves as the *change detector* that drives the
+backstop tick-bump, but it is **never** the freshness stamp itself —
+`counter == stamp` is meaningless (non-injective). Freshness reads the tick.
 
-**`graph_change_counter` is demoted, not deleted.** It remains a sound
-*one-directional dirty hint* — `counter != stamp` reliably means "changed", so
-it is a legal cheap fast-path to *prove staleness* — but it is **never trusted
-to prove freshness** (its non-injectivity, per ADR-203, makes `counter == stamp`
-meaningless). Existing `graph_epoch` columns that today store the counter are
-migrated to store the committed event-log sequence.
+**Keep both: tick for freshness, epoch log for analytics.** The `graph_epochs`
+event log and its `#384` `status` column remain — they are the richer
+logical-time / lifetime record (ADR-203), and `#386` extends event recording to
+all mutation kinds. They are *not* the freshness clock: the in-flight
+watermark machinery that an earlier draft put on the event log is unnecessary for
+freshness, because the universal tick is advanced *after* commit (each tick value
+is already a committed state, no phantom-in-flight problem). `status` stays for
+its original analytics motive (drop zero-instance failed jobs from hot/stale
+signals). `get_committed_epoch()` (and the contract's `read_committed_epoch`) is
+repointed to read the universal tick.
 
-**`graph_accel.generation`** is the in-memory acceleration layer's *own*
-invalidation signal, internal to the `graph_accel` extension — itself a
-materialized derivation. It is not a competing system clock; it is brought under
-the same contract as a separable follow-up, resolving against
-`get_committed_epoch()` or proven to co-advance with it.
+**`graph_epoch` stamp columns are typed `BIGINT`** to match the tick — the
+existing `INTEGER` columns (`artifacts.graph_epoch`, `catalog_node.graph_epoch`)
+and the relevant accessor return types are widened as part of this work.
 
 ### D2 — Mandatory maintenance discipline: deferred, on-read, bounded
 
@@ -306,25 +309,29 @@ Derivations **register** themselves, which buys two things:
 **Clean-rebuild assumption.** The platform carries no production data that must
 be preserved: it is wiped and re-initialized as part of landing this. That
 removes the riskiest piece a freshness-clock change would normally carry — there
-is **no back-fill and no migration machinery** to map old `graph_change_counter`
-stamps (a different number space) onto the new clock, and **no rollback-of-data
-hazard**. Columns are simply defined `BIGINT` from the reset forward; every
-derivation builds fresh against the watermark on first read. (If the platform
-ever holds data worth preserving, this execution section must be revisited —
-back-filling stamps across the counter→event-sequence number-space gap has no
-sound automatic answer.)
+is **no back-fill and no migration machinery** to map old stamps (a different
+number space) onto the new clock, and **no rollback-of-data hazard**. Columns are
+simply defined `BIGINT` from the reset forward; every derivation builds fresh
+against the universal tick on first read. (If the platform ever holds data worth
+preserving, this execution section must be revisited.)
 
 Given that, this is one body of work, best delivered as a single PR whose commits
 read in order as a coherent narrative. Only one ordering constraint is
-load-bearing: **the clock must be trustworthy before any derivation reads it.**
+load-bearing: **the universal tick must advance on every mutation kind before any
+derivation reads it** — otherwise a derivation goes blind to the kinds that don't
+yet bump it.
 
-1. **Make the clock trustworthy.** Land the epoch `status` column and the
-   contiguous-committed-prefix `kg_api.get_committed_epoch()` (D1); widen the
-   `graph_epoch` columns and `get_graph_epoch()` to `BIGINT`; re-comment
-   `graph_change_counter` as a one-directional dirty-hint (with a lint note so it
-   is never reintroduced as a freshness signal). Closes **#384**. Note this fixes
-   false-FRESH only *with* the watermark semantics — the `status` column alone is
-   necessary but not sufficient.
+1. **Make the clock trustworthy and universal.** Land the epoch `status` column
+   and widen the `graph_epoch` stamp columns to `BIGINT` (**#384**). Introduce
+   the **universal monotonic tick** (D1), advanced in `refresh_graph_metrics()`
+   (the choke point every mutation path already calls) and by the periodic
+   background sync as the eventual-consistency backstop; repoint
+   `get_committed_epoch()` to read it. Re-comment `graph_change_counter` as the
+   demoted change-detector, never a freshness stamp. **Record epoch events — and
+   bump the tick — for every mutation kind, not just ingestion (#386)**: this is
+   a prerequisite, because count-preserving AGE mutations (annealing) are
+   invisible to the checksum backstop and must signal explicitly. Without #386 a
+   derivation on the tick would miss annealing/edit mutations.
 2. **Establish the contract against the surface that already obeys it.** Define
    the `FreshnessContract` base + the two specializations + registry +
    conformance test, then bring the **catalog facade** on first — it already
@@ -335,9 +342,9 @@ load-bearing: **the clock must be trustworthy before any derivation reads it.**
    separately (**#422**); artifacts implement `InstanceDerivation`, expose
    `reconcile` via CLI/MCP, and hide the storage tier behind `--verbose`
    (**#233**).
-4. **Follow-up, separable:** bring `graph_accel.generation` under the contract or
-   prove co-advance, and revisit IVM where it is cheap. This can trail in its own
-   PR without holding up the rest.
+4. **Follow-up, separable:** formalize `graph_accel.generation` as a declared
+   sub-counter under the tick (prove co-advance), and revisit IVM where it is
+   cheap. This can trail in its own PR without holding up the rest.
 
 The commits stand on their own in review — the clock fix is a correctness fix,
 the contract is an abstraction with a test, each conformance step closes a
@@ -364,16 +371,24 @@ standing issue — while together they tell the single story this ADR names.
 
 ## Alternatives considered
 
-- **Repair `graph_change_counter` into a monotonic commit-bumped sequence.**
-  Rejected: ADR-203 already established the checksum is
-  the wrong primitive, and a *second* monotonic sequence alongside the epoch log
-  would be a redundant clock. The epoch `event_id` is already the monotonic
-  sequence we need.
-- **Reconcile the two existing clocks and prove co-advance (A.3).** Rejected as
-  the *primary* signal: it preserves two clocks and therefore the snapshot-skew
-  hazard, and proves a property the system would have to keep re-proving on every
-  schema change. Co-advance is retained only as the *follow-up fallback* for the
-  in-memory accel layer, where the generation counter is extension-internal.
+- **The committed-prefix watermark over the epoch event log (an earlier draft of
+  D1).** Rejected on implementation: the epoch event log is recorded only by
+  ingestion, so a watermark over it is blind to edits and annealing — and the
+  in-flight `in_progress`/`completed` watermark machinery only existed to paper
+  over epochs being recorded at job *start*. A tick advanced *after* commit at
+  the universal mutation hook needs none of that. The event log is kept for
+  analytics (D1, "keep both"), not as the freshness clock.
+- **A PostgreSQL trigger bumping a monotonic sequence on every write.** Infeasible
+  here: AGE Cypher bypasses row-level triggers (migration 033), which is the whole
+  reason `graph_change_counter` is a recomputed checksum. The universal tick
+  adopts the *monotonic-counter* idea but advances it in application code at the
+  `refresh_graph_metrics()` choke point, accepting eventual consistency with a
+  periodic backstop (D1).
+- **A second, fully-synchronous clock reconciled with `graph_accel.generation`.**
+  Rejected as primary: synchronous accuracy is unattainable against AGE's
+  trigger-bypass, and maintaining two co-equal clocks reintroduces snapshot skew.
+  `graph_accel.generation` is instead a declared *sub-counter* under the one
+  universal tick.
 - **Per-surface freshness with no shared contract (status quo).** Rejected: it
   is precisely the parallel-hierarchy drift this ADR exists to stop — the same
   anti-pattern ADR-802 collapsed for providers.
@@ -384,8 +399,11 @@ standing issue — while together they tell the single story this ADR names.
 
 ## Implementing / related issues
 
-- **#384** — `graph_epochs.status` (committed vs failed): foundation for the
-  trustworthy clock (D1).
+- **#384** — `graph_epochs.status` (committed vs failed): analytics signal +
+  part of the clock foundation (D1).
+- **#386** — record epoch events for annealing/reasoning/edit kinds, **and bump
+  the universal tick for them**: a *prerequisite* (D1). Without it the tick only
+  advances on ingestion and derivations go blind to count-preserving mutations.
 - **#422** — grounding-cache unbounded warm-path staleness: the on-read
   detection defect the contract forbids (D2).
 - **#233** — artifact lifecycle exposure + storage-tier transparency: the

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -192,19 +192,36 @@ ingestion started at id 6 may finish after a short one at id 7). Therefore the
 naive accessor `MAX(event_id) WHERE status = 'completed'` is **not a safe
 progress cursor**: with 6 in-flight and 7 done it returns 7, and 6's eventual
 commit is never re-surfaced — re-introducing the very false-FRESH it is meant to
-kill. The contract instead resolves freshness against the **contiguous committed
+kill. The contract instead resolves freshness against the **contiguous resolved
 prefix**:
 
 ```text
-get_committed_epoch() := the highest N such that EVERY event_id <= N
-                         has status = 'completed'
-                         (i.e. the high-water mark below which no job is in flight)
+get_committed_epoch() := MIN(event_id WHERE status = 'in_progress') - 1
+                         if any job is in flight, else
+                         MAX(event_id) over all resolved events
+                         (the high-water mark below which no job is in flight)
 ```
 
 This makes **#384 (epoch `status` column) a hard prerequisite** — without a
-commit/fail status the sequence reflects *attempts*, not *commits*. The watermark
-advances only past gap-free committed runs, so an in-flight job at id N holds the
-watermark at N-1 and every derivation correctly reads stale until it commits.
+commit/fail status the sequence reflects *attempts*, not *commits*. An in-flight
+job at id N holds the watermark at N-1, so every derivation correctly reads stale
+until it resolves; sequence gaps (a `BIGSERIAL` rolled-back transaction) are
+tolerated because the watermark keys on the lowest in-flight id, not contiguity
+of values.
+
+**Both `completed` and `failed` events count toward the watermark** — only
+`in_progress` blocks it. This is load-bearing, and it is *why the watermark is
+not `MAX(event_id WHERE completed)`*: ingestion commits **per-chunk**, so a job
+that aborted or was cancelled mid-run may have already committed partial graph
+changes. Excluding it would hide those commits and read false-FRESH. A cleanly-
+rolled-back failed event that committed nothing costs at most one benign no-op
+rebuild — the safe direction to err. The `completed`/`failed` distinction is
+therefore for *analytics* (#384's original motive: drop zero-instance jobs from
+hot/stale signals), **not** for this watermark. Correspondingly, the epoch must
+be resolved on **every** exit path of a mutation — success, cancel, *and*
+exception — or one crashed job holds the watermark behind a phantom in-flight
+event and freezes freshness platform-wide. (Verified end-to-end against the
+ingestion worker, the only epoch-recording path.)
 
 **`graph_epoch` columns are typed `BIGINT`** to match the sequence — the existing
 `INTEGER` columns (`artifacts.graph_epoch`, `catalog_node.graph_epoch`) and the

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -1,0 +1,312 @@
+---
+status: Proposed
+date: 2026-05-31
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-079
+  - ADR-201
+  - ADR-203
+  - ADR-083
+  - ADR-079
+  - ADR-080
+  - ADR-801
+  - ADR-802
+---
+
+# ADR-207: A Uniform Freshness Contract for Materialized Graph Derivations
+
+## Status note
+
+This ADR both **names** the problem (grounding it in the materialized-view /
+bounded-staleness literature) and **decides** the architecture to resolve it.
+The [Context](#context) and [Problem statement](#problem-statement) establish
+the class of problem; the [Decision](#decision) commits to a uniform freshness
+contract over a single trustworthy clock; the [Execution plan](#execution-plan)
+sequences it as a coherent series of changes. It is executable as written — the
+[Alternatives considered](#alternatives-considered) record why the rejected
+clocks were rejected on the merits, not deferred.
+
+## Context
+
+### The system quietly grew three materialized derivations of the graph
+
+Several read-heavy surfaces in the platform are not primary state — they are
+**caches of a graph computation**, persisted in some tier and expected to track
+the graph as it mutates. Three exist today, each built independently at a
+different time, for a different subsystem:
+
+| Derivation | Storage tier | Version signal it reads | Tracking issue |
+|---|---|---|---|
+| Grounding / polarity scores | in-memory cache | `graph_accel.generation` (ADR-201) | #422 |
+| Artifacts (analyses, projections, saved results) | PostgreSQL inline / Garage S3 | `graph_change_counter` via `get_graph_epoch()` (ADR-079) | #233 |
+| Catalog index (`kg_api.catalog_node`) | materialized table | `graph_change_counter` via `get_graph_epoch()` (ADR-079) | — |
+
+Each independently re-implements the same four-part lifecycle:
+
+1. **Stamp** — record which graph version the derivation was computed from.
+2. **Compare** — read the current graph version and diff it against the stamp.
+3. **Detect** — decide, *on the read path*, whether the derivation is stale.
+4. **Reconcile** — act on staleness: rebuild, regenerate, invalidate, or
+   serve-stale-with-a-signal.
+
+They do not agree on how — or whether — they perform each step:
+
+- **Catalog index** does all four correctly. It stamps `graph_epoch` per row,
+  `CatalogFacade.ensure_fresh()` re-reads the current epoch on every read,
+  rebuilds under a lock, and serves the older snapshot gracefully when another
+  worker holds the rebuild lock (migration 073). *It is the de-facto reference
+  implementation of the pattern.*
+- **Artifacts** stamp (`artifacts.graph_epoch`) and compare (`is_fresh`), but
+  **step 4 is not exposed to users** — `POST /artifacts/{id}/regenerate` exists
+  in the API yet has no CLI/MCP surface, and cleanup runs only as an automatic
+  worker. The storage tier (inline vs Garage) also leaks into the user view.
+  (#233)
+- **Grounding cache** stamps and compares, but **skips the compare on the warm
+  path** — the Phase-0 short-circuit returns without re-reading
+  `graph_accel.generation`, so staleness is unbounded in wall-clock time. (#422)
+
+### Three version signals, none of them a shared clock
+
+The comparisons above are not even measured against the same clock:
+
+| Signal | Defined | Nature |
+|---|---|---|
+| `graph_change_counter` (`get_graph_epoch()`) | ADR-079, migration 033 | composite **count checksum** of graph objects |
+| `graph_accel.generation` | ADR-201, migration 051 | separate invalidation counter for the in-memory layer |
+| `kg_api.graph_epochs` event log | ADR-203, migration 063 | monotonic mutation event log, *explicitly "distinct from `graph_change_counter`"* |
+
+Two soundness gaps fall out of this, both already documented in our own ADRs:
+
+1. **The counter is non-injective over time.** ADR-203 proves it: "Delete a
+   concept and add one — the counter is unchanged... `counter_value →
+   wall_clock_time` is not a function." Any derivation whose freshness test is
+   `stamp == get_graph_epoch()` can therefore read **false-FRESH** — a stale
+   derivation passing as current because the count happened to return to a prior
+   value. In-place edits and compensating mutations (delete+add) are invisible
+   to it.
+2. **Independently-maintained derivations produce inconsistent snapshots.** This
+   is a named hazard in the materialized-view literature: multiple views
+   refreshed against different signals, read concurrently, reflect *different
+   points in time*. With three derivations on (up to) three clocks, a single
+   request can compose grounding scores, an artifact, and a catalog listing that
+   each describe a different graph state.
+
+And the clock that *is* monotonic and honest — the epoch event log (ADR-203) —
+**cannot yet distinguish a committed mutation from a failed attempt** (#384): a
+job that aborts mid-extraction still leaves an epoch row, polluting the very
+signal a freshness contract would want to trust.
+
+### We are not the first to hit this
+
+This is a well-trodden class of problem. Naming it in the field's terms lets us
+borrow solutions instead of inventing them:
+
+- **Materialized view maintenance.** Our three derivations *are* materialized
+  views of the graph. The literature's staleness states (FRESH / STALE), its
+  **immediate vs deferred maintenance** distinction (update in the writing
+  transaction, vs. on-read / on-command / periodic), and its **incremental view
+  maintenance (IVM) vs full recompute** trade-off map directly onto our
+  reconcile step. The catalog index does *deferred, on-read, full-recompute*
+  maintenance; the grounding cache attempts deferred maintenance but skips the
+  detect step.
+- **Bounded staleness** (a consistency model). #422 is precisely an
+  *unbounded-staleness* defect: the warm path bounds staleness by neither
+  versions nor wall-clock. Probabilistically Bounded Staleness (PBS) formalizes
+  bounds along both axes — the vocabulary for what "fresh enough" should mean
+  per surface.
+- **Cache invalidation / coherence.** The single-writer + monotonic-versioning
+  framing from coherence protocols is the lens on our three-clocks problem: a
+  derivation is coherent only against a version signal that monotonically and
+  injectively reflects committed writes — which `graph_change_counter` does not.
+
+### Structural precedent inside this repo
+
+This is the same *shape* of problem the provider work just resolved. Vision was
+a **parallel provider hierarchy** that duplicated the extraction hierarchy
+(#379); ADR-801 defined a uniform provider contract and ADR-802 collapsed vision
+onto it. Here, each derivation is a **parallel freshness hierarchy** — its own
+stamp, its own clock, its own ad-hoc reconcile. The remedy rhymes: one contract,
+one trustworthy signal, existing implementations migrated onto it.
+
+## Problem statement
+
+> The platform maintains multiple materialized derivations of the graph
+> (grounding cache, artifacts, catalog index), but has **no uniform contract for
+> derived-state freshness**. Each derivation answers "am I current, and what
+> happens when I'm not?" ad-hoc — against version signals that are not the same
+> clock, at least one of which (`graph_change_counter`) is non-injective and can
+> report false-FRESH, on top of an epoch log that cannot yet tell a committed
+> mutation from a failed attempt. The result is silent staleness (#422),
+> unexposed reconciliation (#233), and the latent risk of composing a single
+> response from derivations that each describe a different graph state.
+
+## Decision
+
+Adopt a **single uniform freshness contract** for every materialized graph
+derivation, resolved against **one canonical logical clock**, with the catalog
+facade's deferred / on-read / serve-stale-under-lock behavior as the reference
+shape. Three concrete decisions:
+
+### D1 — The canonical clock is the ADR-203 epoch event-log sequence
+
+`kg_api.graph_epochs.event_id` is `BIGSERIAL PRIMARY KEY` — **monotonic and
+unique by construction**, therefore injective in both directions: a stored stamp
+equal to the current value *proves* freshness, and an unequal stamp *proves*
+staleness. This is the property cache coherence requires of a version signal and
+the property `graph_change_counter` provably lacks.
+
+The contract resolves freshness against a **commit-gated accessor** over this
+sequence:
+
+```sql
+-- returns the highest event_id whose mutation actually committed
+kg_api.get_committed_epoch() := MAX(event_id) WHERE status = 'completed'
+```
+
+This makes **#384 (epoch `status` column) a hard prerequisite** — without it the
+sequence reflects *attempts*, not *commits*, and a derivation could stamp itself
+against a mutation that rolled back.
+
+**`graph_change_counter` is demoted, not deleted.** It remains a sound
+*one-directional dirty hint* — `counter != stamp` reliably means "changed", so
+it is a legal cheap fast-path to *prove staleness* — but it is **never trusted
+to prove freshness** (its non-injectivity, per ADR-203, makes `counter == stamp`
+meaningless). Existing `graph_epoch` columns that today store the counter are
+migrated to store the committed event-log sequence.
+
+**`graph_accel.generation`** is the in-memory acceleration layer's *own*
+invalidation signal, internal to the `graph_accel` extension — itself a
+materialized derivation. It is not a competing system clock; it is brought under
+the same contract (Phase 4), resolving against `get_committed_epoch()` or proven
+to co-advance with it.
+
+### D2 — Mandatory maintenance discipline: deferred, on-read, bounded
+
+- **Deferred / on-read detection is the floor.** Every derivation re-reads the
+  canonical clock on the read path before serving. **No warm-path short-circuit
+  may skip the compare** — this is the contract clause that #422 violates.
+- **Each derivation declares an explicit staleness budget.** Default is
+  **strict** (0 versions / 0 ms — never serve stale). A derivation opts into
+  tolerance explicitly (`stale_ok_versions: N` / `stale_ok_ms: T`), making
+  "fresh enough" a declared property rather than emergent behavior. (Vocabulary:
+  bounded staleness / PBS.)
+- **Reconcile strategy is per-derivation, full-recompute by default.**
+  Incremental view maintenance (IVM) is permitted where a derivation supports it
+  but is explicitly **out of scope** for the initial contract — the catalog
+  index's full rebuild is the baseline all three adopt first.
+
+### D3 — One uniform surface: a `MaterializedDerivation` contract + registry
+
+Every derivation implements a single interface (Python ABC / Protocol), so the
+four steps stop being re-implemented per surface:
+
+```
+MaterializedDerivation:
+    version_stamp() -> int          # the clock value this derivation was built at
+    current_version() -> int        # get_committed_epoch()
+    is_fresh() -> bool              # deferred, on-read; honors the staleness budget
+    reconcile(strategy) -> None     # rebuild | regenerate | invalidate
+    staleness_budget -> Budget      # declared; default strict
+```
+
+Derivations **register** themselves, which buys two things:
+
+1. A **conformance test** asserting every registered derivation implements the
+   contract (the freshness analogue of `docstring_coverage` / `lint_queries`) —
+   so a *new* derivation that forgets on-read detection fails CI, not production.
+2. A **uniform reconcile surface** across CLI/MCP/operator: list derivations,
+   show freshness, trigger reconcile. This subsumes #233's regenerate/cleanup
+   exposure and storage-tier-hiding items as fallout of conformance rather than
+   as bespoke artifact work.
+
+## Execution plan
+
+This is one body of work, best delivered as a single PR whose commits read in
+order as a coherent narrative — not a multi-phase project. Only one ordering
+constraint is load-bearing: **the clock must be made trustworthy before any
+derivation migrates onto it**, or we re-stamp everything against sand. Beyond
+that, the sequence below is the natural narrative, not a gate sequence.
+
+1. **Make the clock trustworthy.** Land the epoch `status` column, add
+   `kg_api.get_committed_epoch()`, and re-comment `graph_change_counter` as a
+   one-directional dirty-hint (with a lint note so it is never reintroduced as a
+   freshness signal). This closes **#384** and fixes the false-FRESH class on its
+   own merit, independent of the rest.
+2. **Establish the contract against the surface that already obeys it.** Define
+   the `MaterializedDerivation` interface, registry, and conformance test, then
+   migrate the **catalog facade** first — it already behaves correctly, so it is
+   the lowest-risk way to prove the interface is right before reshaping anything
+   that isn't.
+3. **Bring the misbehaving derivations into conformance.** The grounding cache
+   gains on-read re-reads and a declared staleness budget (**#422**); artifacts
+   stamp against the committed sequence, expose `reconcile` via CLI/MCP, and hide
+   the storage tier behind `--verbose` (**#233**).
+4. **Follow-up, separable:** bring `graph_accel.generation` under the contract or
+   prove co-advance, and revisit IVM where it is cheap. This can trail in its own
+   PR without holding up the rest.
+
+The commits stand on their own in review — the clock fix is a correctness fix,
+the contract is an abstraction with a test, each migration closes a standing
+issue — while together they tell the single story this ADR names.
+
+## Consequences
+
+- **Positive:** silent-staleness defects become **contract violations the
+  conformance test catches**, not production incidents; the false-FRESH class is
+  eliminated at the root (D1); new derivations inherit correct freshness behavior
+  by implementing one interface; cross-surface snapshot skew becomes a declared,
+  reasoned property (D2) rather than an accident of which clock a subsystem
+  happened to read.
+- **Cost:** touches three subsystems plus a schema-level clock change; **the
+  clock-trustworthiness work (#384) must land first**; the `graph_epoch`-column
+  data migration (counter → committed sequence) must be planned with the existing
+  artifact and catalog-index rows.
+- **Risk accepted:** IVM is deferred — derivations full-recompute on staleness,
+  which is correct but not always cheapest. Acceptable: correctness first, the
+  contract *permits* IVM later without re-litigation.
+- **Risk if not done:** each new materialized derivation adds another parallel
+  freshness hierarchy on an unsound signal — the drift this ADR names compounds.
+
+## Alternatives considered
+
+- **Repair `graph_change_counter` into a monotonic commit-bumped sequence
+  (decision-space A.2).** Rejected: ADR-203 already established the checksum is
+  the wrong primitive, and a *second* monotonic sequence alongside the epoch log
+  would be a redundant clock. The epoch `event_id` is already the monotonic
+  sequence we need.
+- **Reconcile the two existing clocks and prove co-advance (A.3).** Rejected as
+  the *primary* signal: it preserves two clocks and therefore the snapshot-skew
+  hazard, and proves a property the system would have to keep re-proving on every
+  schema change. Co-advance is retained only as the *follow-up fallback* for the
+  in-memory accel layer, where the generation counter is extension-internal.
+- **Per-surface freshness with no shared contract (status quo).** Rejected: it
+  is precisely the parallel-hierarchy drift this ADR exists to stop — the same
+  anti-pattern ADR-802 collapsed for providers.
+- **Immediate (in-transaction) maintenance instead of deferred/on-read.**
+  Rejected for the initial contract: it couples every graph mutation to the cost
+  of refreshing all derivations and does not fit the artifact/Garage tier at all.
+  Deferred on-read matches the catalog facade's proven model.
+
+## Implementing / related issues
+
+- **#384** — `graph_epochs.status` (committed vs failed): foundation for the
+  trustworthy clock (D1).
+- **#422** — grounding-cache unbounded warm-path staleness: the on-read
+  detection defect the contract forbids (D2).
+- **#233** — artifact lifecycle exposure + storage-tier transparency: the
+  reconcile-surface gap the uniform interface subsumes (D3).
+- Catalog facade (migration 073) — prior art / reference implementation.
+
+## References
+
+External grounding (problem-naming, not prescriptions):
+
+- Incremental View Maintenance — PostgreSQL wiki:
+  https://wiki.postgresql.org/wiki/Incremental_View_Maintenance
+- "Everything You Need to Know About Incremental View Maintenance":
+  https://materializedview.io/p/everything-to-know-incremental-view-maintenance
+- "Probabilistically Bounded Staleness for Practical Partial Quorums" (PBS):
+  https://arxiv.org/pdf/1204.6082
+- Cache coherence (overview): https://en.wikipedia.org/wiki/Cache_coherence

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -177,71 +177,98 @@ derivation, resolved against **one canonical logical clock**, with the catalog
 facade's deferred / on-read / serve-stale-under-lock behavior as the reference
 shape. Three concrete decisions:
 
-### D1 — The canonical clock is one universal monotonic tick, with an eventual-consistency guarantee
+### D1 — The canonical clock is the epoch event sequence: one monotonic tick for all graph actions
 
-The freshness clock is **one universal monotonic tick** that advances on every
-graph action. Sub-counters may exist for specialized cache scopes, but there is
-exactly one universal tick above them, and it is what every derivation stamps
-against.
+The freshness clock is **`kg_api.graph_epochs.event_id`** — a `BIGSERIAL`,
+monotonic, one row per graph mutation event. This *is* the "one universal tick
+for all graph actions": every action that records an epoch event advances it.
+Derivations resolve freshness against it via `kg_api.get_committed_epoch()`,
+which reads it through a **committed-prefix watermark** so in-flight and
+out-of-order jobs cannot expose a half-applied state (see D1a). Sub-counters
+exist for narrower scopes, but this one sequence is above them all.
 
-**Why it is application-level, not a trigger.** The obvious implementation — a
-PostgreSQL trigger that bumps a sequence on every write — does not work here, and
-migration 033 already documents why: *Apache AGE's Cypher operations bypass
-PostgreSQL's trigger mechanism entirely* (AGE manipulates label tables via
-internal C functions that do not fire row-level triggers). That is the original
-reason `graph_change_counter` is a recomputed `COUNT(*)` checksum rather than a
-trigger counter — and the reason it is non-injective (ADR-203: delete one + add
-one leaves the sum unchanged). The universal tick therefore lives where it can
-actually see every mutation: the application choke point `refresh_epoch()` /
-`refresh_graph_metrics()`, which already declares the rule "every mutation path
-must call this, regardless of caller." The tick is a monotonic
-application-incremented counter (migration 033's "category B" pattern, already
-proven to survive AGE).
+**Why an event-recorded sequence, not a trigger counter.** A PostgreSQL trigger
+that bumps a sequence on every write would be the obvious choice, but it does not
+work here, and migration 033 documents why: *Apache AGE's Cypher operations
+bypass PostgreSQL's trigger mechanism entirely* (AGE manipulates label tables via
+internal C functions that fire no row-level triggers). That is also why the
+legacy `graph_change_counter` is a recomputed `COUNT(*)` checksum — and why it is
+non-injective (ADR-203: delete one + add one leaves the sum unchanged), hence
+unusable as a freshness signal. Since neither a trigger nor a checksum works, the
+tick is advanced where the platform *can* see every mutation: **application code
+records an epoch event when it commits a graph mutation.**
 
-**Eventual consistency, guaranteed — not synchronous.** Because the tick is
-advanced out-of-band from the AGE write (not in the same trigger), there is a
-window where it lags the true graph state. We accept that and guarantee
-*convergence* instead of instantaneous accuracy:
+**This makes #386 a hard prerequisite, and it is the entire convergence story.**
+Today `record_epoch()` is called only by the ingestion worker, so the tick
+advances on ingestion alone — edits and annealing record nothing and are
+invisible to the clock. There is no `COUNT`-checksum backstop that rescues this:
+`refresh_graph_metrics()` recomputes counts but never writes an epoch event, so
+it cannot advance this clock. The *only* mechanism that makes the tick universal
+is **#386 — record an epoch event for every mutation kind**. Until #386 lands, a
+derivation on this clock is correct for ingestion and blind to everything else.
+The honest guarantee is therefore: **freshness converges for every mutation kind
+that records an event; #386 is what extends that set to all of them.**
 
-- The periodic `refresh_graph_metrics()` background sync is the **backstop**: it
-  recomputes the snapshot and bumps the tick on any detected change, so a
-  count-changing mutation advances the tick within one interval **even if a
-  mutation path forgot the explicit call**. No mutation stays invisible forever.
-- **Count-preserving** AGE mutations (annealing edge re-scope, delete+add netting
-  zero) are invisible to a `COUNT` checksum and to triggers alike, so those paths
-  must **signal explicitly** — which is exactly what recording an epoch event for
-  every mutation kind buys (**#386**, now a prerequisite, not a follow-up). An
-  explicit signal bumps the tick directly.
-- This guarantee has interplay with the `graph_accel` pgrx extension, whose own
-  `generation` counter is advanced the same out-of-band way (`graph_accel_invalidate`).
-  It is a **sub-counter** under the universal tick with the same
-  eventual-consistency contract, not a competing clock.
+**Annealing is the concrete gap (and the co-advance fix).** The annealing path
+today calls *neither* `record_epoch()` *nor* `graph_accel_invalidate()` — so it
+is invisible to both this clock and the in-memory accelerator. The fix is a
+single application-side mutation-completion helper that does both on every
+mutating path:
+
+```text
+on graph mutation commit:
+    record_epoch(kind, ...)      # advances the universal tick (event_id)
+    graph_accel.invalidate()     # advances the graph_accel sub-counter + pg_notify
+```
+
+Calling both from one place means `event_id` and `graph_accel.generation`
+**co-advance by construction** — no separate "prove co-advance" obligation. This
+is application wiring (the substance of #386); the `graph_accel` extension needs
+**no change** — its `DESIGN.md` deliberately limits it to writing only its own
+`generation` table, and recording our epoch events there would violate that
+boundary.
 
 **Sub-counters stay subordinate.** `graph_accel.generation`,
 `vocabulary_change_counter`, and `vocabulary_embedding_generation_counter` remain
 for their narrower invalidation scopes (e.g. the polarity-axis tier keys on the
-vocab-embedding counter, which changes far more rarely than the graph). One
-universal tick above them; they do not substitute for it.
+vocab-embedding counter, which changes far more rarely than the graph). The one
+`event_id` tick is above them; they do not substitute for it.
 
 **`graph_change_counter` is demoted, not deleted.** The `COUNT` checksum keeps
-its statistics role and serves as the *change detector* that drives the
-backstop tick-bump, but it is **never** the freshness stamp itself —
+its statistics role and is a legitimate cheap *dirty-hint* (`counter != last`
+reliably means "something changed"), but it is **never** the freshness stamp —
 `counter == stamp` is meaningless (non-injective). Freshness reads the tick.
 
-**Keep both: tick for freshness, epoch log for analytics.** The `graph_epochs`
-event log and its `#384` `status` column remain — they are the richer
-logical-time / lifetime record (ADR-203), and `#386` extends event recording to
-all mutation kinds. They are *not* the freshness clock: the in-flight
-watermark machinery that an earlier draft put on the event log is unnecessary for
-freshness, because the universal tick is advanced *after* commit (each tick value
-is already a committed state, no phantom-in-flight problem). `status` stays for
-its original analytics motive (drop zero-instance failed jobs from hot/stale
-signals). `get_committed_epoch()` (and the contract's `read_committed_epoch`) is
-repointed to read the universal tick.
+**Keep both: the same sequence serves freshness and analytics.** `graph_epochs`
+is read two ways. Freshness reads the committed-prefix watermark over `event_id`
+(D1a). Analytics/lifetime (ADR-203) reads the richer event rows — `kind`,
+`actor`, `occurred_at`, and the `#384` `status`. These are not two clocks that
+can skew; they are two read patterns over one table.
 
-**`graph_epoch` stamp columns are typed `BIGINT`** to match the tick — the
+**`graph_epoch` stamp columns are typed `BIGINT`** to match `event_id` — the
 existing `INTEGER` columns (`artifacts.graph_epoch`, `catalog_node.graph_epoch`)
 and the relevant accessor return types are widened as part of this work.
+
+### D1a — The watermark: reading the tick safely
+
+Epoch rows are inserted at job **start** (ADR-203, so the `event_id` can tag
+nodes created during the run), while a job *commits* at its end, and jobs
+complete **out of order**. So the raw `MAX(event_id)` — or `MAX(event_id WHERE
+status='completed')` — is not a safe cursor: it could expose a later job's id
+while an earlier job is still committing. `get_committed_epoch()` returns the
+**contiguous committed prefix** instead:
+
+```text
+get_committed_epoch() := MIN(event_id WHERE status='in_progress') - 1
+                         if any job is in flight, else MAX(event_id)
+```
+
+Both `completed` and `failed` count toward it; only `in_progress` blocks it —
+because ingestion commits **per-chunk**, so a failed/cancelled job may have
+already committed partial changes, and excluding it would read false-FRESH. The
+`status` column (#384) is what makes this possible; resolving the epoch on every
+exit path (success/cancel/exception) is what keeps a crashed job from freezing
+the watermark behind a phantom in-flight event. (Built and verified in step 1.)
 
 ### D2 — Mandatory maintenance discipline: deferred, on-read, bounded
 
@@ -312,26 +339,26 @@ removes the riskiest piece a freshness-clock change would normally carry — the
 is **no back-fill and no migration machinery** to map old stamps (a different
 number space) onto the new clock, and **no rollback-of-data hazard**. Columns are
 simply defined `BIGINT` from the reset forward; every derivation builds fresh
-against the universal tick on first read. (If the platform ever holds data worth
+against the tick on first read. (If the platform ever holds data worth
 preserving, this execution section must be revisited.)
 
 Given that, this is one body of work, best delivered as a single PR whose commits
 read in order as a coherent narrative. Only one ordering constraint is
-load-bearing: **the universal tick must advance on every mutation kind before any
+load-bearing: **the tick must advance on every mutation kind before any
 derivation reads it** — otherwise a derivation goes blind to the kinds that don't
-yet bump it.
+yet record an event.
 
-1. **Make the clock trustworthy and universal.** Land the epoch `status` column
-   and widen the `graph_epoch` stamp columns to `BIGINT` (**#384**). Introduce
-   the **universal monotonic tick** (D1), advanced in `refresh_graph_metrics()`
-   (the choke point every mutation path already calls) and by the periodic
-   background sync as the eventual-consistency backstop; repoint
-   `get_committed_epoch()` to read it. Re-comment `graph_change_counter` as the
-   demoted change-detector, never a freshness stamp. **Record epoch events — and
-   bump the tick — for every mutation kind, not just ingestion (#386)**: this is
-   a prerequisite, because count-preserving AGE mutations (annealing) are
-   invisible to the checksum backstop and must signal explicitly. Without #386 a
-   derivation on the tick would miss annealing/edit mutations.
+1. **Make the clock trustworthy (built, step 1) and universal (#386).** The
+   `status` column, the committed-prefix `get_committed_epoch()` watermark over
+   `event_id`, `complete_epoch()` wiring, and the `BIGINT` widening are done and
+   verified (**#384**). The remaining, load-bearing piece is **#386 — record an
+   epoch event for every mutation kind, not just ingestion**, via one
+   mutation-completion helper that records the event *and* calls
+   `graph_accel.invalidate()` (so the tick and the `graph_accel` sub-counter
+   co-advance). Its concrete first target is the **annealing path, which today
+   records nothing**. Until #386 lands, derivations on the clock see ingestion
+   only — so it gates step 2's catalog migration in practice even though step 1's
+   plumbing is already in place.
 2. **Establish the contract against the surface that already obeys it.** Define
    the `FreshnessContract` base + the two specializations + registry +
    conformance test, then bring the **catalog facade** on first — it already
@@ -371,24 +398,30 @@ standing issue — while together they tell the single story this ADR names.
 
 ## Alternatives considered
 
-- **The committed-prefix watermark over the epoch event log (an earlier draft of
-  D1).** Rejected on implementation: the epoch event log is recorded only by
-  ingestion, so a watermark over it is blind to edits and annealing — and the
-  in-flight `in_progress`/`completed` watermark machinery only existed to paper
-  over epochs being recorded at job *start*. A tick advanced *after* commit at
-  the universal mutation hook needs none of that. The event log is kept for
-  analytics (D1, "keep both"), not as the freshness clock.
 - **A PostgreSQL trigger bumping a monotonic sequence on every write.** Infeasible
   here: AGE Cypher bypasses row-level triggers (migration 033), which is the whole
-  reason `graph_change_counter` is a recomputed checksum. The universal tick
-  adopts the *monotonic-counter* idea but advances it in application code at the
-  `refresh_graph_metrics()` choke point, accepting eventual consistency with a
-  periodic backstop (D1).
-- **A second, fully-synchronous clock reconciled with `graph_accel.generation`.**
-  Rejected as primary: synchronous accuracy is unattainable against AGE's
-  trigger-bypass, and maintaining two co-equal clocks reintroduces snapshot skew.
-  `graph_accel.generation` is instead a declared *sub-counter* under the one
-  universal tick.
+  reason `graph_change_counter` is a recomputed checksum. The clock instead
+  advances by application code recording an epoch event on each mutation — the
+  only layer that reliably sees AGE mutations.
+- **A standalone monotonic counter advanced in `refresh_graph_metrics()`** (a
+  draft of this ADR proposed exactly this). Rejected because it does not actually
+  work: `refresh_graph_metrics()` recomputes a `COUNT(*)` checksum, which is
+  non-injective (misses count-preserving annealing) and so cannot be a sound
+  monotonic tick; and it would be a *second* clock alongside `event_id`. The
+  `graph_epochs.event_id` sequence already *is* the monotonic tick we need — once
+  #386 records an event for every mutation kind. No separate counter buys
+  anything.
+- **Use `graph_accel.generation` as the canonical clock.** It is monotonic and
+  already advances on some mutations, so it is a genuine contender. Rejected as
+  *primary* because: it is internal to the pgrx extension (whose `DESIGN.md`
+  scopes it to in-memory acceleration), it falls back to a vocab-only counter when
+  the extension isn't loaded on a connection, and — like `event_id` today — it is
+  not advanced by the annealing path either. It earns its place as a **sub-counter
+  that co-advances with `event_id`** (both bumped by the one mutation-completion
+  helper), not as the system clock.
+- **Two co-equal, fully-synchronous clocks.** Rejected: synchronous accuracy is
+  unattainable against AGE's trigger-bypass, and two co-equal clocks reintroduce
+  snapshot skew.
 - **Per-surface freshness with no shared contract (status quo).** Rejected: it
   is precisely the parallel-hierarchy drift this ADR exists to stop — the same
   anti-pattern ADR-802 collapsed for providers.

--- a/docs/reference/FRESHNESS-ARCHITECTURE.md
+++ b/docs/reference/FRESHNESS-ARCHITECTURE.md
@@ -1,0 +1,175 @@
+# Freshness Architecture
+
+How the platform keeps its **derived data** consistent with the graph it is
+derived from — the catalog index, the grounding/polarity caches, and saved
+artifacts. This is the "what and how" explainer; the decision record and its
+rationale live in **ADR-207** (`docs/architecture/database-schema/`).
+
+> **TL;DR.** There is **one universal monotonic tick** that advances on every
+> graph mutation. Anything the platform computes *from* the graph stamps itself
+> with the tick value it was built at, and re-checks that stamp against the
+> current tick before it is trusted. The tick is maintained in application code
+> (Apache AGE bypasses database triggers), so it is **eventually consistent** —
+> it always converges, it is not transactionally instantaneous.
+
+## The problem: derived data drifts
+
+Several read surfaces are not primary state — they are **caches of a graph
+computation**:
+
+| Derivation | What it is | Where it lives |
+|---|---|---|
+| Catalog index | the ontology → document → concept browse tree | `kg_api.catalog_node` / `catalog_edge` |
+| Grounding cache (per-concept) | each concept's grounding strength | in-memory, per API process |
+| Grounding cache (polarity axis) | the shared polarity axis | in-memory, per API process |
+| Artifacts | saved analyses / projections / results | PostgreSQL inline + Garage S3 |
+
+Each is correct only as long as the graph it was computed from hasn't changed.
+When the graph mutates and a derivation doesn't notice, it silently serves stale
+data. Historically each derivation answered "am I stale?" its own way, against
+different signals — some of them unsound. ADR-207 unifies that.
+
+## The universal tick
+
+> **One monotonic counter for every possible graph action. Sub-counters may
+> exist for narrower scopes, but there is exactly one universal tick above them.**
+
+Every derivation resolves freshness against this one signal — exposed as
+`kg_api.get_committed_epoch()` and, in Python, the single helper
+`api/app/lib/freshness.py:read_committed_epoch()`. A derivation is **fresh** when
+the tick it was built at still equals the current tick (within its declared
+[staleness budget](#staleness-budgets)).
+
+### Why it lives in application code, not a trigger
+
+The natural implementation would be a PostgreSQL trigger that bumps a sequence on
+every write. **That does not work here, and it is the central constraint of this
+whole design:** Apache AGE's Cypher operations manipulate the underlying label
+tables through internal C functions that **bypass PostgreSQL's row-level trigger
+mechanism entirely** (documented in migration 033). A trigger never fires for an
+AGE mutation.
+
+That is also why the legacy `graph_change_counter` is a recomputed `COUNT(*)`
+checksum rather than a trigger counter — and why it is unsound as a freshness
+signal: deleting one object and adding another leaves the sum unchanged, so two
+different graph states can share a counter value (a derivation can read
+*false-fresh*).
+
+So the universal tick is advanced where the platform *can* see every mutation:
+the application choke point `AGEClient.refresh_epoch()` →
+`refresh_graph_metrics()`, which every mutation path is required to call,
+"regardless of whether the caller is FUSE, CLI, curl, or the web UI."
+
+### Eventual consistency — guaranteed convergence, not instant accuracy
+
+Because the tick is advanced *out of band* from the AGE write (not inside the
+same transaction), there is a brief window where it can lag the true graph state.
+We accept that and guarantee **convergence** instead:
+
+- **Periodic backstop.** The background `refresh_graph_metrics()` sync recomputes
+  the snapshot and advances the tick on any detected change. So a count-changing
+  mutation advances the tick within one interval *even if a mutation path forgot
+  to signal it*. No mutation stays invisible forever.
+- **Explicit signals for count-preserving mutations.** Some AGE mutations don't
+  change object counts — annealing re-scopes an edge, a delete-plus-add nets to
+  zero. A checksum can't see these (and neither could a trigger). Those paths
+  **record an epoch event for their mutation kind**, which bumps the tick
+  directly. (This is why recording epoch events for *all* mutation kinds — not
+  just ingestion — is a prerequisite, tracked as #386.)
+
+The practical contract for anyone writing graph-mutating code:
+
+> **If you mutate the graph, call `refresh_epoch()` (or record an epoch event)
+> when you're done.** Forgetting it doesn't corrupt anything — the periodic
+> backstop will catch any count change — but it delays freshness until the next
+> sync, and count-preserving changes won't be seen at all until you signal them.
+
+### Sub-counters
+
+Specialized invalidation scopes keep their own counters, **subordinate** to the
+universal tick:
+
+- `graph_accel.generation` — the `graph_accel` pgrx extension's own generation,
+  advanced the same out-of-band way (`graph_accel_invalidate`). Same
+  eventual-consistency nature; a sub-counter, not a competing clock.
+- `vocabulary_change_counter` — vocabulary membership changes.
+- `vocabulary_embedding_generation_counter` — vocabulary *embedding* regeneration
+  (the polarity-axis cache keys on this; it changes far more rarely than the
+  graph, so scoping it separately avoids needless axis recompute).
+
+## The freshness contract
+
+`api/app/lib/freshness.py` is where the four freshness questions — *built at what
+version? / current version? / am I stale? / what do I do about it?* — are
+answered once instead of per surface. Derivations come in two shapes (they are
+genuinely different, so one interface would be a leaky fit):
+
+```text
+FreshnessContract                      shared: current_version() + staleness budget
+├── CollectionDerivation               one stamp for the whole derivation
+│     version_stamp() / is_fresh() / reconcile()     rebuild or invalidate the lot
+│     e.g. catalog index, each grounding cache tier
+└── InstanceDerivation                 per-row: each item has its own stamp
+      version_stamp(id) / is_fresh(id) / reconcile(id)   regenerate one item
+      e.g. artifacts
+```
+
+- **`current_version()`** always delegates to `read_committed_epoch()` — the one
+  place the canonical-clock SQL lives, so no derivation can drift onto a
+  different signal.
+- **`is_fresh()`** is deferred and **on-read**: it re-reads the current tick every
+  call. It must never short-circuit on a cached value without re-checking — that
+  was the unbounded-staleness bug (#422).
+- **`reconcile()`** brings the derivation back to current (rebuild / invalidate /
+  regenerate), and is a no-op when already fresh.
+
+Derivations **register** themselves (`@register_derivation`). Registration backs
+two things: a **conformance test** (a new derivation that forgets the contract
+fails CI, not production) and a uniform operator surface to list derivations,
+show freshness, and trigger reconcile.
+
+### Staleness budgets
+
+A derivation declares how stale it may serve. The default is **strict** — it must
+reflect the current tick. A derivation opts into tolerance explicitly (e.g. "may
+be up to N versions behind"), making "fresh enough" a declared property rather
+than emergent behavior.
+
+## Adding a new materialized derivation
+
+1. Subclass `CollectionDerivation` (whole-thing stamp) or `InstanceDerivation`
+   (per-row stamp).
+2. Implement `current_version()` via `read_committed_epoch()`, `version_stamp()`,
+   and `reconcile()`. Inherit `is_fresh()`.
+3. Declare a `name` and a `budget` (default strict).
+4. Decorate with `@register_derivation`.
+5. The conformance test (`tests/unit/lib/test_freshness_contract.py`) will hold
+   you to the contract.
+
+The catalog facade (`api/app/lib/catalog_facade.py`) is the **reference
+implementation** — its deferred / on-read / serve-stale-under-lock rebuild is the
+shape to copy.
+
+## Reference implementation: the catalog index
+
+The catalog index is the clearest worked example:
+
+- **Stamp:** each `catalog_node` row stores the tick value (`graph_epoch`) the
+  index was built at.
+- **Compare/detect:** `ensure_fresh()` reads the current tick and the index's
+  stamp on every browse.
+- **Reconcile:** if the index lags, it rebuilds under a transaction-scoped
+  advisory lock — one worker rebuilds, others serve the slightly-stale snapshot
+  rather than blocking, and the single commit both publishes the new index and
+  releases the lock.
+
+## See also
+
+- **ADR-207** — the decision record and rationale (canonical clock, contract
+  shapes, alternatives considered).
+- **ADR-203** — the graph epoch event log (logical-time / lifetime analytics; the
+  "keep both" companion to the freshness tick).
+- **ADR-079 / migration 033** — `graph_change_counter` and the AGE-bypasses-
+  triggers constraint that shapes everything here.
+- [STORAGE-ARCHITECTURE.md](STORAGE-ARCHITECTURE.md) — the PostgreSQL + Garage +
+  AGE tiers the derivations live in.

--- a/docs/reference/FRESHNESS-ARCHITECTURE.md
+++ b/docs/reference/FRESHNESS-ARCHITECTURE.md
@@ -5,12 +5,15 @@ derived from — the catalog index, the grounding/polarity caches, and saved
 artifacts. This is the "what and how" explainer; the decision record and its
 rationale live in **ADR-207** (`docs/architecture/database-schema/`).
 
-> **TL;DR.** There is **one universal monotonic tick** that advances on every
-> graph mutation. Anything the platform computes *from* the graph stamps itself
-> with the tick value it was built at, and re-checks that stamp against the
-> current tick before it is trusted. The tick is maintained in application code
-> (Apache AGE bypasses database triggers), so it is **eventually consistent** —
-> it always converges, it is not transactionally instantaneous.
+> **TL;DR.** There is **one universal monotonic tick** for all graph actions —
+> the `graph_epochs.event_id` sequence. Anything the platform computes *from* the
+> graph stamps itself with the tick value it was built at, and re-checks that
+> stamp against the current tick before it is trusted. The tick advances when
+> application code **records an epoch event** for a mutation (Apache AGE bypasses
+> database triggers, so a trigger-driven counter is impossible). It is **eventually
+> consistent**: freshness converges for every mutation *kind that records an
+> event*. Today that is ingestion; extending it to edits and annealing is the work
+> tracked as #386.
 
 ## The problem: derived data drifts
 
@@ -31,14 +34,19 @@ different signals — some of them unsound. ADR-207 unifies that.
 
 ## The universal tick
 
-> **One monotonic counter for every possible graph action. Sub-counters may
-> exist for narrower scopes, but there is exactly one universal tick above them.**
+> **One monotonic counter for every possible graph action — the
+> `kg_api.graph_epochs.event_id` sequence. Sub-counters may exist for narrower
+> scopes, but there is exactly one universal tick above them.**
 
-Every derivation resolves freshness against this one signal — exposed as
-`kg_api.get_committed_epoch()` and, in Python, the single helper
-`api/app/lib/freshness.py:read_committed_epoch()`. A derivation is **fresh** when
-the tick it was built at still equals the current tick (within its declared
-[staleness budget](#staleness-budgets)).
+`event_id` is a `BIGSERIAL`: one row per graph mutation event, monotonically
+increasing. That sequence *is* the universal tick — every action that records an
+event advances it. Every derivation resolves freshness against it through
+`kg_api.get_committed_epoch()` (in Python, the single helper
+`api/app/lib/freshness.py:read_committed_epoch()`), which reads the sequence via a
+[committed-prefix watermark](#reading-the-tick-safely-the-watermark) so an
+in-flight or out-of-order job can't expose a half-applied state. A derivation is
+**fresh** when the tick it was built at still equals the current tick (within its
+declared [staleness budget](#staleness-budgets)).
 
 ### Why it lives in application code, not a trigger
 
@@ -55,34 +63,69 @@ signal: deleting one object and adding another leaves the sum unchanged, so two
 different graph states can share a counter value (a derivation can read
 *false-fresh*).
 
-So the universal tick is advanced where the platform *can* see every mutation:
-the application choke point `AGEClient.refresh_epoch()` →
-`refresh_graph_metrics()`, which every mutation path is required to call,
-"regardless of whether the caller is FUSE, CLI, curl, or the web UI."
+So the tick is advanced where the platform *can* see every mutation: **application
+code records an epoch event when it commits a graph mutation.** `event_id` is the
+one signal that fires for the exact set of mutations the application chooses to
+announce — which is why making that set *complete* is the whole game (see below).
 
-### Eventual consistency — guaranteed convergence, not instant accuracy
+### Eventual consistency — convergence per recorded event-kind
 
-Because the tick is advanced *out of band* from the AGE write (not inside the
-same transaction), there is a brief window where it can lag the true graph state.
-We accept that and guarantee **convergence** instead:
+Because the event is recorded *out of band* from the AGE write (not inside one
+trigger), there is a brief window where the tick can lag the true graph state. We
+accept that and guarantee **convergence** — but be precise about its scope:
 
-- **Periodic backstop.** The background `refresh_graph_metrics()` sync recomputes
-  the snapshot and advances the tick on any detected change. So a count-changing
-  mutation advances the tick within one interval *even if a mutation path forgot
-  to signal it*. No mutation stays invisible forever.
-- **Explicit signals for count-preserving mutations.** Some AGE mutations don't
-  change object counts — annealing re-scopes an edge, a delete-plus-add nets to
-  zero. A checksum can't see these (and neither could a trigger). Those paths
-  **record an epoch event for their mutation kind**, which bumps the tick
-  directly. (This is why recording epoch events for *all* mutation kinds — not
-  just ingestion — is a prerequisite, tracked as #386.)
+> **Freshness converges for every mutation *kind* that records an epoch event.
+> It is blind to kinds that record none.**
 
-The practical contract for anyone writing graph-mutating code:
+Today only the **ingestion** path records events, so the clock is correct for
+ingestion and blind to edits and annealing. There is **no `COUNT`-checksum
+backstop** that rescues this: `refresh_graph_metrics()` recomputes object counts
+for statistics, but it never writes an epoch event, so it cannot advance this
+clock. The only thing that makes the tick universal is **#386 — record an event
+for every mutation kind.**
 
-> **If you mutate the graph, call `refresh_epoch()` (or record an epoch event)
-> when you're done.** Forgetting it doesn't corrupt anything — the periodic
-> backstop will catch any count change — but it delays freshness until the next
-> sync, and count-preserving changes won't be seen at all until you signal them.
+The concrete gap #386 closes: the **annealing path today records nothing** — it
+calls neither `record_epoch()` nor `graph_accel_invalidate()`, so after annealing
+re-scopes the graph, *both* the freshness clock and the in-memory accelerator are
+silently stale. The fix is a single mutation-completion helper that every
+mutating path calls:
+
+```text
+on graph mutation commit:
+    record_epoch(kind, ...)      # advances the universal tick (event_id)
+    graph_accel.invalidate()     # advances the graph_accel sub-counter + pg_notify
+```
+
+Recording both from one place means `event_id` and `graph_accel.generation`
+**co-advance by construction**. The practical contract for anyone writing
+graph-mutating code:
+
+> **If you mutate the graph, record an epoch event (via the mutation-completion
+> helper) when you commit.** A path that forgets doesn't corrupt anything, but its
+> mutations are *invisible to freshness* — derivations will serve stale data for
+> that kind until someone wires it in. There is no background sweep that covers
+> for you.
+
+### Reading the tick safely (the watermark)
+
+`get_committed_epoch()` does not return the raw `MAX(event_id)`. Epoch rows are
+inserted at a job's **start** (so the `event_id` can tag the nodes it creates),
+the job commits at its **end**, and jobs finish **out of order** — a long
+ingestion at id 6 can still be running when a short one at id 7 commits. So the
+clock returns the **contiguous committed prefix**:
+
+```text
+get_committed_epoch() := MIN(event_id WHERE status='in_progress') - 1
+                         if any job is in flight, else MAX(event_id)
+```
+
+An in-flight job at id N holds the clock at N-1, so derivations correctly read
+stale until it lands. Both `completed` and `failed` events count (only
+`in_progress` blocks) because ingestion commits **per-chunk** — a failed job may
+have committed partial changes, and ignoring it would read false-fresh. The
+`status` column makes this work, and a job must resolve its event on **every**
+exit (success/cancel/exception) or it would freeze the clock behind a phantom
+in-flight event.
 
 ### Sub-counters
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -90,6 +90,7 @@ reference/
 ├── OPERATOR_ARCHITECTURE.md        (install.sh + operator.sh + kg-operator)
 ├── RECURSIVE_UPSERT_ARCHITECTURE.md (concept matching pattern)
 ├── STORAGE-ARCHITECTURE.md         (PostgreSQL + Garage + AGE tiers)
+├── FRESHNESS-ARCHITECTURE.md       (derived-data freshness: the universal tick)
 ├── openapi.json                    (exported FastAPI schema)
 ├── cli/
 │   ├── README.md                   (CLI index)

--- a/schema/migrations/076_freshness_clock.sql
+++ b/schema/migrations/076_freshness_clock.sql
@@ -1,0 +1,160 @@
+-- Migration 076: Trustworthy freshness clock (ADR-207, #384)
+--
+-- ADR-207 makes the ADR-203 epoch event log the canonical version signal for
+-- every materialized graph derivation (catalog index, grounding cache tiers,
+-- artifacts). Two things are needed before any derivation can stamp against it:
+--
+--   1. Epoch events must distinguish committed mutations from in-flight and
+--      failed ones (#384). record_graph_epoch() inserts a row at job *start*,
+--      so a bare event_id reflects an *attempt*, not a commit.
+--
+--   2. The freshness signal must be a contiguous committed prefix, NOT
+--      MAX(event_id WHERE completed). Epochs complete OUT OF ORDER (a long
+--      ingestion at id 6 may finish after a short one at id 7), so MAX-of-
+--      completed would skip event 6's eventual commit and read false-FRESH.
+--      The watermark is the highest N such that NO event <= N is still
+--      in flight.
+--
+-- This migration also widens the derivation stamp columns to BIGINT (the event
+-- sequence is BIGINT) and re-documents graph_change_counter (ADR-079) as a
+-- one-directional dirty-hint only — sound for proving "changed", never trusted
+-- to prove "fresh" (it is a non-injective count checksum; see ADR-203).
+--
+-- No data back-fill of existing stamps is performed: per ADR-207's clean-
+-- rebuild assumption the platform carries no data to preserve. The status
+-- back-fill below only matters for environments that already hold epoch rows,
+-- where pre-existing rows are by definition historical/committed.
+
+-- ---------------------------------------------------------------------------
+-- 1. Epoch event status (#384): in_progress (default) | completed | failed
+-- ---------------------------------------------------------------------------
+ALTER TABLE kg_api.graph_epochs
+    ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'in_progress'
+    CHECK (status IN ('in_progress', 'completed', 'failed'));
+
+-- Pre-existing rows predate this column and represent completed historical
+-- mutations — mark them committed so they never block the watermark.
+UPDATE kg_api.graph_epochs
+   SET status = 'completed'
+ WHERE status = 'in_progress'
+   AND occurred_at < NOW();
+
+COMMENT ON COLUMN kg_api.graph_epochs.status IS
+    'ADR-207/#384: in_progress (set at record_graph_epoch) | completed | failed. '
+    'Only in_progress blocks the committed watermark — both completed and failed '
+    'count toward it (per-chunk commits mean a failed job may have mutated the '
+    'graph). The completed/failed split is for analytics (drop zero-instance '
+    'jobs from hot/stale signals), not for freshness.';
+
+-- The watermark query probes the lowest still-in-flight event; a partial index
+-- keeps that O(1)-ish regardless of how many committed rows accumulate.
+CREATE INDEX IF NOT EXISTS idx_graph_epochs_in_flight
+    ON kg_api.graph_epochs (event_id)
+    WHERE status = 'in_progress';
+
+-- ---------------------------------------------------------------------------
+-- 2. Mark an epoch resolved (completed or failed)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION kg_api.complete_graph_epoch(
+    p_event_id BIGINT,
+    p_status   TEXT DEFAULT 'completed'
+) RETURNS VOID AS $$
+BEGIN
+    IF p_status NOT IN ('completed', 'failed') THEN
+        RAISE EXCEPTION 'complete_graph_epoch: status must be completed or failed, got %', p_status;
+    END IF;
+
+    UPDATE kg_api.graph_epochs
+       SET status = p_status
+     WHERE event_id = p_event_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION kg_api.complete_graph_epoch IS
+    'ADR-207/#384: resolve an epoch event recorded by record_graph_epoch(). '
+    'Call with completed when the mutation transaction commits, failed when it '
+    'aborts/rolls back. Until called, the event is in_progress and holds the '
+    'committed watermark below its event_id.';
+
+-- ---------------------------------------------------------------------------
+-- 3. The canonical clock: contiguous committed-prefix watermark
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION kg_api.get_committed_epoch()
+RETURNS BIGINT AS $$
+DECLARE
+    v_first_in_flight BIGINT;
+    v_max             BIGINT;
+BEGIN
+    -- Lowest event still in flight: every event below it is RESOLVED (whether
+    -- it committed or failed), and no event above it may be exposed yet (the
+    -- in-flight one is logically earlier and may still be committing).
+    SELECT MIN(event_id) INTO v_first_in_flight
+      FROM kg_api.graph_epochs
+     WHERE status = 'in_progress';
+
+    IF v_first_in_flight IS NOT NULL THEN
+        RETURN v_first_in_flight - 1;
+    END IF;
+
+    -- Nothing in flight: the watermark is the highest event id recorded,
+    -- counting BOTH completed and failed events. Failed events count on
+    -- purpose: ingestion commits per-chunk, so a job that aborted or was
+    -- cancelled mid-run may have already committed partial graph changes.
+    -- Excluding it (MAX WHERE completed) would hide those commits and read
+    -- false-FRESH. A cleanly-rolled-back failed event that committed nothing
+    -- costs at most one benign no-op rebuild — the safe direction to err.
+    -- The completed/failed distinction is for analytics (#384: drop zero-
+    -- instance jobs from hot/stale signals), NOT for this watermark.
+    -- Monotonic: event_id is BIGSERIAL, so a new in-flight event always has a
+    -- higher id than the resolved prefix and the watermark never regresses.
+    SELECT MAX(event_id) INTO v_max FROM kg_api.graph_epochs;
+    RETURN COALESCE(v_max, 0);
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION kg_api.get_committed_epoch IS
+    'ADR-207: canonical freshness clock. Committed-prefix watermark: '
+    'MIN(in_flight)-1 if any job is in flight, else MAX(event_id) over all '
+    'resolved events (completed AND failed both count — per-chunk commits mean '
+    'a failed job may have mutated the graph). Monotonic high-water signal: a '
+    'derivation whose stamp < this value is provably stale. Out-of-order '
+    'completion safe.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Widen derivation stamp columns INTEGER -> BIGINT (match the event seq)
+-- ---------------------------------------------------------------------------
+ALTER TABLE kg_api.artifacts    ALTER COLUMN graph_epoch TYPE BIGINT;
+ALTER TABLE kg_api.catalog_node ALTER COLUMN graph_epoch TYPE BIGINT;
+ALTER TABLE kg_api.catalog_edge ALTER COLUMN graph_epoch TYPE BIGINT;
+
+-- ---------------------------------------------------------------------------
+-- 5. Demote graph_change_counter to a one-directional dirty-hint
+-- ---------------------------------------------------------------------------
+-- get_graph_epoch() still returns the count checksum, but ADR-207 forbids
+-- trusting it for freshness. Widen its return type to BIGINT for consistency
+-- with the clock (DROP first: PostgreSQL will not change a return type in
+-- place via CREATE OR REPLACE).
+DROP FUNCTION IF EXISTS kg_api.get_graph_epoch();
+CREATE OR REPLACE FUNCTION kg_api.get_graph_epoch()
+RETURNS BIGINT AS $$
+DECLARE
+    v_epoch BIGINT;
+BEGIN
+    SELECT counter INTO v_epoch
+    FROM public.graph_metrics
+    WHERE metric_name = 'graph_change_counter';
+
+    RETURN COALESCE(v_epoch, 0);
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION kg_api.get_graph_epoch IS
+    'ADR-079 graph_change_counter (composite count checksum). ADR-207: a '
+    'ONE-DIRECTIONAL DIRTY HINT ONLY — counter != stamp reliably proves the '
+    'graph changed, but counter == stamp does NOT prove freshness (the checksum '
+    'is non-injective; ADR-203). Use kg_api.get_committed_epoch() for any '
+    'freshness/staleness decision. Do not reintroduce this as a freshness signal.';
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (76, 'freshness_clock')
+ON CONFLICT (version) DO NOTHING;

--- a/tests/unit/lib/test_batch_chunk_recovery.py
+++ b/tests/unit/lib/test_batch_chunk_recovery.py
@@ -64,6 +64,12 @@ class FakeCursor:
             self._next_rows = []
             return
 
+        # ADR-207 canonical freshness clock (committed-epoch tick). The cache
+        # keys on this now; the test asserts entries at generation 1.
+        if "get_committed_epoch" in sql:
+            self._next_rows = [{"get_committed_epoch": 1}]
+            return
+
         # Tier-1 graph generation probe (graph_accel.generation)
         if "graph_accel.generation" in sql:
             self._next_rows = [{"current_generation": 1}]

--- a/tests/unit/lib/test_freshness_contract.py
+++ b/tests/unit/lib/test_freshness_contract.py
@@ -23,8 +23,14 @@ from api.app.lib.freshness import (
     registered_derivations,
 )
 
-# Importing this registers CatalogFacade as the reference CollectionDerivation.
+# Importing these registers the shipped derivations (the @register_derivation
+# decorator runs on import), so the registry reflects what actually ships.
 from api.app.lib.catalog_facade import CatalogFacade
+from api.app.lib.age_client.grounding import (
+    GroundingCacheDerivation,
+    PolarityAxisDerivation,
+)
+from api.app.services.confidence_analyzer import ConfidenceCacheDerivation
 
 
 # --------------------------------------------------------------------- registry
@@ -32,6 +38,18 @@ from api.app.lib.catalog_facade import CatalogFacade
 def test_registry_includes_the_catalog_reference_implementation():
     """CatalogFacade registers itself as the reference derivation."""
     assert CatalogFacade in registered_derivations()
+
+
+def test_registry_includes_both_grounding_tiers_separately():
+    """The grounding cluster registers as two derivations on two clocks (D3)."""
+    registered = registered_derivations()
+    assert GroundingCacheDerivation in registered
+    assert PolarityAxisDerivation in registered
+
+
+def test_registry_includes_the_confidence_cache():
+    """The confidence cache registers as its own derivation."""
+    assert ConfidenceCacheDerivation in registered_derivations()
 
 
 def test_every_registered_derivation_conforms():

--- a/tests/unit/lib/test_freshness_contract.py
+++ b/tests/unit/lib/test_freshness_contract.py
@@ -1,0 +1,154 @@
+"""
+Conformance tests for the ADR-207 materialized-derivation freshness contract.
+
+These pin the contract itself (no DB): every registered derivation implements a
+contract shape and declares a budget; the shared clock helper resolves against
+the committed-epoch watermark and never the graph_change_counter; and the
+default on-read detection honors the staleness budget (the #422-forbidding
+behavior). Importing the derivation modules is what triggers their
+@register_derivation, so the registry reflects what actually ships.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.app.lib.freshness import (
+    Budget,
+    CollectionDerivation,
+    FreshnessContract,
+    InstanceDerivation,
+    read_committed_epoch,
+    register_derivation,
+    registered_derivations,
+)
+
+# Importing this registers CatalogFacade as the reference CollectionDerivation.
+from api.app.lib.catalog_facade import CatalogFacade
+
+
+# --------------------------------------------------------------------- registry
+
+def test_registry_includes_the_catalog_reference_implementation():
+    """CatalogFacade registers itself as the reference derivation."""
+    assert CatalogFacade in registered_derivations()
+
+
+def test_every_registered_derivation_conforms():
+    """Each registered derivation is one of the two contract shapes and declares
+    a non-empty registry name plus a Budget. This is the CI gate: a new
+    derivation that forgets the contract fails here, not in production."""
+    derivations = registered_derivations()
+    assert derivations, "no derivations registered — import wiring is broken"
+    for cls in derivations:
+        assert issubclass(cls, (CollectionDerivation, InstanceDerivation)), (
+            f"{cls.__name__} must implement a contract shape"
+        )
+        assert isinstance(cls.name, str) and cls.name, (
+            f"{cls.__name__} must declare a non-empty registry name"
+        )
+        assert isinstance(cls.budget, Budget), (
+            f"{cls.__name__} must declare a Budget"
+        )
+
+
+# ----------------------------------------------------------------- canonical clock
+
+def test_read_committed_epoch_uses_the_watermark_not_the_counter():
+    """The one sanctioned freshness signal is get_committed_epoch(); the
+    non-injective graph_change_counter must never back a freshness decision."""
+    cur = MagicMock()
+    cur.fetchone.return_value = (5,)
+
+    result = read_committed_epoch(cur)
+
+    assert result == 5
+    sql = cur.execute.call_args[0][0]
+    assert "get_committed_epoch" in sql
+    assert "get_graph_epoch" not in sql
+
+
+def test_read_committed_epoch_handles_dict_and_empty_rows():
+    """Works for RealDictCursor (dict) and degrades to 0 on no row / null."""
+    dict_cur = MagicMock()
+    dict_cur.fetchone.return_value = {"get_committed_epoch": 7}
+    assert read_committed_epoch(dict_cur) == 7
+
+    empty_cur = MagicMock()
+    empty_cur.fetchone.return_value = None
+    assert read_committed_epoch(empty_cur) == 0
+
+
+# ------------------------------------------------------------------------- budget
+
+def test_budget_strict_is_exact_match():
+    b = Budget.strict()
+    assert b.versions == 0
+    assert b.tolerates(stamp=5, current=5) is True
+    assert b.tolerates(stamp=4, current=5) is False
+
+
+def test_budget_tolerant_permits_lag_within_bound():
+    b = Budget(versions=2)
+    assert b.tolerates(stamp=3, current=5) is True   # 2 behind, within budget
+    assert b.tolerates(stamp=2, current=5) is False  # 3 behind, exceeds budget
+
+
+# --------------------------------------------------- default on-read detection
+
+class _StubCollection(CollectionDerivation):
+    """Minimal CollectionDerivation to exercise the inherited is_fresh()."""
+
+    name = "stub_collection"
+
+    def __init__(self, stamp, current, budget=Budget.strict()):
+        self._stamp = stamp
+        self._current = current
+        self.budget = budget
+
+    def version_stamp(self):
+        return self._stamp
+
+    def current_version(self):
+        return self._current
+
+    def reconcile(self):  # pragma: no cover - not exercised here
+        pass
+
+
+def test_is_fresh_true_only_when_within_budget():
+    assert _StubCollection(stamp=5, current=5).is_fresh() is True
+    assert _StubCollection(stamp=4, current=5).is_fresh() is False
+    assert _StubCollection(stamp=3, current=5, budget=Budget(versions=2)).is_fresh() is True
+
+
+def test_is_fresh_treats_never_built_as_stale():
+    """A None stamp (never built) is stale — forces an initial build."""
+    assert _StubCollection(stamp=None, current=5).is_fresh() is False
+
+
+def test_is_fresh_reads_current_version_every_call():
+    """Deferred on-read detection must re-read current_version each call — no
+    warm-path short-circuit that skips the compare (the #422 defect)."""
+    d = _StubCollection(stamp=5, current=5)
+    d.current_version = MagicMock(return_value=5)
+    d.is_fresh()
+    d.is_fresh()
+    assert d.current_version.call_count == 2
+
+
+# --------------------------------------------------------------- contract typing
+
+def test_contract_shapes_share_the_base():
+    assert issubclass(CollectionDerivation, FreshnessContract)
+    assert issubclass(InstanceDerivation, FreshnessContract)
+
+
+def test_abstract_methods_block_incomplete_implementations():
+    """A derivation missing a contract method cannot be instantiated."""
+    class _Incomplete(CollectionDerivation):
+        name = "incomplete"
+        # missing version_stamp / current_version / reconcile
+
+    with pytest.raises(TypeError):
+        _Incomplete()

--- a/tests/unit/lib/test_freshness_contract.py
+++ b/tests/unit/lib/test_freshness_contract.py
@@ -31,6 +31,7 @@ from api.app.lib.age_client.grounding import (
     PolarityAxisDerivation,
 )
 from api.app.services.confidence_analyzer import ConfidenceCacheDerivation
+from api.app.lib.artifact_freshness import ArtifactDerivation
 
 
 # --------------------------------------------------------------------- registry
@@ -50,6 +51,12 @@ def test_registry_includes_both_grounding_tiers_separately():
 def test_registry_includes_the_confidence_cache():
     """The confidence cache registers as its own derivation."""
     assert ConfidenceCacheDerivation in registered_derivations()
+
+
+def test_artifacts_register_as_the_instance_derivation():
+    """Artifacts are the one per-row (InstanceDerivation) surface."""
+    assert ArtifactDerivation in registered_derivations()
+    assert issubclass(ArtifactDerivation, InstanceDerivation)
 
 
 def test_every_registered_derivation_conforms():

--- a/tests/unit/lib/test_warm_cache_shortcircuit.py
+++ b/tests/unit/lib/test_warm_cache_shortcircuit.py
@@ -1,24 +1,24 @@
 """
-Warm-cache pool connection short-circuit (ADR-201 Phase 5f #278).
+Warm-cache on-read freshness (ADR-207 #422, superseding ADR-201 #278).
 
-Pre-fix: every call to calculate_grounding_strength_semantic /
-calculate_grounding_strength_batch / calculate_confidence_batch acquired
-a pool connection just to read the graph generation counter — even when
-all the requested concepts were already in the in-process cache. The
-review note on PR #276 (finding #7) called this out: "warm cache should
-not pay a round-trip."
+History: #278 added a connection-free warm-cache short-circuit — when every
+requested concept was already cached, the grounding/confidence methods returned
+WITHOUT acquiring a pool connection or re-reading the graph generation. That
+saved a round-trip but left staleness unbounded in wall-clock time: a hot working
+set kept serving pre-mutation values until some unrelated cold-path call happened
+to re-read the generation.
 
-These tests prove the short-circuit: when all requested concepts have
-entries at `_grounding_cache_generation` / `_confidence_cache_generation`,
-the method returns without calling `pool.getconn`. This is a legitimate
-"method-call count IS the behavior" case — the optimization's whole
-point is to skip the connection acquisition.
+ADR-207 D2 forbids that: freshness must be detected ON READ. So the connection-
+free short-circuit is gone. The new invariant these tests pin:
 
-Soundness reminder: skipping the generation probe means the method can
-serve up-to-one-call-stale data right after a graph mutation. The next
-non-warm call reads the new generation and evicts. The tests below
-exercise the warm path; the cold path is already covered by the existing
-batch tests.
+  - A warm hit (clock unchanged) still avoids the *expensive recompute* (no edge
+    fetch / projection) — the cache's real value — but it DOES read the canonical
+    clock every call (a cheap query) to confirm it isn't stale.
+  - When the clock has advanced, the cache is evicted and the method recomputes —
+    no more serving stale values to a hot working set.
+
+The clock is the committed-epoch tick (kg_api.get_committed_epoch), read via
+freshness.read_committed_epoch.
 """
 
 from unittest.mock import MagicMock
@@ -52,110 +52,80 @@ def reset_confidence_cache():
         cmod._confidence_cache_generation = None
 
 
-class TestGroundingBatchWarmCacheShortcircuit:
-    """100% warm batch skips pool.getconn() entirely."""
+def _client_with_clock(tick: int):
+    """A MagicMock client whose pool connection reports `tick` as the committed
+    epoch (so read_committed_epoch(cur) returns it). Returns (client, cursor)."""
+    cur = MagicMock()
+    cur.fetchone.return_value = {"get_committed_epoch": tick}
+    ctx = MagicMock()
+    ctx.__enter__.return_value = cur
+    ctx.__exit__.return_value = False
+    conn = MagicMock()
+    conn.cursor.return_value = ctx
+    client = MagicMock()
+    client.pool.getconn.return_value = conn
+    return client, cur
 
-    def test_all_concepts_cached_no_pool_connection_acquired(self):
-        """
-        Pre-populate _grounding_cache for 5 IDs at generation=7. Set
-        _grounding_cache_generation=7. Call the batch method. Assert
-        pool.getconn is never called — the entire response comes from
-        the in-process cache without touching the DB.
-        """
+
+class TestGroundingBatchOnReadFreshness:
+    """The batch method reads the clock every call; a warm hit skips recompute."""
+
+    def test_warm_hit_reads_clock_but_skips_recompute(self):
+        """All 5 IDs cached at the current tick → cached values returned, the
+        clock IS read (getconn), but the expensive edge query is NOT run."""
         from api.app.lib.age_client import grounding as gmod
         from api.app.lib.age_client.grounding import GroundingMixin
 
-        # Seed cache: 5 concepts at generation 7
         with gmod._grounding_cache_lock:
             gmod._grounding_cache_generation = 7
             gmod._grounding_cache.update({
-                ("c_alpha", 7): 0.8,
-                ("c_beta", 7): 0.5,
-                ("c_gamma", 7): -0.2,
-                ("c_delta", 7): 0.3,
-                ("c_epsilon", 7): 0.9,
+                ("c_alpha", 7): 0.8, ("c_beta", 7): 0.5, ("c_gamma", 7): -0.2,
+                ("c_delta", 7): 0.3, ("c_epsilon", 7): 0.9,
             })
 
-        # Build a client with a pool that explodes if accessed
-        client = MagicMock()
-        client.pool = MagicMock()
+        client, _ = _client_with_clock(7)
+        client._execute_cypher = MagicMock()
 
         result = GroundingMixin.calculate_grounding_strength_batch(
             client,
             concept_ids=["c_alpha", "c_beta", "c_gamma", "c_delta", "c_epsilon"],
         )
 
-        # Cached values returned correctly
         assert result == {
-            "c_alpha": 0.8,
-            "c_beta": 0.5,
-            "c_gamma": -0.2,
-            "c_delta": 0.3,
-            "c_epsilon": 0.9,
+            "c_alpha": 0.8, "c_beta": 0.5, "c_gamma": -0.2,
+            "c_delta": 0.3, "c_epsilon": 0.9,
         }
-        # Pool was NEVER touched
-        client.pool.getconn.assert_not_called()
-        client.pool.putconn.assert_not_called()
+        client.pool.getconn.assert_called()          # clock WAS read (on-read freshness)
+        client._execute_cypher.assert_not_called()   # but no expensive recompute
 
-    def test_partial_warm_falls_through_to_normal_path(self):
-        """
-        3 of 5 IDs cached. The short-circuit only fires on 100% warm, so
-        the partially-warm case still acquires a pool connection (to hydrate
-        the 2 misses). This proves the optimization doesn't accidentally
-        skip work it's supposed to do.
-        """
+    def test_clock_advance_evicts_and_does_not_serve_stale(self):
+        """The #422 fix: cache says c_alpha=0.8 at tick 7, but the clock now
+        reports 8 (graph mutated). The stale 0.8 must NOT be served — the cache
+        is evicted and c_alpha recomputes (to the default here, since the mock
+        has no real graph data). The old connection-free short-circuit would have
+        returned the stale 0.8."""
         from api.app.lib.age_client import grounding as gmod
         from api.app.lib.age_client.grounding import GroundingMixin
 
         with gmod._grounding_cache_lock:
             gmod._grounding_cache_generation = 7
-            gmod._grounding_cache.update({
-                ("c_alpha", 7): 0.8,
-                ("c_beta", 7): 0.5,
-                ("c_gamma", 7): -0.2,
-                # c_delta, c_epsilon NOT cached
-            })
+            gmod._grounding_cache[("c_alpha", 7)] = 0.8
 
-        # Pool must be reachable now so the cold path can run. We just
-        # raise after the first getconn to short-circuit the rest of the
-        # path — proves only that getconn WAS called, which is the
-        # invariant the test guards.
-        client = MagicMock()
-        client.pool.getconn.side_effect = RuntimeError("pool reached on partial warm")
+        client, _ = _client_with_clock(8)  # graph mutated since the cache filled
+        client._get_polarity_axis = MagicMock(return_value=None)  # → clean 0.0
 
-        with pytest.raises(RuntimeError, match="pool reached on partial warm"):
-            GroundingMixin.calculate_grounding_strength_batch(
-                client,
-                concept_ids=["c_alpha", "c_beta", "c_gamma", "c_delta", "c_epsilon"],
-            )
+        result = GroundingMixin.calculate_grounding_strength_batch(
+            client, concept_ids=["c_alpha"]
+        )
 
-        client.pool.getconn.assert_called()
-
-    def test_no_cached_generation_skips_shortcircuit(self):
-        """
-        Fresh process: _grounding_cache_generation is None (nothing has
-        been cached yet). The short-circuit must NOT fire — there's
-        nothing valid to serve from.
-        """
-        from api.app.lib.age_client.grounding import GroundingMixin
-
-        client = MagicMock()
-        client.pool.getconn.side_effect = RuntimeError("cold-path reached")
-
-        with pytest.raises(RuntimeError, match="cold-path reached"):
-            GroundingMixin.calculate_grounding_strength_batch(
-                client, concept_ids=["c_alpha"]
-            )
-
-        client.pool.getconn.assert_called()
+        assert result["c_alpha"] == 0.0          # stale 0.8 NOT served
+        client.pool.getconn.assert_called()       # clock WAS read
 
 
-class TestGroundingSemanticWarmCacheShortcircuit:
-    """Per-concept method skips pool.getconn() on a cache hit."""
+class TestGroundingSemanticOnReadFreshness:
+    """Per-concept method: same on-read freshness."""
 
-    def test_cache_hit_returns_without_acquiring_connection(self):
-        """The hot path through the per-concept method (search-render-render
-        cycles). One cached concept at the current generation → no DB touch."""
+    def test_warm_hit_reads_clock_but_skips_recompute(self):
         from api.app.lib.age_client import grounding as gmod
         from api.app.lib.age_client.grounding import GroundingMixin
 
@@ -163,78 +133,72 @@ class TestGroundingSemanticWarmCacheShortcircuit:
             gmod._grounding_cache_generation = 3
             gmod._grounding_cache[("c_focus", 3)] = 0.42
 
-        client = MagicMock()
+        client, _ = _client_with_clock(3)
+        client._execute_cypher = MagicMock()
+
         result = GroundingMixin.calculate_grounding_strength_semantic(
             client, concept_id="c_focus"
         )
 
         assert result == 0.42
-        client.pool.getconn.assert_not_called()
+        client.pool.getconn.assert_called()
+        client._execute_cypher.assert_not_called()
 
-    def test_cache_miss_falls_through_to_cold_path(self):
-        """Different concept than what's cached → cold path acquires a conn."""
+    def test_clock_advance_does_not_serve_stale(self):
+        """Cache says c_focus=0.42 at tick 3, but the clock now reports 4 → the
+        stale value must not be served; it recomputes (default 0.0 here)."""
         from api.app.lib.age_client import grounding as gmod
         from api.app.lib.age_client.grounding import GroundingMixin
 
         with gmod._grounding_cache_lock:
             gmod._grounding_cache_generation = 3
-            gmod._grounding_cache[("c_other", 3)] = 0.1
+            gmod._grounding_cache[("c_focus", 3)] = 0.42
 
-        client = MagicMock()
-        client.pool.getconn.side_effect = RuntimeError("cold-path reached")
+        client, _ = _client_with_clock(4)  # graph mutated since the cache filled
+        client._get_polarity_axis = MagicMock(return_value=None)  # → clean 0.0
 
-        with pytest.raises(RuntimeError):
-            GroundingMixin.calculate_grounding_strength_semantic(
-                client, concept_id="c_focus"
-            )
+        result = GroundingMixin.calculate_grounding_strength_semantic(
+            client, concept_id="c_focus"
+        )
+
+        assert result == 0.0                # stale 0.42 NOT served
+        client.pool.getconn.assert_called()  # clock WAS read
 
 
-class TestConfidenceBatchWarmCacheShortcircuit:
-    """Same short-circuit on the confidence-side batch method."""
+class TestConfidenceBatchOnReadFreshness:
+    """Same on-read freshness on the confidence-side batch method."""
 
-    def test_all_concepts_cached_no_pool_connection_acquired(self):
-        """
-        All 3 IDs cached at the current generation. grounding_display gets
-        recomputed from the caller's grounding_map (a deliberate exception
-        to the cache-key invariant — display depends on call-time data
-        outside the graph). But level, score, signals, interpretation
-        all come from cache. No pool touch.
-        """
+    def test_warm_hit_reads_clock_and_returns_cached_levels(self):
+        """All 3 IDs cached at the current tick → cached levels returned and the
+        clock IS read. grounding_display is refreshed from the caller's
+        grounding_map (it depends on call-time data outside the graph)."""
         from api.app.services import confidence_analyzer as cmod
         from api.app.services.confidence_analyzer import ConfidenceAnalyzer
 
-        # Seed confidence cache for 3 concepts at generation 9
         with cmod._confidence_cache_lock:
             cmod._confidence_cache_generation = 9
             cmod._confidence_cache.update({
                 ("c_alpha", 9): {
-                    "level": "high",
-                    "confidence_score": 0.92,
+                    "level": "high", "confidence_score": 0.92,
                     "signals": {"relationship_count": 12},
                     "interpretation": "many supporting edges",
-                    "grounding_display": "Strong",  # will be overwritten
-                    "calculation_time_ms": 5,
+                    "grounding_display": "Strong", "calculation_time_ms": 5,
                 },
                 ("c_beta", 9): {
-                    "level": "medium",
-                    "confidence_score": 0.55,
+                    "level": "medium", "confidence_score": 0.55,
                     "signals": {"relationship_count": 4},
                     "interpretation": "moderate support",
-                    "grounding_display": "Moderate",
-                    "calculation_time_ms": 5,
+                    "grounding_display": "Moderate", "calculation_time_ms": 5,
                 },
                 ("c_gamma", 9): {
-                    "level": "low",
-                    "confidence_score": 0.18,
+                    "level": "low", "confidence_score": 0.18,
                     "signals": {"relationship_count": 1},
                     "interpretation": "thin",
-                    "grounding_display": "Weak",
-                    "calculation_time_ms": 5,
+                    "grounding_display": "Weak", "calculation_time_ms": 5,
                 },
             })
 
-        client = MagicMock()
-        client.pool = MagicMock()
+        client, _ = _client_with_clock(9)
         analyzer = ConfidenceAnalyzer(client)
 
         result = analyzer.calculate_confidence_batch(
@@ -242,9 +206,7 @@ class TestConfidenceBatchWarmCacheShortcircuit:
             grounding_map={"c_alpha": 0.9, "c_beta": 0.4, "c_gamma": -0.1},
         )
 
-        # Cached values came back
         assert result["c_alpha"]["level"] == "high"
         assert result["c_beta"]["level"] == "medium"
         assert result["c_gamma"]["level"] == "low"
-        # And no pool acquisition
-        client.pool.getconn.assert_not_called()
+        client.pool.getconn.assert_called()  # clock WAS read on the warm path


### PR DESCRIPTION
## What

Draft ADR (status: **Proposed**) naming and deciding a structural problem: the platform has grown three independent **materialized derivations of the graph** — the grounding/polarity cache, artifacts, and the catalog index — each re-implementing the same stamp → compare → detect → reconcile freshness lifecycle, against version signals that aren't even the same clock.

## Why it matters

- Two of the three read `graph_change_counter`, which **ADR-203 already proved non-injective** ("delete a concept and add one — the counter is unchanged"). So a stale derivation can read **false-FRESH**. This is a latent correctness bug, not a style issue.
- The grounding cache skips the compare on its warm path → **unbounded staleness** (#422).
- Artifact reconcile (regenerate/cleanup) exists in the API but isn't exposed; storage tier leaks into the user view (#233).
- The honest clock (the ADR-203 epoch event log) can't yet tell a committed mutation from a failed one (#384).

Structurally this is the same parallel-hierarchy problem ADR-802 just collapsed for providers.

## What it decides

- **D1** — canonical clock = the ADR-203 epoch event-log sequence (`graph_epochs.event_id`, monotonic + unique → injective both ways), resolved via a commit-gated `get_committed_epoch()`. `graph_change_counter` demoted to a one-directional dirty-hint. **#384 is a prerequisite.**
- **D2** — mandatory deferred/on-read detection (no warm-path skip), explicit per-derivation staleness budgets, full-recompute baseline (IVM permitted, out of scope).
- **D3** — one `MaterializedDerivation` interface + registry + CI conformance test; uniform reconcile surface subsumes #233's items.

Execution is framed as **one PR / a coherent commit narrative**, not phased project work — the only load-bearing constraint is "trustworthy clock before any migration."

## Grounded in prior art

Named via the materialized-view-maintenance / bounded-staleness (PBS) / cache-coherence literature rather than invented — references in the ADR.

## Related issues
- #384 — epoch `status` (the trustworthy clock) — prerequisite
- #422 — grounding-cache warm-path staleness
- #233 — artifact lifecycle exposure + storage transparency (recast as part of this work, **not** closed by it)

_Review focus: is D1 (epoch sequence as canonical clock) the right call, and is the `graph_epoch`-column data migration (counter → committed sequence) safe for existing artifact + catalog rows?_