### PR TITLE
feat: operator intake controls (lanes, tombstones) + catalog fix

### DIFF
--- a/.claude/ways/kg/web/way.md
+++ b/.claude/ways/kg/web/way.md
@@ -59,3 +59,13 @@ package.json, tsconfig*.json) — those aren't watched by HMR.
 Stores save to API first, fall back to localStorage:
 - Requires OAuth login for database persistence
 - localStorage serves as cache and offline fallback
+
+## Control UI: Show State, Don't Imply It
+
+<!-- epistemic: heuristic -->
+
+An action-labeled button (e.g. "Freeze") is ambiguous about *current* state —
+does "Freeze" mean it's frozen, or that clicking freezes it? For admin/control
+toggles, render an explicit status indicator (an Active/Frozen pill) next to
+the bare action verb, so the user reads the current state directly instead of
+inferring it from the button label.

--- a/api/app/models/ontology.py
+++ b/api/app/models/ontology.py
@@ -182,6 +182,7 @@ class OntologyDeleteResponse(BaseModel):
     deleted: bool
     sources_deleted: int
     orphaned_concepts_deleted: int
+    tombstone_cleared: bool = False  # True if the deletion tombstone was flushed (name re-ingestable)
     error: Optional[str] = None
 
 

--- a/api/app/routes/admin_workers.py
+++ b/api/app/routes/admin_workers.py
@@ -16,12 +16,18 @@ from psycopg2.extras import RealDictCursor
 
 from ..dependencies.auth import CurrentUser
 from ..services.job_queue import get_job_queue
+from ..services.lane_manager import MAX_LANE_SLOTS
 from ..lib.job_permissions import JobPermissionContext
 
 
 class LaneUpdate(BaseModel):
     """Request body for updating a worker lane."""
-    max_slots: Optional[int] = Field(None, ge=0, le=10, description="Max concurrent jobs")
+    # Cap is MAX_LANE_SLOTS (lane_manager) — the same ceiling the worker pool is
+    # sized against, so a configured value here is always backed by threads.
+    max_slots: Optional[int] = Field(
+        None, ge=0, le=MAX_LANE_SLOTS,
+        description=f"Max concurrent jobs in the lane (0–{MAX_LANE_SLOTS})",
+    )
     poll_interval_ms: Optional[int] = Field(None, ge=500, le=120000, description="Poll interval in ms")
     stale_timeout_minutes: Optional[int] = Field(None, ge=5, le=1440, description="Stale job timeout in minutes")
     enabled: Optional[bool] = Field(None, description="Enable/disable the lane")

