### PR TITLE
ADR-102: Portable backup/restore foundations (spec, engine, validator, DR bugfixes)

### DIFF
--- a/api/app/lib/concept_matcher.py
+++ b/api/app/lib/concept_matcher.py
@@ -1,16 +1,20 @@
 """
 Concept matching engine for restore integration mode (ADR-102 §2).
 
-Ported from the legacy ``api/lib/restitching.py`` ``ConceptMatcher`` and adapted
-to ``api/app`` conventions. This module is the *matching engine only*: given an
-external concept (carrying an embedding, and optionally a label) it finds the
-best-matching existing concept in the target graph by cosine similarity, using
-the project's canonical two-tier thresholds. It performs no LLM calls, generates
-no embeddings, and is not wired into any worker, route, or service — that wiring
-is Phase 4 of ADR-102.
+Succeeds the legacy ``api/lib/restitching.py`` ``ConceptMatcher`` as the
+``api/app`` integration-mode engine. NOTE: this is not a line-for-line port —
+the legacy matcher used a single 0.85 threshold; this module implements the
+project's **canonical two-tier policy** (``api/app/lib/ingestion.py:432-461``),
+which is what ADR-102 §2 specifies for integration mode. It is the *matching
+engine only*: given an external concept (carrying an embedding, and optionally a
+label) it finds the best-matching existing concept in the target graph by cosine
+similarity. It performs no LLM calls, generates no embeddings, and is not wired
+into any worker, route, or service — that wiring is Phase 4 of ADR-102.
 
 The matching policy mirrors the canonical ingestion path
-(``api/app/lib/ingestion.py``):
+(``api/app/lib/ingestion.py``), with one deliberate refinement: ingestion
+inspects only the top candidate, whereas this engine walks candidates best-first
+so a label-boosted match just below a non-matching top hit is not missed:
 
 - **Strict tier (>= 0.85):** any candidate at or above this cosine similarity is
   an unconditional match.

--- a/api/app/lib/concept_matcher.py
+++ b/api/app/lib/concept_matcher.py
@@ -1,0 +1,224 @@
+"""
+Concept matching engine for restore integration mode (ADR-102 §2).
+
+Ported from the legacy ``api/lib/restitching.py`` ``ConceptMatcher`` and adapted
+to ``api/app`` conventions. This module is the *matching engine only*: given an
+external concept (carrying an embedding, and optionally a label) it finds the
+best-matching existing concept in the target graph by cosine similarity, using
+the project's canonical two-tier thresholds. It performs no LLM calls, generates
+no embeddings, and is not wired into any worker, route, or service — that wiring
+is Phase 4 of ADR-102.
+
+The matching policy mirrors the canonical ingestion path
+(``api/app/lib/ingestion.py``):
+
+- **Strict tier (>= 0.85):** any candidate at or above this cosine similarity is
+  an unconditional match.
+- **Label-boosted tier (>= 0.75):** a candidate in ``[0.75, 0.85)`` matches only
+  when its label is equal to, or a substring containment of, the incoming
+  concept's label (case-insensitive, whitespace-normalized).
+
+Differences from the legacy version (see "Adaptation notes" in the ADR-102
+Track C report):
+
+- Uses the ``api/app`` :class:`~api.app.lib.age_client.AGEClient` and its
+  :meth:`vector_search` rather than the legacy ``AGEConnection`` +
+  hand-rolled full-scan loop.
+- Does NOT generate embeddings from a label (the legacy code called
+  ``conn.generate_embedding``). A concept with no embedding cannot be matched by
+  similarity here; embedding rehydration is a separate ADR-102 §6 concern that
+  must run before integration matching.
+- Carries only the matching engine — the restitch-plan / execute-restitch /
+  console-printing surface of the legacy class is intentionally omitted.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from api.app.lib.age_client import AGEClient
+
+logger = logging.getLogger(__name__)
+
+# Canonical two-tier matching thresholds (mirrors api/app/lib/ingestion.py).
+STRICT_THRESHOLD = 0.85
+LABEL_BOOST_THRESHOLD = 0.75
+
+
+def _labels_match(incoming_label: Optional[str], candidate_label: Optional[str]) -> bool:
+    """Decide whether two labels are similar enough to boost a borderline match.
+
+    Normalizes both labels (lowercase, stripped) and returns True when they are
+    identical or one contains the other — the same rule used by the canonical
+    ingestion matcher's label-boost tier.
+
+    Args:
+        incoming_label: Label of the external/incoming concept (may be None).
+        candidate_label: Label of the existing candidate concept (may be None).
+
+    Returns:
+        True if the labels are considered a match for boosting purposes.
+
+    @verified 72ba3d3b
+    """
+    if not incoming_label or not candidate_label:
+        return False
+    norm_incoming = incoming_label.lower().strip()
+    norm_candidate = candidate_label.lower().strip()
+    if not norm_incoming or not norm_candidate:
+        return False
+    return (
+        norm_incoming == norm_candidate
+        or norm_incoming in norm_candidate
+        or norm_candidate in norm_incoming
+    )
+
+
+class ConceptMatcher:
+    """Match external concepts to existing target concepts by cosine similarity.
+
+    This is the ADR-102 integration-mode matching engine. It wraps an
+    :class:`~api.app.lib.age_client.AGEClient` and uses its ``vector_search``
+    (cosine similarity over concept embeddings) to find the best existing
+    concept for an incoming external concept, applying the project's canonical
+    two-tier thresholds (strict 0.85 / label-boosted 0.75).
+
+    The matcher is read-only with respect to the graph: it never writes,
+    creates placeholders, or calls an LLM/embedding service. Concepts that do
+    not meet the threshold return ``None`` (the caller's integration logic then
+    falls through to adjacent-mode behaviour — out of scope here).
+
+    Args:
+        client: The ``api/app`` AGEClient used for Cypher / vector search.
+        strict_threshold: Unconditional-match cosine threshold (default 0.85).
+        label_boost_threshold: Lower threshold below which a label match is
+            also required (default 0.75).
+
+    @verified 72ba3d3b
+    """
+
+    def __init__(
+        self,
+        client: AGEClient,
+        strict_threshold: float = STRICT_THRESHOLD,
+        label_boost_threshold: float = LABEL_BOOST_THRESHOLD,
+    ):
+        """Initialize the matcher with an AGEClient and matching thresholds.
+
+        Args:
+            client: AGEClient for graph access (vector search).
+            strict_threshold: Cosine similarity at/above which any candidate
+                matches unconditionally.
+            label_boost_threshold: Lower cosine similarity bound; candidates in
+                ``[label_boost_threshold, strict_threshold)`` match only if
+                their label matches the incoming label.
+
+        Raises:
+            ValueError: If thresholds are out of range or inverted.
+
+        @verified 72ba3d3b
+        """
+        if not 0.0 <= label_boost_threshold <= strict_threshold <= 1.0:
+            raise ValueError(
+                "Thresholds must satisfy 0.0 <= label_boost_threshold "
+                f"<= strict_threshold <= 1.0 (got label={label_boost_threshold}, "
+                f"strict={strict_threshold})"
+            )
+        self.client = client
+        self.strict_threshold = strict_threshold
+        self.label_boost_threshold = label_boost_threshold
+
+    def match_concept_in_database(
+        self,
+        external_concept: Dict[str, Any],
+        top_k: int = 5,
+    ) -> Optional[Dict[str, Any]]:
+        """Find the best-matching existing concept for an external concept.
+
+        Given an external concept dict carrying an ``embedding`` (and optionally
+        a ``label``), search the target graph for the most similar existing
+        concept above threshold using the canonical two-tier policy:
+
+        1. Search candidates at the (lower) label-boost threshold via
+           ``client.vector_search``.
+        2. Walk candidates best-first; accept the first whose similarity is
+           ``>= strict_threshold``, or whose similarity is
+           ``>= label_boost_threshold`` *and* whose label matches the incoming
+           concept's label.
+
+        This method does not generate embeddings: a concept without an
+        ``embedding`` key cannot be matched and returns ``None``. (Per ADR-102
+        §6, embedding rehydration must run before integration matching.)
+
+        Args:
+            external_concept: Incoming concept metadata. Recognized keys:
+                ``embedding`` (List[float], required for matching) and
+                ``label`` (str, used for the label-boost tier).
+            top_k: Maximum candidates to retrieve from the vector search.
+
+        Returns:
+            A dict ``{"concept_id", "label", "similarity"}`` for the best match,
+            or ``None`` if no candidate meets the matching policy.
+
+        @verified 72ba3d3b
+        """
+        embedding = external_concept.get("embedding")
+        if not embedding:
+            # No embedding → cannot perform similarity matching. Label-only
+            # matching is intentionally unsupported (no embedding generation).
+            label = external_concept.get("label")
+            if label:
+                logger.debug(
+                    "ConceptMatcher: concept '%s' has no embedding; cannot "
+                    "match by similarity (embedding rehydration required)",
+                    label,
+                )
+            return None
+
+        incoming_label = external_concept.get("label")
+
+        # Retrieve candidates at the lower threshold so label-boosted matches
+        # in [0.75, 0.85) are visible. vector_search returns results sorted by
+        # similarity descending.
+        try:
+            candidates = self.client.vector_search(
+                embedding=embedding,
+                threshold=self.label_boost_threshold,
+                top_k=top_k,
+            )
+        except Exception as e:
+            logger.warning("ConceptMatcher: vector search failed: %s", e)
+            return None
+
+        if not candidates:
+            return None
+
+        for candidate in candidates:
+            similarity = candidate["similarity"]
+            candidate_label = candidate.get("label")
+
+            if similarity >= self.strict_threshold:
+                matched = True
+            elif similarity >= self.label_boost_threshold and _labels_match(
+                incoming_label, candidate_label
+            ):
+                matched = True
+                logger.info(
+                    "ConceptMatcher: label-boosted match '%s' -> '%s' at %.1f%%",
+                    incoming_label,
+                    candidate_label,
+                    similarity * 100,
+                )
+            else:
+                matched = False
+
+            if matched:
+                return {
+                    "concept_id": candidate["concept_id"],
+                    "label": candidate_label,
+                    "similarity": similarity,
+                }
+
+        return None
+
+
+__all__ = ["ConceptMatcher", "STRICT_THRESHOLD", "LABEL_BOOST_THRESHOLD"]

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -35,6 +35,7 @@ _Containers, deployment, backup, storage, networking_
 | [ADR-088](./infrastructure/ADR-088-semantic-election-protocol.md) | Semantic Election Protocol for Distributed Concept Placement | Proposed |
 | [ADR-100](./infrastructure/ADR-100-database-driven-job-dispatch.md) | Database-Driven Job Dispatch | Accepted |
 | [ADR-101](./infrastructure/ADR-101-rocm-image-variant-and-install-time-selection.md) | ROCm Image Variant and Install-Time Selection | Accepted |
+| [ADR-102](./infrastructure/ADR-102-portable-backup-and-restore-with-clone-merge-semantics.md) | Portable Backup and Restore with Clone/Merge Semantics | Accepted |
 
 ## Database/Schema
 _Apache AGE, migrations, schema design, PostgreSQL_

