### PR TITLE
fix(vocab): remove vestigial vocabulary embedding_model field

### DIFF
--- a/api/app/lib/vocabulary_config.py
+++ b/api/app/lib/vocabulary_config.py
@@ -44,8 +44,7 @@ def load_vocabulary_config() -> VocabularyConfigResponse:
             synonym_threshold_strong=float(client.get_vocab_config('synonym_threshold_strong', '0.90')),
             synonym_threshold_moderate=float(client.get_vocab_config('synonym_threshold_moderate', '0.70')),
             low_value_threshold=float(client.get_vocab_config('low_value_threshold', '1.0')),
-            consolidation_similarity_threshold=float(client.get_vocab_config('consolidation_similarity_threshold', '0.90')),
-            embedding_model=client.get_vocab_config('embedding_model', 'text-embedding-ada-002')
+            consolidation_similarity_threshold=float(client.get_vocab_config('consolidation_similarity_threshold', '0.90'))
         )
     finally:
         client.close()
@@ -92,7 +91,6 @@ def load_vocabulary_config_detail() -> VocabularyConfigDetail:
             synonym_threshold_moderate=float(client.get_vocab_config('synonym_threshold_moderate', '0.70')),
             low_value_threshold=float(client.get_vocab_config('low_value_threshold', '1.0')),
             consolidation_similarity_threshold=float(client.get_vocab_config('consolidation_similarity_threshold', '0.90')),
-            embedding_model=client.get_vocab_config('embedding_model', 'text-embedding-ada-002'),
             current_size=current_size,
             zone=ZoneEnum(zone),
             aggressiveness=aggressiveness

--- a/api/app/models/vocabulary.py
+++ b/api/app/models/vocabulary.py
@@ -210,7 +210,6 @@ class VocabularyConfigResponse(BaseModel):
     synonym_threshold_moderate: float = 0.70
     low_value_threshold: float = 1.0
     consolidation_similarity_threshold: float = 0.90
-    embedding_model: str = "text-embedding-ada-002"
 
 
 class VocabularyConfigDetail(BaseModel):
@@ -225,7 +224,6 @@ class VocabularyConfigDetail(BaseModel):
     synonym_threshold_moderate: float
     low_value_threshold: float
     consolidation_similarity_threshold: float
-    embedding_model: str
     updated_at: Optional[datetime] = None
     updated_by: Optional[str] = None
     # Computed fields

--- a/schema/00_baseline.sql
+++ b/schema/00_baseline.sql
@@ -904,7 +904,6 @@ VALUES
     ('vocab_emergency', '200', 'Emergency threshold (aggressive pruning)', 'system'),
     ('aggressiveness_profile', 'aggressive', 'Bezier curve profile for pruning aggressiveness', 'system'),
     ('pruning_mode', 'hitl', 'Decision mode: naive, hitl, aitl', 'system'),
-    ('embedding_model', 'text-embedding-ada-002', 'OpenAI model for embeddings', 'system'),
     ('auto_expand_enabled', 'false', 'Enable automatic vocabulary expansion', 'system'),
     ('synonym_threshold_strong', '0.90', 'Strong synonym threshold (auto-merge)', 'system'),
     ('synonym_threshold_moderate', '0.70', 'Moderate synonym threshold (review)', 'system'),

--- a/web/src/types/vocabulary.ts
+++ b/web/src/types/vocabulary.ts
@@ -46,7 +46,6 @@ export interface VocabularyConfig {
   synonym_threshold_moderate: number;
   low_value_threshold: number;
   consolidation_similarity_threshold: number;
-  embedding_model: string;
   updated_at?: string | null;
   updated_by?: string | null;
   // Computed fields


### PR DESCRIPTION
## Bug

The vocabulary admin panel reported `embedding_model: text-embedding-ada-002` while the system actually embeds with Nomic v1.5 — a misleading, drifting display.

## Root cause

`vocabulary_config` carried its own `embedding_model` key (seeded `text-embedding-ada-002`) that was **display-only** — no code generated embeddings with it. Synonym detection resolves embeddings from the active `embedding_profile` (Nomic v1.5). There is exactly one embedding space for the whole graph (`embedding_profile` owns it; you can't mix 1536-dim OpenAI and 768-dim Nomic vectors), so a per-vocabulary embedding model is meaningless — it could only ever drift from the truth.

## Fix

Remove the vestigial field from:
- `api/app/lib/vocabulary_config.py` (both loaders)
- `api/app/models/vocabulary.py` (`VocabularyConfigResponse` + `VocabularyConfigDetail`)
- `web/src/types/vocabulary.ts`
- `schema/00_baseline.sql` (seed row)

The panel renders config generically (`Object.entries`), so the field drops from the UI once the API stops returning it. The unrelated `relationship_vocabulary.embedding_model` *column* (per-row provenance of which model embedded each type) is kept.

Note: API restart required to serve the change (deferred — an ingest is running).