### PR TITLE
feat(cli): artifact usability — regenerate, cleanup, stale guidance (#233)

### DIFF
--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -2182,6 +2182,23 @@ export class KnowledgeGraphClient {
     await this.client.delete(`/artifacts/${artifactId}`);
   }
 
+  /**
+   * Regenerate an artifact from its stored parameters (ADR-207).
+   *
+   * Server-side reconcile path for a stale artifact: enqueues an auto-approved
+   * job that recomputes the artifact with the same parameters and stores the
+   * result as a new artifact (the original is preserved). Only artifact types
+   * with a recompute path (polarity_analysis, projection) are supported.
+   */
+  async regenerateArtifact(artifactId: number): Promise<{
+    job_id: string;
+    status: string;
+    message: string;
+  }> {
+    const response = await this.client.post(`/artifacts/${artifactId}/regenerate`);
+    return response.data;
+  }
+
   // ==========================================================================
   // Groups & Grants Methods (ADR-082)
   // ==========================================================================

--- a/cli/src/cli/artifact.ts
+++ b/cli/src/cli/artifact.ts
@@ -11,10 +11,23 @@ import { coloredCount, separator } from './colors';
 import { Table } from '../lib/table';
 import { setCommandHelp } from './help-formatter';
 
+/**
+ * Standard hint shown when an artifact is stale, pointing at the reconcile path.
+ * "Stale" means the graph has advanced past the epoch the artifact was computed
+ * at (ADR-207) — the payload is still readable, just no longer current.
+ */
+const STALE_HINT = (id: string | number) =>
+  colors.status.dim(`  Stale: the graph changed since this was computed. ` +
+    `Recompute with "kg artifact regenerate ${id}".`);
+
 export const artifactCommand = setCommandHelp(
   new Command('artifact'),
-  'Manage artifacts (stored computation results)',
-  'Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Artifacts support multi-tier storage: small payloads inline in PostgreSQL, large payloads in Garage S3. Each artifact tracks its graph_epoch for freshness detection.'
+  'Manage your artifacts (stored computation results)',
+  'Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. ' +
+  'Each artifact records the graph epoch it was computed at, so the platform can tell you when one has gone stale ' +
+  '(the graph changed underneath it) and recompute it on request (ADR-207).\n\n' +
+  'This is the user-facing surface for the results you create. For backend object-storage diagnostics ' +
+  '(S3 buckets, stored objects, integrity, retention) see the admin command "kg storage".'
 )
   .alias('art')
   .showHelpAfterError('(add --help for additional information)')
@@ -27,6 +40,7 @@ export const artifactCommand = setCommandHelp(
       .option('-o, --ontology <name>', 'Filter by ontology')
       .option('-l, --limit <n>', 'Maximum artifacts to return', '20')
       .option('--offset <n>', 'Skip N artifacts (for pagination)', '0')
+      .option('-v, --verbose', 'Show storage tier (inline/garage) — an implementation detail hidden by default')
       .option('-j, --json', 'Output raw JSON instead of formatted table')
       .action(async (options) => {
         try {
@@ -55,49 +69,54 @@ export const artifactCommand = setCommandHelp(
           console.log('\n' + colors.ui.title('📦 Artifacts'));
           console.log(colors.status.dim(`  Showing ${result.artifacts.length} of ${result.total} artifacts\n`));
 
-          const table = new Table({
-            columns: [
-              {
-                header: 'ID',
-                field: 'id',
-                type: 'count',
-                width: 8,
-                align: 'right'
-              },
-              {
-                header: 'Type',
-                field: 'artifact_type',
-                type: 'heading',
-                width: 20
-              },
-              {
-                header: 'Name',
-                field: 'name',
-                type: 'text',
-                width: 'flex',
-                priority: 2
-              },
-              {
-                header: 'Fresh',
-                field: 'is_fresh',
-                type: 'text',
-                width: 8,
-                customFormat: (val: boolean) => val ? colors.status.success('✓') : colors.status.warning('○')
-              },
-              {
-                header: 'Storage',
-                field: 'storage',
-                type: 'text',
-                width: 10
-              },
-              {
-                header: 'Created',
-                field: 'created_at',
-                type: 'timestamp',
-                width: 12
-              }
-            ]
-          });
+          const columns: any[] = [
+            {
+              header: 'ID',
+              field: 'id',
+              type: 'count',
+              width: 8,
+              align: 'right'
+            },
+            {
+              header: 'Type',
+              field: 'artifact_type',
+              type: 'heading',
+              width: 20
+            },
+            {
+              header: 'Name',
+              field: 'name',
+              type: 'text',
+              width: 'flex',
+              priority: 2
+            },
+            {
+              header: 'Fresh',
+              field: 'is_fresh',
+              type: 'text',
+              width: 8,
+              customFormat: (val: boolean) => val ? colors.status.success('✓') : colors.status.warning('○')
+            },
+            {
+              header: 'Created',
+              field: 'created_at',
+              type: 'timestamp',
+              width: 12
+            }
+          ];
+
+          // Storage tier is an implementation detail (inline vs Garage), not a
+          // user concern — surface it only under --verbose (ADR-207 audience split).
+          if (options.verbose) {
+            columns.splice(4, 0, {
+              header: 'Storage',
+              field: 'storage',
+              type: 'text',
+              width: 10
+            });
+          }
+
+          const table = new Table({ columns });
 
           // Transform for display
           const displayData = result.artifacts.map(a => ({
@@ -108,6 +127,15 @@ export const artifactCommand = setCommandHelp(
           }));
 
           table.print(displayData);
+
+          // Point users at the reconcile path when any listed artifact is stale.
+          const staleCount = result.artifacts.filter(a => !a.is_fresh).length;
+          if (staleCount > 0) {
+            console.log(colors.status.dim(
+              `\n  ○ ${staleCount} stale (graph changed since computed). ` +
+              `Recompute one with "kg artifact regenerate <id>", or clear stale ones with "kg artifact cleanup".`
+            ));
+          }
 
           if (result.total > result.artifacts.length) {
             console.log(colors.status.dim(`\n  Use --offset ${result.offset + result.limit} to see more`));
@@ -123,7 +151,8 @@ export const artifactCommand = setCommandHelp(
     new Command('show')
       .description('Show artifact metadata by ID. Does not include the payload - use "payload" command for that.')
       .argument('<id>', 'Artifact ID')
-      .action(async (id) => {
+      .option('-v, --verbose', 'Show storage tier (inline/garage) — an implementation detail hidden by default')
+      .action(async (id, options) => {
         try {
           const client = createClientFromEnv();
           const artifact = await client.getArtifact(parseInt(id));
@@ -141,11 +170,18 @@ export const artifactCommand = setCommandHelp(
           console.log('\n' + colors.stats.section('Freshness'));
           console.log(`  ${colors.stats.label('Graph Epoch:')} ${artifact.graph_epoch}`);
           console.log(`  ${colors.stats.label('Is Fresh:')} ${artifact.is_fresh ? colors.status.success('Yes ✓') : colors.status.warning('No (graph has changed)')}`);
+          if (!artifact.is_fresh) {
+            console.log(STALE_HINT(artifact.id));
+          }
 
-          console.log('\n' + colors.stats.section('Storage'));
-          console.log(`  ${colors.stats.label('Location:')} ${artifact.has_inline_result ? 'Inline (PostgreSQL)' : 'Garage S3'}`);
-          if (artifact.garage_key) {
-            console.log(`  ${colors.stats.label('Garage Key:')} ${colors.status.dim(artifact.garage_key)}`);
+          // Storage tier is an implementation detail; show it only under --verbose
+          // (ADR-207 audience split — "kg storage" is the admin diagnostic surface).
+          if (options.verbose) {
+            console.log('\n' + colors.stats.section('Storage'));
+            console.log(`  ${colors.stats.label('Location:')} ${artifact.has_inline_result ? 'Inline (PostgreSQL)' : 'Garage S3'}`);
+            if (artifact.garage_key) {
+              console.log(`  ${colors.stats.label('Garage Key:')} ${colors.status.dim(artifact.garage_key)}`);
+            }
           }
 
           console.log('\n' + colors.stats.section('Timestamps'));
@@ -286,6 +322,112 @@ export const artifactCommand = setCommandHelp(
           console.log(separator());
         } catch (error: any) {
           console.error(colors.status.error('✗ Failed to delete artifact'));
+          console.error(colors.status.error(error.response?.data?.detail || error.message));
+          process.exit(1);
+        }
+      })
+  )
+  .addCommand(
+    new Command('regenerate')
+      .description('Recompute a stale artifact from its stored parameters (ADR-207). Enqueues an auto-approved job; the result is saved as a NEW artifact and the original is preserved. Supported types: polarity_analysis, projection.')
+      .alias('regen')
+      .argument('<id>', 'Artifact ID')
+      .action(async (id) => {
+        try {
+          const client = createClientFromEnv();
+          const result = await client.regenerateArtifact(parseInt(id));
+
+          console.log('\n' + separator());
+          console.log(colors.status.success(`✓ Regeneration queued for artifact ${id}`));
+          console.log(separator());
+          console.log(`  ${colors.stats.label('Job ID:')} ${result.job_id}`);
+          console.log(`  ${colors.stats.label('Status:')} ${result.status}`);
+          console.log(colors.status.dim(
+            `\n  Track it with "kg job status ${result.job_id}". ` +
+            `The recomputed result is saved as a new artifact — the original is preserved.`
+          ));
+          console.log(separator());
+        } catch (error: any) {
+          console.error(colors.status.error('✗ Failed to regenerate artifact'));
+          console.error(colors.status.error(error.response?.data?.detail || error.message));
+          process.exit(1);
+        }
+      })
+  )
+  .addCommand(
+    new Command('cleanup')
+      .description('Remove stale artifacts in bulk — those whose graph epoch is behind the current graph (ADR-207). Previews by default; pass --force to delete. Regeneratable types can be recomputed afterward with "kg artifact regenerate".')
+      .option('-t, --type <type>', 'Only clean up artifacts of this type')
+      .option('-o, --ontology <name>', 'Only clean up artifacts in this ontology')
+      .option('-f, --force', 'Actually delete (default is a dry-run preview)')
+      .action(async (options) => {
+        try {
+          const client = createClientFromEnv();
+
+          // Page through all matching artifacts (list returns max 500 per page)
+          // and collect the stale ones. Freshness is computed server-side per row.
+          const pageSize = 500;
+          const stale: any[] = [];
+          let offset = 0;
+          let total = Infinity;
+          while (offset < total) {
+            const page = await client.listArtifacts({
+              artifact_type: options.type,
+              ontology: options.ontology,
+              limit: pageSize,
+              offset,
+            });
+            total = page.total;
+            for (const a of page.artifacts) {
+              if (!a.is_fresh) stale.push(a);
+            }
+            if (page.artifacts.length === 0) break;
+            offset += page.artifacts.length;
+          }
+
+          if (stale.length === 0) {
+            console.log(colors.status.success('\n✓ No stale artifacts to clean up'));
+            return;
+          }
+
+          console.log('\n' + separator());
+          console.log(colors.ui.title(`🧹 ${options.force ? 'Cleaning up' : 'Stale artifacts (preview)'}`));
+          console.log(separator());
+          for (const a of stale) {
+            const label = a.name ? `${a.name} ` : '';
+            console.log(`  ${colors.concept.label('#' + a.id)} ${colors.status.dim(a.artifact_type)} ${label}${colors.status.dim('(epoch ' + a.graph_epoch + ')')}`);
+          }
+
+          if (!options.force) {
+            console.log('\n' + colors.status.warning(`⚠ ${stale.length} stale artifact(s) would be deleted.`));
+            console.log(colors.status.dim('  Re-run with --force to delete them, or recompute one with "kg artifact regenerate <id>".'));
+            console.log(separator());
+            return;
+          }
+
+          let deleted = 0;
+          const failures: Array<{ id: number; error: string }> = [];
+          for (const a of stale) {
+            try {
+              await client.deleteArtifact(a.id);
+              deleted++;
+            } catch (err: any) {
+              failures.push({ id: a.id, error: err.response?.data?.detail || err.message });
+            }
+          }
+
+          console.log('\n' + separator());
+          console.log(colors.status.success(`✓ Deleted ${deleted} stale artifact(s)`));
+          if (failures.length > 0) {
+            console.log(colors.status.error(`✗ Failed to delete ${failures.length}:`));
+            for (const f of failures) {
+              console.log(colors.status.error(`  #${f.id}: ${f.error}`));
+            }
+          }
+          console.log(separator());
+          if (failures.length > 0) process.exit(1);
+        } catch (error: any) {
+          console.error(colors.status.error('✗ Failed to clean up artifacts'));
           console.error(colors.status.error(error.response?.data?.detail || error.message));
           process.exit(1);
         }

--- a/cli/src/cli/artifact.ts
+++ b/cli/src/cli/artifact.ts
@@ -11,14 +11,17 @@ import { coloredCount, separator } from './colors';
 import { Table } from '../lib/table';
 import { setCommandHelp } from './help-formatter';
 
-/**
- * Standard hint shown when an artifact is stale, pointing at the reconcile path.
- * "Stale" means the graph has advanced past the epoch the artifact was computed
- * at (ADR-207) — the payload is still readable, just no longer current.
- */
+// Shared stale-guidance vocabulary, so `show`, `list`, and `cleanup` all phrase
+// staleness and its remedy identically (ADR-207). "Stale" means the graph has
+// advanced past the epoch the artifact was computed at — the payload is still
+// readable, just no longer current.
+const STALE_MEANING = 'the graph changed since computed';
+/** The reconcile command for one artifact, or `<id>` placeholder for guidance. */
+const regenerateCmd = (id: string | number = '<id>') => `kg artifact regenerate ${id}`;
+
+/** Standard hint shown when a specific artifact is stale, pointing at reconcile. */
 const STALE_HINT = (id: string | number) =>
-  colors.status.dim(`  Stale: the graph changed since this was computed. ` +
-    `Recompute with "kg artifact regenerate ${id}".`);
+  colors.status.dim(`  Stale: ${STALE_MEANING}. Recompute with "${regenerateCmd(id)}".`);
 
 export const artifactCommand = setCommandHelp(
   new Command('artifact'),
@@ -132,8 +135,8 @@ export const artifactCommand = setCommandHelp(
           const staleCount = result.artifacts.filter(a => !a.is_fresh).length;
           if (staleCount > 0) {
             console.log(colors.status.dim(
-              `\n  ○ ${staleCount} stale (graph changed since computed). ` +
-              `Recompute one with "kg artifact regenerate <id>", or clear stale ones with "kg artifact cleanup".`
+              `\n  ○ ${staleCount} stale (${STALE_MEANING}). ` +
+              `Recompute one with "${regenerateCmd()}", or clear stale ones with "kg artifact cleanup".`
             ));
           }
 
@@ -400,7 +403,7 @@ export const artifactCommand = setCommandHelp(
 
           if (!options.force) {
             console.log('\n' + colors.status.warning(`⚠ ${stale.length} stale artifact(s) would be deleted.`));
-            console.log(colors.status.dim('  Re-run with --force to delete them, or recompute one with "kg artifact regenerate <id>".'));
+            console.log(colors.status.dim(`  Re-run with --force to delete them, or recompute one with "${regenerateCmd()}".`));
             console.log(separator());
             return;
           }

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -34,7 +34,9 @@ Configuration stored in: ~/.config/kg/mcp-allowed-paths.json
 - [`admin`](#admin) - System administration and management - health monitoring, backup/restore, database operations, user/RBAC management, AI model configuration (requires authentication for destructive operations)
 - [`polarity`](#polarity) - Analyze bidirectional semantic dimensions between concept poles
 - [`projection` (proj)](#projection) - Manage t-SNE/UMAP projections of concept embeddings. Projections reduce high-dimensional embeddings to 3D coordinates for the Embedding Landscape Explorer visualization. Use this to compute, view, and manage projection datasets.
-- [`artifact` (art)](#artifact) - Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Artifacts support multi-tier storage: small payloads inline in PostgreSQL, large payloads in Garage S3. Each artifact tracks its graph_epoch for freshness detection.
+- [`artifact` (art)](#artifact) - Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Each artifact records the graph epoch it was computed at, so the platform can tell you when one has gone stale (the graph changed underneath it) and recompute it on request (ADR-207).
+
+This is the user-facing surface for the results you create. For backend object-storage diagnostics (S3 buckets, stored objects, integrity, retention) see the admin command "kg storage".
 - [`group` (grp)](#group) - Manage groups for collaborative access control. Groups allow sharing resources with multiple users. System groups (public, admins) are managed by the platform.
 - [`query-def` (qd)](#query-def) - Manage saved query definitions - recipes that can be re-executed to generate artifacts. Supports block diagrams, cypher queries, searches, polarity analyses, and connection paths.
 - [`program` (prog)](#program) - Validate, store, and retrieve GraphProgram ASTs (ADR-500). Programs are notarized server-side to ensure safety before execution.
@@ -3241,7 +3243,9 @@ kg algorithms [options]
 
 ## artifact (art)
 
-Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Artifacts support multi-tier storage: small payloads inline in PostgreSQL, large payloads in Garage S3. Each artifact tracks its graph_epoch for freshness detection.
+Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Each artifact records the graph epoch it was computed at, so the platform can tell you when one has gone stale (the graph changed underneath it) and recompute it on request (ADR-207).
+
+This is the user-facing surface for the results you create. For backend object-storage diagnostics (S3 buckets, stored objects, integrity, retention) see the admin command "kg storage".
 
 **Usage:**
 ```bash
@@ -3255,6 +3259,8 @@ kg artifact [options]
 - `payload` - Get artifact with full payload. For large artifacts stored in Garage, this fetches from object storage.
 - `create` - Create a test artifact (for API validation). Creates a simple artifact with provided parameters.
 - `delete` - Delete an artifact. Removes both database record and any Garage-stored payload.
+- `regenerate` (`regen`) - Recompute a stale artifact from its stored parameters (ADR-207). Enqueues an auto-approved job; the result is saved as a NEW artifact and the original is preserved. Supported types: polarity_analysis, projection.
+- `cleanup` - Remove stale artifacts in bulk — those whose graph epoch is behind the current graph (ADR-207). Previews by default; pass --force to delete. Regeneratable types can be recomputed afterward with "kg artifact regenerate".
 
 ---
 
@@ -3276,6 +3282,7 @@ kg list [options]
 | `-o, --ontology <name>` | Filter by ontology | - |
 | `-l, --limit <n>` | Maximum artifacts to return | `"20"` |
 | `--offset <n>` | Skip N artifacts (for pagination) | `"0"` |
+| `-v, --verbose` | Show storage tier (inline/garage) — an implementation detail hidden by default | - |
 | `-j, --json` | Output raw JSON instead of formatted table | - |
 
 ### show
@@ -3290,6 +3297,12 @@ kg show <id>
 **Arguments:**
 
 - `<id>` - Artifact ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-v, --verbose` | Show storage tier (inline/garage) — an implementation detail hidden by default | - |
 
 ### payload
 
@@ -3346,6 +3359,36 @@ kg delete <id>
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-f, --force` | Skip confirmation prompt | - |
+
+### regenerate (regen)
+
+Recompute a stale artifact from its stored parameters (ADR-207). Enqueues an auto-approved job; the result is saved as a NEW artifact and the original is preserved. Supported types: polarity_analysis, projection.
+
+**Usage:**
+```bash
+kg regenerate <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+### cleanup
+
+Remove stale artifacts in bulk — those whose graph epoch is behind the current graph (ADR-207). Previews by default; pass --force to delete. Regeneratable types can be recomputed afterward with "kg artifact regenerate".
+
+**Usage:**
+```bash
+kg cleanup [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Only clean up artifacts of this type | - |
+| `-o, --ontology <name>` | Only clean up artifacts in this ontology | - |
+| `-f, --force` | Actually delete (default is a dry-run preview) | - |
 
 
 ## group (grp)

--- a/docs/reference/cli/commands/artifact.md
+++ b/docs/reference/cli/commands/artifact.md
@@ -4,7 +4,9 @@
 
 ## artifact (art)
 
-Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Artifacts support multi-tier storage: small payloads inline in PostgreSQL, large payloads in Garage S3. Each artifact tracks its graph_epoch for freshness detection.
+Manage artifacts - persistent storage for computed results like polarity analyses, projections, and query results. Each artifact records the graph epoch it was computed at, so the platform can tell you when one has gone stale (the graph changed underneath it) and recompute it on request (ADR-207).
+
+This is the user-facing surface for the results you create. For backend object-storage diagnostics (S3 buckets, stored objects, integrity, retention) see the admin command "kg storage".
 
 **Usage:**
 ```bash
@@ -18,6 +20,8 @@ kg artifact [options]
 - `payload` - Get artifact with full payload. For large artifacts stored in Garage, this fetches from object storage.
 - `create` - Create a test artifact (for API validation). Creates a simple artifact with provided parameters.
 - `delete` - Delete an artifact. Removes both database record and any Garage-stored payload.
+- `regenerate` (`regen`) - Recompute a stale artifact from its stored parameters (ADR-207). Enqueues an auto-approved job; the result is saved as a NEW artifact and the original is preserved. Supported types: polarity_analysis, projection.
+- `cleanup` - Remove stale artifacts in bulk — those whose graph epoch is behind the current graph (ADR-207). Previews by default; pass --force to delete. Regeneratable types can be recomputed afterward with "kg artifact regenerate".
 
 ---
 
@@ -39,6 +43,7 @@ kg list [options]
 | `-o, --ontology <name>` | Filter by ontology | - |
 | `-l, --limit <n>` | Maximum artifacts to return | `"20"` |
 | `--offset <n>` | Skip N artifacts (for pagination) | `"0"` |
+| `-v, --verbose` | Show storage tier (inline/garage) — an implementation detail hidden by default | - |
 | `-j, --json` | Output raw JSON instead of formatted table | - |
 
 ### show
@@ -53,6 +58,12 @@ kg show <id>
 **Arguments:**
 
 - `<id>` - Artifact ID
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-v, --verbose` | Show storage tier (inline/garage) — an implementation detail hidden by default | - |
 
 ### payload
 
@@ -109,3 +120,33 @@ kg delete <id>
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-f, --force` | Skip confirmation prompt | - |
+
+### regenerate (regen)
+
+Recompute a stale artifact from its stored parameters (ADR-207). Enqueues an auto-approved job; the result is saved as a NEW artifact and the original is preserved. Supported types: polarity_analysis, projection.
+
+**Usage:**
+```bash
+kg regenerate <id>
+```
+
+**Arguments:**
+
+- `<id>` - Artifact ID
+
+### cleanup
+
+Remove stale artifacts in bulk — those whose graph epoch is behind the current graph (ADR-207). Previews by default; pass --force to delete. Regeneratable types can be recomputed afterward with "kg artifact regenerate".
+
+**Usage:**
+```bash
+kg cleanup [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-t, --type <type>` | Only clean up artifacts of this type | - |
+| `-o, --ontology <name>` | Only clean up artifacts in this ontology | - |
+| `-f, --force` | Actually delete (default is a dry-run preview) | - |


### PR DESCRIPTION
Completes the **CLI usability half of #233**, the separable follow-up to ADR-207. The freshness contract (PR #462) already made artifacts an `InstanceDerivation` with a working server-side reconcile (`POST /artifacts/{id}/regenerate`); this PR surfaces that to users and cleans up the artifact CLI surface.

## What changed (`cli/src/cli/artifact.ts`, `cli/src/api/client.ts`)

- **`kg artifact regenerate <id>`** (alias `regen`) — wraps the regenerate endpoint, reports the queued job and notes the recompute lands as a new artifact (original preserved).
- **`kg artifact cleanup`** — bulk-removes stale artifacts. Previews by default; deletes under `--force`. `--type`/`--ontology` scoping. Pages through all artifacts and filters on server-computed `is_fresh`.
- **Stale guidance** — `list` shows a footer count + pointer when any row is stale; `show` prints an inline hint with the exact `regenerate` command.
- **Storage tier hidden by default** — the inline/Garage tier is an implementation detail, surfaced only under `--verbose` in `list`/`show`.
- **Audience split documented** — top-level `kg artifact` help points at `kg storage` for backend object-storage diagnostics (admin) vs `kg artifact` for your results (user).

## Verification

Built clean (`npm run build`, `tsc --noEmit` exit 0) and exercised live against the dev platform:

- `artifact list` hides the Storage column and shows the stale footer ✓
- `artifact show <id>` gates the Storage section on `--verbose`, prints the stale hint ✓
- `artifact cleanup` previews stale, warns, deletes only under `--force` ✓
- `artifact regenerate <id>` enqueues the recompute job ✓

The one artifact in the wiped dev DB is a synthetic step-3b freshness fixture whose placeholder parameters (`{created_via: ...}`) fail real polarity recompute (`Missing required parameters: positive_pole_id and negative_pole_id`) — expected for a fake fixture; it confirms the wiring submits stored params and the worker validates them.

## Scope

CLI/TypeScript only — no server change (the reconcile path already shipped in #462). After merge, `cd cli && npm run build` and reconnect MCP to pick up the new commands.

Closes the CLI half of #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)