--- a/docs/architecture/infrastructure/ADR-102-portable-backup-and-restore-with-clone-merge-semantics.md
+++ b/docs/architecture/infrastructure/ADR-102-portable-backup-and-restore-with-clone-merge-semantics.md
@@ -1,0 +1,470 @@
+---
+status: Accepted
+date: 2026-06-01
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-015
+  - ADR-079
+  - ADR-083
+  - ADR-203
+  - ADR-205
+  - ADR-207
+---
+
+# ADR-102: Portable Backup and Restore with Clone/Merge Semantics
+
+## Context
+
+We want to fully export the graph (nodes, edges, properties) **and its source media**
+(documents, images, any ingested media) out of a running system and round-trip them
+back into a system — the same one, or a different one — under explicit, user-chosen
+reconciliation rules. Derived products (projections, scores) are deliberately *not*
+part of this payload; they recompute from the restored graph. The existing machinery
+does not deliver this.
+
+### What exists today
+
+- **Logical JSON path** — `DataExporter`/`DataImporter` (`api/lib/serialization.py`)
+  export concepts/sources/instances/relationships/vocabulary with their
+  app-assigned string IDs preserved, and an `overwrite_existing` flag. This is the
+  spine we build on.
+- **Archive path** — `api/app/lib/backup_archive.py` packages the JSON manifest plus
+  Garage document bytes into a `.tar.gz`.
+- **Restore worker** — `api/app/workers/restore_worker.py` adds checkpoint + rollback
+  safety and calls `record_mutation` to advance the freshness clock after a restore.
+- **Semantic re-stitch** — `api/lib/restitching.py` `ConceptMatcher` already performs
+  an O(n) cosine-similarity scan to attach incoming concepts to existing ones
+  (0.85 strict / 0.75 label-boosted, no LLM). This is the engine for integration mode.
+- **Physical path** — `operator/database/{backup,restore}-database.sh` wrap
+  `pg_dump`/`pg_restore`.
+
+### Why it is not viable as a faithful round-trip
+
+1. **Epochs are dropped.** Export emits none of `created_at_epoch` / `last_seen_epoch`
+   (Concepts) or `created_at_event_id` (Instances, FK to `kg_api.graph_epochs`,
+   ADR-203). On restore, instances land with NULL event IDs, collapsing the
+   re-evidence/lifetime ordering; a restore that records an epoch event but fails to
+   complete it can stall the `get_committed_epoch()` watermark (ADR-207).
+2. **No mode machinery.** `overwrite_existing` is a single boolean. There is no way to
+   create a non-colliding parallel namespace, and no way to merge by similarity.
+3. **`pg_dump` cannot do any of this.** It is all-or-nothing table replacement — no
+   merge, no remap — and AGE graph identity is OID-coupled, so logical
+   dump/restore does **not** survive cross-cluster (ADR-205). This is an Apache AGE
+   limitation we do not own.
+4. **Open correctness bugs.** `restore-database.sh` reports success when `pg_restore`
+   fails (#397, the `| grep` swallows the real exit code) and `pg_restore --clean`
+   aborts on AGE label tables (#398). No restore is trustworthy until these are fixed.
+
+### Two facts that shape the design
+
+- **We control every storage key.** No Garage object key is auto-assigned. Keys are
+  deterministic functions of app-assigned IDs: `artifacts/{type}/{id}.json` (Postgres
+  `SERIAL`), `sources/{ontology}/{sha256[:32]}.{ext}` (content hash),
+  `images/{ontology}/{source_id}.{ext}`, `projections/{ontology}/{source}/{ts}.json`.
+  Therefore restore **reconstructs** keys from restored IDs rather than tracking them;
+  transposition is a *mode we offer*, never a constraint the bucket forces.
+- **Identities split into preservable and irrelevant.** App-assigned string properties
+  (`concept_id`, `source_id`, `instance_id`, `ontology_id`) are fully preservable — a
+  restore simply sets the property. AGE's internal `id()`/`graphid` is OID-coupled and
+  **not** preservable, but the application never references it, so its loss is
+  immaterial. (Artifact `id` is a Postgres `SERIAL`, but artifacts are derived products
+  that are not restored — see §4 — so its preservation is moot.)
+
+## Decision
+
+Make the **logical/portable archive the product**, supporting a full faithful
+round-trip with explicit reconciliation. Relegate `pg_dump`/`pg_restore` to
+same-version, same-cluster, empty-target disaster recovery, and fix #397/#398 there.
+
+### 1. The governing discriminator is target emptiness, not the restore mode
+
+A restore inspects whether the target graph is empty and bifurcates:
+
+```
+CLONE  (empty target)         → high-fidelity reconstruction
+  • app-assigned IDs preserved 1:1
+  • epoch log replayed (faithful) — coherent only here
+  • source media restored as-is; derived products regenerate
+
+MERGE  (populated target)     → idempotent | adjacent | integration
+  • IDs preserved / remapped / similarity-matched (per chosen mode)
+  • epoch = simple (one restore event)
+  • derived products regenerate (never carried in the backup)
+```
+
+The rationale is a single invariant: **a derived product is a function of global
+graph state.** A polarity analysis, grounding score, or projection computed on the
+source describes the source's *entire* graph. Introduce *any* foreign node into the
+target and every such product's basis has changed — so all of them are invalid
+wholesale, regardless of restore mode. Source media and the graph itself are *primary
+inputs* — irreplaceable, and round-tripped in every mode. Derived products are
+*recomputable* from those inputs, so they are not carried in the backup at all; they
+regenerate after restore (see §4). The one faithful behaviour that survives only the
+clone case is epoch-log replay, which is coherent only when identity is preserved
+1:1. Emptiness is detected once and gates it.
+
+### 2. Restore modes (apply to MERGE; govern UID-collision behaviour for graph objects)
+
+- **Idempotent** — On UID collision, `MERGE` then `SET` (update in place, no append,
+  no mutation of identity). Extends today's `overwrite_existing=True`.
+- **Adjacent, no integration** — On collision, mint a new UID and record the old→new
+  pair in a persisted mapping table covering concept/source/instance/ontology IDs. All
+  internal references (relationship endpoints, instance↔concept↔source links) are
+  rewritten through the map on import. Produces a non-colliding parallel namespace.
+  (No artifact IDs participate — derived products are not restored; see §4.)
+- **Adjacent, with integration** — Wire `ConceptMatcher` (`restitching.py`) to attach
+  incoming concepts to existing target concepts by cosine similarity, no LLM. Concepts
+  below threshold fall through to adjacent (new UID). Evidence (instances/sources) of a
+  matched concept attaches to the existing target concept.
+
+### 3. Epoch reconciliation
+
+- **Export** adds `created_at_epoch` / `last_seen_epoch` (Concepts),
+  `created_at_event_id` (Instances), and — for faithful mode — the `kg_api.graph_epochs`
+  log rows.
+- **Simple** (default; the only mode valid for MERGE): record one `graph_epochs` event
+  for the whole restore, stamp every imported instance with that event ID, and
+  `complete_epoch` it (never leave it `in_progress`).
+- **Faithful** (CLONE only): recreate the source's `graph_epochs` rows as new event IDs
+  in the target range, preserving `occurred_at`/`kind`/ordering, and remap each
+  instance's `created_at_event_id` through an event-ID map. Gated to the empty-target
+  case, where identity is preserved and the replay is coherent.
+
+The flag interface (`--epoch-mode simple|faithful`) ships day one; `simple` is
+implemented first (valid everywhere), `faithful` is a scoped fast-follow.
+
+### 4. What travels: primary inputs in, derived products out
+
+The backup carries **primary inputs only** — the irreplaceable data that cannot be
+recomputed. Everything derived is regenerated after restore and is never serialized.
+
+**In scope (backed up and restored in every mode):**
+
+- Graph nodes, edges, and properties (including epoch stamps and embedding vectors —
+  embeddings travel as node properties, but may be recomputed on restore if the target's
+  embedding profile differs; see §6).
+- The `kg_api.graph_epochs` log rows (faithful epoch mode only).
+- Source documents (text) — content-addressed.
+- **Images and any other source media** (the raw ingested bytes — irreplaceable
+  primary input, stored under content/`source_id`-derived keys).
+- Vocabulary (`kg_api.relationship_vocabulary` + the `:VocabType`/`:VocabCategory`
+  nodes).
+
+**Out of scope (NOT backed up — regenerated from the restored graph):**
+
+- **Projections** (ADR-079, `projections/...`) — derived embedding-landscape snapshots.
+- **Artifacts / scores** (ADR-083, `artifacts/...`) — polarity analyses, grounding
+  results, and other computed derivations.
+- Grounding caches and the catalog index.
+
+The discriminator is *input vs. derivation*: source media is an input the LLM consumed,
+so losing it loses information; a projection or score is a pure function of the graph,
+so it is cheaper and *more correct* to recompute it against the restored graph than to
+carry a stale copy. The existing freshness machinery makes regeneration automatic — a
+restore advances the global epoch via `record_mutation`, so any derivation is recomputed
+on next access against the true post-restore state.
+
+**Explicitly eliminated** by excluding derived products from the backup: the
+per-artifact-type concept-ID payload rewriter the naïve "remap artifacts with the graph"
+design would have required. There are no derived payloads in the archive, so there is
+nothing to rewrite — removing the single most fragile, highest-maintenance component.
+
+> **Consistency note (decided).** An earlier round selected "include artifacts + remap
+> with the graph." That is superseded: artifacts/scores fall under the derived-products
+> invariant above and are treated exactly like projections — excluded and regenerated —
+> so the rule is uniform across *all* derivations, with no special case for the clone
+> path. Regenerating them after restore (§6) is both correct (recomputed against the
+> true post-restore graph) and simpler (no payload rewriter). If retaining artifact
+> *bytes* for the clone case ever proves worth the recompute cost, that is a narrow,
+> additive follow-up; the default is regenerate.
+
+### 5. The backup is a self-describing, versioned object with a declarative header
+
+A backup must be interpretable by a destination that shares none of the source's
+internal indices. The anti-coupling principle that rules out AGE OIDs (Context) applies
+to the *serialization* too: nothing in the payload may reference a source-local index
+whose meaning the destination cannot reconstruct. Storing "embedding config = row 7" is
+the OID mistake one layer down — row 7 is meaningless, or means something different, on
+the target. The format is therefore self-describing.
+
+**A declarative metadata header precedes the bulk records.** The header is a dictionary
+of portable, human-meaningful descriptors — declared once as actual strings, never as a
+source-platform index:
+
+- **embedding profile(s)** — the model identity string and dimensionality (e.g.
+  `openai:text-embedding-3-small@1536`), not the source's internal embedding-config row
+  id. This is the exact value §6's rehydration reads to decide recompute-vs-keep.
+- **schema / format version**, source platform + version, export timestamp.
+- **relationship vocabulary**, **epoch kinds**, **actors**, **ontology descriptors** —
+  any value that would otherwise repeat across many records.
+
+**Bulk records reference the header by compact local index, not by repeating the
+string.** A concept's embedding carries a small reference to the header's embedding-
+profile entry instead of restating the model string tens of thousands of times
+(dictionary/interning encoding). References **cascade**: a default declared at a parent
+scope (backup → ontology) is inherited, and a record states only its *override*. A
+backup with one uniform embedding profile declares it once at the top; a mixed backup
+declares per-ontology.
+
+**The byte-level schema is NOT defined in this ADR.** It is its own living artifact — a
+versioned **Backup Object Specification** authored and maintained during the build, kept
+as the authoritative reference and ideally discoverable via API (e.g. a format-version
+endpoint) so producer and consumer negotiate compatibility. This ADR fixes the
+*principles* — self-describing; portable strings, never source indices; a normalized
+header with cascading local references; an explicit version carried in the header — and
+requires the spec to exist. The spec fixes the bytes.
+
+### 6. Post-restore rehydration: regenerating derived state
+
+Because derived products are excluded (§4), a restore is not finished when the primary
+data lands — the graph must be *rehydrated*: its derivations recomputed against the
+restored state. Restore therefore ends with a rehydration phase that re-triggers three
+derivation passes. Each is a toggle whose default performs it, so a default restore
+yields a fully usable graph:
+
+- **Embeddings** — default *auto*. Embeddings travel in the backup (node properties), so
+  a clone into a target with the same embedding profile keeps them. But if the target's
+  embedding profile differs (model/dimensions — see ADR-803 and the embedding-profile
+  system), the carried vectors are in the wrong space and MUST be regenerated; `auto`
+  detects the mismatch and recomputes only then. **Hard dependency:** integration mode
+  (§2) matches incoming concepts by cosine similarity and therefore requires target-space
+  embeddings — on a detected profile mismatch, embeddings are recomputed *before*
+  integration matching runs, otherwise integration mode is rejected.
+- **Vocabulary management** — default on. Imported relationship vocabulary is reconciled
+  against the target's: new types embedded, synonyms consolidated, the vocab refreshed
+  (the existing vocab consolidate / embedding / refresh workers). Cheap and
+  correctness-bearing, so on by default.
+- **Scores** — default on (eager warm-up); may be set lazy. Polarity, grounding, and
+  epistemic scores recompute over the settled graph. The freshness machinery already
+  marks them stale post-restore (§4), so *lazy* simply lets them regenerate on first
+  access; the eager default proactively warms them so the restored graph is query-ready.
+
+**Ordering is a dependency chain, not a preference: embeddings → vocabulary → scores.**
+Scores depend on embeddings and settled vocabulary; integration-mode matching depends on
+embeddings. Rehydration runs after the structural import and is the controlled
+counterpart to worker quiescence (§8): the lanes frozen for the critical section are
+re-enabled and kicked in this order, scoped to the restored data.
+
+**Out of scope here:** the concrete request/response **DTO shape** of the
+backup/restore endpoints (which flags, their JSON names, response envelopes). That is an
+API-contract/implementation concern to settle during the build — possibly its own small
+follow-up — not an architectural decision. This ADR fixes only that these passes
+*exist*, their *defaults*, and their *dependency ordering*.
+
+### 7. Storage is engine-agnostic; key collisions are a projection of ID collisions
+
+Garage is one S3-compatible target and may be swapped (MinIO, AWS S3, a filesystem
+backend). Backup/restore must therefore never embed Garage specifics. Two rules:
+
+- **All object I/O goes through the abstract object-store port** — the verbs already
+  exposed by `GarageBaseClient` (`put_object` / `get_object` / `list_objects` /
+  `head_object` / `delete_object` / `delete_by_prefix`). Restore calls these, never a
+  storage SDK and never a hardcoded bucket assumption. The orphan/reference
+  reconciliation this enables (cf. #202/#188) is likewise just `list_objects(prefix)`
+  cross-checked against the graph — storage-engine-agnostic by construction.
+- **Key construction stays owned by the storage-domain layer** (`_build_key` in each
+  storage service) and is *reused* by restore, not re-implemented. Restore reconstructs
+  a key from a (possibly remapped) ID by calling the same scheme function the writer
+  uses.
+
+The consequence is that **a storage-key collision is never an independent event — it
+is the shadow of an ID collision**, and the chosen restore mode already resolves it:
+
+Only **primary inputs** are restored, so only their keys can collide. Derived products
+(`artifacts/...`, `projections/...`) are never written by restore — they regenerate —
+so they cannot collide at all and are absent from this table.
+
+| Restored object | Key derivation | idempotent (ID kept) | adjacent (ID remapped) |
+|---|---|---|---|
+| image / source media | `images/{ontology}/{source_id}` | same key → overwrite in place | new `source_id` → new key |
+| source document | `sources/{ontology}/{sha256[:32]}` | content-addressed: same key ⇒ same content ⇒ benign dedup | content-addressed: dedups regardless of graph remap |
+
+Therefore **no separate storage-key mapping table exists**: the graph-ID mapping
+(Decision §2, adjacent mode) is the single source of truth, and media keys are
+re-derived from the (possibly remapped) IDs. Note that content-addressed source/media
+keys are *immune* to ID remapping — identical bytes always resolve to the same key, so
+adjacent mode dedups them rather than duplicating. Overwrite-vs-mint is decided by an
+existence check expressed in port primitives (`head_object`), not by inspecting Garage.
+
+This ADR does not require swapping the backend, but it does require the restore code to
+depend only on the port. A recommended (non-blocking) follow-up is to **formalize the
+port as an explicit `ObjectStore` interface that `GarageBaseClient` implements** — the
+seam exists de facto today (clean S3-shaped verbs) but is not named, so a future swap
+relies on convention rather than a typed contract.
+
+### 8. Backup is concurrent-safe; restore requires worker quiescence
+
+The two operations are fundamentally asymmetric:
+
+- **Backup is read-only and non-interfering.** It enumerates the IDs of every
+  qualifying object and serializes the data behind them. Run inside a single
+  repeatable-read transaction it gets an MVCC-consistent snapshot, so it needs **no
+  freeze** — workers may continue mutating; the snapshot is unaffected.
+- **Restore fundamentally breaks the graph during the pass.** It is a foreign bulk
+  import that passes through transiently inconsistent states (a concept exists before
+  its edges; a remapped ID is half-rewritten; instances precede their epoch stamp).
+  Other lanes will actively interfere with — or react destructively to — these
+  intermediate states:
+  - **ingestion** — concurrent foreign writes race the import and can collide on UIDs
+    or, in integration mode, change the candidate set mid-similarity-scan, making
+    matching non-deterministic;
+  - **annealing** — promotes/demotes/merges concepts based on graph state and would
+    act on a half-imported graph;
+  - **integrity/healing** (#241) — would "heal" deliberately-transient incomplete
+    structures;
+  - **artifact cleanup** (#202) — would reap objects mid-restore as "orphaned."
+
+  A restore therefore runs as a **bounded critical section** that freezes the
+  interfering lanes for its duration and thaws them afterward, using the lane control
+  shipped in `lane_manager.py` (per-lane `enabled` flag, `PATCH
+  /admin/workers/lanes/{name}`; "Frozen" pill in the web UI). Freezing also keeps the
+  epoch watermark clean: with ingestion paused, the restore's `graph_epochs` event is
+  the only in-flight one, so `get_committed_epoch()` cannot stall on an interleaved
+  foreign event.
+
+  The freeze set scales with how invasive the restore is. **Clone** into an empty
+  target still freezes (intermediate states would trip annealing/integrity if those
+  lanes are running), but the embedding lane is a *dependency*, not interference, for
+  **integration** mode and is left thawed. The exact per-mode freeze set is an
+  implementation detail to be pinned during build and verified by an adversarial
+  "run a worker mid-restore" test; the invariant is that no lane observes or mutates
+  the graph inside the critical section except the restore itself.
+
+### 9. One supported path; superseded code is deleted, not parked
+
+This ADR defines *the* portable backup/restore path. Implementing it means **removing
+the implementations it supersedes in the same PR series** — the tree must never carry
+two restore systems at once. The rationale is not tidiness but safety: parallel,
+half-working restore code is precisely how an operator reaches for the wrong tool and
+loses data — the failure shape of #397. A superseded path left "just in case" is a
+loaded footgun, and the backup we now guarantee is the actual safety net.
+
+Method (not a guessed file list — the authoritative kill-list comes from tracing
+imports, as the workflow's first phase):
+
+- **Retained, explicitly NOT purged:** the operator `pg_dump`/`pg_restore` DR scripts
+  (`operator/database/{backup,restore}-database.sh`). They are *narrowed* to
+  same-version/same-cluster/empty-target DR and *bug-fixed* (#397/#398), not removed.
+  This carve-out is stated so a later cleanup does not delete them as "redundant."
+- **Audit then delete:** the backup/restore surface is currently spread across three
+  trees — `api/lib/` (`serialization.py`, `restitching.py`, `integrity.py`),
+  `api/app/lib/` (`backup_archive.py`, `backup_integrity.py`, `backup_streaming.py`,
+  `gexf_exporter.py`), and `api/admin/` (`backup.py`, `restore.py`, `stitch.py`), plus
+  routes and the `kg` CLI. The `api/lib/` vs `api/app/lib/` split is a strong signal of
+  old-path/new-path coexistence (e.g. `api/lib/integrity.py` vs
+  `api/app/lib/backup_integrity.py`; `api/admin/stitch.py` vs `api/lib/restitching.py`).
+  The first implementation phase produces an import-traced inventory marking each
+  module **keep / fold-into-new / delete**, and deletions land alongside the code that
+  replaces them.
+- **Reconcile the prior ADR:** ADR-015 (Backup/Restore Streaming Architecture) is at
+  least partly superseded by this decision. The audit determines whether its
+  streaming-transport mechanism is retained under the new path or fully replaced, and
+  ADR-015's status is updated accordingly (Superseded, or amended) when this lands —
+  rather than blanket-flipping it now on assumption.
+
+### 10. Bug fixes folded in
+
+- **#397** — capture `pg_restore`'s real exit status (`set -o pipefail` / `PIPESTATUS`)
+  and verify post-restore counts.
+- **#398** — restore into a genuinely empty database (DROP/CREATE then restore without
+  `--clean`) or `drop_graph()` before a `--clean` restore.
+
+## Consequences
+
+### Positive
+
+- True round-trip of all primary inputs: graph + epochs + source documents + images and
+  other source media, IDs preserved. Derived products regenerate against the restored
+  graph — more correct than carrying stale copies.
+- Three explicit, well-defined merge behaviours instead of one opaque boolean.
+- Cross-cluster portability via the logical path, sidestepping AGE OID coupling.
+- The self-describing, versioned format makes backups portable across platforms with
+  different internal indices and even different embedding configs (the declared profile
+  drives recompute), and the normalized header keeps repeated descriptors out of the
+  bulk (one interned string, not tens of thousands).
+- The fragile per-type artifact rewriter is designed out, not merely deferred.
+- Reuses existing engines (`DataExporter/Importer`, `ConceptMatcher`, restore worker,
+  epoch/freshness machinery); the genuinely new surface is the ID-remap/mapping layer
+  and epoch reconciliation.
+- Two long-standing restore bugs (#397/#398) get fixed as a precondition.
+- The backup/restore surface collapses from three overlapping trees to one supported
+  path; the wrong-tool data-loss footgun is removed rather than left loaded.
+
+### Negative
+
+- The ID-remap layer must rewrite *every* internal reference class; a missed class
+  silently orphans relationships. Demands exhaustive reference enumeration + tests.
+- Faithful epoch replay is real complexity (event-ID map + contiguous-watermark proof),
+  even though it is scoped to clone-only and sequenced as a fast-follow.
+- Adjacent mode's mapping table is new persisted state with its own lifecycle.
+- Deleting superseded modules demands careful import-tracing; an over-eager deletion
+  could remove a still-referenced path. The keep/fold/delete inventory is the guard.
+
+### Neutral
+
+- `pg_dump`/`pg_restore` remains, narrowed to same-cluster DR; it is no longer the
+  cross-cluster story.
+- Backups stay lean: only primary inputs travel (graph, epoch log, source media);
+  derived products (projections, scores) are excluded and regenerate post-restore.
+- Target-emptiness detection becomes a load-bearing precondition check at restore time.
+- Restore becomes a maintenance-window operation: it freezes interfering lanes for the
+  duration of the critical section. Backup carries no such cost and stays online.
+
+## Future Direction: Shard Data Exchange (north star, not in scope)
+
+This is explicitly *not* what we are building now, but the endpoints defined here are
+intended to become the data-plane primitives for the distributed sharding research
+(`docs/manual/06-reference/08-DISTRIBUTED_SHARDING_RESEARCH.md`). The alignment is
+direct enough to record so we don't design against it:
+
+- **The portable archive is the shard interchange wire format.** Shards are separate
+  AGE clusters, so AGE's OID coupling (ADR-205) rules out physical transfer between
+  them — the logical/portable path is the *only* viable shard-to-shard channel. A
+  rebalance is literally "export ontology from shard A, import into shard B."
+- **The three restore modes are the three cross-shard data operations:**
+  - *adjacent + mapping table* = **move an ontology to a new shard**, minting fresh
+    IDs in the destination namespace while preserving referential integrity — the
+    research's "re-upsert to better shard" / `move_ontology` (Patterns 3 & 5);
+  - *integration (cosine attach)* = **arrival-side dedup for hub-concept replication**
+    — when a vertex-cut replica lands on a shard that already holds that hub concept
+    (Pattern 4), integration mode is the attach-to-existing primitive;
+  - *idempotent* = **replica sync** — push the authoritative copy, update-in-place on
+    collision (`ConceptReplicator.sync_updates`).
+- **The ID-remap/mapping table is the cross-shard identity layer.** The old→new map
+  adjacent mode persists is the same structure that tracks primary-shard ↔ replica
+  identity for the research's `cross_shard_references`.
+- **Epoch reconciliation prefigures the distributed logical clock.** Each shard owns
+  an independent monotonic `graph_epochs` counter; faithful mode's event-ID remapping
+  into a target range is the seed of per-shard logical clocks / vector-clock freshness
+  across a federation.
+- **Worker quiescence is the shard-migration consistency window.** Freezing the source
+  ontology's lanes, exporting, importing to the target, then thawing is exactly the
+  primitive an online ontology move between shards requires.
+
+In short: the sharding research's router is the *control plane* (FENNEL-style routing,
+coherence monitoring); this ADR builds the *data plane* that control plane would
+command. Building backup/restore well now is building shard exchange later.
+
+## Alternatives Considered
+
+- **Invest equally in `pg_dump` cross-cluster restore.** Rejected: AGE OID coupling
+  (ADR-205) is not ours to fix, and `pg_dump` cannot express merge/remap semantics.
+- **Single epoch strategy only (simple everywhere).** Rejected as the *sole* option: a
+  true clone/DR target legitimately wants the source's temporal ordering preserved.
+  Adopted as the default and the only MERGE option; faithful is the clone-only addition.
+- **Remap-and-keep derived products in all modes** (per-type payload rewriter).
+  Rejected: a derived score is invalid once the target graph differs at all, so a
+  remapped score presents as fresh while describing a graph state that no longer exists
+  — silent corruption. The rewriter is also the highest-maintenance component (one per
+  payload schema). Excluding derived products and regenerating them is both correct and
+  simpler.
+- **Keep derived-product bytes for the clone case only.** Considered and not adopted as
+  the default: it splits the rule (carry-on-clone vs regenerate-on-merge) and reintroduces
+  format/versioning concerns for payloads that recompute cheaply against the restored
+  graph. Uniform "exclude and regenerate" was chosen instead; retaining clone-only bytes
+  remains an additive follow-up if a specific derivation proves expensive to recompute.
+- **Back up source media as derived/optional.** Rejected: images and ingested media are
+  *primary inputs* the model consumed, not recomputable — losing them loses information.
+  They are always backed up and restored, in every mode.

--- a/docs/architecture/infrastructure/ADR-102-portable-backup-and-restore-with-clone-merge-semantics.md
+++ b/docs/architecture/infrastructure/ADR-102-portable-backup-and-restore-with-clone-merge-semantics.md
@@ -35,8 +35,10 @@ does not deliver this.
 - **Restore worker** — `api/app/workers/restore_worker.py` adds checkpoint + rollback
   safety and calls `record_mutation` to advance the freshness clock after a restore.
 - **Semantic re-stitch** — `api/lib/restitching.py` `ConceptMatcher` already performs
-  an O(n) cosine-similarity scan to attach incoming concepts to existing ones
-  (0.85 strict / 0.75 label-boosted, no LLM). This is the engine for integration mode.
+  an O(n) cosine-similarity scan to attach incoming concepts to existing ones, no LLM.
+  It is the engine for integration mode. (The legacy matcher uses a single 0.85
+  threshold; integration mode adopts the canonical two-tier ingestion policy —
+  0.85 strict / 0.75 label-boosted, `ingestion.py:432-461` — when the engine is ported.)
 - **Physical path** — `operator/database/{backup,restore}-database.sh` wrap
   `pg_dump`/`pg_restore`.
 

--- a/docs/reference/BACKUP_OBJECT_SPEC.md
+++ b/docs/reference/BACKUP_OBJECT_SPEC.md
@@ -1,0 +1,449 @@
+# Backup Object Specification
+
+**Status:** Draft
+**Format version:** `kg-backup/2`
+**Authority:** This document is the authoritative byte-level reference for the
+portable backup object. It is the living artifact required by
+[ADR-102](../architecture/infrastructure/ADR-102-portable-backup-and-restore-with-clone-merge-semantics.md)
+§5 ("The backup is a self-describing, versioned object with a declarative
+header"). ADR-102 fixes the *principles*; this spec fixes the *bytes*.
+
+---
+
+## 1. Purpose and scope
+
+A backup object is a **portable, self-describing serialization** of a knowledge
+graph's *primary inputs* — the irreplaceable data that cannot be recomputed. It
+is designed to round-trip into a destination that shares **none** of the
+source's internal indices: a different PostgreSQL cluster, a different platform
+version, even a different embedding configuration.
+
+The governing anti-coupling principle (ADR-102 Context, §5): **nothing in the
+payload may reference a source-local index whose meaning the destination cannot
+reconstruct.** AGE's internal `id()`/`graphid` is OID-coupled and never appears;
+neither does any source-platform row id (e.g. "embedding profile = row 7" — that
+is the OID mistake one layer down). All identity is carried as either an
+app-assigned string id (`concept_id`, `source_id`, …) or a portable,
+human-meaningful descriptor declared in the header.
+
+This spec defines the **logical object**: the header, the dictionaries, and the
+bulk record shapes. It is transport- and container-agnostic — the same logical
+object is what the JSON manifest carries and what the `.tar.gz` archive
+(`backup_archive.py`) wraps alongside Garage media bytes.
+
+---
+
+## 2. Top-level structure
+
+A backup object is a single document with two regions in order:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ HEADER  — declarative dictionary of portable descriptors,     │
+│           declared ONCE (format version, source, profiles,    │
+│           vocabulary, epoch_kinds, actors, ontologies, schema) │
+├──────────────────────────────────────────────────────────────┤
+│ BULK    — record streams that reference HEADER entries by      │
+│           compact integer index, NEVER by repeating strings    │
+│           (concepts, sources, instances, relationships,        │
+│            vocabulary, graph_epochs)                           │
+└──────────────────────────────────────────────────────────────┘
+```
+
+```json
+{
+  "header": { ... },
+  "bulk":   { ... }
+}
+```
+
+The HEADER is read in full *before* any bulk record, so every dictionary a bulk
+record might reference is already resolved. A consumer that cannot interpret the
+HEADER (see §7) MUST refuse the object rather than partially apply the bulk.
+
+---
+
+## 3. HEADER
+
+The HEADER is a dictionary of portable descriptors, each declared exactly once.
+Repeated values that would otherwise appear across tens of thousands of bulk
+records live here as **dictionaries**; bulk records cite them by integer index
+(§4).
+
+```json
+{
+  "header": {
+    "format_version": "kg-backup/2",
+
+    "source": {
+      "platform": "knowledge-graph-system",
+      "version":  "1.7.3"
+    },
+
+    "exported_at": "2026-06-01T17:42:08Z",
+
+    "schema_version": 76,
+
+    "embedding_profiles": [
+      {
+        "identity":           "openai:text-embedding-3-small@1536",
+        "vector_space":       "openai-3-small",
+        "image_vector_space": null,
+        "name":               "default-openai",
+        "multimodal":         false
+      },
+      {
+        "identity":           "nomic:nomic-embed-text-v1.5@768",
+        "vector_space":       "nomic-v1.5",
+        "image_vector_space": "siglip2-base@1024",
+        "name":               "local-multimodal-rig",
+        "multimodal":         false
+      }
+    ],
+
+    "default_embedding_profile": 0,
+
+    "relationship_vocabulary": [
+      {
+        "relationship_type":  "IMPLIES",
+        "description":        "...",
+        "category":           "logical",
+        "added_by":           "system",
+        "added_at":           "2026-01-04T00:00:00Z",
+        "usage_count":        4210,
+        "is_active":          true,
+        "is_builtin":         true,
+        "synonyms":           null,
+        "deprecation_reason": null,
+        "direction_semantics":"directional",
+        "embedding_model":    "openai:text-embedding-3-small@1536",
+        "embedding_generated_at": "2026-01-04T00:00:00Z",
+        "embedding":          [ 0.013, -0.041, ... ]
+      }
+    ],
+
+    "epoch_kinds": [
+      { "kind": "ingestion", "semantic_wallclock": true,  "description": "..." },
+      { "kind": "edit",      "semantic_wallclock": true,  "description": "..." },
+      { "kind": "reasoning", "semantic_wallclock": false, "description": "..." },
+      { "kind": "annealing", "semantic_wallclock": false, "description": "..." }
+    ],
+
+    "actors": [
+      "system",
+      "user:aaronsb",
+      "agent:session-9f3c"
+    ],
+
+    "content_types": [
+      "text/plain",
+      "application/pdf",
+      "image/png"
+    ],
+
+    "ontologies": [
+      {
+        "name":                      "Philosophy Corpus",
+        "default_embedding_profile": 0
+      },
+      {
+        "name":                      "Vision Notes",
+        "default_embedding_profile": 1
+      }
+    ]
+  }
+}
+```
+
+### 3.1 Field reference
+
+| Field | Type | Meaning |
+|---|---|---|
+| `format_version` | string | Always `kg-backup/2` for this spec. The single negotiation token (§7). |
+| `source.platform` | string | Producing platform identifier. |
+| `source.version` | string | Producing platform version (informational; not used for gating). |
+| `exported_at` | string | Export instant, ISO-8601 with explicit `Z` (UTC). |
+| `schema_version` | integer | Highest applied DB migration at export (the value `BackupFormat.get_schema_version` reads from `kg_api.schema_migrations`). Informational compatibility hint. |
+| `embedding_profiles[]` | array | Portable embedding-profile descriptors (§3.2). The dictionary that concept/vocabulary embeddings reference by index. |
+| `default_embedding_profile` | integer | Backup-level default profile index — top of the cascade (§4.1). |
+| `relationship_vocabulary[]` | array | Vocabulary dictionary; also the bulk `vocabulary` rows (§5.5). Edge `type` refs index into this array. |
+| `epoch_kinds[]` | array | The `kg_api.graph_epoch_kinds` lookup rows (migration 064). |
+| `actors[]` | array of strings | Distinct actor identifiers referenced by epoch rows, interned. |
+| `content_types[]` | array of strings | Distinct MIME types referenced by sources, interned. |
+| `ontologies[]` | array | Ontology descriptors, each with its own default embedding-profile index (§4.1). |
+
+### 3.2 Embedding-profile identity string
+
+Each `embedding_profiles[]` entry is a **portable identity**, never a
+source-local row id. The canonical identity string is:
+
+```
+{provider}:{model}@{dims}
+```
+
+e.g. `openai:text-embedding-3-small@1536`, `nomic:nomic-embed-text-v1.5@768`.
+This is the value ADR-102 §6 reads to decide *keep-vs-recompute* on restore: if
+the target's active profile resolves to the same identity, carried vectors are
+kept; if not, they are in the wrong space and MUST be regenerated.
+
+The descriptor is derived from `export_embedding_profile()`
+(`api/app/lib/embedding_config.py`) and the `kg_api.embedding_profile` schema
+(migrations 055 and 075):
+
+| Profile field | Source |
+|---|---|
+| `identity` | `{text_provider}:{text_model_name}@{text_dimensions}` (the universal text/prose space — ADR-803, migration 075). |
+| `vector_space` | `embedding_profile.vector_space` — compatibility key for the universal **text** space. Two profiles with the same `vector_space` produce comparable text embeddings. |
+| `image_vector_space` | `embedding_profile.image_vector_space` (migration 075). The **independent** same-modality image-index space, formatted `{image_provider}:{image_model_name}@{image_dimensions}` (or its `vector_space` tag). `null` for text-only / multimodal profiles. **Never** compared to the text `vector_space`. |
+| `name` | `embedding_profile.name` (informational, not an identity). |
+| `multimodal` | `embedding_profile.multimodal` — when true the text model also serves the image role and `image_vector_space` is `null`. |
+
+> **Why two spaces.** ADR-803 / migration 075: the graph has ONE universal
+> text/prose embedding space (concepts, edges, docs, image-prose). A modality's
+> native embedding (the image vector on a Source) is an **independent**
+> same-modality search index with its own space and dimensions. The header
+> carries both so a destination can decide keep-vs-recompute *per space*.
+
+---
+
+## 4. Dictionary / interning rule
+
+**The HEADER holds the dictionaries; bulk records reference entries by compact
+integer index, never by repeating a string.** A concept's embedding-profile
+reference is an integer index into `header.embedding_profiles[]`; an edge's
+`type` is an integer index into `header.relationship_vocabulary[]`; an epoch
+row's `kind`/`actor` are indices into `header.epoch_kinds[]` / `header.actors[]`;
+a source's `content_type` is an index into `header.content_types[]`.
+
+This is dictionary/interning encoding: the model string `openai:…@1536` is
+written **once** in the header, not restated across every concept.
+
+### 4.1 Cascading-default resolution order
+
+The embedding-profile reference for any record **cascades**. A record states
+only its *override*; absent an override it inherits from its parent scope. The
+resolution order, most-specific-wins:
+
+```
+1. record-level override     (concept.embedding_profile)        — if present
+2. ontology-level default    (ontologies[i].default_embedding_profile) — else
+3. backup-level default      (header.default_embedding_profile)  — else
+```
+
+- A backup with **one uniform** embedding profile declares it once as
+  `header.default_embedding_profile` and emits **no** per-record refs.
+- A **mixed** backup declares per-ontology defaults; only records that deviate
+  from their ontology default carry an explicit `embedding_profile`.
+- The same cascade pattern is the model for any future header dictionary whose
+  values are scope-defaultable; today only the embedding profile cascades.
+
+A consumer resolves a record's effective profile by walking 1 → 2 → 3 and taking
+the first index present. The resolved index then keys
+`header.embedding_profiles[]` for the keep-vs-recompute decision (ADR-102 §6).
+
+---
+
+## 5. BULK records
+
+The `bulk` region holds the primary-input record streams. Field lists below are
+grounded in the current exporter (`api/lib/serialization.py`,
+`DataExporter.export_*`) plus the ADR-102 §3 epoch additions.
+
+```json
+{
+  "bulk": {
+    "concepts":      [ ... ],
+    "sources":       [ ... ],
+    "instances":     [ ... ],
+    "relationships": [ ... ],
+    "vocabulary":    [ ... ],
+    "graph_epochs":  [ ... ]
+  }
+}
+```
+
+### 5.1 concepts
+
+| Field | Type | Notes |
+|---|---|---|
+| `concept_id` | string | App-assigned, preserved 1:1 (CLONE) or remapped (adjacent MERGE). |
+| `label` | string | |
+| `search_terms` | array of strings | |
+| `embedding` | array of floats | The text/prose vector. Interpreted in the space named by the resolved embedding-profile ref (§4.1). May be recomputed on restore if the target profile differs (ADR-102 §6). |
+| `created_at_epoch` | integer | Epoch `event_id` of first appearance (ADR-203). New in `kg-backup/2`; absent in the legacy `1.0` exporter. |
+| `last_seen_epoch` | integer | Epoch `event_id` of most recent re-evidence. New in `kg-backup/2`. |
+| `embedding_profile` | integer (optional) | **Override only.** Index into `header.embedding_profiles[]`. Omitted when the ontology/backup default applies (§4.1). |
+
+### 5.2 sources
+
+| Field | Type | Notes |
+|---|---|---|
+| `source_id` | string | App-assigned. Media keys are *re-derived* from this on restore (ADR-102 §7), not carried. |
+| `document` | string | Ontology/document name. |
+| `file_path` | string | Original ingest path. |
+| `paragraph` | integer | Ordinal within document. |
+| `full_text` | string | The source prose — a **primary input** (always carried). |
+| `garage_key` | string (optional) | Present only when set (sources predating ADR-081 omit it). Informational; restore reconstructs the key from IDs rather than trusting it. |
+| `content_type` | integer (optional) | Index into `header.content_types[]` (interned, replacing the raw MIME string the legacy exporter emitted inline). |
+| `storage_key` | string (optional) | Image/media storage key, present only when set. Like `garage_key`, reconstructed on restore. |
+
+### 5.3 instances
+
+| Field | Type | Notes |
+|---|---|---|
+| `instance_id` | string | App-assigned. |
+| `quote` | string | Evidence quote. |
+| `concept_id` | string | The evidenced concept (`(c)-[:EVIDENCED_BY]->(i)`). Participates in ID remapping. |
+| `source_id` | string | The originating source (`(i)-[:FROM_SOURCE]->(s)`). Participates in ID remapping. |
+| `created_at_event_id` | integer | FK into `graph_epochs.event_id` (ADR-203). New in `kg-backup/2`. In **faithful** epoch mode it is remapped through the event-ID map; in **simple** mode all instances are restamped with the single restore event (ADR-102 §3). The legacy exporter dropped this entirely. |
+
+### 5.4 relationships
+
+| Field | Type | Notes |
+|---|---|---|
+| `from` | string | Source `concept_id`. Participates in ID remapping. |
+| `to` | string | Target `concept_id`. Participates in ID remapping. |
+| `type` | integer | Index into `header.relationship_vocabulary[]` (interned; the legacy exporter wrote the raw type string per edge). Resolves to the dynamic edge label on restore. |
+| `properties` | object | Free-form edge properties. **See §5.4.1.** |
+
+#### 5.4.1 The `learned_id` edge property participates in ID remapping
+
+Edge `properties` is generally free-form, but one key is **load-bearing for
+referential integrity**: `learned_id`. Edges minted from agent-learned knowledge
+carry `{ learned_id: <source_id> }` (see
+`api/app/lib/age_client/query.py` — `CREATE (c1)-[r:{type} {learned_id: $source_id}]->(c2)`).
+
+**`learned_id` is a `source_id` by another name.** It therefore **participates in
+ID remapping** exactly like `instances[].source_id`: in adjacent MERGE mode,
+when a source's `source_id` is remapped to a new UID, every edge property
+`learned_id` referencing the old value MUST be rewritten through the same
+old→new ID map. A consumer that treats `properties` as opaque will silently
+orphan the learned-knowledge linkage (and break `delete_learned_relationships`,
+which matches `()-[r {learned_id: $learned_id}]-()`). Implementations MUST
+enumerate `learned_id` in the reference-remap pass (ADR-102 Consequences:
+"a missed class silently orphans relationships").
+
+### 5.5 vocabulary
+
+The vocabulary rows mirror `DataExporter.export_vocabulary`
+(`kg_api.relationship_vocabulary`). The **same** rows are surfaced in
+`header.relationship_vocabulary[]` so edge `type` refs can resolve; the bulk
+`vocabulary` stream is the import payload (it reconciles against the target's
+vocabulary during rehydration, ADR-102 §6).
+
+| Field | Type |
+|---|---|
+| `relationship_type` | string |
+| `description` | string |
+| `category` | string |
+| `added_by` | string |
+| `added_at` | ISO-8601Z string |
+| `usage_count` | integer |
+| `is_active` | boolean |
+| `is_builtin` | boolean |
+| `synonyms` | array of strings or null |
+| `deprecation_reason` | string or null |
+| `direction_semantics` | string or null |
+| `embedding_model` | string (identity form `{provider}:{model}@{dims}`) |
+| `embedding_generated_at` | ISO-8601Z string or null |
+| `embedding` | array of floats or null |
+
+### 5.6 graph_epochs — **faithful epoch mode ONLY**
+
+Present **only** when the backup is produced for faithful epoch replay
+(ADR-102 §3, CLONE-only). Omitted entirely in simple mode. These are the
+`kg_api.graph_epochs` log rows (migration 063).
+
+| Field | Type | Notes |
+|---|---|---|
+| `event_id` | integer | Source-local logical-time id. On restore (faithful) it is recreated as a **new** id in the target range and the old→new mapping is applied to every `instances[].created_at_event_id`. |
+| `occurred_at` | ISO-8601Z string | Wall-clock axis; preserved. |
+| `kind` | integer | Index into `header.epoch_kinds[]`. |
+| `actor` | integer or null | Index into `header.actors[]`. |
+| `counter_after` | integer or null | `graph_change_counter` snapshot (ADR-079 cross-ref); informational. |
+| `metadata` | object | Free-form event metadata. |
+
+> **Why CLONE-only.** Faithful replay is coherent only when identity is
+> preserved 1:1 (empty target). In MERGE the epoch collapses to one restore
+> event (simple mode), so the source's `graph_epochs` rows are not carried.
+
+---
+
+## 6. Exclusions: derived products are NOT in the backup
+
+Per **ADR-102 §4** (primary-in / derived-out), the backup carries **primary
+inputs only**. The following are **explicitly excluded** and are **regenerated
+post-restore** against the true post-restore graph state — never serialized:
+
+- **Projections** (ADR-079, `projections/...`) — derived embedding-landscape
+  snapshots.
+- **Artifacts / scores** (ADR-083, `artifacts/...`) — polarity analyses,
+  grounding results, epistemic scores, and other computed derivations.
+- **Grounding caches** and the **catalog index**.
+
+The discriminator is *input vs. derivation*. A derived product is a function of
+**global** graph state; introducing any foreign node invalidates it wholesale,
+so a carried copy would be stale-yet-fresh-looking (silent corruption). Carrying
+none of them also designs out the fragile per-type concept-ID payload rewriter
+entirely (ADR-102 §4). The freshness machinery marks derivations stale on
+restore (`record_mutation` advances the epoch), so rehydration recomputes them
+in dependency order **embeddings → vocabulary → scores** (ADR-102 §6).
+
+Note this is what `image`/source **media bytes** are *not*: media is a **primary
+input** the model consumed, so it is always backed up (carried in the archive
+alongside this object, keyed by re-derivable `source_id`/content keys — ADR-102
+§4, §7), whereas a projection is recomputable and excluded.
+
+---
+
+## 7. Versioning and compatibility negotiation
+
+`header.format_version` is the **single negotiation token**. It is a
+slash-delimited `{family}/{major}` string; this spec defines `kg-backup/2`.
+
+**Producer.** Writes its native `format_version` and a HEADER that satisfies the
+contract for that version. A producer never downgrades silently.
+
+**Consumer.** On open, reads `header.format_version` *first* and:
+
+1. **Exact major match** (`kg-backup/2`) — accept and apply.
+2. **Known family, lower major** (`kg-backup/1` — the legacy `1.0` JSON shape:
+   flat `version`/`type`/`data`, no header, no epoch fields, inline type/MIME
+   strings) — a consumer MAY accept it through an explicit upcasting reader that
+   synthesizes a minimal HEADER (one default embedding profile, interns the
+   inline strings) and supplies the missing epoch fields as null/simple-mode
+   defaults. Acceptance of older majors is a consumer capability, never assumed.
+3. **Known family, higher major** — **refuse.** A `kg-backup/2` consumer MUST NOT
+   attempt a `kg-backup/3` object; it may not understand new required HEADER
+   dictionaries, and partially applying primary inputs is unsafe (ADR-102 §8:
+   restore passes through transiently inconsistent states).
+4. **Unknown family** — refuse.
+
+`schema_version` and `source.version` are **informational** and never gate
+acceptance — only `format_version` does. The major component bumps on any change
+that an older consumer could not faithfully interpret (new required HEADER
+dictionary, changed cascade semantics, changed bulk record shape). Additive,
+back-compatible HEADER fields that a `2` consumer can ignore do **not** require a
+major bump.
+
+ADR-102 §5 recommends this `format_version` also be **discoverable via API**
+(e.g. a format-version endpoint) so producer and consumer negotiate
+compatibility before transfer. The concrete endpoint shape is an API-contract
+concern out of scope for this spec.
+
+---
+
+## 8. References
+
+- **ADR-102** — Portable Backup and Restore with Clone/Merge Semantics
+  (§4 primary-in/derived-out; §5 self-describing versioned header; §3 epoch
+  reconciliation; §6 rehydration; §7 storage keys).
+- **ADR-203** — Graph epoch event log (`graph_epochs`, `created_at_event_id`).
+- **ADR-803** — Independent image vector space (migration 075).
+- **ADR-079 / ADR-083** — Projections / artifacts (excluded derived products).
+- **ADR-015** — Prior backup/restore streaming architecture (schema versioning),
+  partly superseded by ADR-102.
+- Source: `api/lib/serialization.py` (`BackupFormat`, `DataExporter`),
+  `api/app/lib/embedding_config.py` (`export_embedding_profile`),
+  migrations `055_embedding_profile.sql`, `075_decouple_image_embedding_space.sql`,
+  `063_graph_epoch_events.sql`, `064_graph_epoch_kinds_lookup.sql`.

--- a/docs/reference/BACKUP_OBJECT_SPEC.md
+++ b/docs/reference/BACKUP_OBJECT_SPEC.md
@@ -237,6 +237,18 @@ resolution order, most-specific-wins:
 - The same cascade pattern is the model for any future header dictionary whose
   values are scope-defaultable; today only the embedding profile cascades.
 
+> **OPEN ITEM (resolve in ADR-102 P2 — export).** The ontology tier above assumes
+> a concept can be associated with an ontology, but a concept record (§5.1) carries
+> **no** ontology field — concepts associate with an ontology only indirectly, via
+> `APPEARS → Source{document}`. P2 must pin one of: (a) add an explicit ontology
+> hint to the concept record so the ontology tier resolves, or (b) drop the ontology
+> tier for concepts entirely (concept cascade = record-override → backup-default),
+> reserving per-ontology defaults for source/media records. Until pinned, a consumer
+> resolving a concept's profile falls through to the backup-level default. The
+> offline validator (`lint_backup.py`) currently keys the ontology tier on a
+> `concept.ontology`/`concept.document` field if present and otherwise falls through
+> — it must be updated in lockstep when this is resolved.
+
 A consumer resolves a record's effective profile by walking 1 → 2 → 3 and taking
 the first index present. The resolved index then keys
 `header.embedding_profiles[]` for the keep-vs-recompute decision (ADR-102 §6).

--- a/operator/database/restore-database.sh
+++ b/operator/database/restore-database.sh
@@ -286,19 +286,18 @@ USER_COUNT=$(docker exec $CONTAINER psql -U $DB_USER -d $DB_NAME -t -A -c \
 CONCEPT_COUNT=$(echo "$CONCEPT_COUNT" | tr -d '[:space:]'); CONCEPT_COUNT=${CONCEPT_COUNT:-0}
 SOURCE_COUNT=$(echo "$SOURCE_COUNT" | tr -d '[:space:]'); SOURCE_COUNT=${SOURCE_COUNT:-0}
 
-# Fail loudly if the restore produced an empty/partial graph. A backup made by
-# backup-database.sh always contains concepts and sources, so zero of both means
-# the restore did not actually land (e.g. silent rollback or wrong-format dump).
-if ! [[ "$CONCEPT_COUNT" =~ ^[0-9]+$ ]] || ! [[ "$SOURCE_COUNT" =~ ^[0-9]+$ ]] \
-   || { [ "$CONCEPT_COUNT" -eq 0 ] && [ "$SOURCE_COUNT" -eq 0 ]; }; then
-    echo -e "${RED}✗${NC} Restore completed but the graph is empty (concepts=$CONCEPT_COUNT, sources=$SOURCE_COUNT)"
-    echo -e "  ${YELLOW}This usually means pg_restore rolled back or the backup is invalid.${NC}"
+# Secondary sanity check on the restored graph. pg_restore's exit status
+# (captured via `set -o pipefail` above) is the AUTHORITATIVE success signal —
+# a genuine failure already took the error path. These counts only catch the
+# rare exit-0-but-rolled-back case, so an empty graph here is a loud WARNING,
+# not a failure: the DROP is already irreversible, and a legitimately empty (or
+# unusually small) backup would otherwise trip a misleading "restore failed".
+if ! [[ "$CONCEPT_COUNT" =~ ^[0-9]+$ ]] || ! [[ "$SOURCE_COUNT" =~ ^[0-9]+$ ]]; then
+    echo -e "${YELLOW}⚠${NC}  Could not read post-restore counts (concepts=$CONCEPT_COUNT, sources=$SOURCE_COUNT); skipping the empty-graph check."
+elif [ "$CONCEPT_COUNT" -eq 0 ] && [ "$SOURCE_COUNT" -eq 0 ]; then
+    echo -e "${YELLOW}⚠${NC}  Restore completed but the graph is empty (0 concepts, 0 sources)."
+    echo -e "  ${YELLOW}If the backup was non-empty this may indicate a silent rollback — check ${BLUE}docker logs $CONTAINER${NC}."
     echo ""
-    echo -e "${YELLOW}Troubleshooting:${NC}"
-    echo "  1. Verify backup file is valid: ${BLUE}file $BACKUP_FILE${NC}"
-    echo "  2. View Docker logs: ${BLUE}docker logs $CONTAINER${NC}"
-    echo ""
-    exit 1
 fi
 
 echo -e "${GREEN}✓${NC} Database restored successfully!"

--- a/operator/database/restore-database.sh
+++ b/operator/database/restore-database.sh
@@ -143,12 +143,12 @@ if [ "$AUTO_CONFIRM" = false ]; then
     echo -e "  Size: ${GREEN}$BACKUP_SIZE${NC}"
     echo -e "  Target database: ${BLUE}$DB_NAME${NC}"
     echo ""
-    echo -e "${RED}⚠️  WARNING: This will REPLACE ALL DATA in $DB_NAME${NC}"
+    echo -e "${RED}⚠️  WARNING: This DROPS the entire $DB_NAME database${NC}"
     echo -e "  ${YELLOW}All existing concepts, relationships, sources, and users will be lost${NC}"
     echo ""
-    echo -e "${BLUE}What this does:${NC}"
-    echo "  • Drops all existing tables and data"
-    echo "  • Restores complete database from backup"
+    echo -e "${BLUE}What this does (binary backups):${NC}"
+    echo "  • DROPs and recreates the $DB_NAME database (irreversible data loss)"
+    echo "  • Restores complete database from backup into the empty database"
     echo "  • Includes all graphs, users, and configuration"
     echo ""
     echo -e "${BLUE}Usage:${NC}"
@@ -180,24 +180,61 @@ if file "$BACKUP_FILE" | grep -q "PostgreSQL custom database dump"; then
     # Binary custom format - use pg_restore
     echo -e "${BLUE}→${NC} Restoring from binary backup (pg_restore)..."
 
-    # pg_restore options:
-    # --clean: Drop objects before recreating
-    # --if-exists: Use IF EXISTS when dropping
+    # ------------------------------------------------------------------------
+    # #398 fix: restore into a genuinely EMPTY database.
+    #
+    # Previously this used `pg_restore --clean --if-exists`, which emits
+    # `DROP TABLE IF EXISTS` for Apache AGE label tables. AGE rejects dropping
+    # those tables directly ("ERROR: table \"X\" is for label \"X\""), so any
+    # --clean restore into a database that already holds a graph aborts.
+    #
+    # Instead we DROP and recreate the target database, then pg_restore WITHOUT
+    # --clean. A freshly created database has no AGE label tables to choke on,
+    # and the dump recreates everything (extensions, graph, data) from scratch.
+    #
+    # ⚠️  DATA LOSS: DROP DATABASE destroys ALL existing data in $DB_NAME before
+    #     the restore begins. This is irreversible. The confirmation prompt above
+    #     already warns the operator; honor it.
+    # ------------------------------------------------------------------------
+    echo -e "${RED}⚠️${NC}  Dropping and recreating database ${BLUE}$DB_NAME${NC} (all current data will be destroyed)..."
+
+    # DROP/CREATE must run against a maintenance database, not the target itself.
+    # Terminate any lingering connections first so DROP DATABASE can proceed.
+    if ! docker exec -i $CONTAINER psql -U $DB_USER -d postgres -v ON_ERROR_STOP=1 <<SQL
+SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity
+ WHERE datname = '$DB_NAME' AND pid <> pg_backend_pid();
+DROP DATABASE IF EXISTS "$DB_NAME";
+CREATE DATABASE "$DB_NAME";
+SQL
+    then
+        echo -e "${RED}✗${NC} Failed to recreate database $DB_NAME"
+        echo -e "  ${YELLOW}The database may be partially dropped. Check: ${BLUE}docker exec $CONTAINER psql -U $DB_USER -l${NC}"
+        echo ""
+        exit 1
+    fi
+
+    # pg_restore options (note: NO --clean / --if-exists — target is empty):
     # --no-owner: Don't restore ownership
     # --no-privileges: Don't restore privileges
     # -1: Run restore in single transaction (all or nothing)
+    #
+    # #397 fix: `set -o pipefail` makes the pipeline below report pg_restore's
+    # exit status rather than grep's, so a failed/rolled-back restore is caught.
+    # AGE emits benign "WARNING" / "already exists" notices we still filter out.
+    set -o pipefail
     if docker exec -i $CONTAINER pg_restore \
         -U $DB_USER \
         -d $DB_NAME \
-        --clean \
-        --if-exists \
         --no-owner \
         --no-privileges \
         -1 \
         < "$BACKUP_FILE" 2>&1 | grep -v "^WARNING:" | grep -v "already exists"; then
 
+        set +o pipefail
         RESTORE_METHOD="pg_restore (binary)"
     else
+        set +o pipefail
         echo -e "${RED}✗${NC} Restore failed"
         echo ""
         echo -e "${YELLOW}Troubleshooting:${NC}"
@@ -227,10 +264,12 @@ else
     fi
 fi
 
-echo -e "${GREEN}✓${NC} Database restored successfully!"
-echo ""
-
-# Show restored database stats
+# Gather restored database stats.
+#
+# #397 fix (part 2): these counts now GATE success instead of being cosmetic.
+# A pg_restore that rolls back inside its single transaction can still exit 0 in
+# some edge cases (and historically the `| grep` masked failures entirely), so we
+# independently verify the graph actually has content before reporting success.
 SCHEMA_VERSION=$(docker exec $CONTAINER psql -U $DB_USER -d $DB_NAME -t -A -c \
     "SELECT MAX(version) FROM public.schema_migrations" 2>/dev/null || echo "unknown")
 
@@ -242,6 +281,28 @@ SOURCE_COUNT=$(docker exec $CONTAINER psql -U $DB_USER -d $DB_NAME -t -A -c \
 
 USER_COUNT=$(docker exec $CONTAINER psql -U $DB_USER -d $DB_NAME -t -A -c \
     "SELECT COUNT(*) FROM kg_auth.users" 2>/dev/null || echo "0")
+
+# Normalize counts (strip whitespace; default to 0 if the query errored).
+CONCEPT_COUNT=$(echo "$CONCEPT_COUNT" | tr -d '[:space:]'); CONCEPT_COUNT=${CONCEPT_COUNT:-0}
+SOURCE_COUNT=$(echo "$SOURCE_COUNT" | tr -d '[:space:]'); SOURCE_COUNT=${SOURCE_COUNT:-0}
+
+# Fail loudly if the restore produced an empty/partial graph. A backup made by
+# backup-database.sh always contains concepts and sources, so zero of both means
+# the restore did not actually land (e.g. silent rollback or wrong-format dump).
+if ! [[ "$CONCEPT_COUNT" =~ ^[0-9]+$ ]] || ! [[ "$SOURCE_COUNT" =~ ^[0-9]+$ ]] \
+   || { [ "$CONCEPT_COUNT" -eq 0 ] && [ "$SOURCE_COUNT" -eq 0 ]; }; then
+    echo -e "${RED}✗${NC} Restore completed but the graph is empty (concepts=$CONCEPT_COUNT, sources=$SOURCE_COUNT)"
+    echo -e "  ${YELLOW}This usually means pg_restore rolled back or the backup is invalid.${NC}"
+    echo ""
+    echo -e "${YELLOW}Troubleshooting:${NC}"
+    echo "  1. Verify backup file is valid: ${BLUE}file $BACKUP_FILE${NC}"
+    echo "  2. View Docker logs: ${BLUE}docker logs $CONTAINER${NC}"
+    echo ""
+    exit 1
+fi
+
+echo -e "${GREEN}✓${NC} Database restored successfully!"
+echo ""
 
 echo -e "${BOLD}Restored Database:${NC}"
 echo -e "  Method: ${BLUE}$RESTORE_METHOD${NC}"

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -348,6 +348,13 @@ def _resolve_concept_profile(
     if _is_int_index(concept.get("embedding_profile")):
         return concept["embedding_profile"]
     # 2. ontology default (concept may name its ontology via 'document'/'ontology')
+    #
+    # OPEN ITEM (BACKUP_OBJECT_SPEC §4.1): concept records carry no ontology field
+    # in the current spec — concepts associate with an ontology only indirectly via
+    # APPEARS->Source{document}. We key on a 'ontology'/'document' field IF present
+    # and otherwise fall through to the backup default. ADR-102 P2 must pin the
+    # concept->ontology association (add a hint field, or drop the ontology tier for
+    # concepts); update this resolution in lockstep when it does.
     ont_name = concept.get("ontology") or concept.get("document")
     ont = ontologies_by_name.get(ont_name) if ont_name else None
     if isinstance(ont, dict) and _is_int_index(ont.get("default_embedding_profile")):

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -1,0 +1,820 @@
+#!/usr/bin/env python3
+"""
+Offline backup-object validator for the ``kg-backup/2`` format.
+
+Validates a portable backup object (per ``docs/reference/BACKUP_OBJECT_SPEC.md``)
+WITHOUT touching the running platform: no database, no Garage, no AGEClient, no
+network, no docker. It is pure file/dict parsing.
+
+It accepts either a raw JSON backup object or a ``.tar.gz`` archive (in which
+case ``manifest.json`` is extracted from the archive and validated as the
+backup object).
+
+Design for reuse (ADR-102 Track D): the core is a pure function
+``validate_backup(obj: dict) -> ValidationResult`` with no I/O. The P3/P6 pytest
+suites and a future live API endpoint import that directly. The CLI is a thin
+wrapper that reads a path, calls the core, prints issues, and exits non-zero if
+any ERROR was found (CI convention, matching the sibling lint tools).
+
+Checks implemented (see ``CHECK_CODES`` for the stable code registry):
+  - HEADER presence / well-formedness and format_version family negotiation (§7)
+  - kg-backup/2 required header fields (§3.1)
+  - legacy kg-backup/1 flat shape detection (notice, then best-effort) (§7)
+  - embedding-profile identity string {provider}:{model}@{dims} (§3.2)
+  - dictionary index resolution: profile / rel-type / content_type / kind / actor (§4)
+  - cascading embedding-profile resolution record→ontology→backup (§4.1)
+  - internal referential integrity: rel from/to, instance concept/source (§5)
+  - learned_id edge property references an existing source_id (§5.4.1)
+  - epoch fields per mode (faithful graph_epochs vs simple) (§5.6, §5.3)
+  - duplicate concept_id / source_id / instance_id (§5)
+  - excluded derived products absent (projections / artifacts) (§6)
+
+Usage:
+    python3 scripts/development/lint/lint_backup.py <path-to-backup.json>
+    python3 scripts/development/lint/lint_backup.py <path-to-archive.tar.gz>
+    python3 scripts/development/lint/lint_backup.py --selftest
+
+@verified cffa180b
+"""
+
+import argparse
+import io
+import json
+import re
+import sys
+import tarfile
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: The format family this validator natively understands.
+KNOWN_FAMILY = "kg-backup"
+#: Major version this validator natively understands (exact-match accept, §7).
+NATIVE_MAJOR = 2
+
+#: Header fields required for a well-formed kg-backup/2 object (spec §3.1).
+REQUIRED_HEADER_FIELDS = [
+    "format_version",
+    "source",
+    "exported_at",
+    "schema_version",
+    "embedding_profiles",
+    "default_embedding_profile",
+    "relationship_vocabulary",
+    "epoch_kinds",
+    "actors",
+    "content_types",
+    "ontologies",
+]
+
+#: Bulk keys that MUST NOT appear — derived products are regenerated post-restore (§6).
+EXCLUDED_BULK_KEYS = ["projections", "artifacts", "scores", "grounding", "catalog"]
+
+#: Embedding-profile identity: {provider}:{model}@{dims}  (§3.2).
+IDENTITY_RE = re.compile(r"^[^:@\s]+:[^@\s]+@\d+$")
+
+#: Stable issue-code registry. Each entry: code -> short human description.
+CHECK_CODES = {
+    # structure / header
+    "E_NOT_OBJECT": "Backup object is not a JSON object.",
+    "E_NO_HEADER": "Missing 'header' region.",
+    "E_NO_FORMAT_VERSION": "header.format_version missing.",
+    "E_FORMAT_VERSION_SHAPE": "format_version is not '{family}/{major}'.",
+    "E_UNKNOWN_FAMILY": "Unknown format family (refuse).",
+    "E_HIGHER_MAJOR": "Higher major version than supported (refuse).",
+    "E_MISSING_HEADER_FIELD": "Required kg-backup/2 header field missing.",
+    "E_NO_BULK": "Missing 'bulk' region.",
+    "N_LEGACY_FORMAT": "Legacy kg-backup/1 flat format (best-effort validation).",
+    # embedding profiles
+    "E_PROFILE_IDENTITY": "embedding profile identity not '{provider}:{model}@{dims}'.",
+    "E_DEFAULT_PROFILE_RANGE": "default_embedding_profile index out of range.",
+    "E_ONTOLOGY_PROFILE_RANGE": "ontology default_embedding_profile index out of range.",
+    # dictionary index resolution
+    "E_CONCEPT_PROFILE_RANGE": "concept.embedding_profile index out of range.",
+    "E_REL_TYPE_RANGE": "relationship.type index out of range.",
+    "E_CONTENT_TYPE_RANGE": "source.content_type index out of range.",
+    "E_EPOCH_KIND_RANGE": "graph_epoch.kind index out of range.",
+    "E_EPOCH_ACTOR_RANGE": "graph_epoch.actor index out of range.",
+    # cascading default
+    "E_NO_PROFILE_CASCADE": "concept resolves to no embedding-profile (cascade failed).",
+    # referential integrity
+    "E_REL_FROM_MISSING": "relationship.from concept_id not in concepts[].",
+    "E_REL_TO_MISSING": "relationship.to concept_id not in concepts[].",
+    "E_INSTANCE_CONCEPT_MISSING": "instance.concept_id not in concepts[].",
+    "E_INSTANCE_SOURCE_MISSING": "instance.source_id not in sources[].",
+    "E_LEARNED_ID_MISSING": "edge properties.learned_id not an existing source_id.",
+    # epochs
+    "E_EVENT_ID_UNRESOLVED": "instance.created_at_event_id not in graph_epochs[].",
+    "W_CONCEPT_NO_EPOCH": "faithful mode: concept missing created_at_epoch/last_seen_epoch.",
+    # duplicates
+    "E_DUP_CONCEPT_ID": "duplicate concept_id.",
+    "E_DUP_SOURCE_ID": "duplicate source_id.",
+    "E_DUP_INSTANCE_ID": "duplicate instance_id.",
+    # exclusions
+    "E_DERIVED_PRESENT": "derived product present in bulk (must be excluded).",
+}
+
+
+# ---------------------------------------------------------------------------
+# Result structures
+# ---------------------------------------------------------------------------
+
+ERROR = "ERROR"
+WARNING = "WARNING"
+NOTICE = "NOTICE"
+
+
+@dataclass
+class Issue:
+    """A single structured validation finding.
+
+    Attributes:
+        severity: one of ``ERROR`` / ``WARNING`` / ``NOTICE``.
+        code: a stable identifier from ``CHECK_CODES`` (machine-matchable).
+        message: human-readable description of the specific finding.
+        location: JSON-path-ish locator (e.g. ``bulk.relationships[3].from``).
+
+    @verified cffa180b
+    """
+
+    severity: str
+    code: str
+    message: str
+    location: str = ""
+
+    def __str__(self) -> str:
+        loc = f" at {self.location}" if self.location else ""
+        return f"[{self.severity}] {self.code}: {self.message}{loc}"
+
+
+@dataclass
+class ValidationResult:
+    """Aggregate result of validating one backup object.
+
+    Holds the ordered list of :class:`Issue` findings. ``ok`` is True when no
+    ``ERROR``-severity issue is present (NOTICE/WARNING do not fail validation).
+
+    @verified cffa180b
+    """
+
+    issues: List[Issue] = field(default_factory=list)
+    format_version: Optional[str] = None
+
+    def add(self, severity: str, code: str, message: str, location: str = "") -> None:
+        """Append a structured issue.  @verified cffa180b"""
+        self.issues.append(Issue(severity, code, message, location))
+
+    @property
+    def errors(self) -> List[Issue]:
+        """Issues with ERROR severity.  @verified cffa180b"""
+        return [i for i in self.issues if i.severity == ERROR]
+
+    @property
+    def warnings(self) -> List[Issue]:
+        """Issues with WARNING severity.  @verified cffa180b"""
+        return [i for i in self.issues if i.severity == WARNING]
+
+    @property
+    def ok(self) -> bool:
+        """True when no ERROR-severity issue is present.  @verified cffa180b"""
+        return len(self.errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# Core validation (pure: dict in, ValidationResult out)
+# ---------------------------------------------------------------------------
+
+def _is_int_index(value: Any) -> bool:
+    """True when value is a usable list index (int, not bool).  @verified cffa180b"""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def validate_backup(obj: Dict[str, Any]) -> ValidationResult:
+    """Validate a kg-backup object offline and return structured findings.
+
+    Pure function: takes the already-parsed backup object (a ``dict``) and
+    returns a :class:`ValidationResult`. Performs NO I/O — no file, network,
+    database, or container access. Safe to call from pytest or an API handler.
+
+    Negotiation (§7) gates the depth of validation:
+      - ``kg-backup/2`` (exact major): full header + bulk validation.
+      - ``kg-backup/1`` (legacy flat): emits ``N_LEGACY_FORMAT`` notice and
+        validates the applicable subset (duplicates, basic referential links).
+      - higher major / unknown family: emits ERROR and stops (refuse, §7).
+
+    Args:
+        obj: the parsed backup object.
+
+    Returns:
+        ValidationResult with ``.issues`` and ``.ok``.
+
+    @verified cffa180b
+    """
+    result = ValidationResult()
+
+    if not isinstance(obj, dict):
+        result.add(ERROR, "E_NOT_OBJECT", "Backup object is not a JSON object.", "$")
+        return result
+
+    # ---- Legacy detection (§7 case 2): flat version/type/data, no header ----
+    if "header" not in obj and "version" in obj and "data" in obj:
+        result.format_version = str(obj.get("version"))
+        result.add(
+            NOTICE,
+            "N_LEGACY_FORMAT",
+            f"Legacy kg-backup/1 flat format detected (version={obj.get('version')!r}, "
+            f"type={obj.get('type')!r}); validating applicable subset only.",
+            "$",
+        )
+        _validate_legacy(obj, result)
+        return result
+
+    # ---- HEADER presence ----
+    header = obj.get("header")
+    if not isinstance(header, dict):
+        result.add(ERROR, "E_NO_HEADER", "Missing or non-object 'header' region.", "$.header")
+        return result
+
+    # ---- format_version negotiation (§7) ----
+    fmt = header.get("format_version")
+    result.format_version = fmt if isinstance(fmt, str) else None
+    if not isinstance(fmt, str) or not fmt:
+        result.add(ERROR, "E_NO_FORMAT_VERSION", "header.format_version missing or empty.",
+                   "$.header.format_version")
+        return result
+
+    if "/" not in fmt:
+        result.add(ERROR, "E_FORMAT_VERSION_SHAPE",
+                   f"format_version {fmt!r} is not '{{family}}/{{major}}'.",
+                   "$.header.format_version")
+        return result
+
+    family, _, major_str = fmt.partition("/")
+    if family != KNOWN_FAMILY:
+        result.add(ERROR, "E_UNKNOWN_FAMILY",
+                   f"Unknown format family {family!r}; refuse.",
+                   "$.header.format_version")
+        return result
+
+    try:
+        major = int(major_str)
+    except ValueError:
+        result.add(ERROR, "E_FORMAT_VERSION_SHAPE",
+                   f"format_version major {major_str!r} is not an integer.",
+                   "$.header.format_version")
+        return result
+
+    if major > NATIVE_MAJOR:
+        result.add(ERROR, "E_HIGHER_MAJOR",
+                   f"format_version {fmt!r} is a higher major than supported "
+                   f"({KNOWN_FAMILY}/{NATIVE_MAJOR}); refuse (spec §7).",
+                   "$.header.format_version")
+        return result
+
+    if major < NATIVE_MAJOR:
+        # Known family, lower major embedded under a header — treat as legacy notice.
+        result.add(NOTICE, "N_LEGACY_FORMAT",
+                   f"Lower-major {fmt!r}; validating applicable subset.",
+                   "$.header.format_version")
+
+    # ---- kg-backup/2 full validation ----
+    _validate_header(header, result)
+    _validate_bulk(obj, header, result)
+    return result
+
+
+def _validate_header(header: Dict[str, Any], result: ValidationResult) -> None:
+    """Validate required header fields and embedding-profile identities (§3).
+
+    @verified cffa180b
+    """
+    for fieldname in REQUIRED_HEADER_FIELDS:
+        if fieldname not in header:
+            result.add(ERROR, "E_MISSING_HEADER_FIELD",
+                       f"Required header field {fieldname!r} missing.",
+                       f"$.header.{fieldname}")
+
+    profiles = header.get("embedding_profiles")
+    if isinstance(profiles, list):
+        for i, prof in enumerate(profiles):
+            identity = prof.get("identity") if isinstance(prof, dict) else None
+            if not isinstance(identity, str) or not IDENTITY_RE.match(identity):
+                result.add(ERROR, "E_PROFILE_IDENTITY",
+                           f"embedding profile identity {identity!r} is not "
+                           f"'{{provider}}:{{model}}@{{dims}}'.",
+                           f"$.header.embedding_profiles[{i}].identity")
+
+    n_profiles = len(profiles) if isinstance(profiles, list) else 0
+
+    # default_embedding_profile index in range
+    default_idx = header.get("default_embedding_profile")
+    if _is_int_index(default_idx) and not (0 <= default_idx < n_profiles):
+        result.add(ERROR, "E_DEFAULT_PROFILE_RANGE",
+                   f"default_embedding_profile={default_idx} out of range "
+                   f"[0,{n_profiles}).",
+                   "$.header.default_embedding_profile")
+
+    # ontology default indices in range
+    ontologies = header.get("ontologies")
+    if isinstance(ontologies, list):
+        for i, ont in enumerate(ontologies):
+            if not isinstance(ont, dict):
+                continue
+            idx = ont.get("default_embedding_profile")
+            if _is_int_index(idx) and not (0 <= idx < n_profiles):
+                result.add(ERROR, "E_ONTOLOGY_PROFILE_RANGE",
+                           f"ontology {ont.get('name')!r} default_embedding_profile="
+                           f"{idx} out of range [0,{n_profiles}).",
+                           f"$.header.ontologies[{i}].default_embedding_profile")
+
+
+def _resolve_concept_profile(
+    concept: Dict[str, Any],
+    ontologies_by_name: Dict[str, Any],
+    backup_default: Any,
+) -> Optional[int]:
+    """Resolve a concept's effective embedding-profile index via the cascade (§4.1).
+
+    Order, most-specific-wins: record override -> ontology default ->
+    backup default. Returns the first present integer index, or ``None`` if the
+    cascade yields nothing.
+
+    @verified cffa180b
+    """
+    # 1. record override
+    if _is_int_index(concept.get("embedding_profile")):
+        return concept["embedding_profile"]
+    # 2. ontology default (concept may name its ontology via 'document'/'ontology')
+    ont_name = concept.get("ontology") or concept.get("document")
+    ont = ontologies_by_name.get(ont_name) if ont_name else None
+    if isinstance(ont, dict) and _is_int_index(ont.get("default_embedding_profile")):
+        return ont["default_embedding_profile"]
+    # 3. backup default
+    if _is_int_index(backup_default):
+        return backup_default
+    return None
+
+
+def _validate_bulk(
+    obj: Dict[str, Any], header: Dict[str, Any], result: ValidationResult
+) -> None:
+    """Validate the bulk region: indices, integrity, epochs, dups, exclusions (§4-6).
+
+    @verified cffa180b
+    """
+    bulk = obj.get("bulk")
+    if not isinstance(bulk, dict):
+        result.add(ERROR, "E_NO_BULK", "Missing or non-object 'bulk' region.", "$.bulk")
+        return
+
+    # ---- §6 exclusions: derived products must be absent ----
+    for key in EXCLUDED_BULK_KEYS:
+        if key in bulk:
+            result.add(ERROR, "E_DERIVED_PRESENT",
+                       f"Derived product {key!r} present in bulk; must be regenerated "
+                       f"post-restore, never serialized (spec §6).",
+                       f"$.bulk.{key}")
+
+    concepts = bulk.get("concepts") or []
+    sources = bulk.get("sources") or []
+    instances = bulk.get("instances") or []
+    relationships = bulk.get("relationships") or []
+    graph_epochs = bulk.get("graph_epochs")  # None => simple mode
+
+    n_profiles = len(header.get("embedding_profiles") or [])
+    n_rel_types = len(header.get("relationship_vocabulary") or [])
+    n_content_types = len(header.get("content_types") or [])
+    n_kinds = len(header.get("epoch_kinds") or [])
+    n_actors = len(header.get("actors") or [])
+    backup_default = header.get("default_embedding_profile")
+
+    ontologies_by_name = {}
+    for ont in (header.get("ontologies") or []):
+        if isinstance(ont, dict) and "name" in ont:
+            ontologies_by_name[ont["name"]] = ont
+
+    faithful = isinstance(graph_epochs, list)
+
+    # ---- concepts: ids, dup, profile index, cascade, epoch fields ----
+    concept_ids = set()
+    for i, c in enumerate(concepts):
+        if not isinstance(c, dict):
+            continue
+        cid = c.get("concept_id")
+        if cid is not None:
+            if cid in concept_ids:
+                result.add(ERROR, "E_DUP_CONCEPT_ID",
+                           f"duplicate concept_id {cid!r}.",
+                           f"$.bulk.concepts[{i}].concept_id")
+            concept_ids.add(cid)
+
+        # record-level profile override in range
+        prof_ref = c.get("embedding_profile")
+        if _is_int_index(prof_ref) and not (0 <= prof_ref < n_profiles):
+            result.add(ERROR, "E_CONCEPT_PROFILE_RANGE",
+                       f"concept.embedding_profile={prof_ref} out of range "
+                       f"[0,{n_profiles}).",
+                       f"$.bulk.concepts[{i}].embedding_profile")
+
+        # cascade resolves to a valid profile
+        resolved = _resolve_concept_profile(c, ontologies_by_name, backup_default)
+        if resolved is None:
+            result.add(ERROR, "E_NO_PROFILE_CASCADE",
+                       f"concept {cid!r} resolves to no embedding-profile via "
+                       f"record→ontology→backup cascade (spec §4.1).",
+                       f"$.bulk.concepts[{i}]")
+
+        # faithful mode: concepts should carry epoch stamps
+        if faithful:
+            if c.get("created_at_epoch") is None or c.get("last_seen_epoch") is None:
+                result.add(WARNING, "W_CONCEPT_NO_EPOCH",
+                           f"faithful mode: concept {cid!r} missing created_at_epoch/"
+                           f"last_seen_epoch (spec §5.1).",
+                           f"$.bulk.concepts[{i}]")
+
+    # ---- sources: ids, dup, content_type index ----
+    source_ids = set()
+    for i, s in enumerate(sources):
+        if not isinstance(s, dict):
+            continue
+        sid = s.get("source_id")
+        if sid is not None:
+            if sid in source_ids:
+                result.add(ERROR, "E_DUP_SOURCE_ID",
+                           f"duplicate source_id {sid!r}.",
+                           f"$.bulk.sources[{i}].source_id")
+            source_ids.add(sid)
+
+        ct = s.get("content_type")
+        if _is_int_index(ct) and not (0 <= ct < n_content_types):
+            result.add(ERROR, "E_CONTENT_TYPE_RANGE",
+                       f"source.content_type={ct} out of range [0,{n_content_types}).",
+                       f"$.bulk.sources[{i}].content_type")
+
+    # ---- relationships: type index, from/to integrity, learned_id ----
+    for i, r in enumerate(relationships):
+        if not isinstance(r, dict):
+            continue
+        rtype = r.get("type")
+        if _is_int_index(rtype) and not (0 <= rtype < n_rel_types):
+            result.add(ERROR, "E_REL_TYPE_RANGE",
+                       f"relationship.type={rtype} out of range [0,{n_rel_types}).",
+                       f"$.bulk.relationships[{i}].type")
+
+        frm = r.get("from")
+        if frm is not None and frm not in concept_ids:
+            result.add(ERROR, "E_REL_FROM_MISSING",
+                       f"relationship.from {frm!r} not present in concepts[].",
+                       f"$.bulk.relationships[{i}].from")
+        to = r.get("to")
+        if to is not None and to not in concept_ids:
+            result.add(ERROR, "E_REL_TO_MISSING",
+                       f"relationship.to {to!r} not present in concepts[].",
+                       f"$.bulk.relationships[{i}].to")
+
+        # §5.4.1 learned_id is a source_id by another name
+        props = r.get("properties")
+        if isinstance(props, dict) and "learned_id" in props:
+            learned = props["learned_id"]
+            if learned is not None and learned not in source_ids:
+                result.add(ERROR, "E_LEARNED_ID_MISSING",
+                           f"edge properties.learned_id {learned!r} does not reference "
+                           f"an existing source_id (spec §5.4.1).",
+                           f"$.bulk.relationships[{i}].properties.learned_id")
+
+    # ---- instances: ids, dup, concept/source integrity, event_id ----
+    event_ids = set()
+    if faithful:
+        for ep in graph_epochs:
+            if isinstance(ep, dict) and "event_id" in ep:
+                event_ids.add(ep["event_id"])
+
+    instance_ids = set()
+    for i, inst in enumerate(instances):
+        if not isinstance(inst, dict):
+            continue
+        iid = inst.get("instance_id")
+        if iid is not None:
+            if iid in instance_ids:
+                result.add(ERROR, "E_DUP_INSTANCE_ID",
+                           f"duplicate instance_id {iid!r}.",
+                           f"$.bulk.instances[{i}].instance_id")
+            instance_ids.add(iid)
+
+        cid = inst.get("concept_id")
+        if cid is not None and cid not in concept_ids:
+            result.add(ERROR, "E_INSTANCE_CONCEPT_MISSING",
+                       f"instance.concept_id {cid!r} not present in concepts[].",
+                       f"$.bulk.instances[{i}].concept_id")
+        sid = inst.get("source_id")
+        if sid is not None and sid not in source_ids:
+            result.add(ERROR, "E_INSTANCE_SOURCE_MISSING",
+                       f"instance.source_id {sid!r} not present in sources[].",
+                       f"$.bulk.instances[{i}].source_id")
+
+        # epoch event-id resolution only enforced in faithful mode (§5.3)
+        if faithful:
+            ev = inst.get("created_at_event_id")
+            if ev is not None and ev not in event_ids:
+                result.add(ERROR, "E_EVENT_ID_UNRESOLVED",
+                           f"instance.created_at_event_id={ev} does not resolve to a "
+                           f"graph_epochs[].event_id (spec §5.3).",
+                           f"$.bulk.instances[{i}].created_at_event_id")
+
+    # ---- graph_epochs: kind/actor index resolution (§5.6) ----
+    if faithful:
+        for i, ep in enumerate(graph_epochs):
+            if not isinstance(ep, dict):
+                continue
+            kind = ep.get("kind")
+            if _is_int_index(kind) and not (0 <= kind < n_kinds):
+                result.add(ERROR, "E_EPOCH_KIND_RANGE",
+                           f"graph_epoch.kind={kind} out of range [0,{n_kinds}).",
+                           f"$.bulk.graph_epochs[{i}].kind")
+            actor = ep.get("actor")
+            if _is_int_index(actor) and not (0 <= actor < n_actors):
+                result.add(ERROR, "E_EPOCH_ACTOR_RANGE",
+                           f"graph_epoch.actor={actor} out of range [0,{n_actors}).",
+                           f"$.bulk.graph_epochs[{i}].actor")
+
+
+def _validate_legacy(obj: Dict[str, Any], result: ValidationResult) -> None:
+    """Best-effort validation of a legacy kg-backup/1 flat object (§7 case 2).
+
+    Legacy has flat ``version``/``type``/``data`` with inline strings and no
+    header/epoch fields. Only duplicate-id and basic referential checks apply.
+
+    @verified cffa180b
+    """
+    data = obj.get("data")
+    if not isinstance(data, dict):
+        return
+    concepts = data.get("concepts") or []
+    sources = data.get("sources") or []
+    instances = data.get("instances") or []
+    relationships = data.get("relationships") or []
+
+    concept_ids = set()
+    for i, c in enumerate(concepts):
+        if not isinstance(c, dict):
+            continue
+        cid = c.get("concept_id")
+        if cid is not None:
+            if cid in concept_ids:
+                result.add(ERROR, "E_DUP_CONCEPT_ID", f"duplicate concept_id {cid!r}.",
+                           f"$.data.concepts[{i}].concept_id")
+            concept_ids.add(cid)
+
+    source_ids = set()
+    for i, s in enumerate(sources):
+        if not isinstance(s, dict):
+            continue
+        sid = s.get("source_id")
+        if sid is not None:
+            if sid in source_ids:
+                result.add(ERROR, "E_DUP_SOURCE_ID", f"duplicate source_id {sid!r}.",
+                           f"$.data.sources[{i}].source_id")
+            source_ids.add(sid)
+
+    instance_ids = set()
+    for i, inst in enumerate(instances):
+        if not isinstance(inst, dict):
+            continue
+        iid = inst.get("instance_id")
+        if iid is not None:
+            if iid in instance_ids:
+                result.add(ERROR, "E_DUP_INSTANCE_ID", f"duplicate instance_id {iid!r}.",
+                           f"$.data.instances[{i}].instance_id")
+            instance_ids.add(iid)
+        cid = inst.get("concept_id")
+        if cid is not None and cid not in concept_ids:
+            result.add(ERROR, "E_INSTANCE_CONCEPT_MISSING",
+                       f"instance.concept_id {cid!r} not present in concepts[].",
+                       f"$.data.instances[{i}].concept_id")
+        sid = inst.get("source_id")
+        if sid is not None and sid not in source_ids:
+            result.add(ERROR, "E_INSTANCE_SOURCE_MISSING",
+                       f"instance.source_id {sid!r} not present in sources[].",
+                       f"$.data.instances[{i}].source_id")
+
+    for i, r in enumerate(relationships):
+        if not isinstance(r, dict):
+            continue
+        frm = r.get("from")
+        if frm is not None and frm not in concept_ids:
+            result.add(ERROR, "E_REL_FROM_MISSING",
+                       f"relationship.from {frm!r} not present in concepts[].",
+                       f"$.data.relationships[{i}].from")
+        to = r.get("to")
+        if to is not None and to not in concept_ids:
+            result.add(ERROR, "E_REL_TO_MISSING",
+                       f"relationship.to {to!r} not present in concepts[].",
+                       f"$.data.relationships[{i}].to")
+
+
+# ---------------------------------------------------------------------------
+# I/O boundary (CLI only — kept out of the pure core)
+# ---------------------------------------------------------------------------
+
+def load_backup_object(path: str) -> Dict[str, Any]:
+    """Load a backup object from a JSON file or a .tar.gz archive.
+
+    For a ``.tar.gz`` archive, the embedded ``manifest.json`` (the logical
+    backup object) is extracted in-memory and parsed. This is the only I/O the
+    module performs and it lives outside :func:`validate_backup`.
+
+    Args:
+        path: filesystem path to a ``.json`` or ``.tar.gz`` backup.
+
+    Returns:
+        The parsed backup object (dict).
+
+    Raises:
+        ValueError: archive has no manifest.json, or content is not a JSON object.
+
+    @verified cffa180b
+    """
+    if path.endswith((".tar.gz", ".tgz")):
+        with tarfile.open(path, "r:gz") as tar:
+            member = None
+            for name in ("manifest.json", "./manifest.json"):
+                try:
+                    member = tar.getmember(name)
+                    break
+                except KeyError:
+                    continue
+            if member is None:
+                # fall back: any *manifest.json in the archive
+                for m in tar.getmembers():
+                    if m.name.endswith("manifest.json"):
+                        member = m
+                        break
+            if member is None:
+                raise ValueError(f"No manifest.json found in archive {path!r}.")
+            fobj = tar.extractfile(member)
+            if fobj is None:
+                raise ValueError(f"Could not read {member.name!r} from {path!r}.")
+            data = json.load(io.TextIOWrapper(fobj, encoding="utf-8"))
+    else:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Backup object in {path!r} is not a JSON object.")
+    return data
+
+
+def print_report(result: ValidationResult) -> None:
+    """Print a human-readable report of a ValidationResult.  @verified cffa180b"""
+    if not result.issues:
+        print("OK: no issues found.")
+        return
+
+    for issue in result.issues:
+        print(str(issue))
+
+    n_err = len(result.errors)
+    n_warn = len(result.warnings)
+    n_notice = sum(1 for i in result.issues if i.severity == NOTICE)
+    print()
+    print(f"Summary: {n_err} error(s), {n_warn} warning(s), {n_notice} notice(s)"
+          f"  [format_version={result.format_version}]")
+
+
+# ---------------------------------------------------------------------------
+# Inline self-test (optional; --selftest)
+# ---------------------------------------------------------------------------
+
+def _selftest() -> int:
+    """Run a minimal valid/invalid self-test. Returns process exit code.
+
+    @verified cffa180b
+    """
+    valid = {
+        "header": {
+            "format_version": "kg-backup/2",
+            "source": {"platform": "kg", "version": "1.7.3"},
+            "exported_at": "2026-06-01T00:00:00Z",
+            "schema_version": 76,
+            "embedding_profiles": [
+                {"identity": "openai:text-embedding-3-small@1536"}
+            ],
+            "default_embedding_profile": 0,
+            "relationship_vocabulary": [{"relationship_type": "IMPLIES"}],
+            "epoch_kinds": [{"kind": "ingestion"}],
+            "actors": ["system"],
+            "content_types": ["text/plain"],
+            "ontologies": [{"name": "Corpus", "default_embedding_profile": 0}],
+        },
+        "bulk": {
+            "concepts": [{"concept_id": "c1", "label": "A"}],
+            "sources": [{"source_id": "s1", "content_type": 0}],
+            "instances": [{"instance_id": "i1", "concept_id": "c1", "source_id": "s1"}],
+            "relationships": [
+                {"from": "c1", "to": "c1", "type": 0,
+                 "properties": {"learned_id": "s1"}}
+            ],
+            "vocabulary": [],
+        },
+    }
+    r1 = validate_backup(valid)
+    assert r1.ok, f"valid sample should pass, got: {[str(i) for i in r1.issues]}"
+
+    invalid = {
+        "header": {
+            "format_version": "kg-backup/2",
+            "source": {}, "exported_at": "x", "schema_version": 1,
+            "embedding_profiles": [{"identity": "bogus-identity"}],
+            "default_embedding_profile": 9,  # out of range
+            "relationship_vocabulary": [],
+            "epoch_kinds": [], "actors": [], "content_types": [], "ontologies": [],
+        },
+        "bulk": {
+            "concepts": [
+                {"concept_id": "c1"}, {"concept_id": "c1"},  # dup
+            ],
+            "sources": [{"source_id": "s1", "content_type": 5}],  # out of range
+            "instances": [{"instance_id": "i1", "concept_id": "cX", "source_id": "sX"}],
+            "relationships": [
+                {"from": "cZ", "to": "c1", "type": 7,
+                 "properties": {"learned_id": "sZ"}}
+            ],
+            "artifacts": [],  # excluded derived product
+        },
+    }
+    r2 = validate_backup(invalid)
+    assert not r2.ok, "invalid sample should fail"
+    codes = {i.code for i in r2.issues}
+    expected = {
+        "E_PROFILE_IDENTITY", "E_DEFAULT_PROFILE_RANGE", "E_DUP_CONCEPT_ID",
+        "E_CONTENT_TYPE_RANGE", "E_INSTANCE_CONCEPT_MISSING",
+        "E_INSTANCE_SOURCE_MISSING", "E_REL_FROM_MISSING", "E_REL_TYPE_RANGE",
+        "E_LEARNED_ID_MISSING", "E_DERIVED_PRESENT",
+    }
+    missing = expected - codes
+    assert not missing, f"invalid sample missing expected codes: {missing}"
+
+    # legacy detection
+    legacy = {"version": "1.0", "type": "full", "data": {"concepts": [], "sources": [],
+              "instances": [], "relationships": []}}
+    r3 = validate_backup(legacy)
+    assert any(i.code == "N_LEGACY_FORMAT" for i in r3.issues), "legacy notice expected"
+
+    print("selftest: PASS")
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point: load a path, validate, print, return exit code.
+
+    Exit code is 1 when any ERROR-severity issue is present (CI convention),
+    else 0. ``--selftest`` runs the inline samples instead.
+
+    @verified cffa180b
+    """
+    parser = argparse.ArgumentParser(
+        description="Offline validator for kg-backup objects (no platform needed)."
+    )
+    parser.add_argument("path", nargs="?",
+                        help="Path to a backup .json or .tar.gz archive.")
+    parser.add_argument("--selftest", action="store_true",
+                        help="Run the inline valid/invalid self-test and exit.")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit issues as JSON instead of human text.")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return _selftest()
+
+    if not args.path:
+        parser.error("a backup path is required (or use --selftest)")
+
+    try:
+        obj = load_backup_object(args.path)
+    except (OSError, ValueError, json.JSONDecodeError, tarfile.TarError) as e:
+        print(f"Error: could not load {args.path!r}: {e}", file=sys.stderr)
+        return 1
+
+    result = validate_backup(obj)
+
+    if args.json:
+        print(json.dumps({
+            "ok": result.ok,
+            "format_version": result.format_version,
+            "issues": [
+                {"severity": i.severity, "code": i.code,
+                 "message": i.message, "location": i.location}
+                for i in result.issues
+            ],
+        }, indent=2))
+    else:
+        print_report(result)
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Foundations for **ADR-102 — Portable Backup and Restore with Clone/Merge Semantics**. Lands the accepted ADR, the format spec, the integration-mode engine, an offline validator, and two restore-script bugfixes. **No change to live restore behavior** — the sequential implementation spine follows on a separate branch.

## Changes
- **ADR-102** (Accepted) — clone/merge by target-emptiness; three restore modes (idempotent / adjacent / integration); phased epoch reconciliation; primary-inputs-in / derived-products-out; self-describing versioned format; post-restore rehydration; engine-agnostic storage; restore-time worker quiescence; single supported path.
- **Backup Object Spec** — `docs/reference/BACKUP_OBJECT_SPEC.md` (`kg-backup/2`): declarative header, dictionary/interning + cascade, record shapes, the `learned_id` remap landmine, version negotiation.
- **ConceptMatcher** ported to `api/app/lib/concept_matcher.py` — the integration-mode engine (cosine attach, no LLM). Not yet wired into the worker.
- **Offline validator** — `scripts/development/lint/lint_backup.py`: pure, importable (`validate_backup`), CI artifact-lint. Reused by future round-trip tests and the post-restore validate endpoint.
- **Fix #397 / #398** — capture `pg_restore`'s real exit code + gate success on graph counts; restore into a freshly recreated DB (avoids AGE label-table `--clean` abort). ⚠️ DR path now DROP/CREATEs the target DB (documented, confirmation-gated).

## Not in this PR (follows on a new branch)
Export + versioned header, restore-core + ID-remap layer, merge modes, epoch reconciliation, verify + purge of superseded code. The Phase 0 audit's reference-class checklist + landmines (`learned_id`, `Source.document` cache, image-key re-derivation) and two latent bugs (silent watermark stall, un-automated lane freeze) are captured for that work.

## Refs
ADR-102 · Closes #397 · Closes #398