--- a/api/app/routes/models.py
+++ b/api/app/routes/models.py
@@ -96,6 +96,39 @@ async def refresh_catalog(
         conn = client.pool.getconn()
         try:
             count = upsert_catalog_entries(conn, entries)
+
+            # --- SKETCH: self-healing catalog reconciliation (not yet implemented) ---
+            # Problem this would solve: upsert is additive. When a provider retires
+            # a dated snapshot, the model vanishes from `entries` but its catalog row
+            # stays enabled=TRUE — so prefer_cheapest/default resolution can still
+            # select a dead model that 404s (this is exactly how claude-3-haiku-
+            # 20240307 broke code-block translation; see migration 059).
+            #
+            # Reconcile idea: `entries` is the set the provider's API says is live.
+            # After upserting, disable any *enabled* catalog row for this provider
+            # whose model_id is NOT in that live set:
+            #
+            #   live = {e["model_id"] for e in entries}
+            #   UPDATE kg_api.provider_model_catalog
+            #      SET enabled = FALSE
+            #    WHERE provider = %s AND enabled = TRUE AND model_id <> ALL(%s)   -- live
+            #   RETURNING model_id;   -- log these as "auto-disabled (retired)"
+            #
+            # Resolve these BEFORE shipping it (why this is a sketch, not code):
+            #   1. Trust completeness of fetch_model_catalog(). If a provider's
+            #      list is paginated/filtered/partial, reconcile would wrongly
+            #      disable valid models. Only reconcile when the fetch is known-
+            #      complete (e.g. a flag from the provider adapter).
+            #   2. Scope by category — don't let an extraction refresh disable
+            #      embedding/vision rows.
+            #   3. Never auto-disable the active extraction model or is_default;
+            #      surface a loud warning instead so the operator re-points config.
+            #   4. Distinguish operator-intent disables from auto-disables (a
+            #      `disabled_reason` column) so a manual enable isn't clobbered.
+            # Pairs with the deferred fail-fast work: a permanent 404 (retired
+            # model) should also surface loudly rather than be silently retried.
+            # --- END SKETCH ---
+
             return {
                 "provider": provider_name,
                 "message": f"Refreshed {count} models",

--- a/api/app/routes/ontology.py
+++ b/api/app/routes/ontology.py
@@ -10,7 +10,8 @@ Provides REST API access to:
 
 from fastapi import APIRouter, Depends, HTTPException, Query as QueryParam
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel
 
 from ..dependencies.auth import CurrentUser, require_role, require_permission
 from ..models.ontology import (
@@ -81,6 +82,10 @@ def _clear_ontology_tombstone(client, ontology_name: str) -> bool:
         conn = client.pool.getconn()
         try:
             with conn.cursor() as cur:
+                # Bounded wait: the tombstone table is read-only to ingestion, so
+                # contention is near-impossible, but cap the lock wait so this can
+                # never hang the caller (e.g. delete) on a pathologically held row.
+                cur.execute("SET LOCAL lock_timeout = '3s'")
                 cur.execute(
                     "DELETE FROM kg_api.ontology_tombstones WHERE name = %s",
                     (ontology_name,),
@@ -147,6 +152,152 @@ def _record_ontology_tombstone(client, ontology_name: str, removed_by: str, reas
             f"Failed to record tombstone for '{ontology_name}': {e}",
             exc_info=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# Tombstone management (operator controls)
+#
+# A tombstone is the operator-delete intent marker (see _record_ontology_tombstone)
+# that blocks re-ingestion into a deleted ontology's name. Before these routes,
+# the only way to inspect or clear tombstones in bulk was raw SQL against
+# kg_api.ontology_tombstones — these give operators a steering wheel.
+#
+# NOTE: declared BEFORE the parameterized /{ontology_name} routes so that
+# "tombstones" is matched as a literal path, not captured as an ontology name.
+# ---------------------------------------------------------------------------
+
+class TombstoneItem(BaseModel):
+    """A recorded operator-delete tombstone."""
+    name: str
+    removed_by: Optional[str] = None
+    removed_at: Optional[str] = None
+    reason: Optional[str] = None
+
+
+class TombstoneListResponse(BaseModel):
+    """Response for listing ontology tombstones."""
+    tombstones: List[TombstoneItem]
+    count: int
+
+
+class TombstoneFlushResponse(BaseModel):
+    """Response for clearing/flushing ontology tombstones."""
+    flushed: int
+    names: List[str]
+
+
+@router.get("/tombstones", response_model=TombstoneListResponse, summary="List ontology tombstones")
+async def list_ontology_tombstones(
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("ontologies", "delete")),
+):
+    """
+    List all ontology tombstones (operator-delete intent markers).
+
+    Each tombstone blocks re-ingestion into its name until cleared — by
+    recreating the ontology, clearing the specific tombstone, or flushing all.
+
+    **Authorization:** Requires `ontologies:delete` permission.
+    """
+    client = get_age_client()
+    try:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    "SELECT name, removed_by, removed_at, reason "
+                    "FROM kg_api.ontology_tombstones ORDER BY removed_at DESC"
+                )
+                rows = cur.fetchall()
+        finally:
+            client.pool.putconn(conn)
+
+        items = [
+            TombstoneItem(
+                name=r["name"],
+                removed_by=r.get("removed_by"),
+                removed_at=r["removed_at"].isoformat() if r.get("removed_at") else None,
+                reason=r.get("reason"),
+            )
+            for r in rows
+        ]
+        return TombstoneListResponse(tombstones=items, count=len(items))
+    finally:
+        client.close()
+
+
+@router.delete("/tombstones", response_model=TombstoneFlushResponse, summary="Flush all ontology tombstones")
+async def flush_ontology_tombstones(
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("ontologies", "delete")),
+):
+    """
+    Delete ALL ontology tombstones, unblocking re-ingestion into every
+    previously-deleted name. Operator convenience for the clean-slate case.
+
+    **Authorization:** Requires `ontologies:delete` permission.
+    """
+    client = get_age_client()
+    try:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL lock_timeout = '3s'")
+                cur.execute("DELETE FROM kg_api.ontology_tombstones RETURNING name")
+                names = [row[0] for row in cur.fetchall()]
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+
+        logger.info(
+            f"Flushed {len(names)} ontology tombstones "
+            f"(by={getattr(current_user, 'username', None) or 'unknown'})"
+        )
+        return TombstoneFlushResponse(flushed=len(names), names=names)
+    finally:
+        client.close()
+
+
+@router.delete("/tombstones/{name}", response_model=TombstoneFlushResponse, summary="Clear one ontology tombstone")
+async def clear_ontology_tombstone_route(
+    name: str,
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("ontologies", "delete")),
+):
+    """
+    Delete the tombstone for a single ontology name, unblocking re-ingestion
+    into that name.
+
+    **Authorization:** Requires `ontologies:delete` permission.
+
+    Raises:
+        404: If no tombstone exists for the given name.
+    """
+    client = get_age_client()
+    try:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SET LOCAL lock_timeout = '3s'")
+                cur.execute(
+                    "DELETE FROM kg_api.ontology_tombstones WHERE name = %s RETURNING name",
+                    (name,),
+                )
+                names = [row[0] for row in cur.fetchall()]
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+
+        if not names:
+            raise HTTPException(status_code=404, detail=f"No tombstone found for '{name}'")
+
+        logger.info(
+            f"Cleared tombstone '{name}' "
+            f"(by={getattr(current_user, 'username', None) or 'unknown'})"
+        )
+        return TombstoneFlushResponse(flushed=len(names), names=names)
+    finally:
+        client.close()
 
 
 @router.post("/", response_model=OntologyNodeResponse, status_code=201)
@@ -1251,7 +1402,16 @@ async def delete_ontology(
     ontology_name: str,
     current_user: CurrentUser,
     _: None = Depends(require_permission("ontologies", "delete")),
-    force: bool = QueryParam(False, description="Skip confirmation and force deletion")
+    force: bool = QueryParam(False, description="Skip confirmation and force deletion"),
+    keep_tombstone: bool = QueryParam(
+        False,
+        description=(
+            "Keep the deletion tombstone after delete. Default False: delete is a "
+            "complete operation and clears its own tombstone so the name is "
+            "immediately re-ingestable. Set True to leave the tombstone in place "
+            "and deliberately block re-ingestion into this name until recreated."
+        ),
+    ),
 ):
     """
     Delete an ontology and all its data (Admin only - ADR-060).
@@ -1451,6 +1611,17 @@ async def delete_ontology(
         if jobs_deleted > 0:
             logger.info(f"Deleted {jobs_deleted} job records for ontology '{ontology_name}'")
 
+        # Delete is a COMPLETE operation: clear our own tombstone by default so
+        # the name is immediately re-ingestable. The tombstone was written
+        # upstream purely to fail in-flight ingests during this delete; once the
+        # graph is gone there's nothing left to protect. keep_tombstone=True
+        # preserves the block (deliberate "do not recreate this name" intent).
+        # The clear is best-effort and never fails the delete (and uses a
+        # lock_timeout so it cannot hang on a contended row).
+        tombstone_cleared = False
+        if not keep_tombstone:
+            tombstone_cleared = _clear_ontology_tombstone(client, ontology_name)
+
         # ADR-207/#386: announce the mutation — advances the universal freshness
         # tick (event_id), invalidates graph_accel, and refreshes the counter.
         client.record_mutation("edit")
@@ -1459,7 +1630,8 @@ async def delete_ontology(
             ontology=ontology_name,
             deleted=True,
             sources_deleted=sources_deleted,
-            orphaned_concepts_deleted=orphaned_count
+            orphaned_concepts_deleted=orphaned_count,
+            tombstone_cleared=tombstone_cleared,
         )
 
     except HTTPException:

--- a/api/app/routes/ontology.py
+++ b/api/app/routes/ontology.py
@@ -209,6 +209,9 @@ async def list_ontology_tombstones(
                     "FROM kg_api.ontology_tombstones ORDER BY removed_at DESC"
                 )
                 rows = cur.fetchall()
+            # Close the implicit read transaction before returning the pooled
+            # connection (don't leave it idle-in-transaction holding a snapshot).
+            conn.rollback()
         finally:
             client.pool.putconn(conn)
 

--- a/api/app/services/lane_manager.py
+++ b/api/app/services/lane_manager.py
@@ -25,6 +25,23 @@ logger = logging.getLogger(__name__)
 # Unique worker ID for this process (survives lane restarts, changes on container restart)
 WORKER_ID = f"worker-{uuid.uuid4().hex[:8]}"
 
+# Hard ceiling on a single lane's max_slots (ADR-100).
+#
+# This is the ONE place the per-lane concurrency cap is defined. It governs two
+# things that MUST stay in lockstep:
+#   1. The API validation for PATCH /admin/workers/lanes/{name} (see
+#      admin_workers.LaneUpdate) — a lane cannot be configured above this.
+#   2. The shared worker thread-pool size (see LaneManager.start) — the pool is
+#      sized so every lane can independently reach MAX_LANE_SLOTS without thread
+#      starvation. If the cap were enforced in the API but the pool stayed small,
+#      raising a lane's max_slots would not actually increase concurrency.
+#
+# Raising this value requires an API restart to resize the pool. Note that real
+# downstream throughput is ALSO bounded by each AI provider's
+# max_concurrent_requests (kg_api.ai_extraction_config) — bumping lane slots
+# beyond that just queues work inside the provider client.
+MAX_LANE_SLOTS = 16
+
 
 @dataclass
 class LaneConfig:
@@ -49,18 +66,32 @@ class LaneManager:
         # All mutations to _active_jobs happen on the event loop thread.
         # Worker threads use call_soon_threadsafe to schedule slot release.
         self._active_jobs: dict[str, set[str]] = {}  # lane_name → {job_id, ...}
-        # Shared executor for running sync workers in threads
-        max_workers = int(os.getenv("MAX_CONCURRENT_JOBS", "4"))
-        self._executor = ThreadPoolExecutor(
-            max_workers=max_workers,
-            thread_name_prefix="kg-lane-"
-        )
+        # Shared executor for running sync workers in threads. Sized in start()
+        # once lane count is known so every lane can reach MAX_LANE_SLOTS without
+        # starving its siblings (see MAX_LANE_SLOTS docs).
+        self._executor: Optional[ThreadPoolExecutor] = None
 
     async def start(self) -> None:
         """Start poll loops for all enabled lanes.  @verified (new)"""
         self._running = True
         self._loop = asyncio.get_running_loop()
         lane_names = await self._get_lane_names()
+
+        # Size the shared pool so every lane can independently reach
+        # MAX_LANE_SLOTS. Floor at MAX_CONCURRENT_JOBS for back-compat. Threads
+        # are cheap while idle (they block on provider I/O), so over-provisioning
+        # here is safe; real concurrency is bounded by provider limits downstream.
+        env_floor = int(os.getenv("MAX_CONCURRENT_JOBS", "4"))
+        pool_size = max(env_floor, len(lane_names) * MAX_LANE_SLOTS)
+        self._executor = ThreadPoolExecutor(
+            max_workers=pool_size,
+            thread_name_prefix="kg-lane-",
+        )
+        logger.info(
+            f"Lane worker pool sized to {pool_size} threads "
+            f"({len(lane_names)} lanes × {MAX_LANE_SLOTS} cap, floor {env_floor})"
+        )
+
         for name in lane_names:
             self._active_jobs[name] = set()
             task = asyncio.create_task(self._lane_loop(name))
@@ -79,7 +110,8 @@ class LaneManager:
                 pass
             logger.info(f"Stopped lane loop: {name}")
         self._tasks.clear()
-        self._executor.shutdown(wait=False, cancel_futures=True)
+        if self._executor is not None:
+            self._executor.shutdown(wait=False, cancel_futures=True)
         logger.info("LaneManager stopped")
 
     def get_lane_status(self) -> dict:

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -993,11 +993,39 @@ export class KnowledgeGraphClient {
    */
   async deleteOntology(
     ontologyName: string,
-    force: boolean = false
+    force: boolean = false,
+    keepTombstone: boolean = false
   ): Promise<OntologyDeleteResponse> {
     const response = await this.client.delete(`/ontology/${encodeURIComponent(ontologyName)}`, {
-      params: { force }
+      params: { force, keep_tombstone: keepTombstone }
     });
+    return response.data;
+  }
+
+  /**
+   * List ontology tombstones (operator-delete markers that block re-ingestion).
+   */
+  async listTombstones(): Promise<{
+    tombstones: Array<{ name: string; removed_by: string | null; removed_at: string | null; reason: string | null }>;
+    count: number;
+  }> {
+    const response = await this.client.get('/ontology/tombstones');
+    return response.data;
+  }
+
+  /**
+   * Flush ALL ontology tombstones, unblocking re-ingestion into every deleted name.
+   */
+  async flushTombstones(): Promise<{ flushed: number; names: string[] }> {
+    const response = await this.client.delete('/ontology/tombstones');
+    return response.data;
+  }
+
+  /**
+   * Clear the tombstone for a single ontology name.
+   */
+  async clearTombstone(name: string): Promise<{ flushed: number; names: string[] }> {
+    const response = await this.client.delete(`/ontology/tombstones/${encodeURIComponent(name)}`);
     return response.data;
   }
 
@@ -1367,6 +1395,37 @@ export class KnowledgeGraphClient {
     }>;
   }> {
     const response = await this.client.get('/admin/workers/lanes');
+    return response.data;
+  }
+
+  /**
+   * Update a worker lane's configuration (ADR-100).
+   * Only the provided fields are changed; changes take effect on the next poll
+   * cycle. max_slots is capped server-side by MAX_LANE_SLOTS.
+   */
+  async updateWorkerLane(
+    name: string,
+    body: {
+      max_slots?: number;
+      poll_interval_ms?: number;
+      stale_timeout_minutes?: number;
+      enabled?: boolean;
+    }
+  ): Promise<{
+    lane: {
+      name: string;
+      job_types: string[];
+      max_slots: number;
+      poll_interval_ms: number;
+      stale_timeout_minutes: number;
+      enabled: boolean;
+    };
+    changed: Record<string, { old: any; new: any }>;
+  }> {
+    const response = await this.client.patch(
+      `/admin/workers/lanes/${encodeURIComponent(name)}`,
+      body
+    );
     return response.data;
   }
 

--- a/cli/src/cli/admin/workers.ts
+++ b/cli/src/cli/admin/workers.ts
@@ -3,10 +3,26 @@
  * Worker lane management - monitor slot utilization, queue depth, active jobs
  */
 
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import { createClientFromEnv } from '../../api/client';
 import * as colors from '../colors';
 import { separator, coloredCount } from '../colors';
+
+// Mirror of api/app/services/lane_manager.py MAX_LANE_SLOTS. The server enforces
+// the cap; this is only for help text so the two don't silently drift.
+const MAX_LANE_SLOTS = 16;
+
+// Commander option parser that rejects non-numeric input instead of passing NaN
+// (which would serialize to null and silently no-op server-side).
+function intArg(label: string): (value: string) => number {
+  return (value: string): number => {
+    const n = parseInt(value, 10);
+    if (Number.isNaN(n)) {
+      throw new InvalidArgumentError(`${label} must be a number`);
+    }
+    return n;
+  };
+}
 
 function formatDuration(startedAt: string | null): string {
   if (!startedAt) return 'unknown';
@@ -109,9 +125,9 @@ export function createWorkersCommand(): Command {
       new Command('set')
         .description('Update a worker lane (slots, poll interval, stale timeout, enable/disable)')
         .argument('<lane>', 'Lane name (e.g. interactive, maintenance, system)')
-        .option('--max-slots <n>', 'Max concurrent jobs in this lane (0–16)', (v) => parseInt(v, 10))
-        .option('--poll-interval <ms>', 'Poll interval in milliseconds (500–120000)', (v) => parseInt(v, 10))
-        .option('--stale-timeout <min>', 'Stale job timeout in minutes (5–1440)', (v) => parseInt(v, 10))
+        .option('--max-slots <n>', `Max concurrent jobs in this lane (0–${MAX_LANE_SLOTS})`, intArg('--max-slots'))
+        .option('--poll-interval <ms>', 'Poll interval in milliseconds (500–120000)', intArg('--poll-interval'))
+        .option('--stale-timeout <min>', 'Stale job timeout in minutes (5–1440)', intArg('--stale-timeout'))
         .option('--enable', 'Enable the lane')
         .option('--disable', 'Disable the lane')
         .action(async (lane: string, opts: any) => {

--- a/cli/src/cli/admin/workers.ts
+++ b/cli/src/cli/admin/workers.ts
@@ -74,8 +74,7 @@ export function createWorkersCommand(): Command {
     });
 
   // workers lanes subcommand
-  workersCommand.addCommand(
-    new Command('lanes')
+  const lanesCommand = new Command('lanes')
       .description('Show worker lane configuration and utilization')
       .action(async () => {
         try {
@@ -103,8 +102,72 @@ export function createWorkersCommand(): Command {
           console.error(colors.status.error(error.response?.data?.detail || error.message));
           process.exit(1);
         }
-      })
-  );
+      });
+
+  // workers lanes set <lane> — update a lane's configuration
+  lanesCommand.addCommand(
+      new Command('set')
+        .description('Update a worker lane (slots, poll interval, stale timeout, enable/disable)')
+        .argument('<lane>', 'Lane name (e.g. interactive, maintenance, system)')
+        .option('--max-slots <n>', 'Max concurrent jobs in this lane (0–16)', (v) => parseInt(v, 10))
+        .option('--poll-interval <ms>', 'Poll interval in milliseconds (500–120000)', (v) => parseInt(v, 10))
+        .option('--stale-timeout <min>', 'Stale job timeout in minutes (5–1440)', (v) => parseInt(v, 10))
+        .option('--enable', 'Enable the lane')
+        .option('--disable', 'Disable the lane')
+        .action(async (lane: string, opts: any) => {
+          try {
+            if (opts.enable && opts.disable) {
+              console.error(colors.status.error('✗ Cannot use both --enable and --disable'));
+              process.exit(1);
+            }
+
+            const body: {
+              max_slots?: number;
+              poll_interval_ms?: number;
+              stale_timeout_minutes?: number;
+              enabled?: boolean;
+            } = {};
+            if (opts.maxSlots !== undefined) body.max_slots = opts.maxSlots;
+            if (opts.pollInterval !== undefined) body.poll_interval_ms = opts.pollInterval;
+            if (opts.staleTimeout !== undefined) body.stale_timeout_minutes = opts.staleTimeout;
+            if (opts.enable) body.enabled = true;
+            if (opts.disable) body.enabled = false;
+
+            if (Object.keys(body).length === 0) {
+              console.error(colors.status.error('✗ Nothing to update'));
+              console.error(colors.status.dim('  Provide at least one of: --max-slots, --poll-interval, --stale-timeout, --enable, --disable'));
+              process.exit(1);
+            }
+
+            const client = createClientFromEnv();
+            const result = await client.updateWorkerLane(lane, body);
+
+            console.log('\n' + separator());
+            console.log(colors.ui.title(`⚙️  Updated lane: ${lane}`));
+            console.log(separator());
+            for (const [field, change] of Object.entries(result.changed)) {
+              console.log(`  ${colors.ui.key(field + ':')} ${colors.status.dim(String(change.old))} → ${colors.ui.value(String(change.new))}`);
+            }
+            console.log(colors.status.dim('\n  Changes take effect on the next poll cycle.'));
+            console.log(separator() + '\n');
+          } catch (error: any) {
+            console.error(colors.status.error('✗ Failed to update worker lane'));
+            const detail = error.response?.data?.detail;
+            if (Array.isArray(detail)) {
+              // FastAPI validation errors: [{loc, msg, ...}]
+              for (const e of detail) {
+                const field = Array.isArray(e.loc) ? e.loc[e.loc.length - 1] : 'request';
+                console.error(colors.status.error(`  ${field}: ${e.msg}`));
+              }
+            } else {
+              console.error(colors.status.error(detail || error.message));
+            }
+            process.exit(1);
+          }
+        })
+    );
+
+  workersCommand.addCommand(lanesCommand);
 
   return workersCommand;
 }

--- a/cli/src/cli/ontology.ts
+++ b/cli/src/cli/ontology.ts
@@ -358,6 +358,7 @@ export const ontologyCommand = setCommandHelp(
       .showHelpAfterError()
       .argument('<name>', 'Ontology name')
       .option('-f, --force', 'Skip confirmation and force deletion')
+      .option('--keep-tombstone', 'Leave the deletion tombstone in place, deliberately blocking re-ingestion into this name until it is recreated (default: delete clears its own tombstone so the name is immediately re-ingestable)')
       .action(async (name, options) => {
         try {
           if (!options.force) {
@@ -370,7 +371,7 @@ export const ontologyCommand = setCommandHelp(
           }
 
           const client = createClientFromEnv();
-          const result = await client.deleteOntology(name, true);
+          const result = await client.deleteOntology(name, true, options.keepTombstone === true);
 
           console.log('\n' + separator());
           console.log(colors.status.success(`✓ Deleted ontology "${result.ontology}"`));
@@ -379,6 +380,13 @@ export const ontologyCommand = setCommandHelp(
           if (result.orphaned_concepts_deleted > 0) {
             console.log(`  ${colors.ui.key('Orphaned concepts cleaned:')} ${coloredCount(result.orphaned_concepts_deleted)}`);
           }
+          // Make the "is it really gone?" state explicit — this is the confusion
+          // this branch fixes: a delete that left a tombstone silently blocking re-ingestion.
+          if (options.keepTombstone) {
+            console.log(`  ${colors.ui.key('Tombstone:')} ${colors.status.warning('kept — re-ingestion into this name is blocked until recreated')}`);
+          } else {
+            console.log(`  ${colors.ui.key('Tombstone:')} ${colors.status.success('cleared — name is free to re-ingest')}`);
+          }
           console.log('\n' + separator());
         } catch (error: any) {
           console.error(colors.status.error('✗ Failed to delete ontology'));
@@ -386,6 +394,115 @@ export const ontologyCommand = setCommandHelp(
           process.exit(1);
         }
       })
+  )
+  // Tombstone management (operator controls) — inspect and clear the
+  // operator-delete markers that block re-ingestion into deleted names.
+  .addCommand(
+    (() => {
+      const tombstones = new Command('tombstones')
+        .description('Manage ontology tombstones (operator-delete markers that block re-ingestion into a deleted name)')
+        .action(async () => {
+          // Default action: list
+          try {
+            const client = createClientFromEnv();
+            const result = await client.listTombstones();
+            console.log('\n' + separator());
+            console.log(colors.ui.title('🪦  Ontology Tombstones'));
+            console.log(separator());
+            if (result.count === 0) {
+              console.log(colors.status.success('\n  None — no names are blocked from re-ingestion.\n'));
+            } else {
+              for (const t of result.tombstones) {
+                console.log(`\n  ${colors.concept.label(t.name)}`);
+                console.log(`    ${colors.ui.key('Removed by:')} ${colors.ui.value(t.removed_by || 'unknown')}`);
+                if (t.removed_at) console.log(`    ${colors.ui.key('Removed at:')} ${colors.ui.value(t.removed_at)}`);
+                if (t.reason) console.log(`    ${colors.ui.key('Reason:')}     ${colors.status.dim(t.reason)}`);
+              }
+              console.log(colors.status.dim(`\n  ${result.count} tombstone(s). Clear with: kg ontology tombstones flush  (or  clear <name>)`));
+            }
+            console.log('\n' + separator() + '\n');
+          } catch (error: any) {
+            console.error(colors.status.error('✗ Failed to list tombstones'));
+            console.error(colors.status.error(error.response?.data?.detail || error.message));
+            process.exit(1);
+          }
+        });
+
+      tombstones.addCommand(
+        new Command('list')
+          .description('List all ontology tombstones')
+          .action(async () => {
+            try {
+              const client = createClientFromEnv();
+              const result = await client.listTombstones();
+              console.log('\n' + separator());
+              console.log(colors.ui.title('🪦  Ontology Tombstones'));
+              console.log(separator());
+              if (result.count === 0) {
+                console.log(colors.status.success('\n  None — no names are blocked from re-ingestion.\n'));
+              } else {
+                for (const t of result.tombstones) {
+                  console.log(`\n  ${colors.concept.label(t.name)}`);
+                  console.log(`    ${colors.ui.key('Removed by:')} ${colors.ui.value(t.removed_by || 'unknown')}`);
+                  if (t.removed_at) console.log(`    ${colors.ui.key('Removed at:')} ${colors.ui.value(t.removed_at)}`);
+                  if (t.reason) console.log(`    ${colors.ui.key('Reason:')}     ${colors.status.dim(t.reason)}`);
+                }
+                console.log(colors.status.dim(`\n  ${result.count} tombstone(s).`));
+              }
+              console.log('\n' + separator() + '\n');
+            } catch (error: any) {
+              console.error(colors.status.error('✗ Failed to list tombstones'));
+              console.error(colors.status.error(error.response?.data?.detail || error.message));
+              process.exit(1);
+            }
+          })
+      );
+
+      tombstones.addCommand(
+        new Command('flush')
+          .description('Clear ALL ontology tombstones, unblocking re-ingestion into every deleted name')
+          .option('-f, --force', 'Skip confirmation')
+          .action(async (options) => {
+            try {
+              if (!options.force) {
+                console.log('\n' + colors.status.warning('This clears every tombstone, allowing re-ingestion into all deleted names.'));
+                console.log('Use ' + colors.ui.key('--force') + ' to confirm.\n');
+                return;
+              }
+              const client = createClientFromEnv();
+              const result = await client.flushTombstones();
+              console.log('\n' + colors.status.success(`✓ Flushed ${result.flushed} tombstone(s)`));
+              if (result.names.length > 0) {
+                console.log(colors.status.dim('  ' + result.names.join(', ')));
+              }
+              console.log('');
+            } catch (error: any) {
+              console.error(colors.status.error('✗ Failed to flush tombstones'));
+              console.error(colors.status.error(error.response?.data?.detail || error.message));
+              process.exit(1);
+            }
+          })
+      );
+
+      tombstones.addCommand(
+        new Command('clear')
+          .description('Clear the tombstone for a single ontology name')
+          .argument('<name>', 'Ontology name')
+          .action(async (name: string) => {
+            try {
+              const client = createClientFromEnv();
+              const result = await client.clearTombstone(name);
+              console.log('\n' + colors.status.success(`✓ Cleared tombstone for "${result.names[0] ?? name}" — name is free to re-ingest\n`));
+            } catch (error: any) {
+              console.error(colors.status.error('✗ Failed to clear tombstone'));
+              console.error(colors.status.error(error.response?.data?.detail || error.message));
+              process.exit(1);
+            }
+          })
+      );
+
+      return tombstones;
+    })()
   )
   // ADR-200 Phase 3a: Scoring & Annealing Control Surface
   .addCommand(

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -467,6 +467,7 @@ export interface OntologyDeleteResponse {
   deleted: boolean;
   sources_deleted: number;
   orphaned_concepts_deleted: number;
+  tombstone_cleared?: boolean;
   error?: string;
 }
 

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -3,7 +3,7 @@
 > **Auto-Generated Documentation**
 > 
 > Generated from CLI source code.
-> Last updated: 2026-05-31
+> Last updated: 2026-06-01
 
 ---
 
@@ -1206,6 +1206,7 @@ kg ontology [options]
 - `lifecycle` - Change ontology lifecycle state (ADR-200 Phase 2). States: active (normal), pinned (immune to demotion), frozen (read-only — rejects ingest and rename).
 - `rename` - Rename an ontology while preserving all its data (concepts, sources, relationships). This is a non-destructive operation useful for reorganization, archiving old ontologies, fixing typos, or improving clarity. Atomic transaction ensures all-or-nothing updates. Requires confirmation unless -y flag is used.
 - `delete` - Delete an ontology and ALL its data (concepts, sources, evidence instances, relationships). This is a DESTRUCTIVE operation that CANNOT BE UNDONE. Use this to remove test data, delete old projects, or free up space. Requires --force flag for confirmation. Consider alternatives: rename to add "Archive" suffix, or export data first (future feature).
+- `tombstones` - Manage ontology tombstones (operator-delete markers that block re-ingestion into a deleted name)
 - `scores` - Show cached annealing scores for an ontology (or all ontologies). Shows mass, coherence, exposure, and protection scores. Use "kg ontology score <name>" to recompute.
 - `score` - Recompute annealing scores for one ontology. Runs mass, coherence, exposure, and protection scoring and caches results.
 - `score-all` - Recompute annealing scores for all ontologies. Runs full scoring pipeline and caches results on each Ontology node.
@@ -1326,6 +1327,61 @@ kg delete <name>
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-f, --force` | Skip confirmation and force deletion | - |
+| `--keep-tombstone` | Leave the deletion tombstone in place, deliberately blocking re-ingestion into this name until it is recreated (default: delete clears its own tombstone so the name is immediately re-ingestable) | - |
+
+### tombstones
+
+Manage ontology tombstones (operator-delete markers that block re-ingestion into a deleted name)
+
+**Usage:**
+```bash
+kg tombstones [options]
+```
+
+**Subcommands:**
+
+- `list` - List all ontology tombstones
+- `flush` - Clear ALL ontology tombstones, unblocking re-ingestion into every deleted name
+- `clear` - Clear the tombstone for a single ontology name
+
+---
+
+#### list
+
+List all ontology tombstones
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+#### flush
+
+Clear ALL ontology tombstones, unblocking re-ingestion into every deleted name
+
+**Usage:**
+```bash
+kg flush [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation | - |
+
+#### clear
+
+Clear the tombstone for a single ontology name
+
+**Usage:**
+```bash
+kg clear <name>
+```
+
+**Arguments:**
+
+- `<name>` - Ontology name
 
 ### scores
 
@@ -2331,6 +2387,35 @@ Show worker lane configuration and utilization
 ```bash
 kg lanes [options]
 ```
+
+**Subcommands:**
+
+- `set` - Update a worker lane (slots, poll interval, stale timeout, enable/disable)
+
+---
+
+##### set
+
+Update a worker lane (slots, poll interval, stale timeout, enable/disable)
+
+**Usage:**
+```bash
+kg set <lane>
+```
+
+**Arguments:**
+
+- `<lane>` - Lane name (e.g. interactive, maintenance, system)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--max-slots <n>` | Max concurrent jobs in this lane (0–16) | - |
+| `--poll-interval <ms>` | Poll interval in milliseconds (500–120000) | - |
+| `--stale-timeout <min>` | Stale job timeout in minutes (5–1440) | - |
+| `--enable` | Enable the lane | - |
+| `--disable` | Disable the lane | - |
 
 ### user
 

--- a/docs/reference/cli/commands/admin.md
+++ b/docs/reference/cli/commands/admin.md
@@ -141,6 +141,35 @@ Show worker lane configuration and utilization
 kg lanes [options]
 ```
 
+**Subcommands:**
+
+- `set` - Update a worker lane (slots, poll interval, stale timeout, enable/disable)
+
+---
+
+##### set
+
+Update a worker lane (slots, poll interval, stale timeout, enable/disable)
+
+**Usage:**
+```bash
+kg set <lane>
+```
+
+**Arguments:**
+
+- `<lane>` - Lane name (e.g. interactive, maintenance, system)
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--max-slots <n>` | Max concurrent jobs in this lane (0–16) | - |
+| `--poll-interval <ms>` | Poll interval in milliseconds (500–120000) | - |
+| `--stale-timeout <min>` | Stale job timeout in minutes (5–1440) | - |
+| `--enable` | Enable the lane | - |
+| `--disable` | Disable the lane | - |
+
 ### user
 
 User management commands (admin only)

--- a/docs/reference/cli/commands/ontology.md
+++ b/docs/reference/cli/commands/ontology.md
@@ -20,6 +20,7 @@ kg ontology [options]
 - `lifecycle` - Change ontology lifecycle state (ADR-200 Phase 2). States: active (normal), pinned (immune to demotion), frozen (read-only — rejects ingest and rename).
 - `rename` - Rename an ontology while preserving all its data (concepts, sources, relationships). This is a non-destructive operation useful for reorganization, archiving old ontologies, fixing typos, or improving clarity. Atomic transaction ensures all-or-nothing updates. Requires confirmation unless -y flag is used.
 - `delete` - Delete an ontology and ALL its data (concepts, sources, evidence instances, relationships). This is a DESTRUCTIVE operation that CANNOT BE UNDONE. Use this to remove test data, delete old projects, or free up space. Requires --force flag for confirmation. Consider alternatives: rename to add "Archive" suffix, or export data first (future feature).
+- `tombstones` - Manage ontology tombstones (operator-delete markers that block re-ingestion into a deleted name)
 - `scores` - Show cached annealing scores for an ontology (or all ontologies). Shows mass, coherence, exposure, and protection scores. Use "kg ontology score <name>" to recompute.
 - `score` - Recompute annealing scores for one ontology. Runs mass, coherence, exposure, and protection scoring and caches results.
 - `score-all` - Recompute annealing scores for all ontologies. Runs full scoring pipeline and caches results on each Ontology node.
@@ -140,6 +141,61 @@ kg delete <name>
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-f, --force` | Skip confirmation and force deletion | - |
+| `--keep-tombstone` | Leave the deletion tombstone in place, deliberately blocking re-ingestion into this name until it is recreated (default: delete clears its own tombstone so the name is immediately re-ingestable) | - |
+
+### tombstones
+
+Manage ontology tombstones (operator-delete markers that block re-ingestion into a deleted name)
+
+**Usage:**
+```bash
+kg tombstones [options]
+```
+
+**Subcommands:**
+
+- `list` - List all ontology tombstones
+- `flush` - Clear ALL ontology tombstones, unblocking re-ingestion into every deleted name
+- `clear` - Clear the tombstone for a single ontology name
+
+---
+
+#### list
+
+List all ontology tombstones
+
+**Usage:**
+```bash
+kg list [options]
+```
+
+#### flush
+
+Clear ALL ontology tombstones, unblocking re-ingestion into every deleted name
+
+**Usage:**
+```bash
+kg flush [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-f, --force` | Skip confirmation | - |
+
+#### clear
+
+Clear the tombstone for a single ontology name
+
+**Usage:**
+```bash
+kg clear <name>
+```
+
+**Arguments:**
+
+- `<name>` - Ontology name
 
 ### scores
 

--- a/schema/migrations/059_provider_model_catalog.sql
+++ b/schema/migrations/059_provider_model_catalog.sql
@@ -91,14 +91,23 @@ ON CONFLICT (provider, model_id, category) DO NOTHING;
 -- Seed: Anthropic extraction models
 -- ============================================================
 
+-- enabled=FALSE for retired dated snapshots. Anthropic has no catalog API
+-- (ADR-800), so these are seeded by hand — and a dated snapshot eventually
+-- retires and 404s. claude-3-haiku-20240307 (retired 2026-04-19) was the
+-- cheapest *enabled* row, so prefer_cheapest resolution (code-block prose
+-- translation in the markdown preprocessor) silently selected it and every
+-- call 404'd; claude-3-5-sonnet-20241022 likewise 404s. They remain in the
+-- catalog (still visible/selectable in admin) but disabled so resolution
+-- never auto-selects a dead model. Durable fix: reconcile the catalog against
+-- live availability on Refresh (see api/app/routes/models.py refresh_catalog).
 INSERT INTO kg_api.provider_model_catalog
     (provider, model_id, display_name, category, context_length, supports_vision, supports_json_mode, supports_tool_use, price_prompt_per_m, price_completion_per_m, enabled, is_default, sort_order)
 VALUES
     ('anthropic', 'claude-sonnet-4-20250514', 'Claude Sonnet 4', 'extraction', 200000, TRUE, TRUE, TRUE, 3.00, 15.00, TRUE, TRUE, 1),
-    ('anthropic', 'claude-3-5-sonnet-20241022', 'Claude 3.5 Sonnet', 'extraction', 200000, TRUE, TRUE, TRUE, 3.00, 15.00, TRUE, FALSE, 2),
+    ('anthropic', 'claude-3-5-sonnet-20241022', 'Claude 3.5 Sonnet', 'extraction', 200000, TRUE, TRUE, TRUE, 3.00, 15.00, FALSE, FALSE, 2),
     ('anthropic', 'claude-3-opus-20240229', 'Claude 3 Opus', 'extraction', 200000, TRUE, TRUE, TRUE, 15.00, 75.00, FALSE, FALSE, 3),
     ('anthropic', 'claude-3-sonnet-20240229', 'Claude 3 Sonnet', 'extraction', 200000, TRUE, TRUE, TRUE, 3.00, 15.00, FALSE, FALSE, 4),
-    ('anthropic', 'claude-3-haiku-20240307', 'Claude 3 Haiku', 'extraction', 200000, TRUE, TRUE, TRUE, 0.25, 1.25, TRUE, FALSE, 5)
+    ('anthropic', 'claude-3-haiku-20240307', 'Claude 3 Haiku', 'extraction', 200000, TRUE, TRUE, TRUE, 0.25, 1.25, FALSE, FALSE, 5)
 ON CONFLICT (provider, model_id, category) DO NOTHING;
 
 -- ============================================================

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -591,6 +591,54 @@ class APIClient {
     return response.data;
   }
 
+  /**
+   * Delete an ontology and ALL its data (graph + Garage storage).
+   * By default this is a complete delete that clears the deletion tombstone so
+   * the name is immediately re-ingestable; pass keepTombstone to leave the block.
+   */
+  async deleteOntology(
+    name: string,
+    keepTombstone: boolean = false
+  ): Promise<{
+    ontology: string;
+    deleted: boolean;
+    sources_deleted: number;
+    orphaned_concepts_deleted: number;
+    tombstone_cleared: boolean;
+  }> {
+    const response = await this.client.delete(`/ontology/${encodeURIComponent(name)}`, {
+      params: { force: true, keep_tombstone: keepTombstone },
+    });
+    return response.data;
+  }
+
+  /**
+   * List ontology tombstones (operator-delete markers that block re-ingestion).
+   */
+  async listTombstones(): Promise<{
+    tombstones: Array<{ name: string; removed_by: string | null; removed_at: string | null; reason: string | null }>;
+    count: number;
+  }> {
+    const response = await this.client.get('/ontology/tombstones');
+    return response.data;
+  }
+
+  /**
+   * Flush ALL ontology tombstones.
+   */
+  async flushTombstones(): Promise<{ flushed: number; names: string[] }> {
+    const response = await this.client.delete('/ontology/tombstones');
+    return response.data;
+  }
+
+  /**
+   * Clear the tombstone for a single ontology name.
+   */
+  async clearTombstone(name: string): Promise<{ flushed: number; names: string[] }> {
+    const response = await this.client.delete(`/ontology/tombstones/${encodeURIComponent(name)}`);
+    return response.data;
+  }
+
   // ============================================================
   // ONTOLOGY ANNEALING LIFECYCLE METHODS (ADR-200 / ADR-703)
   // ============================================================
@@ -1224,6 +1272,18 @@ class APIClient {
     slots_in_use: number;
   }> {
     const response = await this.client.get('/admin/workers/status');
+    return response.data;
+  }
+
+  /**
+   * Update a worker lane (ADR-100): freeze/unfreeze (enabled) or adjust slots.
+   * Only provided fields change; takes effect on the next poll cycle.
+   */
+  async updateWorkerLane(
+    name: string,
+    body: { max_slots?: number; poll_interval_ms?: number; stale_timeout_minutes?: number; enabled?: boolean }
+  ): Promise<{ lane: { name: string; max_slots: number; enabled: boolean }; changed: Record<string, { old: any; new: any }> }> {
+    const response = await this.client.patch(`/admin/workers/lanes/${encodeURIComponent(name)}`, body);
     return response.data;
   }
 

--- a/web/src/components/admin/OntologyTab.tsx
+++ b/web/src/components/admin/OntologyTab.tsx
@@ -24,12 +24,16 @@ import {
   CircleSlash,
   ArrowUpFromLine,
   Sliders,
+  Trash2,
+  Database,
+  Skull,
 } from 'lucide-react';
 import { apiClient } from '../../api/client';
 import { useAuthStore } from '../../store/authStore';
 import { Section, InfoCard, formatDateTime } from './components';
 import { AnnealingPressurePanel } from './AnnealingPressurePanel';
 import type { AnnealingProposal, AnnealingStatus } from '../../types/annealing';
+import type { OntologyItem } from '../../types/ingest';
 
 interface OntologyTabProps {
   onError: (error: string) => void;
@@ -144,6 +148,7 @@ const paramsHighlight = (p: AnnealingProposal): string | null => {
 export const OntologyTab: React.FC<OntologyTabProps> = ({ onError, onSuccess }) => {
   const { hasPermission } = useAuthStore();
   const canManage = hasPermission('ontologies', 'write');
+  const canDelete = hasPermission('ontologies', 'delete');
 
   const [status, setStatus] = useState<AnnealingStatus | null>(null);
   const [proposals, setProposals] = useState<AnnealingProposal[]>([]);
@@ -153,23 +158,35 @@ export const OntologyTab: React.FC<OntologyTabProps> = ({ onError, onSuccess }) 
   const [confirmRun, setConfirmRun] = useState(false);
   const [reviewingId, setReviewingId] = useState<number | null>(null);
 
+  // Ontology lifecycle + tombstone controls (operator surface).
+  const [ontologies, setOntologies] = useState<OntologyItem[]>([]);
+  const [tombstones, setTombstones] = useState<Array<{ name: string; removed_by: string | null; removed_at: string | null; reason: string | null }>>([]);
+  const [deletingOntology, setDeletingOntology] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [clearingTombstone, setClearingTombstone] = useState<string | null>(null);
+  const [flushingTombstones, setFlushingTombstones] = useState(false);
+
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [statusRes, proposalsRes] = await Promise.all([
+      const [statusRes, proposalsRes, ontologiesRes, tombstonesRes] = await Promise.all([
         apiClient.getAnnealingStatus(),
         apiClient.listAnnealingProposals(
           statusFilter === 'all' ? { limit: 50 } : { status: statusFilter, limit: 50 },
         ),
+        apiClient.listOntologies().catch(() => ({ count: 0, ontologies: [] })),
+        canDelete ? apiClient.listTombstones().catch(() => ({ count: 0, tombstones: [] })) : Promise.resolve({ count: 0, tombstones: [] }),
       ]);
       setStatus(statusRes);
       setProposals(proposalsRes.proposals);
+      setOntologies(ontologiesRes.ontologies);
+      setTombstones(tombstonesRes.tombstones);
     } catch (err) {
       onError(err instanceof Error ? err.message : 'Failed to load annealing status');
     } finally {
       setLoading(false);
     }
-  }, [statusFilter, onError]);
+  }, [statusFilter, onError, canDelete]);
 
   useEffect(() => {
     loadData();
@@ -202,6 +219,52 @@ export const OntologyTab: React.FC<OntologyTabProps> = ({ onError, onSuccess }) 
       onError(err instanceof Error ? err.message : `Failed to ${decision} proposal`);
     } finally {
       setReviewingId(null);
+    }
+  };
+
+  // Delete an ontology and ALL its data (graph + storage). Clears the tombstone
+  // by default so the name is immediately re-ingestable.
+  const handleDeleteOntology = async (name: string) => {
+    setConfirmDelete(null);
+    setDeletingOntology(name);
+    try {
+      const result = await apiClient.deleteOntology(name);
+      onSuccess?.(
+        `Deleted "${result.ontology}" — ${result.sources_deleted} source(s), ` +
+          `${result.orphaned_concepts_deleted} orphaned concept(s). ` +
+          `${result.tombstone_cleared ? 'Tombstone cleared (re-ingestable).' : 'Tombstone kept.'}`,
+      );
+      await loadData();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : `Failed to delete ontology "${name}"`);
+    } finally {
+      setDeletingOntology(null);
+    }
+  };
+
+  const handleClearTombstone = async (name: string) => {
+    setClearingTombstone(name);
+    try {
+      await apiClient.clearTombstone(name);
+      onSuccess?.(`Cleared tombstone for "${name}" — name is free to re-ingest.`);
+      await loadData();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : `Failed to clear tombstone "${name}"`);
+    } finally {
+      setClearingTombstone(null);
+    }
+  };
+
+  const handleFlushTombstones = async () => {
+    setFlushingTombstones(true);
+    try {
+      const result = await apiClient.flushTombstones();
+      onSuccess?.(`Flushed ${result.flushed} tombstone(s).`);
+      await loadData();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to flush tombstones');
+    } finally {
+      setFlushingTombstones(false);
     }
   };
 
@@ -453,6 +516,111 @@ export const OntologyTab: React.FC<OntologyTabProps> = ({ onError, onSuccess }) 
           </div>
         )}
       </Section>
+
+      {/* Ontology lifecycle — list + delete (operator control) */}
+      <Section title="Ontologies" icon={<Database className="w-5 h-5" />}>
+        {ontologies.length === 0 ? (
+          <p className="text-muted-foreground text-center py-6 text-sm">No ontologies.</p>
+        ) : (
+          <div className="space-y-2">
+            {ontologies.map((o) => (
+              <div
+                key={o.ontology}
+                className="flex items-center justify-between p-3 rounded-lg border border-border bg-muted/30"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-foreground truncate">{o.ontology}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {o.file_count} file(s) · {o.source_count} source(s) · {o.concept_count} concept(s)
+                    {o.lifecycle_state ? ` · ${o.lifecycle_state}` : ''}
+                  </div>
+                </div>
+                {canDelete && (
+                  confirmDelete === o.ontology ? (
+                    <div className="flex items-center gap-1 shrink-0">
+                      <span className="text-xs text-destructive mr-1">Delete all data?</span>
+                      <button
+                        onClick={() => handleDeleteOntology(o.ontology)}
+                        disabled={deletingOntology === o.ontology}
+                        className="px-2 py-1 text-xs font-medium rounded bg-destructive/20 text-destructive hover:bg-destructive/30 disabled:opacity-50"
+                      >
+                        {deletingOntology === o.ontology ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Confirm'}
+                      </button>
+                      <button
+                        onClick={() => setConfirmDelete(null)}
+                        className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmDelete(o.ontology)}
+                      title="Delete ontology and all its data"
+                      className="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded bg-destructive/10 text-destructive hover:bg-destructive/20 shrink-0"
+                    >
+                      <Trash2 className="w-3 h-3" />
+                      Delete
+                    </button>
+                  )
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      {/* Tombstones — operator-delete markers that block re-ingestion */}
+      {canDelete && (
+        <Section
+          title="Tombstones"
+          icon={<Skull className="w-5 h-5" />}
+          action={
+            tombstones.length > 0 ? (
+              <button
+                onClick={handleFlushTombstones}
+                disabled={flushingTombstones}
+                className="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded bg-status-warning/15 text-status-warning hover:bg-status-warning/25 disabled:opacity-50"
+              >
+                {flushingTombstones ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
+                Flush all
+              </button>
+            ) : undefined
+          }
+        >
+          {tombstones.length === 0 ? (
+            <p className="text-muted-foreground text-center py-6 text-sm">
+              None — no names are blocked from re-ingestion.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {tombstones.map((t) => (
+                <div
+                  key={t.name}
+                  className="flex items-center justify-between p-3 rounded-lg border border-border bg-muted/30"
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-foreground truncate">{t.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      removed by {t.removed_by || 'unknown'}
+                      {t.removed_at ? ` · ${formatDateTime(t.removed_at)}` : ''}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleClearTombstone(t.name)}
+                    disabled={clearingTombstone === t.name}
+                    title="Clear this tombstone (unblock re-ingestion)"
+                    className="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded bg-status-active/15 text-status-active hover:bg-status-active/25 disabled:opacity-50 shrink-0"
+                  >
+                    {clearingTombstone === t.name ? <Loader2 className="w-3 h-3 animate-spin" /> : <Play className="w-3 h-3" />}
+                    Clear
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </Section>
+      )}
     </>
   );
 };

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -30,6 +30,7 @@ import {
   EyeOff,
 } from 'lucide-react';
 import { apiClient, API_BASE_URL } from '../../api/client';
+import { useAuthStore } from '../../store/authStore';
 import { Section, StatusBadge } from './components';
 import { VisionProviderCard } from './VisionProviderCard';
 import type { SystemStatus, EmbeddingConfig, ExtractionConfig, ApiKeyInfo, SchedulerStatus, WorkerStatus } from './types';
@@ -50,6 +51,9 @@ const LOCAL_DEFAULT_BASE_URL: Record<string, string> = {
 const DEFAULT_TEMPERATURE = '0.1';
 
 export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
+  const { hasPermission } = useAuthStore();
+  const canManageWorkers = hasPermission('workers', 'manage');
+
   // Data states
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null);
   const [dbStats, setDbStats] = useState<any>(null);
@@ -712,25 +716,27 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                     <span className="text-xs text-muted-foreground">
                       {lane.enabled ? `${lane.max_slots} slots` : 'no slots'}
                     </span>
-                    <button
-                      onClick={() => handleToggleLane(lane.name, lane.enabled)}
-                      disabled={togglingLane === lane.name}
-                      title={lane.enabled ? 'Freeze lane (stop claiming new jobs)' : 'Unfreeze lane'}
-                      className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors disabled:opacity-50 ${
-                        lane.enabled
-                          ? 'bg-status-warning/15 text-status-warning hover:bg-status-warning/25'
-                          : 'bg-status-active/15 text-status-active hover:bg-status-active/25'
-                      }`}
-                    >
-                      {togglingLane === lane.name ? (
-                        <Loader2 className="w-3 h-3 animate-spin" />
-                      ) : lane.enabled ? (
-                        <Pause className="w-3 h-3" />
-                      ) : (
-                        <Play className="w-3 h-3" />
-                      )}
-                      {lane.enabled ? 'Freeze' : 'Unfreeze'}
-                    </button>
+                    {canManageWorkers && (
+                      <button
+                        onClick={() => handleToggleLane(lane.name, lane.enabled)}
+                        disabled={togglingLane === lane.name}
+                        title={lane.enabled ? 'Freeze lane (stop claiming new jobs)' : 'Unfreeze lane'}
+                        className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors disabled:opacity-50 ${
+                          lane.enabled
+                            ? 'bg-status-warning/15 text-status-warning hover:bg-status-warning/25'
+                            : 'bg-status-active/15 text-status-active hover:bg-status-active/25'
+                        }`}
+                      >
+                        {togglingLane === lane.name ? (
+                          <Loader2 className="w-3 h-3 animate-spin" />
+                        ) : lane.enabled ? (
+                          <Pause className="w-3 h-3" />
+                        ) : (
+                          <Play className="w-3 h-3" />
+                        )}
+                        {lane.enabled ? 'Freeze' : 'Unfreeze'}
+                      </button>
+                    )}
                   </div>
                 </div>
               ))}

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -23,6 +23,7 @@ import {
   BarChart3,
   Layers,
   Play,
+  Pause,
   Trash2,
   TestTube,
   Eye,
@@ -55,6 +56,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const [dbCounters, setDbCounters] = useState<any>(null);
   const [schedulerStatus, setSchedulerStatus] = useState<SchedulerStatus | null>(null);
   const [workerStatus, setWorkerStatus] = useState<WorkerStatus | null>(null);
+  const [togglingLane, setTogglingLane] = useState<string | null>(null);
   const [docsIngested, setDocsIngested] = useState<number>(0);
   const [graphEpoch, setGraphEpoch] = useState<number>(0);
   const [embeddingConfigs, setEmbeddingConfigs] = useState<EmbeddingConfig[]>([]);
@@ -177,6 +179,21 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       onError(err instanceof Error ? err.message : 'Failed to refresh counters');
     } finally {
       setRefreshingCounters(false);
+    }
+  };
+
+  // Freeze/unfreeze a worker lane (ADR-100). Disabling stops the lane claiming
+  // new work; running jobs finish naturally. Takes effect next poll cycle.
+  const handleToggleLane = async (name: string, currentlyEnabled: boolean) => {
+    setTogglingLane(name);
+    try {
+      await apiClient.updateWorkerLane(name, { enabled: !currentlyEnabled });
+      const workers = await apiClient.getWorkerStatus();
+      setWorkerStatus(workers);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : `Failed to ${currentlyEnabled ? 'freeze' : 'unfreeze'} lane`);
+    } finally {
+      setTogglingLane(null);
     }
   };
 
@@ -680,9 +697,30 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                   }`}
                 >
                   <span className="text-sm font-medium text-foreground">{lane.name}</span>
-                  <span className="text-xs text-muted-foreground">
-                    {lane.enabled ? `${lane.max_slots} slots` : 'disabled'}
-                  </span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-muted-foreground">
+                      {lane.enabled ? `${lane.max_slots} slots` : 'disabled'}
+                    </span>
+                    <button
+                      onClick={() => handleToggleLane(lane.name, lane.enabled)}
+                      disabled={togglingLane === lane.name}
+                      title={lane.enabled ? 'Freeze lane (stop claiming new jobs)' : 'Unfreeze lane'}
+                      className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors disabled:opacity-50 ${
+                        lane.enabled
+                          ? 'bg-status-warning/15 text-status-warning hover:bg-status-warning/25'
+                          : 'bg-status-active/15 text-status-active hover:bg-status-active/25'
+                      }`}
+                    >
+                      {togglingLane === lane.name ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : lane.enabled ? (
+                        <Pause className="w-3 h-3" />
+                      ) : (
+                        <Play className="w-3 h-3" />
+                      )}
+                      {lane.enabled ? 'Freeze' : 'Unfreeze'}
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -696,10 +696,21 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
                       : 'bg-muted/50 border-border opacity-60'
                   }`}
                 >
-                  <span className="text-sm font-medium text-foreground">{lane.name}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">{lane.name}</span>
+                    <span
+                      className={`px-2 py-0.5 text-xs rounded-full font-medium ${
+                        lane.enabled
+                          ? 'bg-status-active/20 text-status-active'
+                          : 'bg-status-warning/20 text-status-warning'
+                      }`}
+                    >
+                      {lane.enabled ? 'Active' : 'Frozen'}
+                    </span>
+                  </div>
                   <div className="flex items-center gap-3">
                     <span className="text-xs text-muted-foreground">
-                      {lane.enabled ? `${lane.max_slots} slots` : 'disabled'}
+                      {lane.enabled ? `${lane.max_slots} slots` : 'no slots'}
                     </span>
                     <button
                       onClick={() => handleToggleLane(lane.name, lane.enabled)}


### PR DESCRIPTION
## What

Operator controls for steering document intake, plus the catalog fix that was the root cause of an ingest 404 storm. All surfaced while debugging a large ADR ingestion that \"wasn't doing much.\"

### Worker lanes (ADR-100)
- Configurable per-lane slots: `kg admin workers lanes set <lane> --max-slots/--enable/--disable`, capped by `MAX_LANE_SLOTS` (16) defined once in `lane_manager`.
- Shared executor sized to `lanes × cap` so raising slots actually increases concurrency (was pinned at `MAX_CONCURRENT_JOBS`=4).
- WebUI: per-lane Freeze/Unfreeze toggle + `Active`/`Frozen` status pill.

### Ontology tombstones
- `GET/DELETE /ontology/tombstones` + `kg ontology tombstones list/flush/clear`.
- `kg ontology delete` now clears its own tombstone by default — a *complete* delete, name is immediately re-ingestable — with `--keep-tombstone` to deliberately block. Fixes the silent "deleted but still blocked re-ingestion" confusion.
- WebUI: Ontologies list with per-ontology delete + Tombstones panel.
- Tombstone deletes carry a `lock_timeout` so they can't hang on active work.

### Catalog staleness (the 404 root cause)
- Migration 059 seeded retired dated Anthropic snapshots as `enabled`. `claude-3-haiku-20240307` (retired 2026-04-19) was the cheapest enabled row, so `prefer_cheapest` resolution (markdown code-block prose translation) silently selected a dead model → every translation call 404'd, while main extraction (`sonnet-4-6`) succeeded. Disabled the two retired snapshots in the seed.
- Sketched the durable fix (self-healing reconcile on catalog Refresh) at `models.refresh_catalog`.

## Why

The platform lacked the controls to steer intake — recovering from a stuck/misconfigured run meant raw SQL (freeze lanes, flush tombstones, disable dead models). This adds the missing instrumentation.

## Deferred
- **Fail-fast on permanent provider errors** (the original branch intent): we learned 404s here can be *transient*, so it needs a transient-vs-permanent distinction, not a blanket fatal.
- **Operator actions as jobs** for eventual consistency.