### PR TITLE
feat: Vocabulary lifecycle admin tab + job-dispatch parity (ADR-701)

### DIFF
--- a/api/app/models/vocabulary.py
+++ b/api/app/models/vocabulary.py
@@ -1,7 +1,7 @@
 """Pydantic models for vocabulary management operations (ADR-032)"""
 
 from pydantic import BaseModel, Field
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Literal
 from datetime import datetime
 from enum import Enum
 
@@ -436,6 +436,39 @@ class ConsolidateVocabularyResponse(BaseModel):
     pruned: Optional[List[str]] = None  # List of pruned (deleted) unused types
     pruned_count: Optional[int] = None  # Number of types pruned
     message: str
+
+
+# =============================================================================
+# Job Dispatch (ADR-701 §1a — parity with ontology annealing job model)
+# =============================================================================
+
+# Maps the dispatch "kind" to the registered worker job_type. The four
+# vocabulary worker operations predate the job system (ADR-100); this is how
+# they are triggered manually as jobs instead of running synchronously in-request.
+VOCAB_JOB_KIND_TO_TYPE: Dict[str, str] = {
+    "consolidate": "vocab_consolidate",
+    "refresh": "vocab_refresh",
+    "remeasure": "epistemic_remeasurement",
+    "embed": "vocab_embedding",
+}
+
+
+class VocabularyJobRequest(BaseModel):
+    """Dispatch a vocabulary maintenance operation as a background job (ADR-701 §1a).  @verified e478cb25"""
+    kind: Literal["consolidate", "refresh", "remeasure", "embed"] = Field(
+        ..., description="Which vocabulary worker operation to dispatch"
+    )
+    params: Optional[Dict[str, Any]] = Field(
+        None, description="Optional kind-specific parameters passed through to the worker job_data"
+    )
+
+
+class VocabularyJobDispatchResponse(BaseModel):
+    """Result of dispatching a vocabulary job (returns immediately; poll job status).  @verified e478cb25"""
+    job_id: str
+    kind: str
+    job_type: str
+    status: str
 
 
 # =============================================================================

