### PR TITLE
feat(web): session visibility + declarative capability gating (ADR-705)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -145,6 +145,8 @@ _CLI, web, FUSE, MCP, visualization_
 | [ADR-701](./user-interfaces/ADR-701-vocabulary-administration-interface.md) | Vocabulary Administration Interface | Draft |
 | [ADR-702](./user-interfaces/ADR-702-unified-graph-rendering-engine.md) | Unified Graph Rendering Engine | Proposed |
 | [ADR-703](./user-interfaces/ADR-703-ontology-lifecycle-administration-interface.md) | Ontology Lifecycle Administration Interface | Draft |
+| [ADR-704](./user-interfaces/ADR-704-unified-user-scoped-resource-dispensing.md) | Unified User-Scoped Resource Dispensing | Draft |
+| [ADR-705](./user-interfaces/ADR-705-session-visibility-and-declarative-capability-gating.md) | Session Visibility and Declarative Capability Gating | Draft |
 
 ## AI/Embeddings
 _Providers, extraction, convergence, prompts_

--- a/docs/architecture/user-interfaces/ADR-704-unified-user-scoped-resource-dispensing.md
+++ b/docs/architecture/user-interfaces/ADR-704-unified-user-scoped-resource-dispensing.md
@@ -1,0 +1,259 @@
+---
+status: Draft
+date: 2026-05-31
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-031
+  - ADR-034
+  - ADR-054
+  - ADR-067
+  - ADR-075
+  - ADR-083
+  - ADR-400
+  - ADR-705
+---
+
+# ADR-704: Unified User-Scoped Resource Dispensing
+
+## Context
+
+This started from a UI observation — the web application doesn't visibly
+reflect being logged out — and unwound into a more fundamental gap: the things
+that *belong to a user* are dispensed inconsistently, even though most of them
+are already stored and access-controlled on the server.
+
+A codebase verification (below) found that the backends largely **already
+exist**. What is missing is not storage — it is a consistent *location* and
+*way* these user-owned elements are dispensed: listed, read, edited, and
+access-controlled, in one place for a user ("what is mine") and one place for an
+admin ("what is everyone's").
+
+### What already exists (verified)
+
+| Element | Backend status | Where |
+|---------|----------------|-------|
+| **Credentials / API grants** | **Fully built.** `oauth_clients` table; self-service `GET/POST/DELETE /auth/oauth/clients/personal` + secret rotation; admin client/token routes; MCP uses the builtin `kg-mcp` confidential client. Secrets bcrypt-hashed, tokens SHA-256, revocation + rotation present. | `schema/migrations/022_oauth_client_management.sql`; `api/app/routes/oauth.py`; web `AccountTab` already lists a user's own clients |
+| **Saved queries / programs / block diagrams** | **Fully built.** `kg_api.query_definitions` (`owner_id`, typed: `block_diagram`, `polarity`, `exploration`, `program`, `cypher`, `projection`); full CRUD with owner-or-admin filtering + pagination. | `schema/migrations/035_artifact_persistence.sql`; `api/app/routes/query_definitions.py`; web `queryDefinitionStore`, `SavedQueriesPanel`, `blockDiagramStore` |
+| **Computed artifacts** | **Built.** `kg_api.artifacts` (`owner_id`, 19 types, Garage/inline payloads). | `api/app/routes/artifacts.py`; web `artifactStore` |
+| **owner-or-admin access** | **Exists but scattered.** `verify_resource_ownership()` (best reusable helper), `JobPermissionChecker`, `kg_auth.resource_grants` + `has_access()` (migration 034), and the same inline `owner_id == user_id or admin` check repeated across routes. | `api/app/routes/grants.py:34`; `api/app/lib/job_permissions.py`; `schema/migrations/034_user_scoping_groups.sql` |
+| **Admin surface** | **Built, global/resource-oriented.** `AdminDashboard` has Account, Users, Roles, System, Ontology, Vocabulary tabs. | `web/src/components/admin/AdminDashboard.tsx` |
+| **Settings** (default ontology, ingest defaults, etc.) | **Not on the server.** localStorage-only, per-browser, no management surface. | web `usePreferencesStore`, `useThemeStore` |
+
+So the contract this ADR defines is **retrofitted onto a pattern the codebase
+already implements** (`owner_id` + list-by-owner + owner-or-admin), not invented.
+
+### Why this is adjacent to the logged-out-visibility problem
+
+The dispensing surfaces are exactly where authentication state becomes
+*consequential* rather than cosmetic. "Show me what is mine" only means something
+relative to *who I am right now* — anonymous, authenticated, or expired. A
+server-backed resource must visibly gate to read-only when the session is gone; a
+device-backed one stays editable. The visible-logged-out treatment and the
+dispensing surface are two faces of one UX. That is why an instinct about the
+front door led straight here.
+
+This ADR is **paired** with the companion capability-gating decision
+(forthcoming, `ui` domain): that ADR defines the `anonymous | authenticated |
+expired` session status and the `<Gated>` / `useCapability` primitives; this ADR
+defines what gets gated and where it is shown. Neither is complete without the
+other.
+
+## Decision
+
+### 1. Separate two axes: storage (heterogeneous) vs dispensing (uniform)
+
+| Axis | Stance |
+|------|--------|
+| **Storage** | Stays per-type and appropriate, and mostly **already exists**. Settings → new validated DTO. Theme → `localStorage` (ADR-075). Credentials → `oauth_clients`/encrypted-OAuth (ADR-031/054). Saved items → `query_definitions`/`artifacts` (ADR-083). **No unification here, by design.** |
+| **Dispensing** | Unified. One provider contract, one consolidated access policy, two rendering surfaces. **This is the decision.** |
+
+### 2. The `UserScopedResource` provider contract
+
+Each dispensable thing implements one thin contract — a *convention*, not a
+framework. It standardizes enumeration, access, and presentation while delegating
+storage to whatever already backs it:
+
+```
+UserScopedResource {
+  kind:    string                         // "settings" | "theme" | "credentials" | "saved-queries" | "artifacts" | ...
+  backing: "server" | "device"            // where it lives — varies per kind, and that is fine
+  list(userId)            → item[]
+  read(userId, itemId)    → item
+  write(userId, item)                      // create/update; validated by the provider
+  delete(userId, itemId)
+  access:  owner-or-admin                  // uniform policy (see §4)
+  present: { label, panel }                // how it renders in the shared UI
+}
+```
+
+Most providers wrap existing endpoints/stores: the saved-queries provider is a
+thin adapter over `queryDefinitionStore`, the credentials provider over the
+`/auth/oauth/clients/personal` routes, the theme provider over `localStorage`.
+The `backing` field is what the gating surface keys on: `server` providers gate
+read-only when unauthenticated/expired, `device` providers stay editable.
+
+### 3. Two surfaces, one registry
+
+Providers register into a single registry; exactly two surfaces render it:
+
+- **Preferences view** — every provider scoped to the current user, where they
+  are the owner. This is where a user sees and manages *what is mine* — including
+  (newly) listing and revoking their own credentials/grants. `AccountTab` is the
+  existing seed of this surface (it already lists a user's own OAuth clients).
+- **Admin view** — every provider across all users, gated by admin. The existing
+  `AdminDashboard` is the host; this adds a per-user drill-down (select a user →
+  see their providers), which does not exist today.
+
+Adding a new dispensable kind means implementing the contract once; it then
+appears in both surfaces automatically, with correct access. No component
+re-solves listing, placement, or access control.
+
+### 4. Uniform access: consolidate the scattered owner-or-admin checks
+
+The owner-or-admin rule already exists in at least three forms
+(`verify_resource_ownership()`, `JobPermissionChecker`, repeated inline checks).
+This ADR consolidates them into **one** reusable helper (e.g.
+`api/app/lib/owner_access.py`), built on the ADR-400 baseline and aware of the
+system-owner (`owner_id` NULL / system user) convention, and routes the
+dispensing layer through it. Provider-specific authorization (e.g. a credential's
+revocation semantics) still lives in the provider. The `resource_grants` /
+`has_access()` infrastructure (migration 034) remains available for
+group/instance grants beyond simple ownership.
+
+### 5. First new provider — settings (server-backed, validated)
+
+The only element without a server backend. The settings provider is the
+reference `server`-backed implementation and resolves the original per-browser
+problem.
+
+- **Storage (new):** one validated JSONB blob per user. The server owns the shape
+  via a Pydantic `UserSettings` model; every write is validated and
+  unknown/invalid properties are rejected (`422`). Adding a setting is a one-field
+  model edit, not a DB migration.
+
+  ```sql
+  CREATE TABLE kg_auth.user_settings (
+      user_id    UUID PRIMARY KEY REFERENCES kg_auth.users(id) ON DELETE CASCADE,
+      settings   JSONB NOT NULL DEFAULT '{}'::jsonb,  -- server-validated shape
+      revision   INTEGER NOT NULL DEFAULT 0,          -- concurrency token
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  ```
+
+- **Dispensing:** `list/read/write` map to `GET/PUT /users/me/settings` (admin
+  surface `/admin/users/{id}/settings`), alongside the existing `/users/me/*`
+  endpoints in `api/app/routes/auth.py`. `PUT` validates against `UserSettings`
+  and replaces the whole object; `If-Match: <revision>` guards concurrent writes
+  with a `409`.
+
+- **Contents** (the agreed server-synced set — these *follow the person*): default
+  ontology, ingest tuning (chunk size, overlap, processing mode), job
+  notifications, a small set of UI preferences, and auto-approve.
+
+- **Defaults-only boundary:** the server never *acts* on a stored setting — it may
+  pre-fill a form, but consequential behavior (notably ingest **auto-approve**) is
+  always driven by an explicit, separately-validated request parameter, never read
+  from the settings blob. Auto-approve travels as a convenience default; it never
+  silently authorizes a job.
+
+Device-shaped preferences (theme, fonts, color, compact mode, animations) are a
+separate `device`-backed provider and stay in `localStorage`.
+
+### 6. Non-goal — storage unification (esp. secrets)
+
+This ADR moves no element's storage. **Credentials and grants are never stored in
+the settings DTO.** The credentials provider lists and revokes against the
+existing `oauth_clients`/OAuth machinery (ADR-031/054); the preferences view only
+*surfaces* them. Each provider's backing is its own concern.
+
+### 7. Scope of new work
+
+Because the backends largely exist, the build is mostly unification:
+
+- **New:** the settings provider (table + `UserSettings` model + `/users/me/settings`).
+- **New:** one consolidated `owner-or-admin` helper, replacing scattered checks.
+- **New (UI):** the provider registry + the two surfaces, reusing `AccountTab`,
+  `SavedQueriesPanel`, and existing stores; finishing the credentials management
+  UI; the per-user admin drill-down.
+- **Reused as-is:** `oauth_clients` + personal-client routes, `query_definitions`
+  + `artifacts` + their routes/stores, `resource_grants`/`has_access()`.
+- **Deferred / separate ADRs if pursued:** standardizing `owner_id` NULL
+  semantics across all tables; adding save support to Force Graph / Catalog
+  explorers; OAuth scope enforcement.
+
+### 8. Keep the registry honest: an enumeration check
+
+A registry is where unused abstraction hides — a provider registered once and
+never questioned is how a thin convention silently becomes a framework nobody
+needs. To keep it honest, add a make target / lint (alongside
+`scripts/development/lint/`) that **enumerates every registered provider** — its
+`kind`, `backing`, the surfaces it appears in, and (where cheap to detect)
+whether it is actually rendered/used.
+
+The enumeration serves two purposes at once:
+
+- **"We did X"** — a single, current list of what dispensing surfaces expose, as
+  provenance and onboarding context (useful after a multi-month gap).
+- **"Do we need X?"** — by making every provider visible in one place, it turns
+  each into a standing question. A provider that earns its place stays; one that
+  no longer does is obvious and can be removed. The check is the forcing function
+  that prevents silent accumulation.
+
+Like the §7 work, this is small and static; it wires into CI with a `--check`
+exit code the same way `adr lint --check` does.
+
+## Consequences
+
+### Positive
+
+- One place a user manages everything that is theirs; one place an admin manages
+  everyone's — including credentials/grants, which have no user surface today.
+- New user-owned resources implement one contract and appear, correctly
+  access-controlled, in both surfaces — no re-solving listing/placement/access.
+- Most of the work is wrapping existing, verified backends, not greenfield —
+  materially lower risk than the original "build server preferences" framing.
+- Consolidating the scattered owner-or-admin checks removes a real source of
+  drift and inconsistency.
+- The dispensing surface and the logged-out-visibility treatment become the same
+  UX, defined once.
+
+### Negative
+
+- A registry + provider abstraction is new surface; over-engineered, it could
+  become a framework nobody needs. Mitigation: keep it a thin convention, grow it
+  provider-by-provider as real providers land, and run the §8 enumeration check
+  so every registered provider stays a standing "do we still need this?" question
+  rather than silent accumulation.
+- Two rendering surfaces (preferences, admin) must stay in step as the contract
+  evolves.
+- Consolidating access checks touches many routes; must be done carefully to
+  avoid changing existing authorization behavior.
+- Couples to the companion capability-gating ADR; should not land before it.
+
+### Neutral
+
+- Device-backed providers remain editable while unauthenticated (they are local);
+  server-backed ones gate read-only. The contract carries this via `backing`.
+- The grant/group infrastructure (migration 034) is available but not required by
+  this ADR; simple ownership covers the initial providers.
+
+## Alternatives Considered
+
+- **Unify storage too (one per-user store for everything).** Superficially
+  simpler. Rejected outright: it would put secrets in a settings blob, discard the
+  encrypted/OAuth model (ADR-031/054) and the existing `query_definitions`/
+  `artifacts` tables, and force one shape onto values with very different
+  validation, size, and security needs.
+- **Just add server-side preferences, nothing more (original ADR-704 scope).**
+  Solves settings but leaves the actual goal — a unified location/way to dispense
+  *all* user-owned elements — unaddressed, and ignores that credentials and saved
+  items already have backends needing only a surface.
+- **Keep everything in `localStorage`, label it clearly.** Smallest change;
+  resolves only the perception bug. Rejected because it gives neither cross-device
+  settings nor any management surface for the elements that already persist
+  server-side.
+- **A heavyweight per-user "profile service".** Overkill for a single-tenant,
+  self-hosted platform; the thin provider convention gets the unification without
+  standing infrastructure.

--- a/docs/architecture/user-interfaces/ADR-705-session-visibility-and-declarative-capability-gating.md
+++ b/docs/architecture/user-interfaces/ADR-705-session-visibility-and-declarative-capability-gating.md
@@ -1,0 +1,211 @@
+---
+status: Draft
+date: 2026-05-31
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-067
+  - ADR-400
+  - ADR-704
+---
+
+# ADR-705: Session Visibility and Declarative Capability Gating
+
+## Context
+
+The web application does not visibly reflect being logged out, and — more
+dangerously — it cannot reliably *detect* a session that expired mid-use. A user
+can navigate the entire nav bar, toggle controls, and form a false impression of
+being logged in. The originating complaint: someone whose session has expired (or
+who never logged in) keeps clicking around, and the app neither says so nor
+behaves differently, which is misleading and invites inconsistency.
+
+A codebase verification found three concrete structural gaps:
+
+| Gap | Detail | Source |
+|-----|--------|--------|
+| **No 401 response interceptor** | `client.ts` attaches the bearer token on requests but has no response handler. A token that expires mid-session produces a raw per-call error; the app still believes it is authenticated. | `web/src/api/client.ts:65-76` (request interceptor only) |
+| **`isAuthenticated: false` collapses two states** | "never logged in" and "expired" are indistinguishable, so the UI cannot show a quiet "Sign in" for one and a loud "Your session expired" for the other. Expiry is only checked proactively on app mount via `checkAuth()`; there is no background detection. | `web/src/store/authStore.ts` (`isTokenExpired(expires_at, 60)`, `checkAuth`, `refreshToken`) |
+| **No capability gating layer** | Routes are unguarded; 20+ nav items are fully navigable. Only `HomeWorkspace` and `AdminDashboard` hand-roll `if (!isAuthenticated)`. Every new component re-invents auth-checking or forgets it. | `web/src/App.tsx`, `web/src/components/home/HomeWorkspace.tsx`, `web/src/components/admin/AdminDashboard.tsx` |
+
+The permission model already exists: `authStore` exposes `hasPermission(resource,
+action)` and `isPlatformAdmin()` over a `can['resource:action']` map loaded after
+login (ADR-400). What is missing is (a) an explicit session-status notion, (b)
+detection of mid-session expiry, and (c) a declarative way to consume both so
+components don't each re-solve gating.
+
+A prior decision (this session) chose the **browsable + read-only** model: keep
+the nav navigable for discoverability, but make mutating controls visibly inert
+when the user cannot act, with ambient treatment that makes logged-out state
+unmistakable.
+
+This ADR is the **companion to ADR-704**: ADR-704 defines *what* user-owned
+resources are dispensed and *where* (preferences / admin surfaces); this ADR
+defines the session-awareness and gating primitives that decide *whether* those
+controls are live. ADR-704's `backing: server | device` field keys directly on
+the session status defined here. Neither ADR is complete without the other.
+
+## Decision
+
+### 1. Canonical session status
+
+Add a derived selector to `authStore`:
+
+```
+sessionStatus: 'anonymous' | 'authenticated' | 'expired'
+```
+
+- **`anonymous`** — no stored credentials; the user has never logged in (or has
+  explicitly logged out).
+- **`authenticated`** — a valid, non-expired token is present.
+- **`expired`** — credentials existed but are gone, past expiry, or rejected by
+  the server, and refresh did not (or cannot) restore them.
+
+This replaces the boolean `isAuthenticated` collapse for *presentation*
+purposes. The distinction is the whole point: `anonymous` gets a quiet "Sign in"
+affordance; `expired` gets a loud, interrupting signal because the user's mental
+model says "I'm logged in" and must be corrected.
+
+### 2. Global 401 response interceptor (the keystone)
+
+Add a response interceptor to the axios client (`client.ts`). On a `401` for a
+request that carried a token:
+
+1. If a refresh token exists and this request has not already been retried,
+   attempt a **single** token refresh and replay the original request.
+2. If refresh fails or there is no refresh token, set `sessionStatus = 'expired'`,
+   clear the access token, and let the UI react (§4).
+
+Constraints, to avoid known failure modes:
+
+- **No retry loops** — mark replayed requests so a second 401 does not recurse.
+- **Exempt the auth endpoints** — the token/refresh/revoke routes must not be
+  intercepted into a refresh of themselves.
+- **Single-flight refresh** — concurrent 401s share one in-flight refresh and
+  queue, rather than firing N refreshes.
+- **SSE streams** — job-progress streams pass the token as a query param
+  (`client.ts:755`) and cannot use this interceptor; they detect auth failure on
+  the stream and route to the same `expired` transition.
+
+This interceptor is what makes mid-session expiry *detectable at all*; without
+it, none of the visible treatment below can fire.
+
+### 3. Declarative capability primitives
+
+Consume `sessionStatus` + the existing `can['resource:action']` map (ADR-400)
+through a small, reusable API so components stop hand-rolling checks:
+
+- **`useCapability(resource, action) → { can, reason }`** where `reason ∈
+  { ok, anonymous, expired, forbidden }`. One hook answers "may this user do this
+  right now, and if not, why," combining session and permission.
+- **`<Gated resource action>`** — wraps a mutating control. When `!can`, renders
+  the control disabled with a standard reason tooltip ("Sign in to …" / "Your
+  session expired — sign in to continue" / "You don't have permission"). This is
+  the primary primitive future components use; correct gating becomes the default,
+  not a thing to remember.
+- **`<RequireCapability>` / `<RequireAuth>`** — section wrappers that render
+  children, a read-only/placeholder state, or (where appropriate) a sign-in
+  prompt. Per the browsable + read-only model, the default is render-with-gated-
+  controls, **not** redirect-to-login.
+
+The existing hand-rolled `if (!isAuthenticated)` blocks in `HomeWorkspace` and
+`AdminDashboard` are refactored onto these primitives.
+
+### 4. Ambient treatment, defined once
+
+Drive a single chrome-level treatment off `sessionStatus`, defined once in
+`AppLayout` rather than scattered:
+
+- **`expired`** → a sticky, full-width banner ("Your session expired — sign in to
+  continue"), the loud signal. A context-preserving re-auth modal is an optional
+  enhancement.
+- **`anonymous`** → a quiet, always-on cue: a muted/desaturated header and a
+  "Viewing as guest" indicator, alongside the existing `UserProfile` "Login"
+  affordance (top-right) which already flips between Login and the user menu.
+- **`authenticated`** → normal chrome.
+
+Because this is keyed on one derived value in one place, every page inherits
+consistent logged-out treatment without per-page work.
+
+### 5. Browsable + read-only navigation model
+
+Nav and routes stay navigable (discoverability matters for a knowledge tool).
+Gating happens at the control and ambient level, not by hiding nav or bouncing to
+login:
+
+- Mutating controls gate via `<Gated>` (disabled + reason).
+- Reads are attempted; where they require auth, the failure routes through the
+  401 interceptor into the `expired`/`anonymous` treatment rather than a raw
+  error.
+- A route-level `<RequireAuth>` wrapper exists for the rare page that genuinely
+  cannot render anything useful unauthenticated, but it shows a sign-in prompt
+  in place — it does not redirect.
+
+### 6. Enforce adoption with a web-UI lint
+
+The primitives only pay off if components actually use them; partial adoption
+re-introduces the inconsistency this ADR removes. Rather than rely on memory,
+add a web-UI lint (alongside the existing `scripts/development/lint/` family —
+`docstring_coverage.py`, `lint_queries.py`) that makes adoption checkable:
+
+- **Flag raw session reads in components** — direct `authStore.isAuthenticated`
+  usage outside the sanctioned primitives, which is how the current hand-rolled
+  checks crept in.
+- **Flag un-gated mutating controls** — interactive elements whose handlers call
+  a mutating API method but are not wrapped in `<Gated>` / guarded by
+  `useCapability`.
+- **Report adoption** — a count of gated vs. un-gated mutating call sites, so
+  drift is visible over time.
+
+The lint runs in the static-analysis set (no running platform needed) and wires
+into CI with a `--check` exit code, the same way `adr lint --check` does. It
+converts "the team must adopt this" from an aspiration into a gate.
+
+## Consequences
+
+### Positive
+
+- Mid-session expiry becomes detectable and visible instead of surfacing as a
+  raw error on the next click — the core safety gap is closed.
+- `anonymous` vs `expired` are treated distinctly: quiet invite vs loud
+  correction.
+- New components get correct gating by wrapping a control in `<Gated>` — no
+  re-solving auth visuals, which is the cross-cutting "future components don't
+  worry about this" goal.
+- ADR-704's dispensing surfaces get their read-only behavior for free via the
+  shared `sessionStatus` and primitives.
+- Consolidates the scattered, hand-rolled `isAuthenticated` checks.
+
+### Negative
+
+- The 401 interceptor has real edge cases (retry loops, single-flight refresh,
+  SSE, auth-endpoint exemption) that must be implemented carefully.
+- Introduces new shared primitives the team must adopt for the benefit to
+  compound; partial adoption leaves inconsistency. Mitigation: the web-UI lint
+  (§6) flags raw `isAuthenticated` reads and un-gated mutating controls, making
+  adoption an enforceable gate rather than an aspiration.
+- Ambient treatment is a visible UX change that needs design polish (banner,
+  guest cue) to avoid feeling naggy.
+
+### Neutral
+
+- Nav remains fully browsable by design; this is a deliberate model choice, not
+  an oversight.
+- The permission map and `hasPermission` API are reused unchanged; this ADR adds
+  session-awareness around them, not a new authorization model.
+
+## Alternatives Considered
+
+- **Redirect protected routes to login.** Simplest mental model. Rejected per the
+  browsable + read-only choice: it hides the feature surface from prospective
+  users and is heavier than a knowledge tool wants.
+- **Hide authenticated nav items when logged out.** Cleanest visually, least
+  discoverable. Rejected for the same reason.
+- **Keep per-component `if (!isAuthenticated)` checks.** The status quo. Rejected:
+  it cannot distinguish expired from anonymous, does not detect mid-session
+  expiry, and re-invents gating in every component.
+- **Background token-expiry polling instead of a 401 interceptor.** Detects
+  expiry on a timer. Rejected as redundant and racy: the 401 interceptor reacts to
+  the authoritative signal (the server rejecting the token) exactly when it
+  matters; proactive `checkAuth()` on mount already covers the load-time case.

--- a/scripts/development/lint/lint_gating.py
+++ b/scripts/development/lint/lint_gating.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Gating Adoption Linter - Enforce session-aware capability gating in the web UI
+
+Part of ADR-705 (Session Visibility and Declarative Capability Gating).
+
+The gating primitives (sessionStatus, useCapability, <Gated>, <RequireCapability>)
+only pay off if components actually use them; partial adoption re-introduces the
+inconsistency the ADR removes. This linter makes adoption checkable:
+
+  ERROR  - raw `isAuthenticated` reads from the auth store in components. This is
+           how the original hand-rolled checks crept in; components should read
+           `sessionStatus` / use `useCapability` instead. (Fails --check.)
+
+  REPORT - adoption metrics: how many call sites use <Gated> / useCapability, so
+           drift is visible over time. (Informational; never fails.)
+
+Detecting every un-gated mutating control reliably from source is noisy and
+error-prone, so this linter enforces the precise, unambiguous signal (raw
+isAuthenticated reads) and *reports* the fuzzier adoption surface rather than
+guessing at it.
+
+Usage:
+    python3 scripts/development/lint/lint_gating.py            # report + check
+    python3 scripts/development/lint/lint_gating.py --check    # exit 1 on errors
+    python3 scripts/development/lint/lint_gating.py -v         # list scanned files
+"""
+
+import re
+import sys
+from pathlib import Path
+from typing import List
+from dataclasses import dataclass
+
+# Files allowed to reference `isAuthenticated` directly.
+# The store defines and maintains the flag (kept for backward compat); the lint
+# itself names it in patterns/messages.
+ALLOWED_FILES = {
+    "store/authStore.ts",
+    "scripts/development/lint/lint_gating.py",
+}
+
+# A line that destructures isAuthenticated from the store, e.g.
+#   const { user, isAuthenticated } = useAuthStore();
+DESTRUCTURE_PATTERN = re.compile(r"useAuthStore\s*\([^)]*\)")
+ISAUTH_NAME = re.compile(r"\bisAuthenticated\b")
+
+# A line that accesses .isAuthenticated (selectors, getState, etc.), e.g.
+#   useAuthStore((s) => s.isAuthenticated)   state.isAuthenticated
+PROPERTY_ACCESS_PATTERN = re.compile(r"\.isAuthenticated\b")
+
+GATED_USAGE = re.compile(r"<Gated[\s/>]")
+CAPABILITY_USAGE = re.compile(r"\buseCapability\s*\(")
+
+
+@dataclass
+class Finding:
+    """A raw isAuthenticated read that should move onto the sanctioned path."""
+    file_path: str
+    line_number: int
+    line: str
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def is_allowed(rel_path: str) -> bool:
+    return any(rel_path.endswith(allowed) for allowed in ALLOWED_FILES)
+
+
+class GatingLinter:
+    """Lints web UI source for gating adoption (ADR-705)."""
+
+    def __init__(self, root: Path, verbose: bool = False):
+        self.root = root
+        self.verbose = verbose
+        self.gated_count = 0
+        self.capability_count = 0
+
+    def lint_file(self, file_path: Path) -> List[Finding]:
+        rel = _rel(file_path, self.root)
+        try:
+            lines = file_path.read_text(encoding="utf-8").splitlines()
+        except Exception as e:  # pragma: no cover
+            print(f"Warning: Could not read {file_path}: {e}", file=sys.stderr)
+            return []
+
+        # Don't count adoption inside the primitives' own definitions or in
+        # comment lines (doc examples) — the metric should reflect consumers.
+        is_definition = rel.endswith("components/auth/Gated.tsx") or rel.endswith(
+            "hooks/useCapability.ts"
+        )
+
+        findings: List[Finding] = []
+        for i, line in enumerate(lines, start=1):
+            stripped = line.lstrip()
+            is_comment = stripped.startswith(("*", "//", "/*"))
+
+            # Adoption metrics (real consumer usages only)
+            if not is_definition and not is_comment:
+                self.gated_count += len(GATED_USAGE.findall(line))
+                self.capability_count += len(CAPABILITY_USAGE.findall(line))
+
+            if is_allowed(rel):
+                continue
+
+            destructured = (
+                DESTRUCTURE_PATTERN.search(line) and ISAUTH_NAME.search(line)
+            )
+            accessed = PROPERTY_ACCESS_PATTERN.search(line)
+            if destructured or accessed:
+                findings.append(Finding(rel, i, line.strip()))
+
+        return findings
+
+    def lint_tree(self, directory: Path) -> List[Finding]:
+        findings: List[Finding] = []
+        for file_path in sorted(directory.rglob("*.ts*")):
+            if file_path.suffix not in (".ts", ".tsx"):
+                continue
+            if "node_modules" in file_path.parts:
+                continue
+            if self.verbose:
+                print(f"Scanning {_rel(file_path, self.root)}...", file=sys.stderr)
+            findings.extend(self.lint_file(file_path))
+        return findings
+
+    def print_report(self, findings: List[Finding]) -> None:
+        print("Gating adoption (ADR-705)")
+        print("=" * 60)
+        print(f"  <Gated> usages:       {self.gated_count}")
+        print(f"  useCapability() uses: {self.capability_count}")
+        print()
+
+        if not findings:
+            print("✓ No raw isAuthenticated reads in components.")
+            return
+
+        print(f"❌ Found {len(findings)} raw isAuthenticated read(s) — "
+              f"use sessionStatus / useCapability instead:\n")
+        for f in findings:
+            print(f"📄 {f.file_path}:{f.line_number}")
+            print(f"     {f.line}")
+            print()
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Lint web UI for session-aware capability gating adoption (ADR-705)"
+    )
+    parser.add_argument(
+        "paths", nargs="*", default=["web/src"],
+        help="Paths to scan (default: web/src)",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="List scanned files")
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Exit 1 if any raw isAuthenticated reads are found (CI mode)",
+    )
+    args = parser.parse_args()
+
+    root = Path.cwd()
+    linter = GatingLinter(root=root, verbose=args.verbose)
+    all_findings: List[Finding] = []
+
+    for path_str in args.paths:
+        path = Path(path_str)
+        if not path.exists():
+            print(f"Error: Path does not exist: {path}", file=sys.stderr)
+            sys.exit(2)
+        if path.is_file():
+            all_findings.extend(linter.lint_file(path))
+        else:
+            all_findings.extend(linter.lint_tree(path))
+
+    linter.print_report(all_findings)
+
+    if args.check and all_findings:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/development/lint/lint_gating.py
+++ b/scripts/development/lint/lint_gating.py
@@ -41,13 +41,26 @@ ALLOWED_FILES = {
 }
 
 # A line that destructures isAuthenticated from the store, e.g.
-#   const { user, isAuthenticated } = useAuthStore();
-DESTRUCTURE_PATTERN = re.compile(r"useAuthStore\s*\([^)]*\)")
-ISAUTH_NAME = re.compile(r"\bisAuthenticated\b")
+# Store reads are matched against the FULL file text (DOTALL) so multi-line
+# destructures — the common Prettier wrapping — are caught, and only reads that
+# are clearly the auth store are flagged (no false positives on unrelated
+# objects that happen to have an `isAuthenticated` field).
 
-# A line that accesses .isAuthenticated (selectors, getState, etc.), e.g.
-#   useAuthStore((s) => s.isAuthenticated)   state.isAuthenticated
-PROPERTY_ACCESS_PATTERN = re.compile(r"\.isAuthenticated\b")
+# Destructuring isAuthenticated out of the store, one line or many:
+#   const { user, isAuthenticated } = useAuthStore()
+DESTRUCTURE_STORE = re.compile(
+    r"\{[^{}]*\bisAuthenticated\b[^{}]*\}\s*=\s*useAuthStore\b",
+    re.DOTALL,
+)
+# Selector read:  useAuthStore((s) => s.isAuthenticated)
+SELECTOR_ACCESS = re.compile(
+    r"useAuthStore\s*\(\s*\(?[^)]*\)?\s*=>[^)]*\.isAuthenticated\b",
+    re.DOTALL,
+)
+# Imperative read:  useAuthStore.getState().isAuthenticated
+GETSTATE_ACCESS = re.compile(r"useAuthStore\.getState\(\)\.isAuthenticated\b")
+
+STORE_READ_PATTERNS = (DESTRUCTURE_STORE, SELECTOR_ACCESS, GETSTATE_ACCESS)
 
 GATED_USAGE = re.compile(r"<Gated[\s/>]")
 CAPABILITY_USAGE = re.compile(r"\buseCapability\s*\(")
@@ -84,38 +97,43 @@ class GatingLinter:
     def lint_file(self, file_path: Path) -> List[Finding]:
         rel = _rel(file_path, self.root)
         try:
-            lines = file_path.read_text(encoding="utf-8").splitlines()
+            text = file_path.read_text(encoding="utf-8")
         except Exception as e:  # pragma: no cover
             print(f"Warning: Could not read {file_path}: {e}", file=sys.stderr)
             return []
+
+        lines = text.splitlines()
 
         # Don't count adoption inside the primitives' own definitions or in
         # comment lines (doc examples) — the metric should reflect consumers.
         is_definition = rel.endswith("components/auth/Gated.tsx") or rel.endswith(
             "hooks/useCapability.ts"
         )
-
-        findings: List[Finding] = []
-        for i, line in enumerate(lines, start=1):
+        for line in lines:
             stripped = line.lstrip()
-            is_comment = stripped.startswith(("*", "//", "/*"))
-
-            # Adoption metrics (real consumer usages only)
-            if not is_definition and not is_comment:
-                self.gated_count += len(GATED_USAGE.findall(line))
-                self.capability_count += len(CAPABILITY_USAGE.findall(line))
-
-            if is_allowed(rel):
+            if is_definition or stripped.startswith(("*", "//", "/*")):
                 continue
+            self.gated_count += len(GATED_USAGE.findall(line))
+            self.capability_count += len(CAPABILITY_USAGE.findall(line))
 
-            destructured = (
-                DESTRUCTURE_PATTERN.search(line) and ISAUTH_NAME.search(line)
-            )
-            accessed = PROPERTY_ACCESS_PATTERN.search(line)
-            if destructured or accessed:
-                findings.append(Finding(rel, i, line.strip()))
+        if is_allowed(rel):
+            return []
 
-        return findings
+        # Store-read violations are matched against the full text so multi-line
+        # destructures are caught; report the line the match starts on.
+        findings: List[Finding] = []
+        seen_lines = set()
+        for pattern in STORE_READ_PATTERNS:
+            for m in pattern.finditer(text):
+                line_number = text.count("\n", 0, m.start()) + 1
+                if line_number in seen_lines:
+                    continue
+                seen_lines.add(line_number)
+                findings.append(
+                    Finding(rel, line_number, lines[line_number - 1].strip())
+                )
+
+        return sorted(findings, key=lambda f: f.line_number)
 
     def lint_tree(self, directory: Path) -> List[Finding]:
         findings: List[Finding] = []

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,7 +49,8 @@ const queryClient = new QueryClient({
 
 const AppContent: React.FC = () => {
   const { setTypes, setLoading, setError } = useVocabularyStore();
-  const { checkAuth, isAuthenticated } = useAuthStore();
+  const { checkAuth, sessionStatus } = useAuthStore();
+  const isAuthenticated = sessionStatus === 'authenticated';  // ADR-705
   const { theme, setTheme } = useThemeStore();
 
   // Initialize theme harmony (applies stored color settings)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AppLayout } from './components/layout/AppLayout';
+import { Loader2 } from 'lucide-react';
 import { OAuthCallback } from './components/auth/OAuthCallback';
 import { ProtectedView } from './components/auth/ProtectedView';
 import { useVocabularyStore } from './store/vocabularyStore';
@@ -50,7 +51,7 @@ const queryClient = new QueryClient({
 
 const AppContent: React.FC = () => {
   const { setTypes, setLoading, setError } = useVocabularyStore();
-  const { checkAuth, sessionStatus } = useAuthStore();
+  const { checkAuth, sessionStatus, hydrated } = useAuthStore();
   const isAuthenticated = sessionStatus === 'authenticated';  // ADR-705
   const { theme, setTheme } = useThemeStore();
 
@@ -120,6 +121,18 @@ const AppContent: React.FC = () => {
     };
     loadVocabulary();
   }, [isAuthenticated]); // Re-run when authentication changes
+
+  // ADR-705: until the initial checkAuth (including any token refresh) resolves,
+  // sessionStatus is still the default 'anonymous'. Render a neutral loader
+  // rather than flashing signed-out content (LoggedOutView / guest banner) to an
+  // already-authenticated user on a hard load.
+  if (!hydrated) {
+    return (
+      <div className="h-screen flex items-center justify-center bg-background text-muted-foreground">
+        <Loader2 className="w-6 h-6 animate-spin" />
+      </div>
+    );
+  }
 
   return (
     <AppLayout>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AppLayout } from './components/layout/AppLayout';
 import { OAuthCallback } from './components/auth/OAuthCallback';
+import { ProtectedView } from './components/auth/ProtectedView';
 import { useVocabularyStore } from './store/vocabularyStore';
 import { useAuthStore } from './store/authStore';
 import { useThemeStore } from './store/themeStore';
@@ -123,50 +124,54 @@ const AppContent: React.FC = () => {
   return (
     <AppLayout>
       <Routes>
-        {/* Home - welcome and login page */}
+        {/* Home - welcome and login page (its own signed-out welcome) */}
         <Route path="/" element={<HomeWorkspace />} />
 
+        {/* Content routes are wrapped in <ProtectedView> (ADR-705): when signed
+            out, the workspace doesn't mount/fetch/401 — a consistent
+            LoggedOutView (with the workstation guide) renders instead. */}
+
         {/* Explorers */}
-        <Route path="/explore/graph" element={<ExplorerView explorerType="force-graph" />} />
+        <Route path="/explore/graph" element={<ProtectedView what="the graph"><ExplorerView explorerType="force-graph" /></ProtectedView>} />
         {/* Legacy public routes — preserve bookmarks. The unified plugin
             owns projection via its settings panel, so the URL no longer
             encodes 2D vs 3D. Search params (concept ids, depth, etc.) carry over. */}
         <Route path="/explore/2d" element={<RedirectPreservingSearch to="/explore/graph" />} />
         <Route path="/explore/3d" element={<RedirectPreservingSearch to="/explore/graph" />} />
-        <Route path="/explore/documents" element={<DocumentExplorerWorkspace />} />
-        <Route path="/explore/catalog" element={<CatalogExplorerWorkspace />} />
+        <Route path="/explore/documents" element={<ProtectedView what="documents"><DocumentExplorerWorkspace /></ProtectedView>} />
+        <Route path="/explore/catalog" element={<ProtectedView what="the catalog"><CatalogExplorerWorkspace /></ProtectedView>} />
 
         {/* Block Editor */}
-        <Route path="/blocks" element={<BlockEditorWorkspace />} />
-        <Route path="/blocks/:diagramId" element={<BlockEditorWorkspace />} />
+        <Route path="/blocks" element={<ProtectedView what="the block editor"><BlockEditorWorkspace /></ProtectedView>} />
+        <Route path="/blocks/:diagramId" element={<ProtectedView what="the block editor"><BlockEditorWorkspace /></ProtectedView>} />
 
         {/* Ingest */}
-        <Route path="/ingest" element={<IngestWorkspace />} />
+        <Route path="/ingest" element={<ProtectedView what="ingestion"><IngestWorkspace /></ProtectedView>} />
 
         {/* Jobs */}
-        <Route path="/jobs" element={<JobsWorkspace />} />
+        <Route path="/jobs" element={<ProtectedView what="jobs"><JobsWorkspace /></ProtectedView>} />
 
         {/* Report */}
-        <Route path="/report" element={<ReportWorkspace />} />
+        <Route path="/report" element={<ProtectedView what="reports"><ReportWorkspace /></ProtectedView>} />
 
         {/* Polarity Explorer (ADR-070) */}
-        <Route path="/polarity" element={<PolarityExplorerWorkspace />} />
+        <Route path="/polarity" element={<ProtectedView what="polarity"><PolarityExplorerWorkspace /></ProtectedView>} />
 
         {/* Vocabulary Explorer (ADR-077) */}
-        <Route path="/vocabulary" element={<EdgeExplorerWorkspace />} />
-        <Route path="/vocabulary/chord" element={<VocabularyChordWorkspace />} />
+        <Route path="/vocabulary" element={<ProtectedView what="the vocabulary graph"><EdgeExplorerWorkspace /></ProtectedView>} />
+        <Route path="/vocabulary/chord" element={<ProtectedView what="vocabulary analysis"><VocabularyChordWorkspace /></ProtectedView>} />
 
         {/* Embedding Landscape (ADR-078) */}
-        <Route path="/embeddings" element={<EmbeddingLandscapeWorkspace />} />
+        <Route path="/embeddings" element={<ProtectedView what="the embedding landscape"><EmbeddingLandscapeWorkspace /></ProtectedView>} />
 
         {/* Edit */}
-        <Route path="/edit" element={<GraphEditor />} />
+        <Route path="/edit" element={<ProtectedView what="the graph editor"><GraphEditor /></ProtectedView>} />
 
         {/* Preferences */}
-        <Route path="/preferences" element={<PreferencesWorkspace />} />
+        <Route path="/preferences" element={<ProtectedView what="preferences"><PreferencesWorkspace /></ProtectedView>} />
 
         {/* Admin */}
-        <Route path="/admin" element={<AdminDashboard />} />
+        <Route path="/admin" element={<ProtectedView what="administration"><AdminDashboard /></ProtectedView>} />
       </Routes>
     </AppLayout>
   );

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -138,9 +138,18 @@ class APIClient {
           }
           emitSessionRefreshed();
           return this.client(config);
-        } catch {
-          clearAuthState();
-          emitSessionExpired();
+        } catch (refreshError) {
+          // Only an actual auth rejection (4xx invalid_grant) is terminal
+          // expiry. A transient failure (network error, 5xx, restarting API)
+          // leaves the session intact so the user can retry — don't force a
+          // spurious logout on a blip.
+          const refreshStatus = axios.isAxiosError(refreshError)
+            ? refreshError.response?.status
+            : undefined;
+          if (refreshStatus !== undefined && refreshStatus >= 400 && refreshStatus < 500) {
+            clearAuthState();
+            emitSessionExpired();
+          }
           return Promise.reject(error);
         }
       }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -43,7 +43,20 @@ import type {
   VocabularyJobDispatchResponse,
   AggressivenessProfile,
 } from '../types/vocabulary';
-import { getAuthState } from '../lib/auth/oauth-utils';
+import { getAuthState, clearAuthState, isTokenExpired, type StoredAuthState } from '../lib/auth/oauth-utils';
+import { refreshAccessToken } from '../lib/auth/authorization-code-flow';
+import { emitSessionExpired, emitSessionRefreshed } from '../lib/auth/session-events';
+
+/**
+ * Single-flight refresh guard (ADR-705).
+ * Shared across all requests so concurrent 401s trigger exactly one refresh.
+ */
+let inFlightRefresh: Promise<StoredAuthState> | null = null;
+
+/** Auth endpoints must not be intercepted into refreshing themselves. */
+function isAuthEndpoint(url?: string): boolean {
+  return !!url && url.includes('/auth/oauth/');
+}
 
 // API configuration - runtime config takes precedence over build-time env vars
 // This enables CDN deployment without rebuilding
@@ -72,6 +85,64 @@ class APIClient {
       },
       (error) => {
         return Promise.reject(error);
+      }
+    );
+
+    // Response interceptor: detect mid-session expiry (ADR-705).
+    // The request interceptor only attaches the token; without this, an expired
+    // token surfaces as a raw per-call error while the app still believes it is
+    // authenticated. Here we attempt a single refresh-and-replay, and on failure
+    // signal the session as expired so the UI can react.
+    this.client.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        const status = error.response?.status;
+        const config = error.config as
+          | (InternalAxiosRequestConfig & { __isRetry?: boolean })
+          | undefined;
+
+        // Only act on 401s we can do something about. Skip already-retried
+        // requests (no loops) and the auth endpoints themselves.
+        if (status !== 401 || !config || config.__isRetry || isAuthEndpoint(config.url)) {
+          return Promise.reject(error);
+        }
+
+        const authState = getAuthState();
+
+        // No stored credentials → this is an anonymous 401 ("please log in"),
+        // not an expiry. Let the caller handle it.
+        if (!authState || !authState.access_token) {
+          return Promise.reject(error);
+        }
+
+        // Have a token but no way to refresh → terminal: session expired.
+        if (!authState.refresh_token) {
+          clearAuthState();
+          emitSessionExpired();
+          return Promise.reject(error);
+        }
+
+        // Single-flight refresh shared across concurrent 401s.
+        try {
+          if (!inFlightRefresh) {
+            inFlightRefresh = refreshAccessToken(authState.refresh_token).finally(() => {
+              inFlightRefresh = null;
+            });
+          }
+          const refreshed = await inFlightRefresh;
+
+          // Replay the original request exactly once with the new token.
+          config.__isRetry = true;
+          if (config.headers) {
+            config.headers.Authorization = `Bearer ${refreshed.access_token}`;
+          }
+          emitSessionRefreshed();
+          return this.client(config);
+        } catch {
+          clearAuthState();
+          emitSessionExpired();
+          return Promise.reject(error);
+        }
       }
     );
   }
@@ -790,9 +861,17 @@ class APIClient {
       eventSource.close();
     });
 
-    eventSource.onerror = (err) => {
+    eventSource.onerror = () => {
       callbacks.onError?.(new Error('SSE connection error'));
       eventSource.close();
+      // SSE passes the token as a query param and can't use the response
+      // interceptor. If the failure coincides with an expired token, route it
+      // to the same session-expired transition (ADR-705). Guarded on actual
+      // expiry to avoid false positives on transient network errors.
+      const current = getAuthState();
+      if (current && isTokenExpired(current.expires_at)) {
+        emitSessionExpired();
+      }
     };
 
     // Return cleanup function

--- a/web/src/components/admin/AdminDashboard.tsx
+++ b/web/src/components/admin/AdminDashboard.tsx
@@ -16,12 +16,9 @@ import {
   Network,
   BookOpen,
   AlertCircle,
-  Loader2,
   CheckCircle,
 } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
-import { useCapability } from '../../hooks/useCapability';
-import { SignInPrompt } from '../auth/SignInPrompt';
 import { TabButton } from './components';
 import { AccountTab } from './AccountTab';
 import { UsersTab } from './UsersTab';
@@ -33,7 +30,6 @@ import type { TabType } from './types';
 
 export const AdminDashboard: React.FC = () => {
   const { permissions, hasPermission, isPlatformAdmin } = useAuthStore();
-  const { can: canAccess, reason } = useCapability();  // ADR-705: session-aware gate
 
   // Permission-based access control (ADR-074)
   const canViewUsers = hasPermission('users', 'read');
@@ -57,10 +53,8 @@ export const AdminDashboard: React.FC = () => {
     }
   }, [successMessage]);
 
-  // Not authenticated (or expired) - session-aware in-place prompt (ADR-705)
-  if (!canAccess) {
-    return <SignInPrompt reason={reason} detail="to access admin settings" />;
-  }
+  // Signed-out handling is done at the route via <ProtectedView> (ADR-705);
+  // here we only need per-tab permission gating for authenticated users.
 
   return (
     <div className="h-full flex flex-col bg-background">

--- a/web/src/components/admin/AdminDashboard.tsx
+++ b/web/src/components/admin/AdminDashboard.tsx
@@ -20,6 +20,8 @@ import {
   CheckCircle,
 } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
+import { useCapability } from '../../hooks/useCapability';
+import { SignInPrompt } from '../auth/SignInPrompt';
 import { TabButton } from './components';
 import { AccountTab } from './AccountTab';
 import { UsersTab } from './UsersTab';
@@ -30,7 +32,8 @@ import { VocabularyTab } from './VocabularyTab';
 import type { TabType } from './types';
 
 export const AdminDashboard: React.FC = () => {
-  const { isAuthenticated, permissions, hasPermission, isPlatformAdmin } = useAuthStore();
+  const { permissions, hasPermission, isPlatformAdmin } = useAuthStore();
+  const { can: canAccess, reason } = useCapability();  // ADR-705: session-aware gate
 
   // Permission-based access control (ADR-074)
   const canViewUsers = hasPermission('users', 'read');
@@ -54,21 +57,9 @@ export const AdminDashboard: React.FC = () => {
     }
   }, [successMessage]);
 
-  // Not authenticated
-  if (!isAuthenticated) {
-    return (
-      <div className="h-full flex items-center justify-center bg-background">
-        <div className="text-center">
-          <Shield className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-          <h2 className="text-lg font-semibold text-foreground">
-            Authentication Required
-          </h2>
-          <p className="text-muted-foreground mt-2">
-            Please log in to access admin settings.
-          </p>
-        </div>
-      </div>
-    );
+  // Not authenticated (or expired) - session-aware in-place prompt (ADR-705)
+  if (!canAccess) {
+    return <SignInPrompt reason={reason} detail="to access admin settings" />;
   }
 
   return (

--- a/web/src/components/auth/Gated.tsx
+++ b/web/src/components/auth/Gated.tsx
@@ -1,0 +1,40 @@
+/**
+ * <Gated> (ADR-705)
+ *
+ * Wraps a single interactive control (typically a <button>). When the user
+ * cannot perform the action, the child is rendered disabled with a reason
+ * tooltip (native `title`, matching the codebase convention), per the
+ * browsable + read-only model. Wrapping a control in <Gated> makes correct
+ * gating the default rather than something each component must remember.
+ *
+ *   <Gated resource="jobs" action="approve" label="approve jobs">
+ *     <button onClick={approve}>Approve</button>
+ *   </Gated>
+ */
+
+import React from 'react';
+import { useCapability, reasonMessage } from '../../hooks/useCapability';
+
+interface GatedProps {
+  /** Resource for a permission check (omit for a plain auth check). */
+  resource?: string;
+  /** Action for a permission check. */
+  action?: string;
+  /** Verb phrase for the tooltip, e.g. "approve jobs". */
+  label?: string;
+  /** The single interactive element to gate. */
+  children: React.ReactElement;
+}
+
+export function Gated({ resource, action, label, children }: GatedProps): React.ReactElement {
+  const { can, reason } = useCapability(resource, action);
+  if (can) return children;
+
+  // Disable the control and surface why. `disabled` is honored by form
+  // controls (the intended targets); `aria-disabled` + `title` cover the rest.
+  return React.cloneElement(children, {
+    disabled: true,
+    'aria-disabled': true,
+    title: reasonMessage(reason, label),
+  } as Partial<typeof children.props>);
+}

--- a/web/src/components/auth/LoggedOutView.tsx
+++ b/web/src/components/auth/LoggedOutView.tsx
@@ -1,0 +1,70 @@
+/**
+ * <LoggedOutView> (ADR-705)
+ *
+ * The generalized "you can't load content here while signed out" surface.
+ * Content workspaces fetch on mount and would otherwise dump a raw
+ * "Request failed with status code 401"; this replaces that with a consistent,
+ * session-aware view used everywhere via <ProtectedView>.
+ *
+ * It reuses the real NavigationGraph "Workstation Guide" so a signed-out visitor
+ * also gets an idea of what the platform is and how it fits together — the same
+ * guide authenticated users see on Home, kept as a single source of truth.
+ */
+
+import { useState } from 'react';
+import { LogIn, Network } from 'lucide-react';
+import { NavigationGraph } from '../home/NavigationGraph';
+import { LoginModal } from './LoginModal';
+import { useAuthStore } from '../../store/authStore';
+
+interface LoggedOutViewProps {
+  /** Noun for the headline, e.g. "the graph" → "Sign in to view the graph". */
+  what?: string;
+}
+
+export function LoggedOutView({ what }: LoggedOutViewProps) {
+  const sessionStatus = useAuthStore((s) => s.sessionStatus);
+  const [showLogin, setShowLogin] = useState(false);
+  const expired = sessionStatus === 'expired';
+
+  return (
+    <div className="h-full overflow-auto bg-background">
+      <div className="max-w-3xl mx-auto px-6 py-10">
+        {/* Sign-in prompt */}
+        <div className="text-center mb-10">
+          <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center shadow-lg">
+            <Network className="w-8 h-8 text-white" />
+          </div>
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            {expired ? 'Your session expired' : `Sign in to view ${what ?? 'this content'}`}
+          </h2>
+          <p className="text-muted-foreground mb-6">
+            {expired
+              ? 'Your session expired — sign in again to load this content.'
+              : 'This content requires a signed-in session. Meanwhile, here’s how the workstation fits together.'}
+          </p>
+          <button
+            onClick={() => setShowLogin(true)}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors shadow-md"
+          >
+            <LogIn className="w-5 h-5" />
+            {expired ? 'Sign In Again' : 'Sign In'}
+          </button>
+        </div>
+
+        {/* Workstation guide — doubles as a help navigator for signed-out visitors */}
+        <section>
+          <h3 className="text-lg font-semibold text-foreground mb-1">Workstation Guide</h3>
+          <p className="text-sm text-muted-foreground mb-4">
+            Click any node to explore. This is how the knowledge graph workstation works.
+          </p>
+          <div className="p-4 rounded-lg bg-card border border-border">
+            <NavigationGraph />
+          </div>
+        </section>
+      </div>
+
+      <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
+    </div>
+  );
+}

--- a/web/src/components/auth/ProtectedView.tsx
+++ b/web/src/components/auth/ProtectedView.tsx
@@ -1,0 +1,28 @@
+/**
+ * <ProtectedView> (ADR-705)
+ *
+ * Page-level gate for content workspaces. When the user can't load content
+ * (anonymous or expired), renders the generalized <LoggedOutView> instead of
+ * letting the workspace mount, fetch, and dump a raw 401. Nav stays browsable
+ * (browsable + read-only model) — the content area just shows a graceful,
+ * consistent signed-out surface.
+ *
+ * Use this to wrap whole route elements. For smaller in-section gates, use
+ * <RequireCapability> / <Gated> instead.
+ */
+
+import React from 'react';
+import { useCapability } from '../../hooks/useCapability';
+import { LoggedOutView } from './LoggedOutView';
+
+interface ProtectedViewProps {
+  /** Noun for the signed-out headline, e.g. "the graph". */
+  what?: string;
+  children: React.ReactNode;
+}
+
+export function ProtectedView({ what, children }: ProtectedViewProps): React.ReactElement {
+  const { can } = useCapability();
+  if (!can) return <LoggedOutView what={what} />;
+  return <>{children}</>;
+}

--- a/web/src/components/auth/RequireCapability.tsx
+++ b/web/src/components/auth/RequireCapability.tsx
@@ -1,0 +1,45 @@
+/**
+ * <RequireCapability> / <RequireAuth> (ADR-705)
+ *
+ * Section/page wrappers. When the user has the capability, children render.
+ * Otherwise the section shows an in-place fallback (default: <SignInPrompt>) —
+ * never a redirect — per the browsable + read-only model.
+ *
+ *   <RequireAuth detail="to access admin settings">
+ *     <AdminPanels />
+ *   </RequireAuth>
+ */
+
+import React from 'react';
+import { useCapability } from '../../hooks/useCapability';
+import { SignInPrompt } from './SignInPrompt';
+
+interface RequireCapabilityProps {
+  /** Resource for a permission check (omit for a plain auth check). */
+  resource?: string;
+  /** Action for a permission check. */
+  action?: string;
+  /** Context line passed to the default SignInPrompt, e.g. "to access admin settings". */
+  detail?: string;
+  /** Custom fallback; overrides the default SignInPrompt when provided. */
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function RequireCapability({
+  resource,
+  action,
+  detail,
+  fallback,
+  children,
+}: RequireCapabilityProps): React.ReactElement {
+  const { can, reason } = useCapability(resource, action);
+  if (can) return <>{children}</>;
+  if (fallback !== undefined) return <>{fallback}</>;
+  return <SignInPrompt reason={reason} detail={detail} />;
+}
+
+/** Plain authentication gate — any authenticated user passes. */
+export function RequireAuth(props: Omit<RequireCapabilityProps, 'resource' | 'action'>): React.ReactElement {
+  return <RequireCapability {...props} />;
+}

--- a/web/src/components/auth/SessionBanner.tsx
+++ b/web/src/components/auth/SessionBanner.tsx
@@ -4,63 +4,48 @@
  * Ambient, chrome-level session treatment driven off the canonical
  * sessionStatus — defined once and rendered above the toolbar so every page
  * inherits it:
- *  - expired   → a loud, non-dismissible banner correcting the "I'm logged in"
+ *  - expired   → a loud, non-dismissible strip correcting the "I'm logged in"
  *                mental model.
  *  - anonymous → a quiet always-on "Viewing as guest" strip.
  *  - authenticated → nothing.
+ *
+ * The banner is *explanation only* — the single sign-in affordance lives in the
+ * top-right UserProfile corner, so the banner deliberately carries no button to
+ * avoid a duplicate sign-in control stacked in the same corner.
  */
 
-import { useState } from 'react';
-import { AlertTriangle, Eye, LogIn } from 'lucide-react';
+import { AlertTriangle, Eye } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
-import { LoginModal } from './LoginModal';
 
 export function SessionBanner() {
   const sessionStatus = useAuthStore((s) => s.sessionStatus);
-  const [showLogin, setShowLogin] = useState(false);
 
   if (sessionStatus === 'authenticated') return null;
 
   const expired = sessionStatus === 'expired';
 
   return (
-    <>
-      <div
-        className={
-          expired
-            ? 'bg-status-warning/90 text-black px-4 py-2 flex items-center justify-between text-sm'
-            : 'bg-muted/50 text-muted-foreground border-b border-border px-4 py-1.5 flex items-center justify-between text-xs'
-        }
-        role="status"
-      >
-        <div className="flex items-center gap-2 min-w-0">
-          {expired ? (
-            <AlertTriangle className="w-4 h-4 flex-none" />
-          ) : (
-            <Eye className="w-3.5 h-3.5 flex-none" />
-          )}
-          <span className="font-medium">
-            {expired ? 'Your session expired' : 'Viewing as guest'}
-          </span>
-          <span className="opacity-80 truncate">
-            {expired
-              ? '— sign in to continue.'
-              : '— sign in to save changes and access your data.'}
-          </span>
-        </div>
-        <button
-          onClick={() => setShowLogin(true)}
-          className={
-            expired
-              ? 'flex-none inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-black/10 hover:bg-black/20 font-medium transition-colors'
-              : 'flex-none inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors'
-          }
-        >
-          <LogIn className="w-3.5 h-3.5" />
-          Sign In
-        </button>
-      </div>
-      <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
-    </>
+    <div
+      className={
+        expired
+          ? 'bg-status-warning/90 text-black px-4 py-2 flex items-center gap-2 text-sm'
+          : 'bg-muted/50 text-muted-foreground border-b border-border px-4 py-1.5 flex items-center gap-2 text-xs'
+      }
+      role="status"
+    >
+      {expired ? (
+        <AlertTriangle className="w-4 h-4 flex-none" />
+      ) : (
+        <Eye className="w-3.5 h-3.5 flex-none" />
+      )}
+      <span className="font-medium">
+        {expired ? 'Your session expired' : 'Viewing as guest'}
+      </span>
+      <span className="opacity-80 truncate">
+        {expired
+          ? '— sign in to continue.'
+          : '— sign in to save changes and access your data.'}
+      </span>
+    </div>
   );
 }

--- a/web/src/components/auth/SessionBanner.tsx
+++ b/web/src/components/auth/SessionBanner.tsx
@@ -1,0 +1,66 @@
+/**
+ * <SessionBanner> (ADR-705)
+ *
+ * Ambient, chrome-level session treatment driven off the canonical
+ * sessionStatus — defined once and rendered above the toolbar so every page
+ * inherits it:
+ *  - expired   → a loud, non-dismissible banner correcting the "I'm logged in"
+ *                mental model.
+ *  - anonymous → a quiet always-on "Viewing as guest" strip.
+ *  - authenticated → nothing.
+ */
+
+import { useState } from 'react';
+import { AlertTriangle, Eye, LogIn } from 'lucide-react';
+import { useAuthStore } from '../../store/authStore';
+import { LoginModal } from './LoginModal';
+
+export function SessionBanner() {
+  const sessionStatus = useAuthStore((s) => s.sessionStatus);
+  const [showLogin, setShowLogin] = useState(false);
+
+  if (sessionStatus === 'authenticated') return null;
+
+  const expired = sessionStatus === 'expired';
+
+  return (
+    <>
+      <div
+        className={
+          expired
+            ? 'bg-status-warning/90 text-black px-4 py-2 flex items-center justify-between text-sm'
+            : 'bg-muted/50 text-muted-foreground border-b border-border px-4 py-1.5 flex items-center justify-between text-xs'
+        }
+        role="status"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          {expired ? (
+            <AlertTriangle className="w-4 h-4 flex-none" />
+          ) : (
+            <Eye className="w-3.5 h-3.5 flex-none" />
+          )}
+          <span className="font-medium">
+            {expired ? 'Your session expired' : 'Viewing as guest'}
+          </span>
+          <span className="opacity-80 truncate">
+            {expired
+              ? '— sign in to continue.'
+              : '— sign in to save changes and access your data.'}
+          </span>
+        </div>
+        <button
+          onClick={() => setShowLogin(true)}
+          className={
+            expired
+              ? 'flex-none inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-black/10 hover:bg-black/20 font-medium transition-colors'
+              : 'flex-none inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md hover:bg-accent hover:text-accent-foreground transition-colors'
+          }
+        >
+          <LogIn className="w-3.5 h-3.5" />
+          Sign In
+        </button>
+      </div>
+      <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
+    </>
+  );
+}

--- a/web/src/components/auth/SignInPrompt.tsx
+++ b/web/src/components/auth/SignInPrompt.tsx
@@ -1,0 +1,53 @@
+/**
+ * <SignInPrompt> (ADR-705)
+ *
+ * The default in-place fallback for gated sections: a session-aware message
+ * (anonymous vs expired) plus a Sign In button that opens the login modal.
+ * Shown in place — never a redirect — per the browsable + read-only model.
+ */
+
+import { useState } from 'react';
+import { LogIn, ShieldAlert } from 'lucide-react';
+import { LoginModal } from './LoginModal';
+import { reasonMessage, type CapabilityReason } from '../../hooks/useCapability';
+
+interface SignInPromptProps {
+  /** Why the gate is closed; controls the headline copy. */
+  reason: CapabilityReason;
+  /** Optional context line, e.g. "to access admin settings". */
+  detail?: string;
+}
+
+export function SignInPrompt({ reason, detail }: SignInPromptProps) {
+  const [showLogin, setShowLogin] = useState(false);
+
+  const expired = reason === 'expired';
+  const forbidden = reason === 'forbidden';
+  const headline = expired
+    ? 'Your session expired'
+    : forbidden
+      ? 'You don’t have access'
+      : 'Sign in required';
+
+  return (
+    <div className="h-full flex items-center justify-center bg-background">
+      <div className="text-center max-w-sm">
+        <ShieldAlert className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+        <h2 className="text-lg font-semibold text-foreground">{headline}</h2>
+        <p className="text-muted-foreground mt-2">
+          {forbidden ? reasonMessage(reason) : detail ? `Sign in ${detail}.` : 'Sign in to continue.'}
+        </p>
+        {!forbidden && (
+          <button
+            onClick={() => setShowLogin(true)}
+            className="mt-6 inline-flex items-center gap-2 px-5 py-2.5 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors shadow-md"
+          >
+            <LogIn className="w-4 h-4" />
+            Sign In
+          </button>
+        )}
+        <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/home/HomeWorkspace.tsx
+++ b/web/src/components/home/HomeWorkspace.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/authStore';
+import { useCapability } from '../../hooks/useCapability';
 import { LoginModal } from '../auth/LoginModal';
 import { apiClient } from '../../api/client';
 import { GraphAnimation } from './GraphAnimation';
@@ -41,7 +42,8 @@ interface SystemStatus {
  *  with quick actions and NavigationGraph workstation guide (authenticated).
  *  @verified b38d816f */
 export const HomeWorkspace: React.FC = () => {
-  const { isAuthenticated, user } = useAuthStore();
+  const { user } = useAuthStore();
+  const { can: canUse, reason } = useCapability();  // ADR-705: session-aware gate
   const navigate = useNavigate();
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [status, setStatus] = useState<SystemStatus | null>(null);
@@ -49,10 +51,10 @@ export const HomeWorkspace: React.FC = () => {
 
   // Load system status when authenticated
   useEffect(() => {
-    if (isAuthenticated) {
+    if (canUse) {
       loadStatus();
     }
-  }, [isAuthenticated]);
+  }, [canUse]);
 
   const loadStatus = async () => {
     setLoading(true);
@@ -133,8 +135,8 @@ export const HomeWorkspace: React.FC = () => {
     },
   ];
 
-  // Not authenticated - show welcome and login
-  if (!isAuthenticated) {
+  // Not authenticated - show welcome and login (session-aware: anonymous vs expired)
+  if (!canUse) {
     return (
       <div className="h-full flex flex-col bg-background relative overflow-hidden">
         {/* Animated Graph Background - positioned behind everything */}
@@ -162,13 +164,20 @@ export const HomeWorkspace: React.FC = () => {
               Explore semantic relationships beyond sequential reading.
             </p>
 
+            {/* Session-expired notice (ADR-705) */}
+            {reason === 'expired' && (
+              <p className="mb-6 text-sm font-medium text-status-warning">
+                Your session expired — please sign in again.
+              </p>
+            )}
+
             {/* Login Button */}
             <button
               onClick={() => setShowLoginModal(true)}
               className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors shadow-md"
             >
               <LogIn className="w-5 h-5" />
-              Sign In to Continue
+              {reason === 'expired' ? 'Sign In Again' : 'Sign In to Continue'}
             </button>
 
             {/* Features */}

--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -38,6 +38,7 @@ import {
   X,
 } from 'lucide-react';
 import { UserProfile } from '../shared/UserProfile';
+import { SessionBanner } from '../auth/SessionBanner';
 import { SidebarCategory, SidebarItem } from './SidebarCategory';
 import { GraphAnimation } from '../home/GraphAnimation';
 import { AboutInfoBox } from './AboutInfoBox';
@@ -270,6 +271,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
 
       {/* Main Content Area */}
       <main className="flex-1 flex flex-col overflow-hidden">
+        {/* Session treatment: expired banner / guest strip (ADR-705) */}
+        <SessionBanner />
+
         {/* Insecure Crypto Warning Banner (DEV only) */}
         {showInsecureWarning && (
           <div className="bg-amber-500/90 text-black px-4 py-2 flex items-center justify-between text-sm">

--- a/web/src/components/shared/UserProfile.tsx
+++ b/web/src/components/shared/UserProfile.tsx
@@ -21,7 +21,7 @@ const THEME_CONFIG = {
 } as const;
 
 export const UserProfile: React.FC = () => {
-  const { user, isAuthenticated, isLoading, error, logout, clearError } = useAuthStore();
+  const { user, sessionStatus, isLoading, error, logout, clearError } = useAuthStore();
   const { appliedTheme, cycleTheme } = useThemeStore();
   const themeConfig = THEME_CONFIG[appliedTheme];
   const [isOpen, setIsOpen] = useState(false);
@@ -73,8 +73,10 @@ export const UserProfile: React.FC = () => {
     );
   }
 
-  if (!isAuthenticated) {
+  if (sessionStatus !== 'authenticated') {
     const ThemeIcon = themeConfig.icon;
+    // ADR-705: distinguish expired from never-logged-in in the corner affordance.
+    const expired = sessionStatus === 'expired';
     return (
       <>
         <div className="flex items-center gap-2">
@@ -87,11 +89,18 @@ export const UserProfile: React.FC = () => {
           </button>
           <button
             onClick={handleLogin}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            title="Login with OAuth 2.0"
+            className={`relative flex items-center gap-2 px-3 py-1.5 rounded-lg transition-colors ${
+              expired
+                ? 'bg-status-warning/15 text-status-warning hover:bg-status-warning/25'
+                : 'hover:bg-accent hover:text-accent-foreground'
+            }`}
+            title={expired ? 'Your session expired — sign in again' : 'Login with OAuth 2.0'}
           >
             <LogIn className="w-4 h-4" />
-            <span>Login</span>
+            <span>{expired ? 'Sign In' : 'Login'}</span>
+            {expired && (
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-status-warning" />
+            )}
           </button>
         </div>
         <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />

--- a/web/src/hooks/useCapability.ts
+++ b/web/src/hooks/useCapability.ts
@@ -9,7 +9,7 @@
 
 import { useAuthStore } from '../store/authStore';
 
-export type CapabilityReason = 'ok' | 'anonymous' | 'expired' | 'forbidden';
+export type CapabilityReason = 'ok' | 'anonymous' | 'expired' | 'loading' | 'forbidden';
 
 export interface Capability {
   /** Whether the user may perform the action right now. */
@@ -32,7 +32,11 @@ export function useCapability(resource?: string, action?: string): Capability {
   }
 
   if (resource && action) {
-    const allowed = permissions?.can[`${resource}:${action}`] === true;
+    // Permissions load asynchronously after auth. Until they arrive, report
+    // 'loading' rather than a hard 'forbidden' so consumers don't flash a
+    // "you don't have permission" state for a user who may well have it.
+    if (permissions === null) return { can: false, reason: 'loading' };
+    const allowed = permissions.can[`${resource}:${action}`] === true;
     if (!allowed) return { can: false, reason: 'forbidden' };
   }
 
@@ -49,6 +53,8 @@ export function reasonMessage(reason: CapabilityReason, label = 'do this'): stri
       return `Sign in to ${label}`;
     case 'expired':
       return 'Your session expired — sign in to continue';
+    case 'loading':
+      return 'Checking permissions…';
     case 'forbidden':
       return "You don't have permission to do this";
     default:

--- a/web/src/hooks/useCapability.ts
+++ b/web/src/hooks/useCapability.ts
@@ -1,0 +1,57 @@
+/**
+ * useCapability (ADR-705)
+ *
+ * One hook that answers "may this user do this right now, and if not, why?" by
+ * combining the canonical session status with the ADR-400 permission map.
+ * Components consume this instead of hand-rolling `if (!isAuthenticated)` checks,
+ * so gating stays consistent and distinguishes anonymous from expired.
+ */
+
+import { useAuthStore } from '../store/authStore';
+
+export type CapabilityReason = 'ok' | 'anonymous' | 'expired' | 'forbidden';
+
+export interface Capability {
+  /** Whether the user may perform the action right now. */
+  can: boolean;
+  /** Why not (or 'ok'). Drives the tooltip / prompt copy. */
+  reason: CapabilityReason;
+}
+
+/**
+ * Resolve a capability. Omit resource/action for a plain authentication check
+ * (any authenticated user passes); pass both to also require a permission.
+ */
+export function useCapability(resource?: string, action?: string): Capability {
+  const sessionStatus = useAuthStore((s) => s.sessionStatus);
+  // Subscribe to permissions so the result recomputes when they load/change.
+  const permissions = useAuthStore((s) => s.permissions);
+
+  if (sessionStatus !== 'authenticated') {
+    return { can: false, reason: sessionStatus === 'expired' ? 'expired' : 'anonymous' };
+  }
+
+  if (resource && action) {
+    const allowed = permissions?.can[`${resource}:${action}`] === true;
+    if (!allowed) return { can: false, reason: 'forbidden' };
+  }
+
+  return { can: true, reason: 'ok' };
+}
+
+/**
+ * Standard human-readable copy for a non-`ok` reason. `label` is the verb phrase
+ * for the action, e.g. "approve jobs" → "Sign in to approve jobs".
+ */
+export function reasonMessage(reason: CapabilityReason, label = 'do this'): string {
+  switch (reason) {
+    case 'anonymous':
+      return `Sign in to ${label}`;
+    case 'expired':
+      return 'Your session expired — sign in to continue';
+    case 'forbidden':
+      return "You don't have permission to do this";
+    default:
+      return '';
+  }
+}

--- a/web/src/lib/auth/session-events.ts
+++ b/web/src/lib/auth/session-events.ts
@@ -1,0 +1,44 @@
+/**
+ * Session lifecycle events (ADR-705)
+ *
+ * Decouples the API client's 401 interceptor from the auth store. The
+ * interceptor cannot import the store (the store imports the client), so it
+ * signals session transitions via window CustomEvents and the store subscribes.
+ *
+ *  - `kg:session-expired`   — credentials existed but are now invalid and could
+ *                             not be refreshed; the UI should treat the session
+ *                             as expired (loud treatment).
+ *  - `kg:session-refreshed` — a token refresh succeeded mid-flight; the store
+ *                             should re-sync from storage.
+ */
+
+export const SESSION_EXPIRED_EVENT = 'kg:session-expired';
+export const SESSION_REFRESHED_EVENT = 'kg:session-refreshed';
+
+/** Signal that the session has expired and could not be refreshed. */
+export function emitSessionExpired(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+  }
+}
+
+/** Signal that an in-flight token refresh succeeded. */
+export function emitSessionRefreshed(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(SESSION_REFRESHED_EVENT));
+  }
+}
+
+/** Subscribe to session-expired; returns an unsubscribe function. */
+export function onSessionExpired(handler: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(SESSION_EXPIRED_EVENT, handler);
+  return () => window.removeEventListener(SESSION_EXPIRED_EVENT, handler);
+}
+
+/** Subscribe to session-refreshed; returns an unsubscribe function. */
+export function onSessionRefreshed(handler: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(SESSION_REFRESHED_EVENT, handler);
+  return () => window.removeEventListener(SESSION_REFRESHED_EVENT, handler);
+}

--- a/web/src/store/authStore.ts
+++ b/web/src/store/authStore.ts
@@ -59,6 +59,7 @@ interface AuthStore {
   accessToken: string | null;
   isAuthenticated: boolean;
   sessionStatus: SessionStatus;  // ADR-705: anonymous | authenticated | expired
+  hydrated: boolean;             // ADR-705: initial checkAuth (incl. any refresh) has resolved
   isLoading: boolean;
   error: string | null;
 
@@ -86,6 +87,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   accessToken: null,
   isAuthenticated: false,
   sessionStatus: 'anonymous',
+  hydrated: false,
   isLoading: false,
   error: null,
 
@@ -201,6 +203,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         accessToken: null,
         isAuthenticated: false,
         sessionStatus: hadCredentials ? 'expired' : 'anonymous',
+        hydrated: true,
         error: hadCredentials ? 'No refresh token available' : null,
         permissions: null,  // ADR-074
       });
@@ -215,6 +218,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         accessToken: newAuthState.access_token,
         isAuthenticated: true,
         sessionStatus: 'authenticated',
+        hydrated: true,
         error: null,
       });
 
@@ -228,6 +232,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         accessToken: null,
         isAuthenticated: false,
         sessionStatus: 'expired',
+        hydrated: true,
         error: 'Session expired - please login again',
         permissions: null,  // ADR-074
       });
@@ -248,13 +253,14 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         accessToken: null,
         isAuthenticated: false,
         sessionStatus: 'anonymous',
+        hydrated: true,
       });
       return;
     }
 
     // Check if token is expired
     if (isTokenExpired(authState.expires_at)) {
-      // Try to refresh token automatically (refreshToken sets sessionStatus)
+      // Try to refresh token automatically (refreshToken sets sessionStatus + hydrated)
       if (authState.refresh_token) {
         get().refreshToken();
       } else {
@@ -265,6 +271,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
           accessToken: null,
           isAuthenticated: false,
           sessionStatus: 'expired',
+          hydrated: true,
           error: 'Session expired',
         });
       }
@@ -277,6 +284,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       accessToken: authState.access_token,
       isAuthenticated: true,
       sessionStatus: 'authenticated',
+      hydrated: true,
     });
 
     // Load permissions after restoring auth (ADR-074)
@@ -356,7 +364,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 // and a successful in-flight refresh re-syncs from storage.
 // ============================================================================
 
-onSessionExpired(() => {
+const unsubscribeExpired = onSessionExpired(() => {
   // The interceptor has already cleared stored credentials.
   useAuthStore.setState({
     user: null,
@@ -368,7 +376,7 @@ onSessionExpired(() => {
   });
 });
 
-onSessionRefreshed(() => {
+const unsubscribeRefreshed = onSessionRefreshed(() => {
   // Storage was updated by the refresh; re-sync the in-memory token/user.
   const authState = getAuthState();
   if (authState) {
@@ -379,5 +387,16 @@ onSessionRefreshed(() => {
       sessionStatus: 'authenticated',
       error: null,
     });
+    // Permissions may have changed across the refresh; reload them so the
+    // interceptor-driven refresh path matches refreshToken()/checkAuth().
+    useAuthStore.getState().loadPermissions();
   }
 });
+
+// Avoid stacking duplicate window listeners across Vite HMR reloads (dev only).
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    unsubscribeExpired();
+    unsubscribeRefreshed();
+  });
+}

--- a/web/src/store/authStore.ts
+++ b/web/src/store/authStore.ts
@@ -22,6 +22,7 @@ import {
   isTokenExpired,
   type StoredAuthState,
 } from '../lib/auth/oauth-utils';
+import { onSessionExpired, onSessionRefreshed } from '../lib/auth/session-events';
 import { apiClient } from '../api/client';
 
 interface User {
@@ -29,6 +30,18 @@ interface User {
   username: string;
   role: string;
 }
+
+/**
+ * Canonical session status (ADR-705).
+ *
+ * Un-collapses the `isAuthenticated: false` ambiguity so the UI can treat a
+ * never-logged-in user differently from one whose session expired:
+ *  - `anonymous`     — no credentials (never logged in, or logged out)
+ *  - `authenticated` — a valid, non-expired token is present
+ *  - `expired`       — credentials existed but are gone/rejected and could not
+ *                      be refreshed (gets the loud "session expired" treatment)
+ */
+export type SessionStatus = 'anonymous' | 'authenticated' | 'expired';
 
 /**
  * Permissions state (ADR-074)
@@ -45,6 +58,7 @@ interface AuthStore {
   user: User | null;
   accessToken: string | null;
   isAuthenticated: boolean;
+  sessionStatus: SessionStatus;  // ADR-705: anonymous | authenticated | expired
   isLoading: boolean;
   error: string | null;
 
@@ -71,6 +85,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   user: null,
   accessToken: null,
   isAuthenticated: false,
+  sessionStatus: 'anonymous',
   isLoading: false,
   error: null,
 
@@ -118,6 +133,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         user: null,
         accessToken: null,
         isAuthenticated: false,
+        sessionStatus: 'anonymous',
         isLoading: false,
         error: null,
         permissions: null,  // ADR-074: Clear permissions on logout
@@ -129,6 +145,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         user: null,
         accessToken: null,
         isAuthenticated: false,
+        sessionStatus: 'anonymous',
         isLoading: false,
         error: error instanceof Error ? error.message : 'Logout failed',
         permissions: null,  // ADR-074: Clear permissions on logout
@@ -150,6 +167,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         user: authState.user || null,
         accessToken: authState.access_token,
         isAuthenticated: true,
+        sessionStatus: 'authenticated',
         isLoading: false,
         error: null,
       });
@@ -161,6 +179,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         user: null,
         accessToken: null,
         isAuthenticated: false,
+        sessionStatus: 'anonymous',
         isLoading: false,
         error: error instanceof Error ? error.message : 'Authentication failed',
         permissions: null,  // ADR-074: Clear permissions on auth failure
@@ -175,11 +194,14 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   refreshToken: async () => {
     const authState = getAuthState();
     if (!authState || !authState.refresh_token) {
+      // No credentials at all → anonymous; a present token we cannot refresh → expired.
+      const hadCredentials = !!authState;
       set({
         user: null,
         accessToken: null,
         isAuthenticated: false,
-        error: 'No refresh token available',
+        sessionStatus: hadCredentials ? 'expired' : 'anonymous',
+        error: hadCredentials ? 'No refresh token available' : null,
         permissions: null,  // ADR-074
       });
       return;
@@ -192,6 +214,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         user: newAuthState.user || null,
         accessToken: newAuthState.access_token,
         isAuthenticated: true,
+        sessionStatus: 'authenticated',
         error: null,
       });
 
@@ -204,6 +227,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
         user: null,
         accessToken: null,
         isAuthenticated: false,
+        sessionStatus: 'expired',
         error: 'Session expired - please login again',
         permissions: null,  // ADR-074
       });
@@ -218,26 +242,29 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     const authState = getAuthState();
 
     if (!authState) {
+      // Never logged in (or logged out) → anonymous, not expired.
       set({
         user: null,
         accessToken: null,
         isAuthenticated: false,
+        sessionStatus: 'anonymous',
       });
       return;
     }
 
     // Check if token is expired
     if (isTokenExpired(authState.expires_at)) {
-      // Try to refresh token automatically
+      // Try to refresh token automatically (refreshToken sets sessionStatus)
       if (authState.refresh_token) {
         get().refreshToken();
       } else {
-        // No refresh token - clear state
+        // No refresh token - session expired
         clearAuthState();
         set({
           user: null,
           accessToken: null,
           isAuthenticated: false,
+          sessionStatus: 'expired',
           error: 'Session expired',
         });
       }
@@ -249,6 +276,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       user: authState.user || null,
       accessToken: authState.access_token,
       isAuthenticated: true,
+      sessionStatus: 'authenticated',
     });
 
     // Load permissions after restoring auth (ADR-074)
@@ -318,3 +346,38 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     return permissions.roleHierarchy.includes('platform_admin');
   },
 }));
+
+// ============================================================================
+// Session event wiring (ADR-705)
+//
+// The API client's 401 interceptor signals session transitions via window
+// events (it cannot import this store). Subscribe once at module load so a
+// mid-session expiry — detected on any request — flips the store to `expired`
+// and a successful in-flight refresh re-syncs from storage.
+// ============================================================================
+
+onSessionExpired(() => {
+  // The interceptor has already cleared stored credentials.
+  useAuthStore.setState({
+    user: null,
+    accessToken: null,
+    isAuthenticated: false,
+    sessionStatus: 'expired',
+    error: 'Session expired - please login again',
+    permissions: null,
+  });
+});
+
+onSessionRefreshed(() => {
+  // Storage was updated by the refresh; re-sync the in-memory token/user.
+  const authState = getAuthState();
+  if (authState) {
+    useAuthStore.setState({
+      user: authState.user || null,
+      accessToken: authState.access_token,
+      isAuthenticated: true,
+      sessionStatus: 'authenticated',
+      error: null,
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes a real UX/safety gap: the web app didn't visibly reflect being logged out, and — more dangerously — couldn't *detect* a session that expired mid-use. A user could navigate the whole nav bar, see no change, and form a false impression of being logged in; an expired session looked identical to an authenticated one until the next action failed with a raw error.

This PR implements **ADR-705 — Session Visibility and Declarative Capability Gating** (the four planned phases plus verification fixes). It also lands **ADR-704 — Unified User-Scoped Resource Dispensing** as a **Draft design record only** (its companion; not implemented here — see Follow-up).

## What changed (ADR-705)

- **P1 · Session status + 401 interceptor (the keystone).** Adds a canonical `sessionStatus: anonymous | authenticated | expired` to `authStore`, un-collapsing the `isAuthenticated: false` ambiguity. Adds a global 401 response interceptor to the API client: on a 401 with a token, a single single-flight refresh + replay; on failure, signal session-expired. Handles the edge cases — no retry loops, auth-endpoint exemption, shared in-flight refresh across concurrent 401s, and the SSE query-param path. Interceptor and store stay decoupled via `window` events (no import cycle).
- **P2 · Declarative gating primitives.** `useCapability(resource, action) → { can, reason }` over the ADR-400 permission map, plus `<Gated>` (disable + reason tooltip), `<RequireCapability>`/`<RequireAuth>`, and a session-aware `<SignInPrompt>`. Hand-rolled `if (!isAuthenticated)` checks refactored onto these.
- **P3 · Ambient treatment.** `<SessionBanner>` rendered once in `AppLayout`, keyed on `sessionStatus`: a loud banner when expired, a quiet "Viewing as guest" strip when anonymous.
- **P4 · Adoption lint.** `scripts/development/lint/lint_gating.py` enforces the precise signal (raw `isAuthenticated` reads → fails `--check`) and reports the fuzzier adoption surface (`<Gated>`/`useCapability` counts).
- **Verification fixes.** De-duplicated the sign-in affordance (banner is now explanation-only; the corner `UserProfile` is the single login control). Replaced raw `Request failed with status code 401` on content pages with a generalized `<ProtectedView>` → `<LoggedOutView>` that reuses the real `NavigationGraph` "Workstation Guide" as a signed-out help navigator.

## Verification

Verified live against the running dev stack (logout → re-login → expired). API logs corroborate: `revoke → 200` on logout, `token/users/me → 200` on re-login, `token → 401` on an invalid token (the interceptor's expired trigger). No web runtime errors. Typecheck, web tests (40/40), eslint (new files), and the gating lint all green.

## Scope / Follow-up

- **ADR-704 is Draft only here** — included as the companion design record. Its implementation (settings provider, consolidated owner-or-admin helper, provider registry + preferences/admin surfaces, enumeration check) is a separate follow-up PR (tasks P5–P8).
- **Known deferred (noted in ADR-705 / commit):** the workstation-guide nodes still navigate when signed out (each lands on the same signed-out view). Making the guide instructional/non-navigating when signed out is a later enhancement.

## Commits

- `docs(adr)` ADR-704 + ADR-705
- `P1` session status + 401 interceptor
- `P2` gating primitives
- `P3` ambient banner
- `P4` gating lint
- `fix` de-dup sign-in + generalized logged-out view
