### PR TITLE
feat(freshness): declare graph_accel.generation as a sub-counter; prove co-advance (ADR-207 step 4)

### DIFF
--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -42,6 +42,16 @@ class IngestionMixin:
         that unit of work. `kind` discriminates whether wall-clock is
         semantically meaningful for the rows attributable to this event.
 
+        Co-advance caveat (ADR-207): this advances ONLY the universal tick.
+        `record_mutation()` advances the tick AND the `graph_accel` sub-counter
+        together, by construction — but the `record_epoch()`/`complete_epoch()`
+        pair (used by long-running jobs that must tag nodes mid-run) does not. A
+        caller using this pair directly owns the accelerator co-advance itself:
+        call `self.graph.invalidate()` when the mutation lands, or the in-memory
+        grounding/polarity cache stays fresh-looking past a graph that changed.
+        See `SUBCOUNTERS` in `api/app/lib/freshness.py` for the declared
+        relationship; only `record_mutation`'s path is pinned by a co-advance test.
+
         Returns None on failure — callers must treat that as "epoch
         tagging disabled for this run" rather than fatal. The downstream
         behavior is that Instances created during the run carry no

--- a/api/app/lib/age_client/ingestion.py
+++ b/api/app/lib/age_client/ingestion.py
@@ -50,7 +50,9 @@ class IngestionMixin:
         call `self.graph.invalidate()` when the mutation lands, or the in-memory
         grounding/polarity cache stays fresh-looking past a graph that changed.
         See `SUBCOUNTERS` in `api/app/lib/freshness.py` for the declared
-        relationship; only `record_mutation`'s path is pinned by a co-advance test.
+        relationship; only `record_mutation`'s path is pinned by a co-advance
+        test. Hardening this direct path (test/lint/lifecycle helper) is tracked
+        in issue #465.
 
         Returns None on failure — callers must treat that as "epoch
         tagging disabled for this run" rather than fatal. The downstream

--- a/api/app/lib/freshness.py
+++ b/api/app/lib/freshness.py
@@ -83,6 +83,10 @@ class SubCounter:
       move together *by construction* (pinned by the co-advance test). It is not a
       second clock; it exists because the in-memory accelerator (ADR-201) needs a
       `pg_notify`-backed signal the SQL watermark cannot deliver to API processes.
+      The "by construction" guarantee holds for `record_mutation` callers; a path
+      that uses the `record_epoch`/`complete_epoch` pair directly (long-running
+      jobs) advances only the tick and must invalidate the accelerator itself —
+      see the caveat on `AGEClient.record_epoch`.
 
     - an **independent narrower scope** (`coadvances_with_tick=False`): advances
       only when its own, narrower source-of-truth changes. A derivation whose