--- a/api/app/routes/vocabulary.py
+++ b/api/app/routes/vocabulary.py
@@ -69,6 +69,11 @@ from ..models.vocabulary import (
     ReviewInfo,
     RejectionInfo,
 
+    # Job dispatch (ADR-701 §1a)
+    VocabularyJobRequest,
+    VocabularyJobDispatchResponse,
+    VOCAB_JOB_KIND_TO_TYPE,
+
     # Epistemic Status (ADR-065 Phase 2)
     EpistemicStatusMeasureRequest,
     EpistemicStatusMeasureResponse,
@@ -587,6 +592,68 @@ async def consolidate_vocabulary(
     except Exception as e:
         logger.error(f"Failed to consolidate vocabulary: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to consolidate vocabulary: {str(e)}")
+
+
+# =============================================================================
+# Job Dispatch (ADR-701 §1a — parity with ontology annealing job model)
+# =============================================================================
+
+@router.post(
+    "/jobs",
+    response_model=VocabularyJobDispatchResponse,
+    dependencies=[Depends(require_permission("vocabulary", "write"))],
+)
+async def dispatch_vocabulary_job(
+    current_user: CurrentUser,
+    request: VocabularyJobRequest,
+):
+    """
+    Dispatch a vocabulary maintenance operation as a background job (ADR-701 §1a).
+
+    The vocabulary subsystem predates the database-driven job system (ADR-100):
+    its worker operations run as jobs when fired automatically by their launchers
+    (hysteresis/cron), but the manual HTTP triggers historically ran synchronously
+    in-request. This endpoint brings manual triggers onto the job model, mirroring
+    `POST /ontology/annealing-cycle` — enqueue + auto-approve, then poll job status.
+
+    Supported `kind` values map to existing workers:
+      - `consolidate` → `vocab_consolidate`
+      - `refresh`     → `vocab_refresh`
+      - `remeasure`   → `epistemic_remeasurement`
+      - `embed`       → `vocab_embedding`
+
+    **Authorization:** Requires `vocabulary:write` permission.
+
+    Returns immediately with the `job_id`; the client polls job status.
+
+    @verified e478cb25
+    """
+    job_type = VOCAB_JOB_KIND_TO_TYPE.get(request.kind)
+    if not job_type:
+        raise HTTPException(status_code=400, detail=f"Unknown vocabulary job kind: {request.kind}")
+
+    from api.app.services.job_queue import get_job_queue
+
+    queue = get_job_queue()
+    triggered_by = current_user.username if current_user else "api"
+
+    job_data = dict(request.params or {})
+    job_data["triggered_by"] = triggered_by
+
+    job_id = queue.enqueue(job_type=job_type, job_data=job_data)
+
+    # Auto-approve so the ADR-100 lane manager claims it immediately
+    queue.update_job(job_id, {
+        "status": "approved",
+        "approved_by": triggered_by,
+    })
+
+    return VocabularyJobDispatchResponse(
+        job_id=job_id,
+        kind=request.kind,
+        job_type=job_type,
+        status="approved",
+    )
 
 
 # =============================================================================

--- a/api/app/routes/vocabulary.py
+++ b/api/app/routes/vocabulary.py
@@ -99,28 +99,15 @@ from ..models.vocabulary import (
 
 from api.app.lib.age_client import AGEClient
 from api.app.lib.ai_providers import get_provider
-from api.app.services.vocabulary_manager import VocabularyManager
+from api.app.services.vocabulary_manager import VocabularyManager, get_vocabulary_manager
 from api.app.lib.aggressiveness_curve import calculate_aggressiveness
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vocabulary", tags=["vocabulary"])
 
 
-def get_vocabulary_manager() -> VocabularyManager:
-    """Get VocabularyManager instance with current configuration"""
-    client = AGEClient()
-    provider = get_provider()
-
-    # Get configuration from database (with .env fallback)
-    mode = client.get_vocab_config('pruning_mode') or os.getenv("VOCAB_PRUNING_MODE", "aitl")
-    profile = client.get_vocab_config('aggressiveness_profile') or os.getenv("VOCAB_AGGRESSIVENESS", "aggressive")
-
-    return VocabularyManager(
-        db_client=client,
-        ai_provider=provider,
-        mode=mode,
-        aggressiveness_profile=profile
-    )
+# get_vocabulary_manager now lives in services.vocabulary_manager so the
+# vocab_consolidate worker and these routes share one factory (imported above).
 
 
 # =============================================================================

--- a/api/app/routes/vocabulary.py
+++ b/api/app/routes/vocabulary.py
@@ -615,6 +615,9 @@ async def dispatch_vocabulary_job(
 
     @verified e478cb25
     """
+    # `kind` is a Literal, so Pydantic rejects unknown values with 422 before
+    # we get here; this guard is belt-and-suspenders in case the enum and the
+    # mapping ever drift apart.
     job_type = VOCAB_JOB_KIND_TO_TYPE.get(request.kind)
     if not job_type:
         raise HTTPException(status_code=400, detail=f"Unknown vocabulary job kind: {request.kind}")

--- a/api/app/services/vocabulary_manager.py
+++ b/api/app/services/vocabulary_manager.py
@@ -1330,6 +1330,32 @@ def format_recommendations_summary(
     return "\n".join(lines)
 
 
+def get_vocabulary_manager() -> "VocabularyManager":
+    """Construct a VocabularyManager with current DB configuration.
+
+    Factory shared by the vocabulary routes and the vocab_consolidate worker so
+    both build the manager identically. Imports are deferred to keep the
+    services→lib dependency direction lazy and avoid import cycles.  @verified c1cdf76d
+    """
+    import os
+    from api.app.lib.age_client import AGEClient
+    from api.app.lib.ai_providers import get_provider
+
+    client = AGEClient()
+    provider = get_provider()
+
+    # Configuration from database (with .env fallback)
+    mode = client.get_vocab_config('pruning_mode') or os.getenv("VOCAB_PRUNING_MODE", "aitl")
+    profile = client.get_vocab_config('aggressiveness_profile') or os.getenv("VOCAB_AGGRESSIVENESS", "aggressive")
+
+    return VocabularyManager(
+        db_client=client,
+        ai_provider=provider,
+        mode=mode,
+        aggressiveness_profile=profile,
+    )
+
+
 if __name__ == "__main__":
     # Quick demonstration
     import asyncio

--- a/api/app/workers/vocab_consolidate_worker.py
+++ b/api/app/workers/vocab_consolidate_worker.py
@@ -45,7 +45,7 @@ def run_vocab_consolidate_worker(
     """
     try:
         from api.app.lib.age_client import AGEClient
-        from api.app.lib.vocabulary_manager import get_vocabulary_manager
+        from api.app.services.vocabulary_manager import get_vocabulary_manager
 
         logger.info(f"🔄 Vocab consolidation worker started: {job_id}")
 

--- a/docs/architecture/user-interfaces/ADR-701-vocabulary-administration-interface.md
+++ b/docs/architecture/user-interfaces/ADR-701-vocabulary-administration-interface.md
@@ -4,229 +4,162 @@ date: 2026-01-29
 deciders:
   - aaronsb
   - claude
-related: [22, 25, 26, 46, 47, 53, 65, 77]
+related: [22, 25, 26, 32, 46, 47, 52, 53, 65, 77, 200, 206, 703]
 ---
 
 # ADR-701: Vocabulary Administration Interface
 
 ## Context
 
-The vocabulary system is one of the platform's most sophisticated subsystems. It manages a dynamic, self-regulating set of relationship types that grow from LLM extraction, are categorized probabilistically via embeddings (ADR-047), scored by grounding contribution (ADR-046), classified by epistemic status (ADR-065), and consolidated through AI-assisted workflows (ADR-026). Tuning vocabulary parameters directly affects extraction quality, graph coherence, and system performance.
+The vocabulary system is a **self-regulating agentic cycle**, structurally the
+twin of ontology annealing (ADR-200). Relationship types grow from LLM
+extraction (ADR-025), are auto-categorized via embeddings (ADR-047), scored by
+grounding contribution (ADR-046), classified by epistemic status (ADR-065), and
+periodically **consolidated** — the expansion/consolidation "dreaming" cycle of
+ADR-052, driven by zone pressure (ADR-032: COMFORT/WATCH/DANGER/EMERGENCY) and
+an AITL consolidation worker that produces merge proposals. This is a loop that
+restructures the vocabulary on a heartbeat, much as the annealing worker
+restructures ontologies.
 
-Today, all vocabulary management happens through the CLI (`kg vocab` — 20 subcommands across 8 modules) or raw API calls (~20 REST endpoints). The web workstation has no vocabulary administration UI. The only web-side vocabulary awareness is `vocabularyStore.ts` (explorer color coding) and `OntologyFilterBlock` (query builder filter).
+Two facts frame this ADR:
 
-This creates several problems:
+**1. The vocabulary cycle is already live — and already surfaced everywhere
+except the web.** All vocabulary management happens through the CLI (`kg vocab`
+— 20 subcommands) or ~20 REST endpoints. The backend is mature: schema, workers,
+and endpoints for status/zones, types, profiles, config, consolidation, and
+epistemic measurement all exist (see *Backend Alignment Verification*). The web
+workstation has no vocabulary administration surface at all — only
+`vocabularyStore.ts` (explorer color coding) and `OntologyFilterBlock` (query
+filter).
 
-1. **Accessibility barrier.** Non-CLI users cannot see vocabulary health, adjust parameters, or respond to zone alerts (WATCH/DANGER/EMERGENCY). Vocabulary tuning requires terminal comfort and memorizing command options.
+**2. Its sibling cycle just got a web surface — and a pattern to follow.**
+ADR-703 ("Ontology Lifecycle Administration Interface") faced the structurally
+identical problem for ontology annealing: a self-regulating loop reachable only
+through the CLI. ADR-703 resolved it with an **operational cohort** in the Admin
+panel — the live `Ontology` tab in `AdminDashboard` (loop health / ecological
+pressure / read-only config / proposals queue) — shipped as an MVP tab first,
+with a dedicated `/admin/ontology-lifecycle` route as the deferred target state.
+The vocabulary cycle is the direct sibling (ADR-200 Design Principle 4:
+self-similarity across scale) and warrants **the same cohort, the same shape,
+the same incremental path.**
 
-2. **Curve blindness.** Aggressiveness profiles are defined by Bezier control points (x1, y1, x2, y2) — four floating point values that map to a curve shape. In the CLI, users set these numerically and see an ASCII approximation. This is a fundamentally visual concept trapped in a text interface.
-
-3. **Consolidation friction.** The AITL (AI-in-the-Loop) consolidation workflow produces merge recommendations with confidence scores. In the CLI, reviewing these is sequential and stateless — you cannot compare candidates, defer decisions, or return to a partially-reviewed batch.
-
-4. **Epistemic opacity.** Grounding measurements and epistemic classifications (WELL_GROUNDED through CONTRADICTED) are powerful data consistency signals, but the CLI presents them as flat tables. Trends, distributions, and anomalies are not visible.
-
-5. **Configuration coupling.** The 12 vocabulary config parameters interact — changing `vocab_max` shifts the zone, which changes effective aggressiveness, which changes consolidation behavior. In the CLI these are adjusted one at a time with no preview of cascading effects.
-
-Meanwhile, the existing Admin dashboard (`/admin`) has four tabs (Account, Users, Roles, System). The System tab is already 884 lines handling AI extraction, API keys, and embedding profiles. Vocabulary management is too deep to fit as another section there.
+> **Revision note (2026-05).** This ADR was originally drafted (2026-01-29) as a
+> six-tab, dedicated-route interface (Dashboard / Types / Profiles / Config /
+> Health / Merge) — before the ADR-703 OntologyTab pattern existed. That design
+> was over-scoped for a first increment: it led with a draggable Bézier curve
+> editor and chord diagrams rather than the operating loop. This revision
+> reframes the ADR around **parity with the ontology lifecycle cohort**, leads
+> with a lean MVP tab, and demotes the rich six-tab design to a clearly-deferred
+> target state. The backend verification below is unchanged and still valid.
 
 ## Decision
 
-### 1. Add "Vocabulary" as a Top-Level Admin Entry
+Surface the vocabulary consolidation cycle in the web workstation as a
+**first-class agentic-cycle cohort**, mirroring the ontology lifecycle interface
+(ADR-703). Ship it the same way ADR-703 shipped: an MVP tab in the existing
+`AdminDashboard` first, graduating to a dedicated route as richer surfaces
+accrete.
 
-Add a new sidebar entry under the Admin category:
+### 1. MVP — a "Vocabulary" tab in Administration, cohort to "Ontology"
 
-```
-Admin
-  ├── Administration    (existing: Account, Users, Roles, System)
-  └── Vocabulary        (new: dedicated vocabulary management)
-```
+Add a `Vocabulary` tab to the existing `AdminDashboard` (alongside Account /
+Users / Roles / System / **Ontology**), as the **direct cohort to the Ontology
+tab**. It reuses the OntologyTab structure (`web/src/components/admin/`,
+`components.tsx` shared `Section`/`InfoCard`/`StatusBadge`), so the two cycles
+read as siblings. Four panels map one-to-one onto the OntologyTab cohort:
 
-Route: `/admin/vocabulary`
+| Vocabulary panel (MVP) | Mirrors OntologyTab panel | Data source |
+|------------------------|---------------------------|-------------|
+| **Consolidation Loop** — pruning mode (Naive/HITL/AITL), enable state, last/next run, pending merge proposals, vocab size, "Run consolidation" | Annealing Loop | `GET /vocabulary/status`, consolidation worker status |
+| **Vocabulary Pressure** — zone badge (COMFORT/WATCH/DANGER/EMERGENCY), aggressiveness curve with current-position marker, effective aggressiveness | Ecological Pressure | `GET /vocabulary/status` (zone, size, thresholds, profile) |
+| **Configuration** — durable vocabulary config (thresholds, profile, pruning mode), **read-only here — adjust via `kg vocab` CLI** | Configuration (`annealing_options`) | `GET /admin/vocabulary/config` |
+| **Proposals** — merge/consolidation recommendations queue (AITL): auto-executed / needs-review / rejected, approve/reject | Proposals (CLEAVE/DISSOLVE/…) | `POST /vocabulary/consolidate`, `POST /vocabulary/merge` |
 
-This gives vocabulary its own full-page layout with room for multiple tabs and rich visualizations, rather than competing for space inside the existing System tab. The pattern mirrors how explorers each get dedicated workspace — vocabulary management deserves equivalent treatment given its complexity.
+This is **not** an explorer plugin (explorers visualize graph *data*; this
+operates the vocabulary *cycle* — the Edge Explorer, ADR-077, already covers
+visualization). It follows the non-explorer admin pattern of the Ontology tab.
+The MVP requires **zero backend changes** — every endpoint above already exists.
 
-### 2. Tab Structure
+The aggressiveness curve renders read-only in the MVP (the CLI already produces
+an ASCII version; the web shows the real curve with the current-position
+marker). Interactive curve *editing* is target-state, below.
 
-The vocabulary interface organizes into tabs by user intent:
+### 2. Target state — dedicated route with richer tabs (deferred)
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│  Vocabulary                                                          │
-├───────────┬──────────┬───────────┬────────────┬──────────┬──────────┤
-│ Dashboard │  Types   │ Profiles  │   Config   │  Health  │  Merge   │
-└───────────┴──────────┴───────────┴────────────┴──────────┴──────────┘
-```
+As the cohort proves out, graduate to a dedicated `/admin/vocabulary` route with
+the fuller tab set the original draft described. These are **deferred target
+state**, not MVP scope, and should accrete one at a time the way ADR-703's tabs
+do:
 
-#### Dashboard Tab
+- **Types** — sortable/filterable table of all relationship types with a detail
+  panel (category scores, similar/opposite types, QA analysis, epistemic
+  detail). Data: `GET /vocabulary/types`, `/category-scores/{type}`,
+  `/similar/{type}`, `/analyze/{type}`, `/epistemic-status/{type}`.
+- **Profiles** — interactive Bézier curve editor for aggressiveness profiles
+  (draggable control points replacing numeric CLI input). The single most
+  complex UI element; deferred precisely because it is not load-bearing for
+  operating the loop. Data: `GET/POST/DELETE /admin/vocabulary/profiles`.
+- **Config (interactive)** — threshold sliders with live zone/aggressiveness
+  preview, addressing configuration coupling. Promotes the MVP's read-only
+  Configuration panel to editable. Data: `PUT /admin/vocabulary/config`.
+- **Health** — epistemic status diagnostics: classification table, distribution,
+  anomaly highlights, category-flow chord diagram, sync detection. Data:
+  `GET/POST /vocabulary/epistemic-status`, `/category-flows`, `/sync`.
+- **Merge (full)** — the consolidation workbench with comparison, deferral, and
+  persisted review state (see the *Consolidation Review Is Stateless* gap).
 
-At-a-glance vocabulary health. The landing view.
+The MVP's four panels become the route's landing "Dashboard"; the rest are the
+progressive-disclosure tabs.
 
-- **Zone indicator** — Large, colored status badge (GREEN / WATCH / DANGER / EMERGENCY) with vocabulary size and threshold context (`142 types — max 150, emergency 200`).
-- **Summary cards** — Builtin vs custom count, active vs inactive, categories in use, last consolidation timestamp.
-- **Category distribution** — Bar or donut chart showing type counts per category (causation, logical, evidential, etc.) with confidence coloring (high/medium/low).
-- **Epistemic distribution** — Classification breakdown (WELL_GROUNDED, MIXED, WEAK, CONTRADICTED, INSUFFICIENT_DATA) as a stacked bar or pie.
-- **Staleness indicator** — Graph change counter delta since last measurement, with a "Remeasure" button if stale.
-- **Recent activity** — Last N vocabulary changes (merges, additions, category reassignments).
+### 3. CLI parity
 
-Data sources: `GET /vocabulary/status`, `GET /vocabulary/types`, `GET /vocabulary/epistemic-status`
+The CLI already carries the full vocabulary surface (`kg vocab status`, `list`,
+`consolidate`, `merge`, `similar`, `analyze`, profiles, config, epistemic). No
+new CLI commands are required for the MVP — unlike ADR-703, which had to *add*
+automation-policy commands. The web surface is catching the CLI up, not the
+reverse. Every web control must keep a CLI equivalent (project norm); the
+read-only Configuration panel explicitly directs operators to `kg vocab` for
+mutation.
 
-#### Types Tab
+### 4. Permission model
 
-The workhorse. Browse, search, filter, and inspect all relationship types.
+Reuses existing RBAC (ADR-028 / ADR-082), parallel to ADR-703's ontology gates:
 
-- **Table view** — Sortable columns: type name, category, edge count, confidence, grounding (avg), epistemic status, active/builtin flags. Filterable by category, status, active/inactive.
-- **Type detail panel** — Click a row to expand or open a side panel showing:
-  - Category assignment with confidence score and similarity breakdown (bar chart of scores against all 11 categories, from `GET /vocabulary/category-scores/{type}`).
-  - Similar types (top 5 by embedding similarity, from `GET /vocabulary/similar/{type}`).
-  - Opposite types (least similar, from `GET /vocabulary/similar/{type}?reverse=true`).
-  - QA analysis (miscategorization warnings, from `GET /vocabulary/analyze/{type}`).
-  - Epistemic detail (grounding stats: avg, std, min, max, sample size).
-  - Quick actions: merge into another type, toggle active/inactive, refresh category.
-- **Search** — Natural language search across vocabulary (`GET /vocabulary/similar/{type}` with query mode).
-- **Bulk actions** — Multi-select for batch category refresh or deactivation.
+| Action | Minimum capability |
+|--------|-------------------|
+| View the Vocabulary tab / any panel | `vocabulary:read` |
+| Approve/reject a consolidation proposal, run consolidation, trigger merge | `vocabulary:write` |
+| Edit profiles / mutate config (target-state interactive tabs) | `vocabulary_config:write` |
 
-Data sources: `GET /vocabulary/types`, `GET /vocabulary/category-scores/{type}`, `GET /vocabulary/similar/{type}`, `GET /vocabulary/analyze/{type}`, `GET /vocabulary/epistemic-status/{type}`
+The tab requires `vocabulary:read` to appear; `hasPermission()` disables
+(not hides-then-rejects) controls a user cannot use.
 
-#### Profiles Tab
+### 5. Component architecture
 
-Visual Bezier curve editor for aggressiveness profiles. This is where graphical controls replace numeric CLI input.
-
-- **Profile list** — All profiles (8 builtin + custom) as cards. Each shows a small curve thumbnail, name, and whether it's the active profile. Click to select.
-- **Curve editor** — The selected profile's Bezier curve rendered on a canvas:
-  - X-axis: normalized vocabulary utilization (0% to 100% of range).
-  - Y-axis: aggressiveness output (0.0 to 1.0, potentially overshooting to ~1.5 with aggressive profiles).
-  - **Draggable control point handles** (P1 and P2) — Drag to reshape the curve. Values update in real-time. The start point (0,0) and end point (1,1) are fixed; the two control points define the curve character.
-  - **Current position marker** — A dot on the curve showing where the vocabulary currently sits (based on current size vs min/max), with the effective aggressiveness value labeled.
-  - **Zone bands** — Background colored bands showing comfort/watch/merge/emergency zones along the X-axis.
-- **Profile metadata** — Name, description, created/updated timestamps, builtin flag.
-- **Actions** — Create new profile (set name, description, drag points or enter values), duplicate existing, delete custom profiles. Activate a profile (updates `aggressiveness_profile` in config).
-
-Data sources: `GET /admin/vocabulary/profiles`, `GET /admin/vocabulary/profiles/{name}`, `POST /admin/vocabulary/profiles`, `DELETE /admin/vocabulary/profiles/{name}`, `PUT /admin/vocabulary/config` (to activate)
-
-#### Config Tab
-
-All vocabulary configuration parameters with live preview of effects.
-
-- **Threshold sliders** — `vocab_min`, `vocab_max`, `vocab_emergency` as range sliders on a shared number line. Dragging one shows how the zone boundaries shift. Current vocabulary size marked as a reference point.
-- **Pruning mode** — Radio selector: Naive / HITL / AITL, with description of each mode's behavior.
-- **Similarity thresholds** — `synonym_threshold_strong` and `synonym_threshold_moderate` as sliders with visual indicator of what "strong" vs "moderate" similarity means (example pairs at each threshold).
-- **Other parameters** — `low_value_threshold`, `consolidation_similarity_threshold`, `auto_expand_enabled` toggle, `embedding_model` selector.
-- **Live preview panel** — As parameters are adjusted, show computed effects: new zone classification, new aggressiveness score, estimated types that would qualify for pruning at new thresholds. This addresses the "configuration coupling" problem — users see cascading effects before saving.
-- **Save / Reset** — Explicit save with diff summary of what changed. Reset to last saved state.
-
-Data sources: `GET /admin/vocabulary/config`, `PUT /admin/vocabulary/config`, `GET /vocabulary/status` (for live preview)
-
-#### Health Tab
-
-Epistemic status and data consistency — the diagnostic view.
-
-- **Measurement controls** — Run epistemic measurement with configurable sample size. Progress indicator during measurement. Last measurement timestamp and staleness delta.
-- **Classification table** — All types with epistemic status, sortable and filterable. Color-coded: green (WELL_GROUNDED), yellow (MIXED), orange (WEAK), red (CONTRADICTED), gray (INSUFFICIENT_DATA), blue (HISTORICAL).
-- **Distribution chart** — Stacked bar or sunburst showing classification counts. Trend over time if multiple measurements exist.
-- **Anomaly highlights** — Flag types where epistemic status and category confidence disagree (e.g., high-confidence category assignment but CONTRADICTED grounding), or where status changed since last measurement. These are the "conflicts or problems with data consistency" that need attention.
-- **Category flow diagram** — Chord diagram from `GET /vocabulary/category-flows` showing inter-category edge flow patterns. Reveals whether categories are well-separated or bleeding into each other.
-- **Sync status** — Missing types detected in graph but not in vocabulary table. One-click sync with dry-run preview.
-
-Data sources: `POST /vocabulary/epistemic-status/measure`, `GET /vocabulary/epistemic-status`, `GET /vocabulary/category-flows`, `POST /vocabulary/sync`
-
-#### Merge Tab
-
-AITL consolidation workflow and manual merge operations.
-
-- **Consolidation launcher** — Target vocabulary size slider (30-200), auto-execute threshold slider (0.0-1.0), dry-run toggle. "Run Consolidation" button.
-- **Recommendation review** — Results displayed as three groups:
-  - **Auto-executed** (confidence ≥ threshold) — Already merged, shown for audit. Expandable to see reasoning.
-  - **Needs review** (medium confidence) — Cards with source type, target type, similarity score, LLM reasoning. Approve/reject buttons per recommendation. Batch approve/reject.
-  - **Rejected** (low confidence or directional inverse) — Shown for transparency.
-- **Manual merge** — Select source type and target type from dropdowns (with similarity score preview). Reason text field (audit trail). Execute with confirmation showing affected edge count.
-- **Merge history** — Log of past merges with who, when, why, and how many edges moved. Enables audit and potential rollback investigation.
-- **Unused type pruning** — List of types with zero edges. Bulk deactivate with confirmation.
-
-Data sources: `POST /vocabulary/consolidate`, `POST /vocabulary/merge`, `GET /vocabulary/types` (for unused detection)
-
-### 3. Permission Model
-
-Vocabulary administration uses existing RBAC resources:
-
-| Tab | Read Permission | Write Permission |
-|-----|-----------------|------------------|
-| Dashboard | `vocabulary:read` | — |
-| Types | `vocabulary:read` | `vocabulary:write` (toggle active, refresh categories) |
-| Profiles | `vocabulary_config:read` | `vocabulary_config:write` (create/delete/activate profiles) |
-| Config | `vocabulary_config:read` | `vocabulary_config:write` (update parameters) |
-| Health | `vocabulary:read` | `vocabulary:write` (run measurements, sync) |
-| Merge | `vocabulary:read` | `vocabulary:write` (execute merges, consolidation) |
-
-The sidebar entry itself requires `vocabulary:read` to appear. Tabs without write permission show data read-only with action buttons hidden.
-
-### 4. Component Architecture
+MVP — one tab component mirroring `OntologyTab.tsx`:
 
 ```
-web/src/components/admin/vocabulary/
-├── VocabularyDashboard.tsx       # Route component, tab orchestration
-├── DashboardTab.tsx              # Health overview
-├── TypesTab.tsx                  # Type browser + detail panel
-├── ProfilesTab.tsx               # Bezier curve editor
-├── BezierCurveEditor.tsx         # Reusable curve canvas component
-├── ConfigTab.tsx                 # Parameter form with live preview
-├── HealthTab.tsx                 # Epistemic status + diagnostics
-├── MergeTab.tsx                  # Consolidation workflow
-├── components.tsx                # Shared vocabulary UI components
-├── types.ts                     # TypeScript interfaces
-└── index.ts                     # Exports
+web/src/components/admin/
+├── VocabularyTab.tsx              # MVP: 4-panel cohort (loop/pressure/config/proposals)
+└── VocabularyPressurePanel.tsx    # mirrors AnnealingPressurePanel.tsx (read-only curve)
 ```
 
-New store (or extend existing `vocabularyStore`):
+Registered in `AdminDashboard.tsx` exactly like the Ontology tab: add
+`'vocabulary'` to the `TabType` union (`types.ts`), a permission-gated
+`TabButton`, and a conditional render. A `vocabularyAdminStore` (Zustand,
+parallel to `ontologyLifecycleStore`) holds status/config/proposals; it may
+extend or sit beside the existing `vocabularyStore` (explorer coloring).
 
-```typescript
-interface VocabularyAdminStore {
-  // Status
-  status: VocabStatus | null;
-  loadStatus(): Promise<void>;
-
-  // Types
-  types: EdgeTypeInfo[];
-  loadTypes(opts?: { inactive?: boolean }): Promise<void>;
-
-  // Profiles
-  profiles: AggressivenessProfile[];
-  activeProfile: string;
-  loadProfiles(): Promise<void>;
-
-  // Config
-  config: VocabularyConfig | null;
-  loadConfig(): Promise<void>;
-  updateConfig(updates: Partial<VocabularyConfig>): Promise<void>;
-
-  // Epistemic
-  epistemicStatuses: EpistemicStatusInfo[];
-  loadEpistemicStatuses(): Promise<void>;
-  runMeasurement(sampleSize: number): Promise<void>;
-}
-```
-
-### 5. Sidebar Integration
-
-In `AppLayout.tsx`, add a new `SidebarItem` under the Admin category:
-
-```typescript
-{
-  icon: Waypoints,  // lucide-react — represents connected vocabulary
-  label: 'Vocabulary',
-  description: 'Edge types, profiles, health',
-  path: '/admin/vocabulary',
-  requiredPermission: { resource: 'vocabulary', action: 'read' },
-}
-```
-
-Route in `App.tsx`:
-```typescript
-<Route path="/admin/vocabulary" element={<VocabularyDashboard />} />
-```
+Target-state route components (`VocabularyDashboard.tsx`, `TypesTab.tsx`,
+`ProfilesTab.tsx`, `BezierCurveEditor.tsx`, `HealthTab.tsx`, `MergeTab.tsx`)
+land with their respective deferred tabs.
 
 ## Backend Alignment Verification
 
-Before committing to this interface design, the database schema, API endpoints, and worker implementations were audited against the UI's expectations. The vocabulary backend has been built incrementally across 8+ ADRs and ~10 migrations. This section documents what's confirmed working, what has gaps, and what the UI must account for.
+The database schema, API endpoints, and worker implementations were audited
+against the UI's expectations. The vocabulary backend has been built
+incrementally across 8+ ADRs and ~10 migrations. This section documents what's
+confirmed working and the two gaps that affect only the deferred Merge tab.
 
 ### Confirmed: Schema Supports All UI Features
 
@@ -246,8 +179,9 @@ Before committing to this interface design, the database schema, API endpoints, 
 
 All ~20 vocabulary endpoints verified present and functional:
 
-- **Profiles**: `GET/POST/DELETE /admin/vocabulary/profiles` — Bezier control points accepted with validation (x: 0.0–1.0, y: -2.0–2.0). Profile creation, listing, deletion all work. Builtin profiles protected.
-- **Config**: `PUT /admin/vocabulary/config` — Supports all 11 parameters as optional partial updates. Returns computed zone/aggressiveness after update (enables live preview).
+- **Status**: `GET /vocabulary/status` — vocab size, zone, aggressiveness, builtin/custom/category counts, thresholds. Powers the MVP's Consolidation Loop and Vocabulary Pressure panels directly.
+- **Profiles**: `GET/POST/DELETE /admin/vocabulary/profiles` — Bézier control points accepted with validation (x: 0.0–1.0, y: -2.0–2.0). Profile creation, listing, deletion all work. Builtin profiles protected.
+- **Config**: `GET`/`PUT /admin/vocabulary/config` — Supports all 11 parameters as optional partial updates. Returns computed zone/aggressiveness after update (enables live preview).
 - **Types**: `GET /vocabulary/types` — Returns `EdgeTypeListResponse` with active/builtin/custom counts and full `EdgeTypeInfo` per type including category scoring and epistemic status.
 - **Category flows**: `GET /vocabulary/category-flows` — Returns inter-category chord diagram matrix. Ready for visualization.
 - **Merge**: `POST /vocabulary/merge` — Creates audit trail in `vocabulary_history` via `AGEClient.merge_edge_types()`.
@@ -263,113 +197,168 @@ All ~20 vocabulary endpoints verified present and functional:
 | `vocab_refresh_worker` | `api/app/workers/vocab_refresh_worker.py` | CategoryRefreshLauncher |
 | `epistemic_remeasurement_worker` | `api/app/workers/epistemic_remeasurement_worker.py` | EpistemicRemeasurementLauncher (change counter delta ≥ threshold) |
 
-All three workers are registered in `main.py` and integrated with the job queue system. The epistemic remeasurement runs on a cron schedule (`0 * * * *` — hourly) with hysteresis via the graph_metrics delta mechanism.
+All three workers are registered in `main.py` and integrated with the job queue
+system. The epistemic remeasurement runs on a cron schedule (`0 * * * *` —
+hourly) with hysteresis via the graph_metrics delta mechanism. The consolidation
+worker is the vocabulary analog of the annealing worker — the loop the MVP's
+Consolidation Loop panel observes.
 
-### Gap: Consolidation Review Is Stateless
+### Gap (Merge tab only): Consolidation Review Is Stateless
 
-The AITL consolidation endpoint (`POST /vocabulary/consolidate`) returns `needs_review` items in the HTTP response, but **does not persist them** for later retrieval. If the user navigates away from the Merge tab after running consolidation, deferred review items are lost.
+The AITL consolidation endpoint (`POST /vocabulary/consolidate`) returns
+`needs_review` items in the HTTP response, but **does not persist them**. If the
+user navigates away after running consolidation, deferred review items are lost.
 
-The schema infrastructure exists — `kg_api.pruning_recommendations` has a `status` column (pending/approved/rejected/executed) with `reviewed_by`, `reviewer_notes`, and `expires_at` fields — but the consolidation code path does not write to this table.
+The schema exists — `kg_api.pruning_recommendations` has a `status` column
+(pending/approved/rejected/executed) with `reviewed_by`, `reviewer_notes`, and
+`expires_at` — but the consolidation code path does not write to it. The correct
+long-term fix is to persist recommendations to that table (no schema change
+needed). This affects only the deferred full Merge tab, not the MVP.
 
-**UI implication for Merge tab:** Phase 3 should either:
-- (a) Hold consolidation results in component state and warn users that navigating away loses unreviewed items, or
-- (b) Require a backend change to persist recommendations to `pruning_recommendations` so they survive page navigation. This table is already designed for exactly this purpose — it just needs wiring.
+### Gap (Merge tab only): Prune and Deprecate Execution Are Stubbed
 
-Option (b) is the correct long-term fix and should be addressed during Phase 3 implementation. The table schema requires no changes.
+`VocabularyManager._execute_prune()` and `._execute_deprecate()`
+(vocabulary_manager.py lines ~1091-1150) contain TODO placeholders. Merge
+execution works fully, but hard-delete pruning and formal deprecation are
+incomplete. **Consistent with the platform's append-only / no-destructive-delete
+posture (ADR-203, ADR-206), the UI should never expose a hard-delete action.**
+Unused-type cleanup uses **deactivation** (`is_active = false`), which works
+today — types are deprecated, never destroyed, preserving the epistemic trail.
 
-### Gap: Prune and Deprecate Execution Are Stubbed
+### MVP Requires Zero Backend Changes
 
-`VocabularyManager._execute_prune()` and `._execute_deprecate()` (vocabulary_manager.py lines ~1091-1150) contain TODO placeholders. Merge execution works fully, but hard-delete pruning and formal deprecation workflows are incomplete.
-
-**UI implication for Merge tab:** The "Unused type pruning" section should use **deactivation** (set `is_active = false`) rather than deletion. This works today via the existing type update pathway. The UI should not expose a "permanently delete" action until the backend prune execution is implemented.
-
-### No Backend Changes Required for MVP
-
-Phases 1 and 2 (Dashboard, Types, Profiles, Config) require **zero backend changes**. All API endpoints, schema, and workers are in place. The two gaps above affect only Phase 3 (Merge tab), and both have viable workarounds until backend work catches up.
+The MVP cohort (Consolidation Loop / Vocabulary Pressure / read-only
+Configuration / Proposals) consumes only endpoints that already exist. The two
+gaps above are scoped entirely to the deferred full Merge tab.
 
 ## Consequences
 
 ### Positive
 
-- Vocabulary tuning becomes accessible to non-CLI users — the primary audience for the web workstation
-- Bezier curve editing transforms from "set four numbers" to "drag a curve shape" — a natural fit for the inherently visual aggressiveness model
-- Consolidation review becomes a batch workflow with comparison and deferral, instead of sequential CLI prompts
-- Live preview in Config eliminates trial-and-error parameter adjustment
-- Epistemic health gets a proper diagnostic view, making data consistency problems discoverable rather than hidden
-- Category flow visualization (already has API support) gets a permanent home
-- Backend verification confirms Phases 1-2 require zero backend changes — all API endpoints, schema, and workers are already in place
+- The vocabulary consolidation cycle becomes observable in the web workstation,
+  reading as the direct sibling of the ontology annealing cycle — one mental
+  model, two scales (ADR-200 self-similarity).
+- The MVP ships against today's backend with zero backend changes and minimal UI
+  (one tab mirroring OntologyTab) — fast path to value.
+- The interface degrades gracefully and accretes incrementally, exactly as
+  ADR-703 does; each deferred tab renders against whatever backend exists.
+- Non-CLI operators can finally see vocabulary zone/pressure and review
+  consolidation proposals without terminal access.
+- Reuses established patterns wholesale — OntologyTab cohort, `AdminDashboard`
+  tab registration, ADR-046 Bézier infrastructure (for the deferred Profiles
+  tab), ADR-028/082 permission gating.
 
 ### Negative
 
-- Adds a second admin route (`/admin/vocabulary`), breaking the single-dashboard pattern. This is intentional — the alternative (cramming into System tab) was evaluated and rejected.
-- The Bezier curve editor (`BezierCurveEditor.tsx`) is a non-trivial interactive canvas component — likely the most complex single UI element in the admin section.
-- The Merge tab's AITL workflow involves async job execution and polling, which adds state management complexity. Additionally, consolidation review is currently stateless on the backend — the `pruning_recommendations` table exists but isn't wired to the consolidation endpoint, so Phase 3 needs either client-side state management with navigation warnings or a backend fix to persist recommendations.
-- Unused type pruning is limited to deactivation (set `is_active = false`) because backend prune/deprecate execution is stubbed. Hard deletion requires backend completion before the UI can expose it.
-- Six tabs is a lot. If user testing shows overwhelm, Dashboard + Types + Profiles could be the initial set, with Health and Merge as progressive disclosure.
+- Two surfaces (the ontology and vocabulary cohorts) now share a maintenance
+  burden; changes to the shared admin `components.tsx` affect both.
+- The deferred Profiles tab's interactive Bézier editor remains non-trivial UI
+  work — but it is explicitly out of MVP scope, which removes it from the
+  critical path.
+- The full Merge tab depends on the two backend gaps above; until they land,
+  consolidation review is best-effort (component state) and pruning is
+  deactivation-only.
 
 ### Neutral
 
-- Requires extending `VisualizationType` or admin routing, but not the explorer plugin system (this is admin, not an explorer)
-- The `vocabularyStore` may need extension or a parallel `vocabularyAdminStore` to hold admin-specific state (config, profiles, epistemic data) separately from explorer state (type metadata for coloring)
-- New RBAC resources (`vocabulary:read/write`, `vocabulary_config:read/write`) need registration in the resource registry if not already present
-- The category flow chord diagram component could be shared with the Edge Explorer (ADR-077) if both use the same `GET /vocabulary/category-flows` endpoint
+- The MVP stays inside `AdminDashboard`; the dedicated `/admin/vocabulary` route
+  is deferred until the richer tabs justify it (mirrors ADR-703's MVP→route
+  graduation).
+- A `vocabularyAdminStore` may extend or sit beside the existing
+  `vocabularyStore` (explorer coloring vs admin state).
+- New RBAC resources (`vocabulary:read/write`, `vocabulary_config:read/write`)
+  need registration if not already present.
+- The category-flow chord diagram (deferred Health tab) could be shared with the
+  Edge Explorer (ADR-077).
 
 ## Alternatives Considered
 
-### A. Add a Vocabulary Section to the System Tab
+### A. Add a Vocabulary section to the System tab
 
-Put vocabulary management as another collapsible `<Section>` inside the existing System tab.
+Put vocabulary management as another collapsible `<Section>` inside the existing
+System tab.
 
-**Rejected because:** The System tab is already 884 lines with three major sections (AI extraction, API keys, embedding profiles). Vocabulary management has 6 distinct concern areas and needs interactive visualizations (curve editor, chord diagram, consolidation workflow). Cramming this in would make System tab unmaintainable and the UI cramped. The depth of vocabulary management warrants dedicated space.
+**Rejected because:** the System tab is already ~884 lines (AI extraction, API
+keys, embedding profiles). The vocabulary cycle deserves its own cohort, peer to
+the Ontology tab — not a section buried inside an unrelated tab. ADR-703 rejected
+the identical option for the annealing cohort.
 
-### B. Build as an Explorer Plugin
+### B. Build as an explorer plugin
 
-Register vocabulary management as an explorer in the workstation, alongside Force Graph, Document Explorer, etc.
+Register vocabulary management as an explorer alongside Force Graph, Document
+Explorer, etc.
 
-**Rejected because:** Vocabulary management is an administrative function, not a data exploration function. Explorers visualize graph data; vocabulary admin configures how the graph is built. Placing it in the explorer registry would confuse the mental model (explorers are for understanding data, admin is for tuning the system). The Edge Explorer (ADR-077) already handles vocabulary *visualization* — this ADR handles vocabulary *administration*.
+**Rejected because:** vocabulary administration *operates a cycle*; explorers
+*visualize data*. The Edge Explorer (ADR-077) already handles vocabulary
+visualization. ADR-703 drew the same boundary for ontologies (operate at
+`/admin`, explore at `/explore`).
 
-### C. Standalone Page Outside Admin
+### C. Lead with the dedicated six-tab route (the original 2026-01 draft)
 
-Create `/vocabulary-admin` as a top-level route, not nested under Admin.
+Ship the full `/admin/vocabulary` route with six intent-based tabs as the first
+increment.
 
-**Rejected because:** Vocabulary configuration is an administrative concern. Users expect admin functions grouped together. A standalone route fragments the admin experience and complicates sidebar organization.
+**Rejected because:** over-scoped for increment one, and it led with the wrong
+thing — a draggable Bézier editor and chord diagrams instead of the operating
+loop. It also predated the OntologyTab cohort pattern, so the two sibling cycles
+would not have rhymed. The six-tab design survives as **deferred target state**
+(§2); the MVP cohort (§1) is increment one, matching ADR-703's MVP→route path.
 
-### D. Fewer Tabs with Denser Layout
+### D. One combined "vocabulary + ontology lifecycle" admin surface
 
-Combine Dashboard + Health into one tab, Types + Merge into another, Profiles + Config into a third. Three tabs total.
+Fold both cycles into a single lifecycle admin page.
 
-**Not rejected, but deferred.** This is a valid simplification if six tabs proves overwhelming. The tab structure proposed here maps one concern per tab, which is clearest for documentation and initial implementation. Consolidation can happen after user testing reveals actual navigation patterns.
+**Rejected because:** they are distinct subsystems with distinct vocabularies,
+proposals, and configuration. ADR-703 keeps the ontology cohort its own tab;
+this ADR keeps vocabulary its own tab. They *rhyme* via a shared cohort shape and
+cross-link, but neither owns the other.
 
 ## Implementation Notes
 
-### Phase 1: Foundation + Dashboard + Types
+**MVP (increment one):** a single `Vocabulary` tab in `AdminDashboard`, peer to
+the `Ontology` tab, with the four-panel cohort (§1): Consolidation Loop,
+Vocabulary Pressure (read-only curve), read-only Configuration, Proposals queue.
+Backed entirely by existing endpoints — zero backend changes. Mirror
+`OntologyTab.tsx` / `AnnealingPressurePanel.tsx` structure and the
+`AdminDashboard` tab-registration steps.
 
-- Create route, sidebar entry, tab skeleton
-- Dashboard tab with zone status, summary cards, category/epistemic distribution charts
-- Types tab with sortable/filterable table and detail panel
-- Read-only — no write actions yet
+Recommended order, mirroring ADR-703's incremental graduation:
 
-### Phase 2: Profiles + Config
+1. **MVP cohort tab** — the four panels above. Delivers vocabulary-cycle
+   visibility against today's backend first; the most urgent gap.
+2. **Types tab** — buildable today against `GET /vocabulary/types`; promotes the
+   tab toward the dedicated route.
+3. **Interactive Config** — promote the read-only Configuration panel to editable
+   (`PUT /admin/vocabulary/config`) with live zone preview.
+4. **Profiles tab** — the Bézier curve editor (ADR-046 infrastructure). Deferred;
+   not load-bearing for operating the loop.
+5. **Health tab** — epistemic diagnostics and category-flow chord diagram.
+6. **Full Merge tab** — depends on the two backend gaps (persisted review,
+   deactivation-only cleanup) landing first.
 
-- Bezier curve editor component (canvas-based, draggable control points)
-- Profile list, selection, create/delete
-- Config form with threshold sliders and live zone preview
-
-### Phase 3: Health + Merge
-
-- Epistemic measurement controls and classification table
-- Category flow chord diagram
-- Sync detection and execution
-- AITL consolidation launcher and recommendation review
-- Manual merge workflow with audit trail
+Graduate from the `AdminDashboard` tab to the dedicated `/admin/vocabulary`
+route once tabs 2–6 justify the space — the §1 cohort becomes the route's
+landing Dashboard.
 
 ## Related ADRs
 
+- **ADR-200** — Annealing Ontologies (the sibling cycle; this ADR is its
+  vocabulary-scale twin — Design Principle 4, self-similarity across scale)
+- **ADR-206** — Closed-vocabulary annealing actions & epistemic ledger
+  (append-only / no-destructive-delete posture this interface honors)
+- **ADR-703** — Ontology Lifecycle Administration Interface (the cohort pattern,
+  MVP→route path, and permission model this ADR mirrors)
+- **ADR-052** — Vocabulary Expansion-Consolidation Cycle (the "dreaming" loop
+  this interface operates)
+- **ADR-032** — Automatic edge vocabulary expansion with zones (COMFORT/WATCH/
+  DANGER/EMERGENCY pressure surfaced in the Vocabulary Pressure panel)
 - **ADR-022** — Original 30-type taxonomy (the vocabulary this interface manages)
 - **ADR-025** — Dynamic relationship vocabulary (capture and expansion model)
 - **ADR-026** — Autonomous vocabulary curation (AITL consolidation workflow)
-- **ADR-046** — Grounding-aware vocabulary management (scoring model)
-- **ADR-047** — Probabilistic vocabulary categorization (category confidence system)
-- **ADR-053** — Vocabulary embedding similarity (similar/opposite type detection)
+- **ADR-046** — Grounding-aware vocabulary management & Bézier profiles (scoring
+  model; curve infrastructure for the deferred Profiles tab)
+- **ADR-047** — Probabilistic vocabulary categorization (category confidence)
+- **ADR-053** — Vocabulary embedding similarity (similar/opposite detection)
 - **ADR-065** — Epistemic status classification (health measurement model)
-- **ADR-077** — Vocabulary explorers (visualization complement — explores data; this ADR administers configuration)
+- **ADR-077** — Vocabulary explorers (visualization complement — explores data;
+  this ADR operates the cycle)

--- a/docs/architecture/user-interfaces/ADR-701-vocabulary-administration-interface.md
+++ b/docs/architecture/user-interfaces/ADR-701-vocabulary-administration-interface.md
@@ -4,7 +4,7 @@ date: 2026-01-29
 deciders:
   - aaronsb
   - claude
-related: [22, 25, 26, 32, 46, 47, 52, 53, 65, 77, 200, 206, 703]
+related: [22, 25, 26, 32, 46, 47, 52, 53, 65, 77, 100, 200, 206, 703]
 ---
 
 # ADR-701: Vocabulary Administration Interface
@@ -73,16 +73,50 @@ read as siblings. Four panels map one-to-one onto the OntologyTab cohort:
 | **Consolidation Loop** — pruning mode (Naive/HITL/AITL), enable state, last/next run, pending merge proposals, vocab size, "Run consolidation" | Annealing Loop | `GET /vocabulary/status`, consolidation worker status |
 | **Vocabulary Pressure** — zone badge (COMFORT/WATCH/DANGER/EMERGENCY), aggressiveness curve with current-position marker, effective aggressiveness | Ecological Pressure | `GET /vocabulary/status` (zone, size, thresholds, profile) |
 | **Configuration** — durable vocabulary config (thresholds, profile, pruning mode), **read-only here — adjust via `kg vocab` CLI** | Configuration (`annealing_options`) | `GET /admin/vocabulary/config` |
-| **Proposals** — merge/consolidation recommendations queue (AITL): auto-executed / needs-review / rejected, approve/reject | Proposals (CLEAVE/DISSOLVE/…) | `POST /vocabulary/consolidate`, `POST /vocabulary/merge` |
+| **Actions** — job-dispatch triggers for the four worker operations (consolidate / refresh categories / remeasure epistemic / generate embeddings); fire-and-poll, toast the `job_id` | Annealing Loop's "Run cycle" trigger | `POST /vocabulary/jobs {kind}` (new), job-status polling |
+
+The MVP is **present-information plus triggers** — it surfaces state and
+*dispatches jobs*, but does **not** review/approve individual proposals
+(per-proposal merge approval is deferred to the target-state Merge tab).
 
 This is **not** an explorer plugin (explorers visualize graph *data*; this
 operates the vocabulary *cycle* — the Edge Explorer, ADR-077, already covers
 visualization). It follows the non-explorer admin pattern of the Ontology tab.
-The MVP requires **zero backend changes** — every endpoint above already exists.
 
 The aggressiveness curve renders read-only in the MVP (the CLI already produces
 an ASCII version; the web shows the real curve with the current-position
 marker). Interactive curve *editing* is target-state, below.
+
+### 1a. Vocabulary operations dispatch as jobs (parity with annealing)
+
+The vocabulary subsystem predates the database-driven job system (ADR-100). Its
+four worker operations — `vocab_consolidate`, `vocab_refresh`,
+`epistemic_remeasurement`, `vocab_embedding` — already run as **jobs** when
+fired *automatically* by their launchers (hysteresis / cron), but their *manual*
+HTTP entry points (`POST /vocabulary/consolidate`, `/refresh-categories`,
+`/epistemic-status/measure`, `/generate-embeddings`) execute **synchronously
+inside the request** — a pre-jobs legacy. Ontology annealing, by contrast,
+triggers a job (`POST /ontology/annealing-cycle` → `queue.enqueue(...)`).
+
+To reach parity, manual vocabulary triggers move onto the job model. Add a
+single unified dispatch endpoint:
+
+```
+POST /vocabulary/jobs   { "kind": "consolidate" | "refresh" | "remeasure" | "embed", ...params }
+  → queue.enqueue(job_type=<worker for kind>, job_data=...) ; auto-approve ; return { job_id }
+```
+
+This mirrors `/ontology/annealing-cycle` exactly (enqueue + auto-approve, client
+polls job status — ADR-100), reuses the four existing workers unchanged, and is
+gated `vocabulary:write`. One endpoint, four kinds — minimal new surface, no
+collision with the existing synchronous endpoints (which remain for the CLI and
+for callers that want inline results). The synchronous endpoints are **not**
+wired to the UI: a button must not block on an LLM consolidation, and dispatch
+is what gives the operation job-queue visibility.
+
+This is the only backend addition the MVP requires; the read panels
+(Consolidation Loop, Vocabulary Pressure, Configuration) consume endpoints that
+already exist.
 
 ### 2. Target state — dedicated route with richer tabs (deferred)
 
@@ -114,12 +148,14 @@ progressive-disclosure tabs.
 ### 3. CLI parity
 
 The CLI already carries the full vocabulary surface (`kg vocab status`, `list`,
-`consolidate`, `merge`, `similar`, `analyze`, profiles, config, epistemic). No
-new CLI commands are required for the MVP — unlike ADR-703, which had to *add*
-automation-policy commands. The web surface is catching the CLI up, not the
-reverse. Every web control must keep a CLI equivalent (project norm); the
-read-only Configuration panel explicitly directs operators to `kg vocab` for
-mutation.
+`consolidate`, `merge`, `similar`, `analyze`, profiles, config, epistemic), so
+the web MVP needs no new CLI commands — it is catching the CLI up, not the
+reverse. The read-only Configuration panel directs operators to `kg vocab` for
+mutation. One nuance follows from §1a: the web Actions panel *dispatches jobs*,
+whereas the existing CLI verbs (`kg vocab consolidate`, etc.) still run
+*synchronously*. Giving those CLI verbs an optional job-dispatch flag (so both
+surfaces enqueue identically) is a sensible follow-up but is not MVP-blocking —
+the synchronous CLI path remains valid.
 
 ### 4. Permission model
 
@@ -348,6 +384,8 @@ landing Dashboard.
   (append-only / no-destructive-delete posture this interface honors)
 - **ADR-703** — Ontology Lifecycle Administration Interface (the cohort pattern,
   MVP→route path, and permission model this ADR mirrors)
+- **ADR-100** — Database-driven job dispatch (the queue the §1a unified
+  `/vocabulary/jobs` endpoint enqueues onto; parity with `/ontology/annealing-cycle`)
 - **ADR-052** — Vocabulary Expansion-Consolidation Cycle (the "dreaming" loop
   this interface operates)
 - **ADR-032** — Automatic edge vocabulary expansion with zones (COMFORT/WATCH/

--- a/docs/architecture/user-interfaces/ADR-703-ontology-lifecycle-administration-interface.md
+++ b/docs/architecture/user-interfaces/ADR-703-ontology-lifecycle-administration-interface.md
@@ -39,7 +39,7 @@ autonomy *trustworthy* rather than merely *automatic*:
 | Graduated automation | #251 Autonomous safety bounds | Consecutive-cycle demotion gate, high-confidence promotion gate | `_auto_approve_and_dispatch()` approves all proposals unconditionally |
 | Adaptive control | #249 Bezier ecological pressure | Dynamic `demotion_threshold` / `promotion_min_degree` driven by the ecological ratio | `annealing_manager.py` carries the comment *"Threshold feedback is deferred (#249)"* — thresholds are static |
 | Execution fidelity | #252 Per-source affinity routing | Route each source in a dying ontology to its own best-affinity target | `proposal_executor.execute_demotion()` calls `dissolve_ontology()` with a single absorption target |
-| Execution fidelity | #241 Integrity worker | Detect and heal structural edge misuse (LLM emitting `SCOPED_BY`/`APPEARS` as semantic edges) | No structural-edge integrity worker exists |
+| Execution fidelity | #241 Integrity worker | Detect (not heal) structural edge misuse (LLM emitting `SCOPED_BY`/`APPEARS` as semantic edges); remediate non-destructively via classify/deactivate | No structural-edge detection exists; destructive healing rejected (see Integrity Tab) |
 
 These five are not five separate features. They are one body of work — the
 unfinished half of ADR-200 Phase 4 — and they have a dependency order:
@@ -193,20 +193,32 @@ concept trapped in a text interface. The same applies here.
 Data sources: `GET /ontology/annealing/ecology`, `GET`/`PUT` on the ecological
 pressure profile within `annealing_options`.
 
-#### Integrity Tab — structural guard (#241)
+#### Integrity Tab — structural guard (#241, detection/classify only)
 
-Surfaces the graph integrity worker.
+Surfaces structural-edge detection. **Detection and classification only — no
+destructive healing.** The original #241 proposal (rewrite illegal structural
+edges to `SIMILAR_TO` at low confidence, delete offending VocabType nodes) is
+**rejected** as inconsistent with the platform's append-only, no-destructive-
+delete posture (ADR-203 epoch event log, ADR-206 "no deletion, only movement")
+and its classify-don't-prune vocabulary stance (ADR-046, ADR-052). A destructive
+janitor would overwrite LLM-emitted signal and fabricate dishonest provenance.
+Crucially, the misuse it targeted is already neutralized by ADR-200 Design
+Principle 6 (edge-agnostic lifecycle): lifecycle queries match on node types,
+not edge labels, so a mislabeled semantic edge cannot break traversal. The
+operator-facing need is therefore **visibility and classification**, not repair.
 
 - **Violations table** — structural edge names (`SCOPED_BY`, `APPEARS`,
   `EVIDENCED_BY`, `FROM_SOURCE`) found connecting wrong node types, and
   structural names appearing as VocabType nodes (ADR-204 node-type pollution).
-- **Run check** — trigger detection on demand (detection is safe; available
-  before healing ships).
-- **Healing log** — replacements made (illegal structural edge → `SIMILAR_TO`
-  at low confidence), VocabType nodes removed, each logged as a warning per the
-  #241 design.
+  Read-only; flags for operator awareness.
+- **Run check** — trigger detection on demand (read-only; mutates nothing).
+- **Remediation (non-destructive)** — flagged VocabType names are *classified*
+  by epistemic status and may be **deactivated** (`is_active = false`,
+  preserving all edges and history), the same mechanism the vocabulary cycle
+  uses (ADR-701). No edge rewriting, no node deletion. Any remediation is logged
+  to the epoch event log (ADR-203).
 
-Data sources: the new `POST /ontology/integrity/check` and
+Data sources: the new `POST /ontology/integrity/check` (read-only detection) and
 `GET /ontology/integrity/report` (see §4).
 
 ### 3. CLI parity additions
@@ -409,9 +421,10 @@ present. The recommended order follows the backend dependency graph:
 2. **Dashboard + Proposals tabs** — buildable today against existing endpoints
    (`GET /ontology/`, `GET /ontology/proposals`). Delivers visibility into the
    already-running autonomous loop first — the most urgent gap.
-3. **#241 (integrity worker)** — detection-only first (safe, no graph
-   mutation), surfaced in the Integrity tab; healing follows once autonomous
-   execution is hardened. Worker and UI alerts panel ship together.
+3. **#241 (integrity worker)** — **detection/classify only** (safe, no graph
+   mutation), surfaced in the Integrity tab; destructive healing is rejected
+   (see Integrity Tab). Non-destructive remediation is deactivation, not
+   rewrite/delete. Worker and UI alerts panel ship together.
 4. **#249 (Bezier ecological feedback)** — backend feedback loop, then the
    Ecology tab curve editor.
 5. **#250 (AITL)** then **#251 (autonomous safety bounds)** — the Automation
@@ -420,9 +433,11 @@ present. The recommended order follows the backend dependency graph:
    issue, not as a separate pass.
 
 The integrity worker (#241) is treated here rather than in ADR-200 because its
-operator-facing half — detection reporting and the healing log — is part of this
-interface; ADR-200 Design Principle 6 already establishes the edge-agnostic
-principle the worker enforces.
+operator-facing half — detection reporting and non-destructive classification —
+is part of this interface; ADR-200 Design Principle 6 already establishes the
+edge-agnostic principle that makes the misuse benign (mislabeled edges cannot
+break node-type-based lifecycle queries), so the worker's job is visibility, not
+repair.
 
 ## Related ADRs
 

--- a/tests/api/test_vocabulary_jobs.py
+++ b/tests/api/test_vocabulary_jobs.py
@@ -1,0 +1,111 @@
+"""
+Vocabulary job-dispatch route tests (ADR-701 §1a).
+
+Tests POST /vocabulary/jobs — the unified dispatch endpoint that enqueues the
+four vocabulary worker operations onto the ADR-100 job queue, mirroring
+/ontology/annealing-cycle. The job queue is mocked; auth/permission gating is
+covered by the shared endpoint-security tests.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture(autouse=True)
+def setup_auth_mocks(mock_oauth_validation):
+    """Auto-use mock OAuth validation for all tests in this module."""
+    pass
+
+
+@pytest.fixture(autouse=True)
+def bypass_permission_check(monkeypatch):
+    """Bypass require_permission for route tests — auth is tested separately."""
+    monkeypatch.setattr(
+        "api.app.dependencies.auth.check_permission",
+        lambda *args, **kwargs: True,
+    )
+
+
+def _mock_queue(job_id="job_test123"):
+    """A job queue whose enqueue returns a fixed id and update_job is a no-op."""
+    queue = MagicMock()
+    queue.enqueue = MagicMock(return_value=job_id)
+    queue.update_job = MagicMock(return_value=True)
+    return queue
+
+
+@pytest.mark.unit
+class TestDispatchVocabularyJob:
+    """Tests for POST /vocabulary/jobs."""
+
+    @pytest.mark.parametrize(
+        "kind,expected_type",
+        [
+            ("consolidate", "vocab_consolidate"),
+            ("refresh", "vocab_refresh"),
+            ("remeasure", "epistemic_remeasurement"),
+            ("embed", "vocab_embedding"),
+        ],
+    )
+    def test_dispatch_enqueues_correct_worker(
+        self, api_client, auth_headers_admin, kind, expected_type
+    ):
+        """Each kind enqueues its mapped worker job_type and auto-approves."""
+        queue = _mock_queue()
+        with patch("api.app.services.job_queue.get_job_queue", return_value=queue):
+            response = api_client.post(
+                "/vocabulary/jobs", json={"kind": kind}, headers=auth_headers_admin
+            )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["kind"] == kind
+        assert data["job_type"] == expected_type
+        assert data["job_id"] == "job_test123"
+        assert data["status"] == "approved"
+
+        # Enqueued with the right worker job_type...
+        queue.enqueue.assert_called_once()
+        assert queue.enqueue.call_args.kwargs["job_type"] == expected_type
+        # ...then auto-approved so the lane manager claims it (ADR-100).
+        queue.update_job.assert_called_once()
+        approve_updates = queue.update_job.call_args.args[1]
+        assert approve_updates["status"] == "approved"
+
+    def test_params_passed_through_to_job_data(self, api_client, auth_headers_admin):
+        """Optional params flow into job_data alongside triggered_by."""
+        queue = _mock_queue()
+        with patch("api.app.services.job_queue.get_job_queue", return_value=queue):
+            response = api_client.post(
+                "/vocabulary/jobs",
+                json={"kind": "consolidate", "params": {"target_size": 80, "dry_run": True}},
+                headers=auth_headers_admin,
+            )
+
+        assert response.status_code == 200, response.text
+        job_data = queue.enqueue.call_args.kwargs["job_data"]
+        assert job_data["target_size"] == 80
+        assert job_data["dry_run"] is True
+        assert "triggered_by" in job_data
+
+    def test_invalid_kind_rejected(self, api_client, auth_headers_admin):
+        """An unknown kind is rejected by Pydantic validation before enqueue."""
+        queue = _mock_queue()
+        with patch("api.app.services.job_queue.get_job_queue", return_value=queue):
+            response = api_client.post(
+                "/vocabulary/jobs", json={"kind": "bogus"}, headers=auth_headers_admin
+            )
+
+        assert response.status_code == 422
+        queue.enqueue.assert_not_called()
+
+    def test_missing_kind_rejected(self, api_client, auth_headers_admin):
+        """kind is required."""
+        queue = _mock_queue()
+        with patch("api.app.services.job_queue.get_job_queue", return_value=queue):
+            response = api_client.post(
+                "/vocabulary/jobs", json={}, headers=auth_headers_admin
+            )
+
+        assert response.status_code == 422
+        queue.enqueue.assert_not_called()

--- a/tests/api/test_vocabulary_jobs.py
+++ b/tests/api/test_vocabulary_jobs.py
@@ -67,8 +67,9 @@ class TestDispatchVocabularyJob:
         # Enqueued with the right worker job_type...
         queue.enqueue.assert_called_once()
         assert queue.enqueue.call_args.kwargs["job_type"] == expected_type
-        # ...then auto-approved so the lane manager claims it (ADR-100).
+        # ...then auto-approved (by job_id) so the lane manager claims it (ADR-100).
         queue.update_job.assert_called_once()
+        assert queue.update_job.call_args.args[0] == "job_test123"
         approve_updates = queue.update_job.call_args.args[1]
         assert approve_updates["status"] == "approved"
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -36,6 +36,13 @@ import type {
   EcologicalPressureResponse,
   EcologicalPressureHistoryResponse,
 } from '../types/annealing';
+import type {
+  VocabularyStatus,
+  VocabularyConfig,
+  VocabJobKind,
+  VocabularyJobDispatchResponse,
+  AggressivenessProfile,
+} from '../types/vocabulary';
 import { getAuthState } from '../lib/auth/oauth-utils';
 
 // API configuration - runtime config takes precedence over build-time env vars
@@ -579,6 +586,55 @@ class APIClient {
     const response = await this.client.get<EcologicalPressureHistoryResponse>(
       '/ontology/annealing/pressure/history',
       { params: { limit } },
+    );
+    return response.data;
+  }
+
+  // ============================================================
+  // VOCABULARY LIFECYCLE METHODS (ADR-701)
+  // ============================================================
+
+  /**
+   * Get vocabulary status: size, zone, aggressiveness, profile, thresholds.
+   * Powers the Consolidation Loop and Vocabulary Pressure panels.
+   */
+  async getVocabularyStatus(): Promise<VocabularyStatus> {
+    const response = await this.client.get<VocabularyStatus>('/vocabulary/status');
+    return response.data;
+  }
+
+  /**
+   * Get the full durable vocabulary configuration (admin view). Read-only in
+   * the MVP — mutation flows through the kg vocab CLI.
+   */
+  async getVocabularyConfig(): Promise<VocabularyConfig> {
+    const response = await this.client.get<VocabularyConfig>('/admin/vocabulary/config');
+    return response.data;
+  }
+
+  /**
+   * Get an aggressiveness profile's Bézier control points, used to render the
+   * read-only aggressiveness curve in the Vocabulary Pressure panel.
+   */
+  async getVocabularyProfile(name: string): Promise<AggressivenessProfile> {
+    const response = await this.client.get<AggressivenessProfile>(
+      `/admin/vocabulary/profiles/${encodeURIComponent(name)}`,
+    );
+    return response.data;
+  }
+
+  /**
+   * Dispatch a vocabulary worker operation as a background job (ADR-701 §1a).
+   * Mirrors triggerAnnealingCycle — returns immediately with a job_id to poll
+   * via getJob(). Requires vocabulary:write.
+   */
+  async dispatchVocabularyJob(
+    kind: VocabJobKind,
+    params?: Record<string, unknown>,
+  ): Promise<VocabularyJobDispatchResponse> {
+    const response = await this.client.post<VocabularyJobDispatchResponse>(
+      '/vocabulary/jobs',
+      { kind, params: params ?? null },
     );
     return response.data;
   }

--- a/web/src/components/admin/AdminDashboard.tsx
+++ b/web/src/components/admin/AdminDashboard.tsx
@@ -14,6 +14,7 @@ import {
   Users,
   Activity,
   Network,
+  BookOpen,
   AlertCircle,
   Loader2,
   CheckCircle,
@@ -25,6 +26,7 @@ import { UsersTab } from './UsersTab';
 import { RolesTab } from './RolesTab';
 import { SystemTab } from './SystemTab';
 import { OntologyTab } from './OntologyTab';
+import { VocabularyTab } from './VocabularyTab';
 import type { TabType } from './types';
 
 export const AdminDashboard: React.FC = () => {
@@ -35,6 +37,7 @@ export const AdminDashboard: React.FC = () => {
   const canViewRoles = hasPermission('rbac', 'read');
   const canViewSystemStatus = hasPermission('admin', 'status');
   const canViewOntology = hasPermission('ontologies', 'read');
+  const canViewVocabulary = hasPermission('vocabulary', 'read');
 
   // Tab state
   const [activeTab, setActiveTab] = useState<TabType>('account');
@@ -134,6 +137,15 @@ export const AdminDashboard: React.FC = () => {
                 label="Ontology"
               />
             )}
+            {/* Vocabulary lifecycle tab - requires vocabulary:read permission (ADR-701) */}
+            {canViewVocabulary && (
+              <TabButton
+                active={activeTab === 'vocabulary'}
+                onClick={() => setActiveTab('vocabulary')}
+                icon={<BookOpen className="w-4 h-4" />}
+                label="Vocabulary"
+              />
+            )}
           </div>
         </div>
       </div>
@@ -184,6 +196,9 @@ export const AdminDashboard: React.FC = () => {
 
           {activeTab === 'ontology' && canViewOntology && (
             <OntologyTab onError={setError} onSuccess={setSuccessMessage} />
+          )}
+          {activeTab === 'vocabulary' && canViewVocabulary && (
+            <VocabularyTab onError={setError} onSuccess={setSuccessMessage} />
           )}
         </div>
       </div>

--- a/web/src/components/admin/VocabularyPressurePanel.tsx
+++ b/web/src/components/admin/VocabularyPressurePanel.tsx
@@ -1,0 +1,269 @@
+/**
+ * Vocabulary Pressure Panel (ADR-701).
+ *
+ * The vocabulary-cycle sibling of AnnealingPressurePanel. Renders the current
+ * vocabulary zone plus the aggressiveness response curve as an SVG Bézier,
+ * with a "you-are-here" marker at the current vocabulary size. Read-only —
+ * interactive curve editing is the deferred Profiles tab. Draws the real curve
+ * from the active profile's control points so it always matches the server.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Gauge, Loader2 } from 'lucide-react';
+import { apiClient } from '../../api/client';
+import { Section } from './components';
+import type { VocabularyStatus, AggressivenessProfile } from '../../types/vocabulary';
+
+interface VocabularyPressurePanelProps {
+  onError: (error: string) => void;
+}
+
+// Zone values are lowercase (ZoneEnum in api/app/models/vocabulary.py).
+const ZONE_STYLES: Record<string, string> = {
+  comfort: 'bg-status-active/20 text-status-active',
+  watch: 'bg-status-info/20 text-status-info',
+  merge: 'bg-status-warning/20 text-status-warning',
+  mixed: 'bg-status-warning/30 text-status-warning',
+  emergency: 'bg-destructive/20 text-destructive',
+  block: 'bg-destructive/20 text-destructive',
+};
+
+/**
+ * Cubic Bézier with fixed endpoints (0,0) and (1,1). Mirrors the Python
+ * implementation in api/app/lib/aggressiveness_curve.py — we render from the
+ * profile's control points so the curve matches whatever the server computes.
+ */
+function bezierY(t: number, p1y: number, p2y: number): number {
+  const u = 1 - t;
+  return 3 * u * u * t * p1y + 3 * u * t * t * p2y + t * t * t;
+}
+
+function bezierX(t: number, p1x: number, p2x: number): number {
+  const u = 1 - t;
+  return 3 * u * u * t * p1x + 3 * u * t * t * p2x + t * t * t;
+}
+
+/** Build SVG path for the curve, sampled at 50 points. */
+function buildCurvePath(
+  profile: AggressivenessProfile,
+  width: number,
+  height: number,
+): string {
+  const samples = 50;
+  const points: string[] = [];
+  for (let i = 0; i <= samples; i++) {
+    const t = i / samples;
+    const x = bezierX(t, profile.control_x1, profile.control_x2) * width;
+    const y = height - bezierY(t, profile.control_y1, profile.control_y2) * height;
+    points.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return `M ${points.join(' L ')}`;
+}
+
+/** Current vocabulary utilization on [0,1] across the min→max range. */
+function utilization(status: VocabularyStatus): number {
+  const span = status.vocab_max - status.vocab_min;
+  if (span <= 0) return 0;
+  return Math.min(1, Math.max(0, (status.vocab_size - status.vocab_min) / span));
+}
+
+interface AggressivenessCurveSvgProps {
+  profile: AggressivenessProfile;
+  status: VocabularyStatus;
+}
+
+const AggressivenessCurveSvg: React.FC<AggressivenessCurveSvgProps> = ({ profile, status }) => {
+  const width = 400;
+  const height = 140;
+  const padLeft = 36;
+  const padBottom = 28;
+  const padTop = 12;
+  const padRight = 12;
+  const innerW = width - padLeft - padRight;
+  const innerH = height - padTop - padBottom;
+
+  const curvePath = buildCurvePath(profile, innerW, innerH);
+
+  // Place the dot at the server-computed aggressiveness for the current
+  // utilization — no need to invert the Bézier.
+  const posX = utilization(status);
+  const dotY = Math.min(1, Math.max(0, status.aggressiveness));
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-auto"
+      role="img"
+      aria-label="Vocabulary aggressiveness response curve"
+    >
+      <rect
+        x={padLeft}
+        y={padTop}
+        width={innerW}
+        height={innerH}
+        fill="currentColor"
+        className="text-muted/10"
+      />
+
+      <g transform={`translate(${padLeft} ${padTop})`}>
+        <path d={curvePath} fill="none" strokeWidth={2} className="stroke-primary" />
+
+        {/* baseline */}
+        <line
+          x1={0}
+          y1={innerH}
+          x2={innerW}
+          y2={innerH}
+          strokeWidth={1}
+          strokeDasharray="2 3"
+          className="stroke-status-active/40"
+        />
+
+        {/* you-are-here dot */}
+        <circle
+          cx={posX * innerW}
+          cy={innerH - dotY * innerH}
+          r={5}
+          className="fill-status-warning stroke-status-warning"
+        />
+        <circle
+          cx={posX * innerW}
+          cy={innerH - dotY * innerH}
+          r={10}
+          fill="none"
+          strokeWidth={1.5}
+          className="stroke-status-warning/40"
+        />
+      </g>
+
+      <text x={padLeft} y={height - 8} className="fill-muted-foreground text-[10px]">
+        {status.vocab_min}
+      </text>
+      <text
+        x={padLeft + innerW}
+        y={height - 8}
+        textAnchor="end"
+        className="fill-muted-foreground text-[10px]"
+      >
+        {status.vocab_max}
+      </text>
+      <text x={6} y={padTop + 8} className="fill-muted-foreground text-[10px]">
+        1.0
+      </text>
+      <text x={6} y={padTop + innerH} className="fill-muted-foreground text-[10px]">
+        0.0
+      </text>
+      <text
+        x={padLeft + innerW / 2}
+        y={height - 8}
+        textAnchor="middle"
+        className="fill-muted-foreground text-[10px]"
+      >
+        vocabulary size — aggressiveness curve
+      </text>
+    </svg>
+  );
+};
+
+export const VocabularyPressurePanel: React.FC<VocabularyPressurePanelProps> = ({ onError }) => {
+  const [status, setStatus] = useState<VocabularyStatus | null>(null);
+  const [profile, setProfile] = useState<AggressivenessProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const statusData = await apiClient.getVocabularyStatus();
+      setStatus(statusData);
+      // The curve needs the active profile's control points; tolerate failure
+      // (e.g. custom/unknown profile) by simply not drawing the curve.
+      try {
+        setProfile(await apiClient.getVocabularyProfile(statusData.profile));
+      } catch {
+        setProfile(null);
+      }
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to load vocabulary status');
+    } finally {
+      setLoading(false);
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading && !status) {
+    return (
+      <Section title="Vocabulary Pressure" icon={<Gauge className="w-5 h-5" />}>
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+        </div>
+      </Section>
+    );
+  }
+
+  if (!status) {
+    return null;
+  }
+
+  const zoneClass =
+    ZONE_STYLES[String(status.zone).toLowerCase()] ?? 'bg-muted text-muted-foreground';
+
+  return (
+    <Section title="Vocabulary Pressure" icon={<Gauge className="w-5 h-5" />}>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <div className="flex items-baseline gap-3 mb-2">
+            <span className="text-sm text-muted-foreground">Aggressiveness</span>
+            <span className="text-2xl font-mono font-medium text-foreground">
+              {(status.aggressiveness * 100).toFixed(1)}%
+            </span>
+            <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${zoneClass}`}>
+              {status.zone}
+            </span>
+          </div>
+          {profile ? (
+            <AggressivenessCurveSvg profile={profile} status={status} />
+          ) : (
+            <p className="text-xs text-muted-foreground py-4">
+              Curve unavailable for profile{' '}
+              <code className="font-mono">{status.profile}</code>.
+            </p>
+          )}
+          <p className="mt-3 text-xs text-muted-foreground">
+            {status.vocab_size} types — min {status.vocab_min}, max {status.vocab_max},
+            emergency {status.vocab_emergency}. Profile{' '}
+            <code className="font-mono">{status.profile}</code>.
+          </p>
+        </div>
+
+        <div>
+          <h4 className="text-sm font-medium text-foreground mb-3">Composition</h4>
+          <div className="space-y-2">
+            {[
+              ['Builtin types', status.builtin_types],
+              ['Custom types', status.custom_types],
+              ['Categories', status.categories],
+            ].map(([label, value]) => (
+              <div
+                key={label}
+                className="flex items-center justify-between gap-3 px-3 py-2 bg-muted/40 rounded"
+              >
+                <span className="text-xs text-foreground">{label}</span>
+                <span className="font-mono font-medium text-sm text-foreground">{value}</span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">
+            The aggressiveness curve maps vocabulary size to consolidation
+            pressure (ADR-032). Tune the curve via the <code className="font-mono">kg vocab</code>{' '}
+            CLI; interactive editing is a deferred Profiles tab.
+          </p>
+        </div>
+      </div>
+    </Section>
+  );
+};
+
+export default VocabularyPressurePanel;

--- a/web/src/components/admin/VocabularyTab.tsx
+++ b/web/src/components/admin/VocabularyTab.tsx
@@ -87,7 +87,7 @@ const JOB_STATUS_STYLES: Record<string, string> = {
 };
 
 export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess }) => {
-  const { hasPermission } = useAuthStore();
+  const { hasPermission, isPlatformAdmin } = useAuthStore();
   const canManage = hasPermission('vocabulary', 'write');
 
   const [status, setStatus] = useState<VocabularyStatus | null>(null);
@@ -95,6 +95,8 @@ export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess
   const [recentJobs, setRecentJobs] = useState<JobStatus[]>([]);
   const [loading, setLoading] = useState(true);
   const [dispatching, setDispatching] = useState<VocabJobKind | null>(null);
+  // Consolidate executes merges (see handleActionClick); it gets a confirm step.
+  const [confirmKind, setConfirmKind] = useState<VocabJobKind | null>(null);
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -125,10 +127,26 @@ export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess
     loadData();
   }, [loadData]);
 
+  const handleActionClick = (action: VocabAction) => {
+    // Consolidate executes merges (auto_mode below), so it gets a two-step
+    // confirm like the ontology "Run cycle". The other three are idempotent
+    // recomputations and fire immediately.
+    if (action.kind === 'consolidate' && confirmKind !== 'consolidate') {
+      setConfirmKind('consolidate');
+      return;
+    }
+    setConfirmKind(null);
+    void handleDispatch(action);
+  };
+
   const handleDispatch = async (action: VocabAction) => {
     setDispatching(action.kind);
     try {
-      const res = await apiClient.dispatchVocabularyJob(action.kind);
+      // Without auto_mode the consolidate worker runs a dry-run no-op
+      // (computes proposals, executes nothing). Opt into execution explicitly,
+      // mirroring OntologyTab's triggerAnnealingCycle(false).
+      const params = action.kind === 'consolidate' ? { auto_mode: true } : undefined;
+      const res = await apiClient.dispatchVocabularyJob(action.kind, params);
       onSuccess?.(`${action.label} job dispatched (#${res.job_id}). Track it in Jobs.`);
       await loadData();
     } catch (err) {
@@ -236,33 +254,48 @@ export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess
           {!canManage && ' Requires the vocabulary:write permission.'}
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {ACTIONS.map((action) => (
-            <button
-              key={action.kind}
-              onClick={() => handleDispatch(action)}
-              disabled={!canManage || dispatching !== null}
-              className="flex items-start gap-3 p-3 text-left bg-muted/40 rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              title={canManage ? action.description : 'Requires vocabulary:write'}
-            >
-              <span className="mt-0.5 text-muted-foreground">
-                {dispatching === action.kind ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  action.icon
-                )}
-              </span>
-              <span>
-                <span className="block text-sm font-medium text-foreground">{action.label}</span>
-                <span className="block text-xs text-muted-foreground">{action.description}</span>
-              </span>
-            </button>
-          ))}
+          {ACTIONS.map((action) => {
+            const awaitingConfirm = confirmKind === action.kind;
+            return (
+              <button
+                key={action.kind}
+                onClick={() => handleActionClick(action)}
+                disabled={!canManage || dispatching !== null}
+                className={`flex items-start gap-3 p-3 text-left rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
+                  awaitingConfirm
+                    ? 'bg-status-warning/15 ring-1 ring-status-warning/40 hover:bg-status-warning/20'
+                    : 'bg-muted/40 hover:bg-muted'
+                }`}
+                title={canManage ? action.description : 'Requires vocabulary:write'}
+              >
+                <span className="mt-0.5 text-muted-foreground">
+                  {dispatching === action.kind ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    action.icon
+                  )}
+                </span>
+                <span>
+                  <span className="block text-sm font-medium text-foreground">
+                    {awaitingConfirm ? `Confirm — ${action.label} (executes merges)` : action.label}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    {awaitingConfirm ? 'Click again to run, or pick another action to cancel.' : action.description}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
         </div>
       </Section>
 
       {/* Recent runs — the previous-runs log, sourced from the jobs the Actions
           panel dispatches (analogous to the ontology proposals log, but for vocab
-          the natural record is the job history). */}
+          the natural record is the job history).
+          NOTE: GET /jobs is permission-scoped — non-admins see only their own
+          jobs, and vocab_consolidate runs in the "system" lane (excluded for
+          non-admins). So a non-admin's view here is partial; platform admins see
+          the full history including the hysteresis/cron auto-runs. */}
       <Section title="Recent Runs" icon={<History className="w-5 h-5" />}>
         {recentJobs.length === 0 ? (
           <p className="text-sm text-muted-foreground py-2">
@@ -298,6 +331,12 @@ export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess
               );
             })}
           </div>
+        )}
+        {recentJobs.length > 0 && !isPlatformAdmin && (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Showing your jobs only. Platform admins see all vocabulary runs,
+            including automatic consolidation cycles.
+          </p>
         )}
       </Section>
     </div>

