### PR TITLE
fix(annealing): refractory gate — defer cycles while ingestion is in-flight

### DIFF
--- a/api/app/launchers/annealing.py
+++ b/api/app/launchers/annealing.py
@@ -28,6 +28,10 @@ DEFAULTS = {
     "automation_level": "autonomous",
     "min_ontology_age_epochs": 3,
     "min_ontology_concept_count": 5,
+    # Refractory gate (ADR-200): defer annealing while ingestion is in-flight,
+    # but force a cycle once this many epochs have accumulated so a continuous
+    # ingestion stream can't starve annealing entirely. ~10x epoch_interval.
+    "inflight_defer_max_epochs": 50,
 }
 
 
@@ -46,6 +50,7 @@ def _read_options(conn) -> Dict:
                     "max_proposals",
                     "min_ontology_age_epochs",
                     "min_ontology_concept_count",
+                    "inflight_defer_max_epochs",
                 ):
                     options[key] = int(value)
                 elif key in ("demotion_threshold", "overlap_threshold", "specializes_threshold"):
@@ -55,6 +60,26 @@ def _read_options(conn) -> Dict:
     except Exception as e:
         logger.warning(f"AnnealingLauncher: could not read annealing_options, using defaults: {e}")
     return options
+
+
+def _should_defer_for_inflight(
+    inflight_count: int, epoch_delta: int, max_defer_epochs: int
+) -> bool:
+    """Decide whether to defer an annealing cycle because ingestion is in-flight.
+
+    Refractory gate (ADR-200, Approach A): annealing reorganizes the graph, so
+    running it while documents are still being ingested churns work that the
+    next chunk invalidates — the "panic mode" observed when a large ingest
+    bumps the epoch faster than the epoch_interval cadence. Defer while
+    ingestion is active, but only up to `max_defer_epochs` of accumulated epoch
+    delta, after which we force a cycle so a continuous ingestion stream can't
+    starve annealing entirely.
+
+    Pure function (no I/O) so the policy is unit-testable in isolation.
+    """
+    if inflight_count <= 0:
+        return False
+    return epoch_delta < max_defer_epochs
 
 
 class AnnealingLauncher(JobLauncher):
@@ -102,6 +127,29 @@ class AnnealingLauncher(JobLauncher):
                 current_epoch = client.get_current_epoch()
                 epoch_interval = options["epoch_interval"]
 