--- a/api/app/lib/freshness.py
+++ b/api/app/lib/freshness.py
@@ -39,6 +39,9 @@ from typing import List, Optional, Type
 
 __all__ = [
     "read_committed_epoch",
+    "SubCounter",
+    "SUBCOUNTERS",
+    "subcounters",
     "Budget",
     "FreshnessContract",
     "CollectionDerivation",
@@ -61,6 +64,78 @@ def read_committed_epoch(cur) -> int:
         return 0
     val = list(row.values())[0] if isinstance(row, dict) else row[0]
     return int(val) if val is not None else 0
+
+
+# ----------------------------------------------------------------- sub-counters
+
+@dataclass(frozen=True)
+class SubCounter:
+    """A monotonic counter subordinate to the universal tick (ADR-207 D1, step 4).
+
+    The committed-epoch watermark (`read_committed_epoch`) is the ONE clock for
+    graph-topology freshness. A sub-counter is a narrower monotonic signal that
+    lives *under* it, of one of two kinds:
+
+    - a **co-advancing mirror** (`coadvances_with_tick=True`): moves in lockstep
+      with the tick, for a layer that needs its own invalidation channel.
+      `graph_accel.generation` is the only one — `AGEClient.record_mutation`
+      advances the tick AND calls `graph.invalidate()` from one place, so the two
+      move together *by construction* (pinned by the co-advance test). It is not a
+      second clock; it exists because the in-memory accelerator (ADR-201) needs a
+      `pg_notify`-backed signal the SQL watermark cannot deliver to API processes.
+
+    - an **independent narrower scope** (`coadvances_with_tick=False`): advances
+      only when its own, narrower source-of-truth changes. A derivation whose
+      input is narrower than the whole graph tracks this *instead of* the tick —
+      the polarity axis is derived from vocabulary embeddings, so it keys on
+      `vocabulary_embedding_generation_counter` (which changes far more rarely than
+      the graph); keying it on the tick would force needless axis recompute.
+
+    Declaring them makes the hierarchy a code-backed fact, not just prose: there
+    is exactly one universal tick, and every other counter is enumerated here as
+    subordinate to it, each with its relationship stated.
+    """
+
+    #: SQL/identifier name of the counter.
+    name: str
+    #: What it invalidates / what it is the freshness signal for.
+    scope: str
+    #: True iff it advances in lockstep with the universal tick (every
+    #: record_mutation co-advances it); False for independent narrower clocks.
+    coadvances_with_tick: bool
+    #: The wiring that advances it (what keeps it monotonic).
+    advanced_by: str
+
+
+#: Every monotonic counter subordinate to the universal tick (ADR-207 step 4).
+#: The universal tick itself (the `event_id` watermark, read via
+#: `read_committed_epoch`) is deliberately NOT listed — it is the clock these are
+#: subordinate to, not a peer.
+SUBCOUNTERS: List["SubCounter"] = [
+    SubCounter(
+        name="graph_accel.generation",
+        scope="in-memory grounding/polarity accelerator (ADR-201, migration 051)",
+        coadvances_with_tick=True,
+        advanced_by="AGEClient.record_mutation → graph.invalidate() (+ pg_notify)",
+    ),
+    SubCounter(
+        name="vocabulary_change_counter",
+        scope="vocabulary (relationship-type) membership",
+        coadvances_with_tick=False,
+        advanced_by="vocabulary add/remove",
+    ),
+    SubCounter(
+        name="vocabulary_embedding_generation_counter",
+        scope="vocabulary embedding regeneration (the polarity axis keys on this)",
+        coadvances_with_tick=False,
+        advanced_by="vocabulary embedding regeneration (migration 069)",
+    ),
+]
+
+
+def subcounters() -> List["SubCounter"]:
+    """All declared sub-counters subordinate to the universal tick (ADR-207 step 4)."""
+    return list(SUBCOUNTERS)
 
 
 @dataclass(frozen=True)

--- a/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
+++ b/docs/architecture/database-schema/ADR-207-derived-state-freshness-contract.md
@@ -382,9 +382,13 @@ yet record an event.
    separately (**#422**); artifacts implement `InstanceDerivation`, expose
    `reconcile` via CLI/MCP, and hide the storage tier behind `--verbose`
    (**#233**).
-4. **Follow-up, separable:** formalize `graph_accel.generation` as a declared
-   sub-counter under the tick (prove co-advance), and revisit IVM where it is
-   cheap. This can trail in its own PR without holding up the rest.
+4. **Follow-up, separable (done):** `graph_accel.generation` is now a declared
+   sub-counter (`api/app/lib/freshness.py:SUBCOUNTERS`), and its co-advance with
+   the tick is pinned by `tests/unit/lib/test_record_mutation_coadvance.py`
+   (`record_mutation` advances the tick *and* calls `graph.invalidate()` from one
+   place, so they move together by construction). The IVM revisit found **no
+   cheap win available today** (see the IVM consequence below) — it stays
+   deferred with a concrete trigger condition rather than being implemented.
 
 The commits stand on their own in review — the clock fix is a correctness fix,
 the contract is an abstraction with a test, each conformance step closes a
@@ -405,7 +409,17 @@ standing issue — while together they tell the single story this ADR names.
   data worth preserving.
 - **Risk accepted:** IVM is deferred — derivations full-recompute on staleness,
   which is correct but not always cheapest. Acceptable: correctness first, the
-  contract *permits* IVM later without re-litigation.
+  contract *permits* IVM later without re-litigation. The step-4 revisit found no
+  cheap win today: the cache tiers (grounding, polarity, confidence) already
+  reconcile **lazily on-read**, so they re-derive only what is actually requested
+  at their natural granularity — IVM as a distinct mechanism buys nothing; and
+  artifacts are already per-row (`InstanceDerivation`). The only true
+  full-recompute is the **catalog index rebuild**, and incremental maintenance
+  there is blocked on a missing prerequisite: the epoch log records *that* a
+  mutation happened, not *what* changed. **Trigger to revisit:** when
+  `record_mutation` carries a structured per-event change-set (affected
+  ontology / document / concept ids), the catalog index can patch the changed
+  subtree incrementally instead of rebuilding wholesale.
 - **Risk if not done:** each new materialized derivation adds another parallel
   freshness hierarchy on an unsound signal — the drift this ADR names compounds.
 

--- a/docs/reference/FRESHNESS-ARCHITECTURE.md
+++ b/docs/reference/FRESHNESS-ARCHITECTURE.md
@@ -130,15 +130,23 @@ in-flight event.
 ### Sub-counters
 
 Specialized invalidation scopes keep their own counters, **subordinate** to the
-universal tick:
+universal tick. They are **declared in code** — `api/app/lib/freshness.py:SUBCOUNTERS`
+enumerates each with its scope, what advances it, and whether it co-advances with
+the tick — so the hierarchy is a code-backed fact, not just prose (ADR-207 step 4):
 
 - `graph_accel.generation` — the `graph_accel` pgrx extension's own generation,
-  advanced the same out-of-band way (`graph_accel_invalidate`). Same
-  eventual-consistency nature; a sub-counter, not a competing clock.
-- `vocabulary_change_counter` — vocabulary membership changes.
+  advanced the same out-of-band way (`graph_accel_invalidate`). It is the one
+  **co-advancing mirror**: `AGEClient.record_mutation` advances the tick *and*
+  calls `graph.invalidate()` from one place, so the two move together **by
+  construction** (pinned by `tests/unit/lib/test_record_mutation_coadvance.py`).
+  A sub-counter, not a competing clock — it exists because the in-memory layer
+  needs a `pg_notify`-backed signal the SQL watermark can't push to API processes.
+- `vocabulary_change_counter` — vocabulary membership changes. An **independent
+  narrower clock** (does not co-advance with the tick).
 - `vocabulary_embedding_generation_counter` — vocabulary *embedding* regeneration
   (the polarity-axis cache keys on this; it changes far more rarely than the
-  graph, so scoping it separately avoids needless axis recompute).
+  graph, so scoping it separately avoids needless axis recompute). Also
+  independent.
 
 ## The freshness contract
 

--- a/tests/unit/lib/test_freshness_contract.py
+++ b/tests/unit/lib/test_freshness_contract.py
@@ -18,6 +18,8 @@ from api.app.lib.freshness import (
     CollectionDerivation,
     FreshnessContract,
     InstanceDerivation,
+    SubCounter,
+    subcounters,
     read_committed_epoch,
     register_derivation,
     registered_derivations,
@@ -102,6 +104,37 @@ def test_read_committed_epoch_handles_dict_and_empty_rows():
     empty_cur = MagicMock()
     empty_cur.fetchone.return_value = None
     assert read_committed_epoch(empty_cur) == 0
+
+
+# ------------------------------------------------------------------- sub-counters
+
+def test_subcounters_are_declared_and_well_formed():
+    """Every declared sub-counter (ADR-207 step 4) names itself, its scope, how
+    it advances, and its relationship to the tick — the hierarchy is code, not
+    just prose."""
+    declared = subcounters()
+    assert declared, "no sub-counters declared — the hierarchy is undocumented"
+    for sc in declared:
+        assert isinstance(sc, SubCounter)
+        assert sc.name and sc.scope and sc.advanced_by
+        assert isinstance(sc.coadvances_with_tick, bool)
+
+
+def test_exactly_graph_accel_coadvances_with_the_tick():
+    """graph_accel.generation is the one co-advancing mirror; the vocabulary
+    counters are independent narrower clocks, not lockstep with the tick."""
+    by_name = {s.name: s for s in subcounters()}
+    assert by_name["graph_accel.generation"].coadvances_with_tick is True
+    coadvancing = [s for s in subcounters() if s.coadvances_with_tick]
+    assert [s.name for s in coadvancing] == ["graph_accel.generation"]
+
+
+def test_universal_tick_is_not_listed_as_a_subcounter():
+    """The tick (event_id watermark) is the clock the sub-counters are
+    subordinate to, not a peer — it must not appear in the list."""
+    names = {s.name for s in subcounters()}
+    assert "event_id" not in names
+    assert "get_committed_epoch" not in names
 
 
 # ------------------------------------------------------------------------- budget

--- a/tests/unit/lib/test_record_mutation_coadvance.py
+++ b/tests/unit/lib/test_record_mutation_coadvance.py
@@ -1,0 +1,83 @@
+"""
+Co-advance proof for the universal tick and its graph_accel sub-counter (ADR-207
+step 4).
+
+ADR-207 declares exactly one universal tick (the `event_id` watermark) and
+enumerates `graph_accel.generation` as a sub-counter that *co-advances* with it.
+The whole point of declaring it co-advancing is that the two move together by
+construction — and "by construction" means one method does both. That method is
+`AGEClient.record_mutation`: it records+completes an epoch event (advances the
+tick) AND calls `graph.invalidate()` (advances the accelerator's generation) from
+one place. These tests pin that orchestration so a refactor cannot quietly split
+the two and let the in-memory accelerator drift from the SQL clock.
+
+No DB: the epoch/accel calls are mocked; we assert the wiring, not the SQL.
+"""
+
+from unittest.mock import MagicMock
+
+from api.app.lib.age_client.ingestion import IngestionMixin
+from api.app.lib.freshness import subcounters
+
+
+class _Harness(IngestionMixin):
+    """Minimal IngestionMixin with the four collaborators record_mutation drives
+    replaced by mocks, so we can assert the orchestration in isolation."""
+
+    def __init__(self, event_id=42):
+        self.record_epoch = MagicMock(return_value=event_id)
+        self.complete_epoch = MagicMock()
+        self.refresh_epoch = MagicMock()
+        self.graph = MagicMock()
+
+
+def test_record_mutation_coadvances_tick_and_accel():
+    """One call advances BOTH the tick (record+complete epoch) and the
+    graph_accel sub-counter (graph.invalidate) — the co-advance invariant."""
+    h = _Harness(event_id=42)
+
+    result = h.record_mutation("edit", actor="tester")
+
+    assert result == 42
+    # Tick advances: epoch recorded then resolved completed.
+    h.record_epoch.assert_called_once_with("edit", actor="tester", metadata=None)
+    h.complete_epoch.assert_called_once_with(42, "completed")
+    # Sub-counter co-advances from the same call.
+    h.graph.invalidate.assert_called_once()
+    # graph_change_counter snapshot kept fresh for pollers (FUSE).
+    h.refresh_epoch.assert_called_once()
+
+
+def test_failed_epoch_still_invalidates_the_accelerator():
+    """If the tick can't advance (record_epoch returns None), the accelerator is
+    invalidated anyway — fail-safe (evict, never serve stale), not fail-stale.
+    complete_epoch is skipped because there is no event to resolve."""
+    h = _Harness(event_id=None)
+
+    result = h.record_mutation("edit")
+
+    assert result is None
+    h.complete_epoch.assert_not_called()
+    h.graph.invalidate.assert_called_once()
+    h.refresh_epoch.assert_called_once()
+
+
+def test_accelerator_invalidate_failure_is_non_fatal():
+    """The extension may not be loaded on a given connection; a raising
+    invalidate() must not break the mutation announcement or the tick advance."""
+    h = _Harness(event_id=7)
+    h.graph.invalidate.side_effect = RuntimeError("extension not loaded")
+
+    result = h.record_mutation("annealing")
+
+    assert result == 7  # tick still advanced despite the accel hiccup
+    h.complete_epoch.assert_called_once_with(7, "completed")
+    h.refresh_epoch.assert_called_once()
+
+
+def test_graph_accel_is_the_declared_coadvancing_subcounter():
+    """The counter record_mutation drives is exactly the one declared as the
+    co-advancing sub-counter — declaration and mechanism agree."""
+    coadvancing = [s for s in subcounters() if s.coadvances_with_tick]
+    assert len(coadvancing) == 1, "exactly one counter co-advances with the tick"
+    assert coadvancing[0].name == "graph_accel.generation"


### PR DESCRIPTION
Completes **step 4 of ADR-207** — the last separable follow-up. The freshness contract (PR #462) already made the universal tick (`event_id` watermark) the one clock; this formalizes the sub-counter hierarchy under it and proves the co-advance the contract relies on.

## Sub-counter declaration (`api/app/lib/freshness.py`)

A new `SubCounter` dataclass + `SUBCOUNTERS` list enumerate every monotonic counter subordinate to the tick, each with its scope, what advances it, and whether it co-advances. The hierarchy is now a **code-backed fact, not just prose**: exactly one universal tick, everything else declared subordinate to it.

- `graph_accel.generation` — the one **co-advancing mirror** (moves in lockstep with the tick).
- `vocabulary_change_counter`, `vocabulary_embedding_generation_counter` — **independent narrower clocks** (advance only when their own source changes; the polarity axis keys on the latter, not the tick).

## Co-advance proof (`tests/unit/lib/test_record_mutation_coadvance.py`)

Pins that `AGEClient.record_mutation` advances the tick (record + complete epoch) **and** the `graph_accel` sub-counter (`graph.invalidate()`) from one place — so they move together *by construction*, not by a convention a refactor could quietly break. Also pins the fail-safe (a failed epoch still invalidates the accelerator — evict, never serve stale) and that a raising `invalidate()` is non-fatal. Conformance tests in `test_freshness_contract.py` assert the declaration is well-formed and the tick is not mislisted as a peer.

## IVM revisit — no code, documented in ADR-207

The "revisit IVM where it's cheap" half found **no cheap win today**:
- The cache tiers (grounding, polarity, confidence) already reconcile **lazily on-read** — incremental at their natural granularity, so IVM-as-a-mechanism buys nothing.
- Artifacts are already per-row (`InstanceDerivation`).
- The one true full-recompute is the **catalog index rebuild**, and incremental maintenance there is blocked on a missing prerequisite: the epoch log records *that* a mutation happened, not *what* changed.

**Trigger to revisit** (recorded in the ADR): when `record_mutation` carries a structured per-event change-set (affected ontology / document / concept ids), the catalog index can patch the changed subtree incrementally instead of rebuilding wholesale.

## Scope

No pgrx extension change — `graph_accel` only writes its own generation table; the co-advance lives in application code (`record_mutation`), which is where it was already happening. Declaration + tests + docs only.

## Verification

`docs/scripts/adr lint` clean (0 errors, 0 warnings). Freshness suite green: `pytest tests/unit/lib/test_freshness_contract.py test_record_mutation_coadvance.py test_warm_cache_shortcircuit.py test_batch_chunk_recovery.py` → 30 passed.

Closes ADR-207 step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)