### PR TITLE
fix(embedding): use get_embedding_dimension with fallback

### DIFF
--- a/api/app/lib/embedding_model_manager.py
+++ b/api/app/lib/embedding_model_manager.py
@@ -144,7 +144,15 @@ class EmbeddingModelManager:
                 )
                 logger.info("  Downloaded and cached")
 
-            self.dimensions = self.model.get_sentence_embedding_dimension()
+            # sentence-transformers renamed get_sentence_embedding_dimension() →
+            # get_embedding_dimension(). Prefer the new name when present, fall
+            # back to the old — forward-compatible (survives the old name's
+            # removal) and backward-compatible (older ST lacks the new name).
+            self.dimensions = (
+                self.model.get_embedding_dimension()
+                if hasattr(self.model, "get_embedding_dimension")
+                else self.model.get_sentence_embedding_dimension()
+            )
             logger.info(f"Embedding model loaded: {self.model_name} ({self.dimensions} dims, {device})")
 
         except Exception as e:


### PR DESCRIPTION
Silences the `FutureWarning` on every embedding-model load: sentence-transformers renamed `get_sentence_embedding_dimension()` → `get_embedding_dimension()`. The fix prefers the new method when present and falls back to the old, so it's both forward-compatible (survives the old name's eventual removal) and backward-compatible (older sentence-transformers lacks the new name). Surfaced alongside the benign Nomic/ROCm `AOTriton backend` UserWarning (informational — GPU efficient-attention active, no action needed).