--- a/web/src/components/admin/VocabularyTab.tsx
+++ b/web/src/components/admin/VocabularyTab.tsx
@@ -1,0 +1,237 @@
+/**
+ * Vocabulary Tab — Vocabulary Consolidation Lifecycle Administration (ADR-701).
+ *
+ * The vocabulary-cycle cohort to the Ontology tab (ADR-703): the consolidation
+ * loop, the pressure/zone read-out, read-only durable config, and the job-
+ * dispatch actions. Present-information plus triggers — it surfaces state and
+ * dispatches the four vocabulary worker operations as jobs (ADR-701 §1a),
+ * mirroring the annealing "Run cycle". Per-proposal merge review is deferred.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  BookOpen,
+  Activity,
+  RefreshCw,
+  Loader2,
+  Settings,
+  GitMerge,
+  Sparkles,
+  Layers,
+  Play,
+} from 'lucide-react';
+import { apiClient } from '../../api/client';
+import { useAuthStore } from '../../store/authStore';
+import { Section, InfoCard, formatDateTime } from './components';
+import { VocabularyPressurePanel } from './VocabularyPressurePanel';
+import type { VocabularyStatus, VocabularyConfig, VocabJobKind } from '../../types/vocabulary';
+
+interface VocabularyTabProps {
+  onError: (error: string) => void;
+  onSuccess?: (message: string) => void;
+}
+
+interface VocabAction {
+  kind: VocabJobKind;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const ACTIONS: VocabAction[] = [
+  {
+    kind: 'consolidate',
+    label: 'Consolidate',
+    description: 'AITL merge of similar/redundant types',
+    icon: <GitMerge className="w-4 h-4" />,
+  },
+  {
+    kind: 'refresh',
+    label: 'Refresh categories',
+    description: 'Recompute category assignments from embeddings',
+    icon: <RefreshCw className="w-4 h-4" />,
+  },
+  {
+    kind: 'remeasure',
+    label: 'Remeasure epistemic',
+    description: 'Recompute grounding / epistemic status',
+    icon: <Activity className="w-4 h-4" />,
+  },
+  {
+    kind: 'embed',
+    label: 'Generate embeddings',
+    description: 'Backfill vocabulary type embeddings',
+    icon: <Sparkles className="w-4 h-4" />,
+  },
+];
+
+export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess }) => {
+  const { hasPermission } = useAuthStore();
+  const canManage = hasPermission('vocabulary', 'write');
+
+  const [status, setStatus] = useState<VocabularyStatus | null>(null);
+  const [config, setConfig] = useState<VocabularyConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [dispatching, setDispatching] = useState<VocabJobKind | null>(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const statusRes = await apiClient.getVocabularyStatus();
+      setStatus(statusRes);
+      // Config is admin-only and non-essential for the loop view; tolerate failure.
+      try {
+        setConfig(await apiClient.getVocabularyConfig());
+      } catch {
+        setConfig(null);
+      }
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to load vocabulary status');
+    } finally {
+      setLoading(false);
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleDispatch = async (action: VocabAction) => {
+    setDispatching(action.kind);
+    try {
+      const res = await apiClient.dispatchVocabularyJob(action.kind);
+      onSuccess?.(`${action.label} job dispatched (#${res.job_id}). Track it in Jobs.`);
+      await loadData();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : `Failed to dispatch ${action.label}`);
+    } finally {
+      setDispatching(null);
+    }
+  };
+
+  if (loading && !status) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-8 h-8 text-primary animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Consolidation loop */}
+      <Section
+        title="Consolidation Loop"
+        icon={<BookOpen className="w-5 h-5" />}
+        action={
+          <button
+            onClick={loadData}
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
+            title="Refresh"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+        }
+      >
+        {status && (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <InfoCard
+                icon={<Layers className="w-4 h-4" />}
+                label="Vocabulary size"
+                value={status.vocab_size}
+                subValue={`min ${status.vocab_min} · max ${status.vocab_max}`}
+              />
+              <InfoCard
+                icon={<BookOpen className="w-4 h-4" />}
+                label="Custom types"
+                value={status.custom_types}
+                subValue={`${status.builtin_types} builtin`}
+              />
+              <InfoCard
+                icon={<Layers className="w-4 h-4" />}
+                label="Categories"
+                value={status.categories}
+              />
+              <InfoCard
+                icon={<Settings className="w-4 h-4" />}
+                label="Pruning mode"
+                value={config?.pruning_mode ?? '—'}
+                subValue={`profile ${status.profile}`}
+              />
+            </div>
+            {config?.updated_at && (
+              <div className="mt-4 text-sm flex justify-between">
+                <span className="text-muted-foreground">Config last updated</span>
+                <span className="text-foreground">
+                  {formatDateTime(config.updated_at)}
+                  {config.updated_by ? ` by ${config.updated_by}` : ''}
+                </span>
+              </div>
+            )}
+          </>
+        )}
+      </Section>
+
+      {/* Vocabulary pressure read-out */}
+      <VocabularyPressurePanel onError={onError} />
+
+      {/* Configuration (read-only) */}
+      {config && (
+        <Section title="Configuration" icon={<Settings className="w-5 h-5" />}>
+          <p className="text-sm text-muted-foreground mb-3">
+            Durable vocabulary configuration. Read-only here — adjust via the{' '}
+            <code className="font-mono">kg vocab</code> CLI.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1.5 text-sm">
+            {Object.entries(config)
+              .filter(([key]) => !['current_size', 'zone', 'aggressiveness'].includes(key))
+              .filter(([, value]) => value !== null && value !== undefined)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([key, value]) => (
+                <div key={key} className="flex justify-between border-b border-border/50 py-1">
+                  <span className="text-muted-foreground">{key.replace(/_/g, ' ')}</span>
+                  <span className="text-foreground font-mono text-xs">{String(value)}</span>
+                </div>
+              ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Actions — job dispatch (ADR-701 §1a) */}
+      <Section title="Actions" icon={<Play className="w-5 h-5" />}>
+        <p className="text-sm text-muted-foreground mb-3">
+          Dispatch a vocabulary maintenance operation as a background job, the
+          same way ontology annealing dispatches a cycle. Each returns a job to
+          track in Jobs.
+          {!canManage && ' Requires the vocabulary:write permission.'}
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {ACTIONS.map((action) => (
+            <button
+              key={action.kind}
+              onClick={() => handleDispatch(action)}
+              disabled={!canManage || dispatching !== null}
+              className="flex items-start gap-3 p-3 text-left bg-muted/40 rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              title={canManage ? action.description : 'Requires vocabulary:write'}
+            >
+              <span className="mt-0.5 text-muted-foreground">
+                {dispatching === action.kind ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  action.icon
+                )}
+              </span>
+              <span>
+                <span className="block text-sm font-medium text-foreground">{action.label}</span>
+                <span className="block text-xs text-muted-foreground">{action.description}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+export default VocabularyTab;

--- a/web/src/components/admin/VocabularyTab.tsx
+++ b/web/src/components/admin/VocabularyTab.tsx
@@ -19,12 +19,14 @@ import {
   Sparkles,
   Layers,
   Play,
+  History,
 } from 'lucide-react';
 import { apiClient } from '../../api/client';
 import { useAuthStore } from '../../store/authStore';
 import { Section, InfoCard, formatDateTime } from './components';
 import { VocabularyPressurePanel } from './VocabularyPressurePanel';
 import type { VocabularyStatus, VocabularyConfig, VocabJobKind } from '../../types/vocabulary';
+import type { JobStatus } from '../../types/jobs';
 
 interface VocabularyTabProps {
   onError: (error: string) => void;
@@ -65,12 +67,32 @@ const ACTIONS: VocabAction[] = [
   },
 ];
 
+// The four vocabulary worker job_types, mapped to friendly labels. Mirrors the
+// server-side VOCAB_JOB_KIND_TO_TYPE — used to filter the jobs feed into a
+// "previous runs" log (reuses the ADR-100 jobs the Actions panel dispatches).
+const VOCAB_JOB_LABELS: Record<string, string> = {
+  vocab_consolidate: 'Consolidate',
+  vocab_refresh: 'Refresh categories',
+  epistemic_remeasurement: 'Remeasure epistemic',
+  vocab_embedding: 'Generate embeddings',
+};
+
+const JOB_STATUS_STYLES: Record<string, string> = {
+  completed: 'bg-status-active/20 text-status-active',
+  processing: 'bg-status-info/20 text-status-info',
+  approved: 'bg-status-info/20 text-status-info',
+  pending: 'bg-muted text-muted-foreground',
+  failed: 'bg-destructive/20 text-destructive',
+  cancelled: 'bg-muted text-muted-foreground',
+};
+
 export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess }) => {
   const { hasPermission } = useAuthStore();
   const canManage = hasPermission('vocabulary', 'write');
 
   const [status, setStatus] = useState<VocabularyStatus | null>(null);
   const [config, setConfig] = useState<VocabularyConfig | null>(null);
+  const [recentJobs, setRecentJobs] = useState<JobStatus[]>([]);
   const [loading, setLoading] = useState(true);
   const [dispatching, setDispatching] = useState<VocabJobKind | null>(null);
 
@@ -84,6 +106,13 @@ export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess
         setConfig(await apiClient.getVocabularyConfig());
       } catch {
         setConfig(null);
+      }
+      // Previous-runs log: pull recent jobs and keep the vocabulary ones.
+      try {
+        const jobs = await apiClient.listJobs({ limit: 50 });
+        setRecentJobs(jobs.filter((j) => j.job_type in VOCAB_JOB_LABELS).slice(0, 10));
+      } catch {
+        setRecentJobs([]);
       }
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to load vocabulary status');
@@ -229,6 +258,47 @@ export const VocabularyTab: React.FC<VocabularyTabProps> = ({ onError, onSuccess
             </button>
           ))}
         </div>
+      </Section>
+
+      {/* Recent runs — the previous-runs log, sourced from the jobs the Actions
+          panel dispatches (analogous to the ontology proposals log, but for vocab
+          the natural record is the job history). */}
+      <Section title="Recent Runs" icon={<History className="w-5 h-5" />}>
+        {recentJobs.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            No vocabulary jobs have run yet. Dispatch one from Actions above.
+          </p>
+        ) : (
+          <div className="space-y-1.5">
+            {recentJobs.map((job) => {
+              const statusClass =
+                JOB_STATUS_STYLES[job.status] ?? 'bg-muted text-muted-foreground';
+              return (
+                <div
+                  key={job.job_id}
+                  className="flex items-center justify-between gap-3 px-3 py-2 bg-muted/40 rounded text-sm"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="text-foreground">
+                      {VOCAB_JOB_LABELS[job.job_type] ?? job.job_type}
+                    </span>
+                    <code className="font-mono text-xs text-muted-foreground truncate">
+                      {job.job_id}
+                    </code>
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    <span className="text-xs text-muted-foreground">
+                      {formatDateTime(job.completed_at ?? job.created_at ?? null)}
+                    </span>
+                    <span className={`px-2 py-0.5 text-xs rounded-full font-medium ${statusClass}`}>
+                      {job.status}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </Section>
     </div>
   );

--- a/web/src/components/admin/types.ts
+++ b/web/src/components/admin/types.ts
@@ -167,4 +167,4 @@ export interface WorkerStatus {
   slots_in_use: number;
 }
 
-export type TabType = 'account' | 'users' | 'roles' | 'system' | 'ontology';
+export type TabType = 'account' | 'users' | 'roles' | 'system' | 'ontology' | 'vocabulary';

--- a/web/src/types/vocabulary.ts
+++ b/web/src/types/vocabulary.ts
@@ -1,0 +1,87 @@
+/**
+ * Vocabulary administration types (ADR-701).
+ *
+ * Mirrors the Pydantic models in api/app/models/vocabulary.py. The vocabulary
+ * consolidation cycle is the sibling of ontology annealing (ADR-200) — these
+ * types back the Vocabulary admin tab cohort (loop / pressure / config /
+ * actions), parallel to the annealing types in ./annealing.ts.
+ */
+
+/**
+ * Vocabulary pressure zone (ADR-032 / ZoneEnum). Lowercase to match the API.
+ * Kept as a permissive string union so alternate labels don't break typing.
+ */
+export type VocabularyZone =
+  | 'comfort'
+  | 'watch'
+  | 'merge'
+  | 'mixed'
+  | 'emergency'
+  | 'block'
+  | string;
+
+/** Current vocabulary status — mirrors VocabularyStatusResponse. */
+export interface VocabularyStatus {
+  vocab_size: number;
+  vocab_min: number;
+  vocab_max: number;
+  vocab_emergency: number;
+  aggressiveness: number;
+  zone: VocabularyZone;
+  builtin_types: number;
+  custom_types: number;
+  categories: number;
+  profile: string;
+}
+
+/** Full durable vocabulary configuration (admin view) — mirrors VocabularyConfigDetail. */
+export interface VocabularyConfig {
+  vocab_min: number;
+  vocab_max: number;
+  vocab_emergency: number;
+  pruning_mode: string;
+  aggressiveness_profile: string;
+  auto_expand_enabled: boolean;
+  synonym_threshold_strong: number;
+  synonym_threshold_moderate: number;
+  low_value_threshold: number;
+  consolidation_similarity_threshold: number;
+  embedding_model: string;
+  updated_at?: string | null;
+  updated_by?: string | null;
+  // Computed fields
+  current_size?: number | null;
+  zone?: VocabularyZone | null;
+  aggressiveness?: number | null;
+}
+
+/** Aggressiveness profile Bézier control points — mirrors AggressivenessProfile. */
+export interface AggressivenessProfile {
+  profile_name: string;
+  control_x1: number;
+  control_y1: number;
+  control_x2: number;
+  control_y2: number;
+  description?: string | null;
+  is_builtin: boolean;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+/**
+ * The four worker-backed vocabulary operations dispatchable as jobs
+ * (ADR-701 §1a). Maps server-side to job_type via VOCAB_JOB_KIND_TO_TYPE:
+ *   consolidate → vocab_consolidate
+ *   refresh     → vocab_refresh
+ *   remeasure   → epistemic_remeasurement
+ *   embed       → vocab_embedding
+ */
+export type VocabJobKind = 'consolidate' | 'refresh' | 'remeasure' | 'embed';
+
+/** Result of POST /vocabulary/jobs — returns immediately; poll job status. */
+export interface VocabularyJobDispatchResponse {
+  job_id: string;
+  kind: VocabJobKind;
+  job_type: string;
+  status: string;
+}


### PR DESCRIPTION
## What

Adds a **Vocabulary** tab to the Admin panel, the operational cohort to the **Ontology** tab (ADR-703) — surfacing the vocabulary consolidation cycle as a first-class agentic surface, the sibling of ontology annealing (ADR-200).

Four panels mirror OntologyTab one-to-one:

| Vocabulary panel | Mirrors |
|---|---|
| Consolidation Loop | Annealing Loop |
| Vocabulary Pressure (zone + aggressiveness curve) | Ecological Pressure |
| Configuration (read-only, via `kg vocab`) | Configuration |
| Actions (4 job-dispatch triggers) | "Run cycle" |
| Recent Runs (jobs feed, filtered) | Proposals log¹ |

## Backend (ADR-701 §1a)

Vocabulary predates the ADR-100 job system, so its manual triggers ran *synchronously in-request*. This adds a unified `POST /vocabulary/jobs {kind}` endpoint that enqueues the four existing workers (`vocab_consolidate` / `vocab_refresh` / `epistemic_remeasurement` / `vocab_embedding`) + auto-approves, mirroring `/ontology/annealing-cycle`. Read panels reuse existing endpoints — **zero new reads**.

¹ The ontology Proposals log reads a dedicated `annealing_proposals` table; for vocabulary the natural run record is the job history, so Recent Runs filters the jobs feed. Vocab rhymes with ontology without having to be shaped identically.

## Bug fixed

The `vocab_consolidate` worker imported `get_vocabulary_manager` from a non-existent module — every consolidation job failed (auto-dispatched *or* UI-triggered). Surfaced by the new Recent Runs log. Fixed by moving the factory into `services/vocabulary_manager.py` so route and worker share it (no worker→routes import).

## ADR changes

- **ADR-701** reframed from a six-tab standalone-route design to the lean lifecycle cohort (MVP tab → deferred richer tabs), parity with ADR-703.
- **ADR-703** Integrity tab reconciled to detection/classify-only; destructive healing rejected (append-only, ADR-203/206).
- **#241** closed won't-do (destructive healing worker); its valid detection half lives in ADR-703.

## Tests

`tests/api/test_vocabulary_jobs.py` — 7 tests: each kind → correct worker job_type + auto-approve, params pass-through, invalid/missing kind → 422. All passing. (No web component tests — consistent with the project's convention; OntologyTab has none.)

## Verified

Tab renders as Ontology's sibling; dispatch works end-to-end (UI → 200 in 16ms → lane claim → worker completed); TS typecheck clean.

## Follow-ups (not blocking)

- `routes/vocabulary.py` is 1631 lines — split candidate.
- Bare Consolidate dispatch uses worker defaults; a confirm-gate or explicit params would be a nice touch.
- CLI `kg vocab consolidate` still runs synchronously; an optional job-dispatch flag would complete CLI/web parity (ADR-701 §3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)