+                # Refractory gate (Approach A): defer while ingestion is actively
+                # in-flight so we don't anneal a graph that's still being flooded
+                # with concepts. Bounded by inflight_defer_max_epochs so a
+                # continuous stream can't starve annealing. (Graded pressure-curve
+                # response is the Approach B follow-up — see GitHub issue.)
+                inflight = self._count_inflight_ingestion(conn)
+                if inflight > 0:
+                    max_defer = options["inflight_defer_max_epochs"]
+                    epoch_delta = current_epoch - self._read_last_annealing_epoch(conn)
+                    if _should_defer_for_inflight(inflight, epoch_delta, max_defer):
+                        logger.info(
+                            f"AnnealingLauncher: deferring — {inflight} ingestion "
+                            f"job(s) in-flight (epoch_delta={epoch_delta} < "
+                            f"max_defer={max_defer}); waiting for the influx to settle"
+                        )
+                        conn.rollback()
+                        return False
+                    logger.info(
+                        f"AnnealingLauncher: {inflight} ingestion job(s) in-flight "
+                        f"but epoch_delta={epoch_delta} >= max_defer={max_defer}; "
+                        f"forcing a cycle to avoid starvation"
+                    )
+
                 # Atomic check-and-claim: UPDATE only succeeds if delta is sufficient
                 with conn.cursor() as cur:
                     cur.execute(
@@ -135,6 +183,39 @@ class AnnealingLauncher(JobLauncher):
 
         finally:
             client.close()
+
+    @staticmethod
+    def _count_inflight_ingestion(conn) -> int:
+        """Count ingestion jobs that are queued or actively running (the influx).
+
+        Counts pending/queued/approved/running ingestion + image-ingestion jobs.
+        Excludes terminal states (completed/failed/cancelled) and
+        awaiting_approval (not yet committed to run — could sit indefinitely and
+        would otherwise defer annealing forever). Fails open (returns 0) so an
+        error here never blocks annealing.
+        """
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM kg_api.jobs "
+                    "WHERE job_type IN ('ingestion', 'ingest_image') "
+                    "AND status IN ('pending', 'queued', 'approved', 'running')"
+                )
+                return int(cur.fetchone()[0])
+        except Exception as e:
+            logger.warning(f"AnnealingLauncher: in-flight ingestion check failed: {e}")
+            return 0
+
+    @staticmethod
+    def _read_last_annealing_epoch(conn) -> int:
+        """Read the last claimed annealing epoch (0 if the metric is absent)."""
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT counter FROM public.graph_metrics "
+                "WHERE metric_name = 'last_annealing_epoch'"
+            )
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
 
     def prepare_job_data(self) -> Dict:
         """

--- a/tests/unit/launchers/test_annealing_launcher.py
+++ b/tests/unit/launchers/test_annealing_launcher.py
@@ -1,0 +1,44 @@
+"""
+AnnealingLauncher refractory gate (ADR-200, Approach A).
+
+The launcher used to fire purely on epoch cadence (current_epoch -
+last_annealing_epoch >= epoch_interval). During a large ingest every mutation
+bumps the epoch, so the interval was crossed constantly and annealing ran hot
+("panic mode") while documents were still flooding in — reorganizing a graph
+that the next chunk invalidates. The ecological-pressure curve was computed but
+observational-only; it never gated the trigger.
+
+These tests pin the in-flight defer policy: defer while ingestion is active,
+but force a cycle once max_defer_epochs of epoch delta accumulate so a
+continuous stream can't starve annealing.
+"""
+
+import pytest
+
+from api.app.launchers.annealing import _should_defer_for_inflight
+
+
+class TestShouldDeferForInflight:
+    def test_no_inflight_never_defers(self):
+        # System at rest — annealing should run regardless of epoch delta.
+        assert _should_defer_for_inflight(0, 3, 50) is False
+        assert _should_defer_for_inflight(0, 999, 50) is False
+
+    def test_inflight_under_cap_defers(self):
+        # Ingestion actively flooding and we haven't waited too long yet — defer.
+        assert _should_defer_for_inflight(1, 3, 50) is True
+        assert _should_defer_for_inflight(8, 49, 50) is True
+
+    def test_inflight_at_or_past_cap_forces(self):
+        # Continuous stream: once the cap is reached, force a cycle (no starvation).
+        assert _should_defer_for_inflight(8, 50, 50) is False
+        assert _should_defer_for_inflight(8, 120, 50) is False
+
+    def test_negative_inflight_treated_as_none(self):
+        assert _should_defer_for_inflight(-1, 3, 50) is False
+
+    @pytest.mark.parametrize("max_defer", [0, 5, 50, 200])
+    def test_cap_boundary_is_strict_less_than(self, max_defer):
+        # epoch_delta < max_defer defers; epoch_delta == max_defer forces.
+        assert _should_defer_for_inflight(1, max_defer - 1, max_defer) is (max_defer - 1 < max_defer)
+        assert _should_defer_for_inflight(1, max_defer, max_defer) is False


### PR DESCRIPTION
## Bug

Annealing ran in "panic mode" during a large ingest — firing constantly and auto-executing batches of ESCALATE proposals — even with ecological pressure pegged at **1.00 / emergency**.

## Root cause: built, not wired

- The pressure curve is computed but **observational-only** (`annealing_manager._get_ecological_snapshot`) — it emits `ADJUST_CONTROL` *recommendations*, never throttles anything live.
- The trigger gate (`AnnealingLauncher.check_conditions`) fired purely on **epoch cadence** (`epoch_delta >= epoch_interval`, default 5). During ingest every mutation bumps the epoch, so the interval is crossed constantly.
- The in-flight-ingestion signal already existed but only **vetoed individual candidates inside a cycle**, never gated whether the cycle ran.

So annealing reorganized a graph that the next chunk immediately invalidated.

## Fix (Approach A — refractory gate)

Add an in-flight guard to `check_conditions`, *before* the atomic epoch-claim: defer while ingestion jobs are queued/running (don't claim the epoch window, so the accumulated delta fires one clean cycle once the influx settles). Bounded by a new `inflight_defer_max_epochs` option (default 50) so a continuous stream can't starve annealing. The defer decision is a pure helper (`_should_defer_for_inflight`) with unit tests.

Touches only `api/app/launchers/annealing.py` + a new test. No change to proposal/review/autonomy semantics.

## Follow-up

Graded pressure-curve modulation (the literal "action potential curve" — pressure scales cadence/aggressiveness continuously) is **#471** — ADR-territory because it changes ADR-200 Phase-4's observational→control boundary.

## Note

Requires an API restart to take effect (deferred — an ingest is running).