### PR TITLE
feat(backup): portable single-path kg-backup/2 export + restore (ADR-102 P2/P3)

### DIFF
--- a/api/admin/backup.py
+++ b/api/admin/backup.py
@@ -24,8 +24,16 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from api.lib.console import Console, Colors
 from api.lib.config import Config
 from api.lib.age_ops import AGEConnection, AGEQueries
-from api.lib.serialization import DataExporter
-from api.lib.integrity import BackupAssessment
+from api.lib.serialization import DataExporter, KgBackupV2Reader
+
+
+def _external_concepts(backup_data) -> set:
+    """Cross-ontology concept references in the backup (kg-backup/2 model).
+
+    Replaces the v1-shape BackupAssessment external-dependency scan with the shared
+    reader method.
+    """
+    return KgBackupV2Reader(backup_data).external_concept_ids()
 
 
 class BackupCLI:
@@ -111,7 +119,7 @@ class BackupCLI:
         # Export
         Console.info("\nExporting database...")
         client = self.conn.get_client()
-        backup_data = DataExporter.export_full_backup(client)
+        backup_data = DataExporter.export_kg_backup_v2(client)
 
         # Write to file
         Console.info(f"Writing to {backup_file}...")
@@ -122,13 +130,14 @@ class BackupCLI:
         file_size = backup_file.stat().st_size
         size_mb = file_size / (1024 * 1024)
 
+        counts = KgBackupV2Reader(backup_data).counts()
         Console.section("Backup Complete")
         Console.success(f"✓ Full backup created: {backup_file}")
         Console.info(f"  Size: {size_mb:.2f} MB")
-        Console.info(f"  Concepts: {backup_data['statistics']['concepts']}")
-        Console.info(f"  Sources: {backup_data['statistics']['sources']}")
-        Console.info(f"  Instances: {backup_data['statistics']['instances']}")
-        Console.info(f"  Relationships: {backup_data['statistics']['relationships']}")
+        Console.info(f"  Concepts: {counts['concepts']}")
+        Console.info(f"  Sources: {counts['sources']}")
+        Console.info(f"  Instances: {counts['instances']}")
+        Console.info(f"  Relationships: {counts['relationships']}")
 
         self._show_tips()
 
@@ -167,7 +176,7 @@ class BackupCLI:
             Console.info(f"\n[{i}/{len(ontologies)}] Backing up: {ontology}")
 
             client = self.conn.get_client()
-            backup_data = DataExporter.export_ontology_backup(client, ontology)
+            backup_data = DataExporter.export_kg_backup_v2(client, ontology=ontology)
 
             with open(backup_file, 'w') as f:
                 json.dump(backup_data, f, indent=2)
@@ -212,10 +221,10 @@ class BackupCLI:
 
             # Export
             client = self.conn.get_client()
-            backup_data = DataExporter.export_ontology_backup(client, ontology)
+            backup_data = DataExporter.export_kg_backup_v2(client, ontology=ontology)
 
-            # Assess backup integrity
-            assessment = BackupAssessment.analyze_backup(backup_data)
+            # Assess external dependencies (cross-ontology concept references)
+            external = _external_concepts(backup_data)
 
             # Write
             with open(backup_file, 'w') as f:
@@ -225,12 +234,9 @@ class BackupCLI:
             size_mb = file_size / (1024 * 1024)
             Console.success(f"✓ Backed up ({size_mb:.2f} MB)")
 
-            # Show warnings if external dependencies exist
-            if assessment["warnings"] or assessment["issues"]:
-                Console.warning(f"  ⚠ {len(assessment['warnings'])} warnings, {len(assessment['issues'])} issues")
-                if assessment["external_dependencies"]["concepts"]:
-                    ext_count = len(assessment["external_dependencies"]["concepts"])
-                    Console.warning(f"  ⚠ {ext_count} relationships to external concepts")
+            # Show warning if external dependencies exist
+            if external:
+                Console.warning(f"  ⚠ {len(external)} references to external concepts")
 
             backup_files.append(backup_file)
 
@@ -243,8 +249,7 @@ class BackupCLI:
         for f in backup_files:
             with open(f, 'r') as bf:
                 backup_data = json.load(bf)
-            assessment = BackupAssessment.analyze_backup(backup_data)
-            if assessment["external_dependencies"]["concepts"]:
+            if _external_concepts(backup_data):
                 has_external_deps = True
                 print(f"  • {f.name} {Colors.WARNING}(has external dependencies){Colors.ENDC}")
             else:
@@ -285,7 +290,7 @@ class BackupCLI:
                 backup_file = self.backup_dir / f"ontology_{safe_name}_{timestamp}.json"
 
             Console.info(f"Backing up ontology: {ontology}")
-            backup_data = DataExporter.export_ontology_backup(client, ontology)
+            backup_data = DataExporter.export_kg_backup_v2(client, ontology=ontology)
 
         else:
             # Full backup
@@ -295,7 +300,7 @@ class BackupCLI:
                 backup_file = self.backup_dir / f"full_backup_{timestamp}.json"
 
             Console.info("Backing up full database")
-            backup_data = DataExporter.export_full_backup(client)
+            backup_data = DataExporter.export_kg_backup_v2(client)
 
         # Write
         with open(backup_file, 'w') as f:

--- a/api/admin/restore.py
+++ b/api/admin/restore.py
@@ -160,6 +160,10 @@ class RestoreCLI:
             o.get("name") for o in backup_data.get("header", {}).get("ontologies", [])
             if o.get("name")
         ]
+        # Scope for downstream integrity ops: one ontology entry == a scoped backup;
+        # otherwise graph-wide. (kg-backup/2 has no top-level "ontology" field —
+        # passing None here would silently widen a scoped prune to the whole graph.)
+        scope = _ontologies[0] if len(_ontologies) == 1 else None
         if len(_ontologies) == 1:
             ontology_name = _ontologies[0]
             client = self.conn.get_client()
@@ -221,7 +225,7 @@ class RestoreCLI:
                 client = self.conn.get_client()
                 prune_result = DatabaseIntegrity.prune_dangling_relationships(
                     client,
-                    ontology=backup_data.get('ontology'),
+                    ontology=scope,
                     dry_run=False
                 )
 
@@ -240,7 +244,7 @@ class RestoreCLI:
             client = self.conn.get_client()
             integrity = DatabaseIntegrity.check_integrity(
                 client,
-                ontology=backup_data.get('ontology')
+                ontology=scope
             )
 
             if integrity["issues"] or integrity["warnings"]:
@@ -253,7 +257,7 @@ class RestoreCLI:
                         Console.info("Repairing orphaned concepts...")
                         repairs = DatabaseIntegrity.repair_orphaned_concepts(
                             client,
-                            ontology=backup_data.get('ontology')
+                            ontology=scope
                         )
                         Console.success(f"✓ Repaired {repairs} orphaned concepts")
 
@@ -261,7 +265,7 @@ class RestoreCLI:
                         Console.info("Re-validating...")
                         integrity = DatabaseIntegrity.check_integrity(
                             client,
-                            ontology=backup_data.get('ontology')
+                            ontology=scope
                         )
                         if not integrity["issues"]:
                             Console.success("✓ All issues resolved")

--- a/api/admin/restore.py
+++ b/api/admin/restore.py
@@ -23,8 +23,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from api.lib.console import Console, Colors
 from api.lib.config import Config
 from api.lib.age_ops import AGEConnection, AGEQueries
-from api.lib.serialization import DataImporter, BackupFormat
-from api.lib.integrity import BackupAssessment, DatabaseIntegrity
+from api.lib.serialization import DataImporter, KgBackupV2Reader
+from api.lib.integrity import DatabaseIntegrity
 from api.lib.restitching import ConceptMatcher
 
 
@@ -103,22 +103,17 @@ class RestoreCLI:
             Console.error(f"✗ Invalid backup file: {e}")
             sys.exit(1)
 
-        # Assess backup before restore
+        # Assess external dependencies before restore (single kg-backup/2 model).
+        # Format validity was already gated by validate_backup above.
         Console.info("\nAnalyzing backup...")
-        assessment = BackupAssessment.analyze_backup(backup_data)
-        BackupAssessment.print_assessment(assessment)
-
-        # Check for serious issues
-        if assessment["issues"]:
-            Console.error("\n⚠ This backup has integrity issues!")
-            if not Console.confirm("Continue anyway?"):
-                Console.warning("Restore cancelled")
-                sys.exit(0)
+        external_concepts = KgBackupV2Reader(backup_data).external_concept_ids()
+        if external_concepts:
+            Console.warning(f"  ⚠ {len(external_concepts)} cross-ontology concept references")
 
         # Handle external dependencies - MUST choose stitch or prune
         restitch_action = None
-        if assessment["external_dependencies"]["concepts"]:
-            ext_count = len(assessment["external_dependencies"]["concepts"])
+        if external_concepts:
+            ext_count = len(external_concepts)
 
             # Check if target database is empty (nothing to stitch to)
             client = self.conn.get_client()
@@ -159,9 +154,14 @@ class RestoreCLI:
                     Console.warning("Restore cancelled")
                     sys.exit(0)
 
-        # Check for conflicts
-        if backup_data.get('ontology'):
-            ontology_name = backup_data['ontology']
+        # Check for conflicts (single kg-backup/2 model: scope is named in the header;
+        # one ontology entry == a scoped backup).
+        _ontologies = [
+            o.get("name") for o in backup_data.get("header", {}).get("ontologies", [])
+            if o.get("name")
+        ]
+        if len(_ontologies) == 1:
+            ontology_name = _ontologies[0]
             client = self.conn.get_client()
             existing = AGEQueries.get_ontology_info(client, ontology_name)
 
@@ -274,7 +274,7 @@ class RestoreCLI:
             if restitch_action == "defer":
                 # URGENT: graph is broken
                 self._show_tips(backup_file=backup_file, urgent=True)
-            elif assessment["external_dependencies"]["concepts"]:
+            elif external_concepts:
                 # Pruned - graph is clean
                 self._show_tips(backup_file=None, urgent=False)
             else:

--- a/api/admin/stitch.py
+++ b/api/admin/stitch.py
@@ -144,6 +144,9 @@ Note:
     Console.success("✓ Connected to target database")
     reader = KgBackupV2Reader(backup_data)
     _ontologies = [o.get("name") for o in reader.header.get("ontologies", []) if o.get("name")]
+    # Scope for integrity ops: one ontology entry == scoped; else graph-wide
+    # (passing None to a scoped prune would silently widen it to the whole graph).
+    scope = _ontologies[0] if len(_ontologies) == 1 else None
     Console.key_value("  Backup format", reader.format_version)
     if len(_ontologies) == 1:
         Console.key_value("  Ontology", _ontologies[0])
@@ -227,7 +230,7 @@ Note:
                 Console.warning(f"\n⚠ {len(restitch_plan['unmatched'])} external concepts could not be matched")
                 Console.info("  Pruning relationships to unmatched concepts...")
 
-                ontology = backup_data.get('ontology')
+                ontology = scope
                 client = conn.get_client()
                 prune_result = DatabaseIntegrity.prune_dangling_relationships(
                     client,
@@ -249,7 +252,7 @@ Note:
             Console.section("Pruning Dangling Relationships")
             Console.info("Removing relationships to external concepts...")
 
-            ontology = backup_data.get('ontology')
+            ontology = scope
             client = conn.get_client()
             prune_result = DatabaseIntegrity.prune_dangling_relationships(
                 client,

--- a/api/admin/stitch.py
+++ b/api/admin/stitch.py
@@ -30,8 +30,34 @@ from api.lib.console import Console, Colors
 from api.lib.config import Config
 from api.lib.age_ops import AGEConnection
 from api.lib.restitching import ConceptMatcher
-from api.lib.serialization import DataImporter
+from api.lib.serialization import DataImporter, KgBackupV2Reader
 from api.lib.integrity import DatabaseIntegrity
+
+
+def _find_external_concepts(reader: KgBackupV2Reader):
+    """Find concept references with no matching concept record in the backup.
+
+    Reads the single backup model (kg-backup/2) via the reader (relationship types
+    are de-interned). Produces the same structure the legacy
+    ConceptMatcher.create_restitch_plan consumes, so the DB-side re-stitch engine is
+    unchanged. Full migration of the engine to api/app/lib/concept_matcher.py is
+    ADR-102 P4 (integration mode).
+    """
+    internal = {c["concept_id"] for c in reader.concepts()}
+    external = {}
+    for rel in reader.relationships():
+        for endpoint, direction in ((rel.get("from"), "outgoing"), (rel.get("to"), "incoming")):
+            if endpoint and endpoint not in internal:
+                external.setdefault(endpoint, {
+                    "concept_id": endpoint,
+                    "referencing_relationships": [],
+                    "label": None,
+                    "embedding": None,
+                })["referencing_relationships"].append({
+                    "from": rel.get("from"), "to": rel.get("to"),
+                    "type": rel.get("type"), "direction": direction,
+                })
+    return list(external.values())
 
 
 def main():
@@ -116,17 +142,19 @@ Note:
         sys.exit(1)
 
     Console.success("✓ Connected to target database")
-    Console.key_value("  Backup type", backup_data['type'])
-    if backup_data.get('ontology'):
-        Console.key_value("  Ontology", backup_data['ontology'])
+    reader = KgBackupV2Reader(backup_data)
+    _ontologies = [o.get("name") for o in reader.header.get("ontologies", []) if o.get("name")]
+    Console.key_value("  Backup format", reader.format_version)
+    if len(_ontologies) == 1:
+        Console.key_value("  Ontology", _ontologies[0])
     Console.key_value("  Similarity threshold", f"{args.threshold:.0%}")
 
     # Create matcher
     matcher = ConceptMatcher(conn, similarity_threshold=args.threshold)
 
-    # Find external concepts
+    # Find external concepts (read from the single kg-backup/2 model)
     Console.info("\nAnalyzing backup for external concept references...")
-    external_concepts = matcher.find_external_concepts(backup_data)
+    external_concepts = _find_external_concepts(reader)
 
     if not external_concepts:
         Console.success("\n✓ No external concept references found")

--- a/api/app/lib/backup_archive.py
+++ b/api/app/lib/backup_archive.py
@@ -25,7 +25,7 @@ import logging
 from datetime import datetime
 from typing import Dict, Any, Optional, AsyncGenerator, List
 
-from ...lib.serialization import DataExporter, BackupFormat
+from ...lib.serialization import DataExporter, KgBackupV2Reader
 from .age_client import AGEClient
 from .backup_integrity import check_backup_data
 from .garage import get_source_storage, get_image_storage
@@ -89,12 +89,13 @@ def create_backup_archive(
     if backup_type not in ("full", "ontology"):
         raise ValueError(f"Invalid backup_type: {backup_type}")
 
-    # Generate backup data
+    # Generate backup data (single model: kg-backup/2)
     logger.info(f"Generating backup data (type={backup_type}, ontology={ontology_name})")
     if backup_type == "full":
-        backup_data = DataExporter.export_full_backup(client)
+        backup_data = DataExporter.export_kg_backup_v2(client)
     else:
-        backup_data = DataExporter.export_ontology_backup(client, ontology_name)
+        backup_data = DataExporter.export_kg_backup_v2(client, ontology=ontology_name)
+    reader = KgBackupV2Reader(backup_data)
 
     # Validate backup
     integrity = check_backup_data(backup_data)
@@ -106,11 +107,8 @@ def create_backup_archive(
     archive_base = _get_archive_base_name(ontology_name)
     filename = f"{archive_base}.tar.gz"
 
-    # Add document paths to sources
-    backup_data["data"]["sources"] = _add_document_paths_to_sources(
-        backup_data["data"]["sources"],
-        archive_base
-    )
+    # Add archive-relative document paths to the manifest's source records.
+    _add_document_paths_to_sources(backup_data["bulk"]["sources"], archive_base)
 
     # Create tarball in memory
     buffer = io.BytesIO()
@@ -131,7 +129,7 @@ def create_backup_archive(
         docs_failed = 0
         added_keys: set = set()  # Track which keys we've already added
 
-        for source in backup_data["data"]["sources"]:
+        for source in reader.sources():
             # Add source document from Garage (skip if already added)
             garage_key = source.get("garage_key")
             if garage_key and garage_key not in added_keys:
@@ -151,9 +149,10 @@ def create_backup_archive(
                     logger.warning(f"Failed to fetch {garage_key}: {e}")
                     docs_failed += 1
 
-            # Add image from Garage (if content_type is image, skip if already added)
+            # Add image from Garage (storage_key is set only on image sources;
+            # skip if already added)
             storage_key = source.get("storage_key")
-            if storage_key and source.get("content_type") == "image" and storage_key not in added_keys:
+            if storage_key and storage_key not in added_keys:
                 try:
                     content = image_storage.base.get_object(storage_key)
                     if content:
@@ -172,11 +171,11 @@ def create_backup_archive(
     # Reset buffer position for reading
     buffer.seek(0)
 
-    stats = backup_data.get("statistics", {})
+    counts = reader.counts()
     logger.info(
         f"Created backup archive: {filename} - "
-        f"Concepts: {stats.get('concepts', 0)}, "
-        f"Sources: {stats.get('sources', 0)}, "
+        f"Concepts: {counts.get('concepts', 0)}, "
+        f"Sources: {counts.get('sources', 0)}, "
         f"Documents: {docs_added}"
     )
 
@@ -295,7 +294,7 @@ def restore_documents_to_garage(
     stats = {"uploaded": 0, "skipped": 0, "failed": 0}
     processed_keys: set = set()  # Track which keys we've processed
 
-    sources = manifest_data.get("data", {}).get("sources", [])
+    sources = manifest_data.get("bulk", {}).get("sources", [])
 
     for source in sources:
         # Handle source documents

--- a/api/app/lib/backup_integrity.py
+++ b/api/app/lib/backup_integrity.py
@@ -235,7 +235,9 @@ class BackupIntegrityChecker:
                 if endpoint and endpoint not in local_concept_ids:
                     external_in_rels.add(endpoint)
 
-        total_external = len(external_in_evidence) + len(external_in_rels)
+        # Distinct external concepts (a concept external in BOTH evidence and
+        # relationships must not be counted twice).
+        total_external = len(external_in_evidence | external_in_rels)
         result.external_deps = total_external
 
         if total_external > 0:

--- a/api/app/lib/backup_integrity.py
+++ b/api/app/lib/backup_integrity.py
@@ -1,13 +1,17 @@
 """
-Backup Integrity Check Module (ADR-015 Phase 2)
+Backup Integrity Check Module (ADR-015 Phase 2; retargeted to kg-backup/2 in ADR-102 P3)
 
-Validates backup files before restore operations. Checks:
-- JSON format validity
-- Required fields presence
-- Data completeness
-- Reference integrity (concept_id, source_id consistency)
-- External dependencies (cross-ontology references)
-- Data consistency (statistics accuracy)
+Runtime defense-in-depth validation of a backup object before it is streamed,
+archived, or restored. Validates the single backup model (``kg-backup/2``):
+- Structural format (declarative ``header`` + ``bulk`` regions; negotiable version)
+- Data completeness (required bulk record streams present and list-typed)
+- Reference integrity (instance→source, evidence→concept/instance, relationship endpoints)
+- External dependencies (concept references not contained in this backup — partial backups)
+- Statistics (record counts surfaced for logging)
+
+This is the *runtime* checker. The exhaustive *offline* oracle is
+``scripts/development/lint/lint_backup.py`` (used in tests/linting). Consolidating
+the two v2 validators is tracked for ADR-102 P6.
 """
 
 from typing import Dict, List, Optional, Any, Set
@@ -15,7 +19,8 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 
-from ..constants import RELATIONSHIP_TYPES, BACKUP_TYPES
+from ..constants import RELATIONSHIP_TYPES
+from ...lib.serialization import KgBackupV2Reader
 
 
 @dataclass
@@ -37,8 +42,8 @@ class BackupIntegrity:
         errors: Critical issues that prevent restore
         warnings: Non-critical issues that should be reviewed
         info: Informational messages about backup content
-        external_deps: Count of external concept references (for ontology backups)
-        statistics: Validated statistics from backup
+        external_deps: Count of external concept references (partial backups)
+        statistics: Validated record counts from the backup
     """
     valid: bool
     errors: List[IntegrityIssue]
@@ -68,52 +73,34 @@ class BackupIntegrity:
 
 class BackupIntegrityChecker:
     """
-    Validates backup file integrity before restore
+    Validates a kg-backup/2 object before stream/archive/restore (ADR-102 P3).
 
     Usage:
         checker = BackupIntegrityChecker()
-
-        # From file path
-        result = checker.check_file("/path/to/backup.json")
-
-        # From loaded data
-        result = checker.check_data(backup_dict)
-
+        result = checker.check_file("/path/to/backup.json")   # from path
+        result = checker.check_data(backup_dict)               # from loaded data
         if not result.valid:
             print(f"Backup validation failed: {result.errors}")
     """
 
-    # Required top-level fields
-    REQUIRED_FIELDS = {"version", "type", "timestamp", "data", "statistics"}
+    # Required bulk record streams (graph_epochs / evidence / vocabulary are optional).
+    REQUIRED_BULK_SECTIONS = {"concepts", "sources", "instances", "relationships"}
 
-    # Required data sections
-    REQUIRED_DATA_SECTIONS = {"concepts", "sources", "instances", "relationships"}
+    # Structural edge types reconstructed on restore (never in the vocabulary table).
+    STRUCTURAL_TYPES = {"APPEARS", "EVIDENCED_BY", "FROM_SOURCE"}
 
-    # Valid backup types (from data contract)
-    VALID_TYPES = BACKUP_TYPES
-
-    # Valid relationship types (from data contract)
+    # Builtin relationship types — fallback when a backup carries no vocabulary stream.
     VALID_RELATIONSHIP_TYPES = RELATIONSHIP_TYPES
 
     def check_file(self, file_path: str) -> BackupIntegrity:
-        """
-        Check backup file integrity
-
-        Args:
-            file_path: Path to backup JSON file
-
-        Returns:
-            BackupIntegrity result with validation status
-        """
+        """Check a backup file on disk: load JSON, then validate the object."""
         result = BackupIntegrity(valid=True, errors=[], warnings=[], info=[])
 
-        # Check file exists
         path = Path(file_path)
         if not path.exists():
             result.add_error("format", f"Backup file not found: {file_path}")
             return result
 
-        # Try to load JSON
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
@@ -124,293 +111,157 @@ class BackupIntegrityChecker:
             result.add_error("format", f"Failed to read backup file: {e}")
             return result
 
-        # Check loaded data
         return self.check_data(data, file_path=file_path)
 
     def check_data(self, data: Dict[str, Any], file_path: Optional[str] = None) -> BackupIntegrity:
-        """
-        Check backup data integrity
-
-        Args:
-            data: Loaded backup dictionary
-            file_path: Optional path for error messages
-
-        Returns:
-            BackupIntegrity result with validation status
-        """
+        """Validate a loaded kg-backup/2 object. Returns a BackupIntegrity result."""
         result = BackupIntegrity(valid=True, errors=[], warnings=[], info=[])
 
-        # Validate format
-        self._check_format(data, result)
+        # Format + structure: constructing the reader negotiates format_version and
+        # asserts the header/bulk regions exist (raises ValueError otherwise).
+        try:
+            reader = KgBackupV2Reader(data)
+        except ValueError as e:
+            result.add_error("format", str(e))
+            return result
+
+        self._check_bulk_sections(reader, result)
         if not result.valid:
             return result
 
-        # Validate data completeness
-        self._check_data_sections(data, result)
-        if not result.valid:
-            return result
+        self._check_references(reader, result)
+        self._check_external_deps(reader, result)
 
-        # Validate reference integrity
-        self._check_references(data, result)
+        counts = reader.counts()
+        result.statistics = {
+            k: counts[k] for k in ("concepts", "sources", "instances", "relationships", "vocabulary")
+        }
 
-        # Validate statistics consistency
-        self._check_statistics(data, result)
-
-        # Check for external dependencies (ontology backups)
-        if data.get("type") == "ontology_backup":
-            self._check_external_deps(data, result)
-
-        # Add info messages
-        backup_type = data.get("type", "unknown")
-        ontology = data.get("ontology")
-        stats = data.get("statistics", {})
-        data_section = data.get("data", {})
-
-        if ontology:
-            result.add_info("info", f"Ontology backup: {ontology}", stats)
+        ontologies = [o.get("name") for o in reader.header.get("ontologies", []) if o.get("name")]
+        if len(ontologies) == 1:
+            result.add_info("info", f"Ontology backup: {ontologies[0]}", result.statistics)
         else:
-            result.add_info("info", f"Full database backup", stats)
+            result.add_info("info", "Full database backup", result.statistics)
 
-        # Check vocabulary section (ADR-032)
-        if "vocabulary" in data_section:
-            vocab_entries = data_section.get("vocabulary", [])
-            builtin_count = sum(1 for v in vocab_entries if v.get("is_builtin"))
-            custom_count = len(vocab_entries) - builtin_count
-            result.add_info("vocabulary",
-                f"Vocabulary: {len(vocab_entries)} types ({builtin_count} builtin, {custom_count} extended)",
-                {"builtin": builtin_count, "extended": custom_count})
+        vocab = reader.vocabulary()
+        if vocab:
+            builtin_count = sum(1 for v in vocab if v.get("is_builtin"))
+            result.add_info(
+                "vocabulary",
+                f"Vocabulary: {len(vocab)} types ({builtin_count} builtin, "
+                f"{len(vocab) - builtin_count} extended)",
+                {"builtin": builtin_count, "extended": len(vocab) - builtin_count},
+            )
 
-        result.statistics = stats
+        if all(counts[s] == 0 for s in self.REQUIRED_BULK_SECTIONS):
+            result.add_warning("consistency", "Backup contains no data (all bulk sections empty)")
 
         return result
 
-    def _check_format(self, data: Dict[str, Any], result: BackupIntegrity):
-        """Validate backup format and required fields"""
-
-        # Check required top-level fields
-        missing = self.REQUIRED_FIELDS - set(data.keys())
+    def _check_bulk_sections(self, reader: KgBackupV2Reader, result: BackupIntegrity):
+        """Ensure the required bulk record streams are present and list-typed."""
+        bulk = reader.bulk
+        missing = self.REQUIRED_BULK_SECTIONS - set(bulk.keys())
         if missing:
-            result.add_error("format", f"Missing required fields: {missing}")
+            result.add_error("format", f"Missing bulk sections: {missing}")
             return
+        for section in self.REQUIRED_BULK_SECTIONS:
+            if not isinstance(bulk.get(section), list):
+                result.add_error("format", f"Bulk section '{section}' must be a list")
 
-        # Check backup type
-        backup_type = data.get("type")
-        if backup_type not in self.VALID_TYPES:
-            result.add_error(
-                "format",
-                f"Invalid backup type: {backup_type}",
-                {"expected": list(self.VALID_TYPES)}
-            )
+    def _check_references(self, reader: KgBackupV2Reader, result: BackupIntegrity):
+        """Validate reference integrity across the normalized record streams."""
+        concept_ids: Set[str] = {c.get("concept_id") for c in reader.concepts() if c.get("concept_id")}
+        source_ids: Set[str] = {s.get("source_id") for s in reader.sources() if s.get("source_id")}
+        instance_ids: Set[str] = {i.get("instance_id") for i in reader.instances() if i.get("instance_id")}
 
-        # Check version format
-        version = data.get("version")
-        if not isinstance(version, str) or not version:
-            result.add_error("format", "Invalid or missing version field")
-
-        # Check timestamp format
-        timestamp = data.get("timestamp")
-        if not isinstance(timestamp, str) or not timestamp:
-            result.add_warning("format", "Invalid or missing timestamp field")
-
-    def _check_data_sections(self, data: Dict[str, Any], result: BackupIntegrity):
-        """Validate data sections completeness"""
-
-        data_section = data.get("data")
-        if not isinstance(data_section, dict):
-            result.add_error("format", "Invalid or missing 'data' section")
-            return
-
-        # Check required sections
-        missing = self.REQUIRED_DATA_SECTIONS - set(data_section.keys())
-        if missing:
-            result.add_error("format", f"Missing data sections: {missing}")
-            return
-
-        # Validate section types
-        for section in self.REQUIRED_DATA_SECTIONS:
-            if not isinstance(data_section.get(section), list):
-                result.add_error("format", f"Section '{section}' must be a list")
-
-        # Check for empty backup (warning, not error)
-        if all(len(data_section.get(s, [])) == 0 for s in self.REQUIRED_DATA_SECTIONS):
-            result.add_warning("consistency", "Backup contains no data (all sections empty)")
-
-    def _check_references(self, data: Dict[str, Any], result: BackupIntegrity):
-        """Validate reference integrity between entities"""
-
-        data_section = data.get("data", {})
-        is_ontology_backup = data.get("type") == "ontology_backup"
-
-        # Build ID sets for validation
-        concept_ids: Set[str] = {c.get("concept_id") for c in data_section.get("concepts", []) if c.get("concept_id")}
-        source_ids: Set[str] = {s.get("source_id") for s in data_section.get("sources", []) if s.get("source_id")}
-
-        # Check instances reference valid concepts and sources
-        instances = data_section.get("instances", [])
-        for idx, instance in enumerate(instances):
-            concept_id = instance.get("concept_id")
-            source_id = instance.get("source_id")
-
-            if not concept_id:
-                result.add_error("references", f"Instance {idx} missing concept_id field")
-            elif concept_id not in concept_ids:
-                # External concept references are allowed in ontology backups (warnings handled separately)
-                if not is_ontology_backup:
-                    result.add_error("references",
-                        f"Referential integrity: Instance {idx} references concept_id '{concept_id}' which doesn't exist in backup")
-
+        # Instances must name an instance_id and a source that exists in the backup.
+        # (Instances are normalized: no concept_id — Concept↔Instance is in evidence.)
+        for idx, inst in enumerate(reader.instances()):
+            if not inst.get("instance_id"):
+                result.add_error("references", f"Instance {idx} missing instance_id field")
+            source_id = inst.get("source_id")
             if not source_id:
                 result.add_error("references", f"Instance {idx} missing source_id field")
             elif source_id not in source_ids:
-                result.add_error("references",
-                    f"Referential integrity: Instance {idx} references source_id '{source_id}' which doesn't exist in backup")
+                result.add_error(
+                    "references",
+                    f"Referential integrity: Instance {idx} references source_id "
+                    f"'{source_id}' which doesn't exist in backup",
+                )
 
-        # Check relationships reference valid concepts
-        relationships = data_section.get("relationships", [])
-        for idx, rel in enumerate(relationships):
-            from_id = rel.get("from")
-            to_id = rel.get("to")
-            rel_type = rel.get("type")
+        # Evidence links (Concept→Instance). Missing instance is structural (error);
+        # missing concept is treated as an external dependency (warning) since partial
+        # backups legitimately evidence concepts held in other ontologies.
+        for idx, ev in enumerate(reader.bulk.get("evidence", [])):
+            if ev.get("instance_id") not in instance_ids:
+                result.add_error(
+                    "references",
+                    f"Evidence {idx} references instance_id "
+                    f"'{ev.get('instance_id')}' which doesn't exist in backup",
+                )
 
-            if not from_id:
+        # Relationships: endpoints reference concepts; missing endpoints are external
+        # deps (warnings) — the restore skips edges with absent endpoints. Validate the
+        # de-interned edge type against the carried vocabulary.
+        vocab_types = {v.get("relationship_type") for v in reader.vocabulary() if v.get("relationship_type")}
+        if not vocab_types:
+            vocab_types = set(self.VALID_RELATIONSHIP_TYPES)
+
+        for idx, rel in enumerate(reader.relationships()):
+            if not rel.get("from"):
                 result.add_error("references", f"Relationship {idx} missing 'from' field")
-            elif from_id not in concept_ids:
-                # External concept references are allowed in ontology backups (warnings handled separately)
-                if not is_ontology_backup:
-                    result.add_error("references",
-                        f"Referential integrity: Relationship {idx} 'from' references concept_id '{from_id}' which doesn't exist in backup")
-
-            if not to_id:
+            if not rel.get("to"):
                 result.add_error("references", f"Relationship {idx} missing 'to' field")
-            elif to_id not in concept_ids:
-                # External concept references are allowed in ontology backups (warnings handled separately)
-                if not is_ontology_backup:
-                    result.add_error("references",
-                        f"Referential integrity: Relationship {idx} 'to' references concept_id '{to_id}' which doesn't exist in backup")
+            rel_type = rel.get("type")
+            if rel_type and rel_type not in vocab_types and rel_type not in self.STRUCTURAL_TYPES:
+                result.add_warning(
+                    "references",
+                    f"Vocabulary integrity: Relationship {idx} uses edge type "
+                    f"'{rel_type}' which is not in the vocabulary stream",
+                )
 
-            # Check relationship type (ADR-032: Extended vocabulary support)
-            # If backup has vocabulary section, check against that; otherwise use builtin types
-            vocabulary_types = set()
-            if "vocabulary" in data_section:
-                vocabulary_types = {v.get("relationship_type") for v in data_section.get("vocabulary", []) if v.get("relationship_type")}
-            else:
-                # Old backups without vocabulary section - use builtin types only
-                vocabulary_types = self.VALID_RELATIONSHIP_TYPES
+    def _check_external_deps(self, reader: KgBackupV2Reader, result: BackupIntegrity):
+        """Count concept references not contained in this backup (partial/adjacent restores)."""
+        local_concept_ids: Set[str] = {c.get("concept_id") for c in reader.concepts() if c.get("concept_id")}
 
-            if rel_type and rel_type not in vocabulary_types:
-                # Only warn if type is not in vocabulary AND not a structural type
-                structural_types = {"APPEARS", "EVIDENCED_BY", "FROM_SOURCE"}
-                if rel_type not in structural_types:
-                    result.add_warning("references",
-                        f"Vocabulary integrity: Relationship {idx} uses edge type '{rel_type}' which is not in vocabulary table (pre-ADR-032 data)")
-
-    def _check_statistics(self, data: Dict[str, Any], result: BackupIntegrity):
-        """Validate statistics match actual data"""
-
-        stats = data.get("statistics", {})
-        data_section = data.get("data", {})
-
-        # Count actual data
-        actual = {
-            "concepts": len(data_section.get("concepts", [])),
-            "sources": len(data_section.get("sources", [])),
-            "instances": len(data_section.get("instances", [])),
-            "relationships": len(data_section.get("relationships", []))
+        external_in_evidence = {
+            ev.get("concept_id") for ev in reader.bulk.get("evidence", [])
+            if ev.get("concept_id") and ev.get("concept_id") not in local_concept_ids
         }
+        external_in_rels: Set[str] = set()
+        for rel in reader.relationships():
+            for endpoint in (rel.get("from"), rel.get("to")):
+                if endpoint and endpoint not in local_concept_ids:
+                    external_in_rels.add(endpoint)
 
-        # Compare with claimed statistics
-        for key, expected in stats.items():
-            if key in actual:
-                if actual[key] != expected:
-                    result.add_warning(
-                        "consistency",
-                        f"Statistics mismatch for {key}: claimed {expected}, actual {actual[key]}"
-                    )
-
-    def _check_external_deps(self, data: Dict[str, Any], result: BackupIntegrity):
-        """Check for external concept dependencies (ontology backups)"""
-
-        ontology_name = data.get("ontology")
-        if not ontology_name:
-            result.add_warning("external_deps", "Ontology backup missing ontology name")
-            return
-
-        data_section = data.get("data", {})
-        concepts = data_section.get("concepts", [])
-        instances = data_section.get("instances", [])
-        relationships = data_section.get("relationships", [])
-
-        # Build set of concept IDs in this backup
-        local_concept_ids: Set[str] = {c.get("concept_id") for c in concepts if c.get("concept_id")}
-
-        # Check for external concept references in instances
-        external_concept_refs = set()
-        for instance in instances:
-            concept_id = instance.get("concept_id")
-            if concept_id and concept_id not in local_concept_ids:
-                external_concept_refs.add(concept_id)
-
-        # Check for external concept references in relationships
-        external_rel_refs = set()
-        for rel in relationships:
-            from_id = rel.get("from")
-            to_id = rel.get("to")
-
-            if from_id and from_id not in local_concept_ids:
-                external_rel_refs.add(from_id)
-            if to_id and to_id not in local_concept_ids:
-                external_rel_refs.add(to_id)
-
-        # Report external dependencies
-        total_external = len(external_concept_refs) + len(external_rel_refs)
+        total_external = len(external_in_evidence) + len(external_in_rels)
         result.external_deps = total_external
 
         if total_external > 0:
             result.add_warning(
                 "external_deps",
-                f"Cross-ontology referential integrity: Ontology backup references {total_external} concept_ids from other ontologies not included in this backup",
+                f"Cross-ontology referential integrity: backup references {total_external} "
+                f"concept_ids not contained in this backup",
                 {
-                    "external_concepts_in_instances": len(external_concept_refs),
-                    "external_concepts_in_relationships": len(external_rel_refs)
-                }
+                    "external_concepts_in_evidence": len(external_in_evidence),
+                    "external_concepts_in_relationships": len(external_in_rels),
+                },
             )
             result.add_info(
                 "external_deps",
-                "These external references will create dangling edges if other ontologies are not present in target database"
+                "These external references create dangling edges unless the referenced "
+                "concepts already exist in the target database",
             )
 
 
 def check_backup_integrity(file_path: str) -> BackupIntegrity:
-    """
-    Convenience function to check backup file integrity
-
-    Args:
-        file_path: Path to backup JSON file
-
-    Returns:
-        BackupIntegrity result
-
-    Example:
-        result = check_backup_integrity("/path/to/backup.json")
-        if result.valid:
-            print("Backup is valid")
-        else:
-            for error in result.errors:
-                print(f"ERROR: {error.message}")
-    """
+    """Convenience function to check a backup file's integrity by path."""
     checker = BackupIntegrityChecker()
     return checker.check_file(file_path)
 
 
 def check_backup_data(data: Dict[str, Any]) -> BackupIntegrity:
-    """
-    Convenience function to check loaded backup data integrity
-
-    Args:
-        data: Loaded backup dictionary
-
-    Returns:
-        BackupIntegrity result
-    """
+    """Convenience function to check a loaded kg-backup/2 object's integrity."""
     checker = BackupIntegrityChecker()
     return checker.check_data(data)

--- a/api/app/lib/backup_streaming.py
+++ b/api/app/lib/backup_streaming.py
@@ -98,12 +98,12 @@ async def create_backup_stream(
     if format not in ("json", "gexf"):
         raise ValueError(f"Invalid format: {format}. Must be 'json' or 'gexf'")
 
-    # Generate backup data
+    # Generate backup data (single model: kg-backup/2)
     if backup_type == "full":
-        backup_data = DataExporter.export_full_backup(client)
+        backup_data = DataExporter.export_kg_backup_v2(client)
         ontology_name_for_file = None
     else:
-        backup_data = DataExporter.export_ontology_backup(client, ontology_name)
+        backup_data = DataExporter.export_kg_backup_v2(client, ontology=ontology_name)
         ontology_name_for_file = ontology_name
 
     # Generate filename based on format

--- a/api/app/lib/gexf_exporter.py
+++ b/api/app/lib/gexf_exporter.py
@@ -131,6 +131,8 @@ from datetime import datetime
 from typing import Dict, Any, List
 import hashlib
 
+from ...lib.serialization import KgBackupV2Reader
+
 
 def _prettify_xml(elem: ET.Element) -> str:
     """
@@ -224,22 +226,28 @@ def export_to_gexf(backup_data: Dict[str, Any]) -> str:
     Returns:
         GEXF XML string
     """
-    # Extract data from nested structure
-    # Backup format: {"metadata": {...}, "data": {"concepts": [...], ...}}
-    data = backup_data.get("data", {})
-    concepts = data.get("concepts", [])
-    relationships = data.get("relationships", [])
-    instances = data.get("instances", [])
+    # Read the single backup model (kg-backup/2): de-interns relationship types
+    # and exposes the normalized record streams (ADR-102 P3).
+    reader = KgBackupV2Reader(backup_data)
+    concepts = list(reader.concepts())
+    relationships = list(reader.relationships())   # type de-interned to its label
+    instances = list(reader.instances())
 
-    # Metadata is at top level
+    # Metadata: a single-ontology backup names that ontology in the header.
+    ontologies = [o.get("name") for o in reader.header.get("ontologies", []) if o.get("name")]
     metadata = {
-        "export_type": backup_data.get("type", "unknown"),
-        "ontology": backup_data.get("ontology", None)
+        "export_type": "ontology" if len(ontologies) == 1 else "full",
+        "ontology": ontologies[0] if len(ontologies) == 1 else None,
     }
 
-    # Calculate instance counts per concept
+    # Instance count per concept comes from the M:N evidence stream (instances are
+    # normalized and no longer carry concept_id).
     from collections import Counter
-    instance_counts = Counter(inst.get("concept_id", "") for inst in instances)
+    instance_counts = Counter(
+        concept_id
+        for concept_ids in reader.evidence_by_instance().values()
+        for concept_id in concept_ids
+    )
 
     # Create root element
     gexf = ET.Element("gexf", {

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -332,14 +332,20 @@ async def restore_backup(
             f"Relationships: {stats.get('relationships', 0)}"
         )
 
-        # Safety check: If ontology backup and target ontology exists, require --merge flag
+        # Safety check: If a single-ontology backup targets an existing ontology,
+        # require the --merge flag. The single kg-backup/2 model names the scope in
+        # the header (one ontology entry == a scoped backup) — ADR-102 P3.
         with open(temp_path, 'r') as f:
             import json
+            from ...lib.serialization import KgBackupV2Reader
             backup_data = json.load(f)
-            backup_type = backup_data.get("type", "")
-            backup_ontology = backup_data.get("ontology")
+            _header_ontologies = [
+                o.get("name") for o in KgBackupV2Reader(backup_data).header.get("ontologies", [])
+                if o.get("name")
+            ]
+            backup_ontology = _header_ontologies[0] if len(_header_ontologies) == 1 else None
 
-            if backup_type == "ontology_backup" and backup_ontology and overwrite:
+            if backup_ontology and overwrite:
                 # Safety check: If ontology exists and user didn't specify --merge, error
                 try:
                     # Use ontology list API to check existence

--- a/api/app/services/admin_service.py
+++ b/api/app/services/admin_service.py
@@ -155,11 +155,16 @@ class AdminService:
         backup_path = Path(backup_file)
         file_size_mb = backup_path.stat().st_size / (1024 * 1024)
 
-        # Load backup to get statistics
+        # Load backup to get statistics (single kg-backup/2 model: counts come from
+        # the bulk record streams, not a top-level statistics field).
         with open(backup_path, 'r') as f:
             backup_data = json.load(f)
 
-        statistics = backup_data.get('statistics', {})
+        from ...lib.serialization import KgBackupV2Reader
+        _counts = KgBackupV2Reader(backup_data).counts()
+        statistics = {
+            k: _counts[k] for k in ("concepts", "sources", "instances", "relationships", "vocabulary")
+        }
 
         # TODO: Add integrity assessment
         integrity = None

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from ..lib.age_client import AGEClient
 from ..lib.backup_streaming import create_backup_stream
 from ..lib.backup_archive import restore_documents_to_garage, cleanup_extracted_archive
-from ...lib.serialization import DataImporter
+from ...lib.serialization import DataImporter, KgBackupV2Reader
 
 logger = logging.getLogger(__name__)
 
@@ -100,23 +100,20 @@ def run_restore_worker(
         with open(temp_file, 'r', encoding='utf-8') as f:
             backup_data = json.load(f)
 
-        # Stage 2.5: For full backups, clear database first
-        backup_type = backup_data.get("type", "")
-        if backup_type == "full_backup":
-            logger.info(f"[{job_id}] Detected full backup - clearing database before restore")
-            job_queue.update_job(job_id, {
-                "progress": {
-                    "stage": "clearing_database",
-                    "percent": 15,
-                    "message": "Clearing existing database for full backup restore"
-                }
-            })
-            _clear_database(client, job_id)
-            # Force overwrite for full backups (though database is now empty)
+        # Stage 2.5: ADR-102 clone/merge gate — target emptiness, not a backup-type
+        # flag (the single kg-backup/2 model carries no v1 "full_backup" type).
+        #   empty target   → CLONE: ids preserved 1:1, props set fresh.
+        #   populated target → MERGE: MERGE-by-id in place (adjacent/integration in P4).
+        # A destructive "replace everything" is now an explicit reset (then clone),
+        # never an implicit wipe during restore.
+        if _target_is_empty(client):
+            logger.info(f"[{job_id}] Empty target — clone restore (ids preserved 1:1)")
             overwrite = True
+        else:
+            logger.info(f"[{job_id}] Populated target — merge restore (overwrite={overwrite})")
 
         # Stage 3: Execute restore with progress tracking
-        logger.info(f"[{job_id}] Starting restore operation (overwrite={overwrite}, backup_type={backup_type})")
+        logger.info(f"[{job_id}] Starting restore operation (overwrite={overwrite})")
 
         restore_stats = _execute_restore(
             client=client,
@@ -263,9 +260,9 @@ def _create_checkpoint_backup(client: AGEClient, job_id: str) -> Path:
     # Ensure backup directory exists
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Export full database backup
+    # Export full database backup (single model: kg-backup/2)
     from ...lib.serialization import DataExporter
-    backup_data = DataExporter.export_full_backup(client)
+    backup_data = DataExporter.export_kg_backup_v2(client)
 
     # Save checkpoint
     with open(checkpoint_path, 'w', encoding='utf-8') as f:
@@ -298,6 +295,25 @@ def _clear_database(client: AGEClient, job_id: str) -> None:
     logger.info(f"[{job_id}] Concept graph cleared successfully (vocabulary preserved)")
 
 
+def _target_is_empty(client: AGEClient) -> bool:
+    """Return True if the concept graph holds no Concept/Source/Instance nodes.
+
+    The ADR-102 clone/merge gate: an empty target is restored by CLONE (ids
+    preserved 1:1); a populated target is a MERGE. A label whose backing table does
+    not exist yet (fresh database) counts as empty.
+    """
+    for label in ("Concept", "Source", "Instance"):
+        try:
+            row = client._execute_cypher(
+                f"MATCH (n:{label}) RETURN count(n) AS c", fetch_one=True
+            )
+        except Exception:
+            continue  # label table absent → no such nodes
+        if row and int(str(row.get("c", 0)).strip('"')) > 0:
+            return False
+    return True
+
+
 def _execute_restore(
     client: AGEClient,
     backup_data: Dict[str, Any],
@@ -312,13 +328,13 @@ def _execute_restore(
     Returns:
         Dict with restore statistics
     """
-    data_section = backup_data.get("data", {})
-    concepts = data_section.get("concepts", [])
-    sources = data_section.get("sources", [])
-    instances = data_section.get("instances", [])
-    relationships = data_section.get("relationships", [])
+    counts = KgBackupV2Reader(backup_data).counts()
+    n_concepts = counts["concepts"]
+    n_sources = counts["sources"]
+    n_instances = counts["instances"]
+    n_relationships = counts["relationships"]
 
-    total_items = len(concepts) + len(sources) + len(instances) + len(relationships)
+    total_items = n_concepts + n_sources + n_instances + n_relationships
 
     if total_items == 0:
         return {"concepts": 0, "sources": 0, "instances": 0, "relationships": 0}
@@ -339,11 +355,11 @@ def _execute_restore(
         if stage == "concepts":
             items_processed_cumulative = current
         elif stage == "sources":
-            items_processed_cumulative = len(concepts) + current
+            items_processed_cumulative = n_concepts + current
         elif stage == "instances":
-            items_processed_cumulative = len(concepts) + len(sources) + current
+            items_processed_cumulative = n_concepts + n_sources + current
         elif stage == "relationships":
-            items_processed_cumulative = len(concepts) + len(sources) + len(instances) + current
+            items_processed_cumulative = n_concepts + n_sources + n_instances + current
 
         # Calculate overall percent (0-100)
         overall_percent = int((items_processed_cumulative / total_items) * 100) if total_items > 0 else 0

--- a/api/lib/id_remap.py
+++ b/api/lib/id_remap.py
@@ -1,0 +1,143 @@
+"""ID remapping for ADJACENT-mode restore (ADR-102 P3).
+
+Adjacent mode imports a ``kg-backup/2`` backup *alongside* existing graph data
+without identity collisions: every app-assigned id (concept / source / instance)
+is rewritten old→new, and **every reference class** that cites those ids is
+rewritten through the maps. A missed class silently orphans edges (ADR-102
+Consequences: "a missed class silently orphans relationships"), so the rewrite is
+exhaustive and is covered class-by-class by the test matrix:
+
+  - ``concept_id``  → concepts, ``evidence.concept_id``, relationship ``from``/``to``
+  - ``source_id``   → sources, ``instances.source_id``, **and the ``learned_id`` EDGE
+                      property** (a source_id carried on agent-learned edges)
+  - ``instance_id`` → instances, ``evidence.instance_id``
+  - image ``storage_key`` → **recomputed** from the new source_id (derived, not an id)
+  - ``garage_key`` (source document) → content-addressed (sha256): **IMMUNE**, preserved
+
+Pure and DB-free: emits a NEW valid ``kg-backup/2`` object (which flows through the
+normal clone path unchanged) plus the old→new mapping table — a restore artifact
+that lets callers transpose ids afterward. The clone/merge *mode selection* and the
+DB fetch of the target's existing ids are wired in P4.
+"""
+import uuid
+from typing import Dict, Any, Optional, Set, Callable, Tuple
+
+
+def _default_id_factory(kind: str, old_id: str) -> str:
+    """Mint a fresh, collision-free id, prefixed by kind initial for debuggability."""
+    return f"{kind[0]}_{uuid.uuid4().hex}"
+
+
+def _remap_storage_key(storage_key: str, old_sid: str, new_sid: str) -> str:
+    """Recompute an image storage_key for a new source_id.
+
+    Key format (``api/app/lib/garage/image_storage.py``):
+    ``images/{ontology}/{source_id}.{ext}``. The ontology (``Source.document``) is
+    preserved in adjacent mode, so only the source_id filename stem changes; anchor
+    on ``/{old}.`` so nothing else in the path is touched.
+    """
+    needle = f"/{old_sid}."
+    if needle in storage_key:
+        return storage_key.replace(needle, f"/{new_sid}.", 1)
+    # Fallback: source_id used without a clean filename anchor.
+    return storage_key.replace(old_sid, new_sid, 1)
+
+
+class IdRemapper:
+    """Rewrite all app-assigned ids in a kg-backup/2 object for adjacent-mode restore.
+
+    Modes:
+      - ``always`` — mint a new id for every record (adjacent-without-integration:
+        the backup lands as a wholly independent copy).
+      - ``collision`` — remap an id only when it already exists in the target
+        (``existing_ids``); non-colliding ids are preserved.
+    """
+
+    MODE_ALWAYS = "always"
+    MODE_COLLISION = "collision"
+
+    def __init__(self, mode: str = MODE_ALWAYS,
+                 existing_ids: Optional[Dict[str, Set[str]]] = None,
+                 id_factory: Optional[Callable[[str, str], str]] = None):
+        if mode not in (self.MODE_ALWAYS, self.MODE_COLLISION):
+            raise ValueError(f"Unknown remap mode: {mode!r}")
+        self.mode = mode
+        self.existing = existing_ids or {}
+        self._mint = id_factory or _default_id_factory
+
+    def _decide(self, kind: str, old_id: str) -> str:
+        """Return the new id for ``old_id`` under the active mode."""
+        if self.mode == self.MODE_ALWAYS:
+            return self._mint(kind, old_id)
+        if old_id in self.existing.get(kind, set()):
+            return self._mint(kind, old_id)
+        return old_id  # collision mode, no collision → preserve
+
+    def remap(self, obj: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Dict[str, str]]]:
+        """Return ``(new_backup_object, mapping_table)``.
+
+        The header is carried unchanged (it holds no app-ids — only ontology names,
+        profile identities, and interned dictionaries). All ids live in ``bulk``.
+        """
+        bulk = obj["bulk"]
+
+        concept_map = {c["concept_id"]: self._decide("concept", c["concept_id"])
+                       for c in bulk.get("concepts", [])}
+        source_map = {s["source_id"]: self._decide("source", s["source_id"])
+                      for s in bulk.get("sources", [])}
+        instance_map = {i["instance_id"]: self._decide("instance", i["instance_id"])
+                        for i in bulk.get("instances", [])}
+
+        new_bulk: Dict[str, Any] = {}
+
+        new_bulk["concepts"] = [
+            {**c, "concept_id": concept_map[c["concept_id"]]} for c in bulk.get("concepts", [])
+        ]
+
+        new_sources = []
+        for s in bulk.get("sources", []):
+            old_sid = s["source_id"]
+            new_sid = source_map[old_sid]
+            s2 = {**s, "source_id": new_sid}
+            if s2.get("storage_key"):
+                s2["storage_key"] = _remap_storage_key(s2["storage_key"], old_sid, new_sid)
+            # garage_key is content-addressed (sha256) — immune, left untouched.
+            new_sources.append(s2)
+        new_bulk["sources"] = new_sources
+
+        new_bulk["instances"] = [
+            {**i,
+             "instance_id": instance_map[i["instance_id"]],
+             "source_id": source_map.get(i["source_id"], i["source_id"])}
+            for i in bulk.get("instances", [])
+        ]
+
+        new_bulk["evidence"] = [
+            {"concept_id": concept_map.get(e["concept_id"], e["concept_id"]),
+             "instance_id": instance_map.get(e["instance_id"], e["instance_id"])}
+            for e in bulk.get("evidence", [])
+        ]
+
+        new_rels = []
+        for r in bulk.get("relationships", []):
+            r2 = {**r,
+                  "from": concept_map.get(r["from"], r["from"]),
+                  "to": concept_map.get(r["to"], r["to"])}
+            props = r.get("properties")
+            if props:
+                p2 = dict(props)
+                # learned_id is a source_id carried on the edge — remap via SOURCE map.
+                if p2.get("learned_id") is not None:
+                    p2["learned_id"] = source_map.get(p2["learned_id"], p2["learned_id"])
+                r2["properties"] = p2
+            new_rels.append(r2)
+        new_bulk["relationships"] = new_rels
+
+        # Streams with no app-ids are carried through unchanged.
+        new_bulk["vocabulary"] = bulk.get("vocabulary", [])
+        if "graph_epochs" in bulk:
+            new_bulk["graph_epochs"] = bulk["graph_epochs"]
+
+        new_obj = {"header": obj["header"], "bulk": new_bulk}
+        mapping_table = {"concepts": concept_map, "sources": source_map, "instances": instance_map}
+        return new_obj, mapping_table

--- a/api/lib/integrity.py
+++ b/api/lib/integrity.py
@@ -21,7 +21,13 @@ from .console import Console, Colors
 
 
 class BackupAssessment:
-    """Assess backup completeness and dependencies"""
+    """Assess backup completeness and dependencies.
+
+    DEAD (ADR-102 P6): reads the removed v1 ``data["data"]`` shape and has no live
+    caller — backup/restore/stitch now use KgBackupV2Reader.external_concept_ids() /
+    check_backup_data(). Scheduled for deletion in P6 (the runtime DatabaseIntegrity
+    prune/repair below stays until its logic is ported). Do not wire to new code.
+    """
 
     @staticmethod
     def analyze_backup(backup_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/api/lib/restitching.py
+++ b/api/lib/restitching.py
@@ -38,6 +38,11 @@ class ConceptMatcher:
         """
         Find all external concept references in backup
 
+        DEAD (ADR-102 P6): reads the removed v1 ``data["data"]`` shape. stitch.py now
+        derives external concepts from KgBackupV2Reader (``_find_external_concepts``)
+        and feeds them to ``create_restitch_plan``; this method has no live caller.
+        Do not wire to new code.
+
         Args:
             backup_data: Parsed backup JSON
 

--- a/api/lib/serialization.py
+++ b/api/lib/serialization.py
@@ -780,10 +780,12 @@ def _execute_with_age_retry(client, query, params=None, *, fetch_one=False, max_
             return client._execute_cypher(query, params=params, fetch_one=fetch_one)
         except Exception as e:
             es = str(e)
+            # Only genuinely transient AGE conditions are retried: first-use label
+            # table creation racing across threads, and MVCC write conflicts. A
+            # malformed SET is deterministic and must surface, not be masked.
             transient = (
                 "already exists" in es
                 or "Entity failed to be updated" in es
-                or "SET clause expects a map" in es
             )
             if transient and attempt < max_retries:
                 m = re.search(r'relation "(\w+)" already exists', es)
@@ -1296,8 +1298,16 @@ class DataImporter:
 
     @staticmethod
     def _merge_relationship(client: AGEClient, rel: Dict[str, Any]) -> int:
-        """MERGE a single concept relationship (dynamic edge label). Returns 1 if created/matched."""
+        """MERGE a single concept relationship (dynamic edge label). Returns 1 if created/matched.
+
+        The edge label is interpolated into the Cypher text (AGE has no parameterized
+        edge labels), so a backup — an untrusted-input boundary in adjacent mode — must
+        not inject through ``type``. Labels are identifiers; reject anything else.
+        """
         rel_type = rel["type"]  # de-interned label string
+        if not isinstance(rel_type, str) or not DataImporter._PROP_KEY.match(rel_type):
+            Console.warning(f"  Skipping relationship with unsafe edge type: {rel_type!r}")
+            return 0
         query = f"""
             OPTIONAL MATCH (c1:Concept {{concept_id: $from_id}})
             OPTIONAL MATCH (c2:Concept {{concept_id: $to_id}})

--- a/api/lib/serialization.py
+++ b/api/lib/serialization.py
@@ -19,6 +19,28 @@ from api.app.lib.age_client import AGEClient
 
 from .console import Console, Colors
 
+# kg-backup/2 format version emitted by build_kg_backup_v2 (BACKUP_OBJECT_SPEC).
+KG_BACKUP_FORMAT_VERSION = "kg-backup/2"
+
+
+def _parse_nullable_int(raw: Any) -> Optional[int]:
+    """Parse a nullable integer from an AGE agtype scalar.
+
+    AGE returns scalars as agtype; absent/NULL properties surface as ``None`` or
+    the literal string ``"null"``. Returns the int value, or ``None`` when the
+    value is absent/null/unparseable (e.g. a pre-epoch concept with no
+    created_at_epoch).
+    """
+    if raw is None:
+        return None
+    s = str(raw).strip().strip('"')
+    if s == "" or s.lower() == "null":
+        return None
+    try:
+        return int(s)
+    except (ValueError, TypeError):
+        return None
+
 
 class BackupFormat:
     """Backup data format specification"""
@@ -118,7 +140,9 @@ class DataExporter:
                 RETURN c.concept_id as concept_id,
                        c.label as label,
                        c.search_terms as search_terms,
-                       c.embedding as embedding
+                       c.embedding as embedding,
+                       c.created_at_epoch as created_at_epoch,
+                       c.last_seen_epoch as last_seen_epoch
                 ORDER BY c.concept_id
             """
             result = client._execute_cypher(query, params={"ontology": ontology})
@@ -128,7 +152,9 @@ class DataExporter:
                 RETURN c.concept_id as concept_id,
                        c.label as label,
                        c.search_terms as search_terms,
-                       c.embedding as embedding
+                       c.embedding as embedding,
+                       c.created_at_epoch as created_at_epoch,
+                       c.last_seen_epoch as last_seen_epoch
                 ORDER BY c.concept_id
             """
             result = client._execute_cypher(query)
@@ -157,7 +183,10 @@ class DataExporter:
                 "concept_id": concept_id,
                 "label": label,
                 "search_terms": search_terms,
-                "embedding": embedding  # Full 1536-dim array
+                "embedding": embedding,  # Full 1536-dim array
+                # ADR-102 §3: epoch stamps (nullable for pre-epoch concepts).
+                "created_at_epoch": _parse_nullable_int(record.get("created_at_epoch")),
+                "last_seen_epoch": _parse_nullable_int(record.get("last_seen_epoch")),
             })
 
         return concepts
@@ -204,14 +233,30 @@ class DataExporter:
             result = client._execute_cypher(query)
 
         sources = []
+        seen_ids = set()
         for record in result:
+            source_id = str(record.get("source_id", "")).strip('"')
+
+            # Defense-in-depth (ADR-102): a duplicate source_id is a graph integrity
+            # issue (suspected ingest race — tracked separately for a runtime
+            # integrity-check expansion). Drop the dup from the backup so it stays
+            # restorable, but WARN — do not silently mask it.
+            if source_id in seen_ids:
+                Console.warning(
+                    f"Duplicate source_id {source_id!r} in graph — dropping the "
+                    f"duplicate from the backup (defense-in-depth; investigate the "
+                    f"graph integrity issue)"
+                )
+                continue
+            seen_ids.add(source_id)
+
             # Parse agtype values
             garage_key = str(record.get("garage_key", "")).strip('"')
             content_type = str(record.get("content_type", "")).strip('"')
             storage_key = str(record.get("storage_key", "")).strip('"')
 
             source = {
-                "source_id": str(record.get("source_id", "")).strip('"'),
+                "source_id": source_id,
                 "document": str(record.get("document", "")).strip('"'),
                 "file_path": str(record.get("file_path", "")).strip('"'),
                 "paragraph": int(str(record.get("paragraph", 0))),
@@ -242,25 +287,27 @@ class DataExporter:
         Returns:
             List of instance dictionaries
         """
+        # ADR-102: instances are normalized — UNIQUE per instance node, with no
+        # concept_id. An instance evidences M concepts (M:N via EVIDENCED_BY); those
+        # links live in the separate evidence stream (see export_evidence). This
+        # avoids repeating the full quote once per evidenced concept.
         if ontology:
             query = """
                 MATCH (i:Instance)-[:FROM_SOURCE]->(s:Source {document: $ontology})
-                MATCH (i)<-[:EVIDENCED_BY]-(c:Concept)
-                RETURN i.instance_id as instance_id,
+                RETURN DISTINCT i.instance_id as instance_id,
                        i.quote as quote,
-                       c.concept_id as concept_id,
-                       s.source_id as source_id
+                       s.source_id as source_id,
+                       i.created_at_event_id as created_at_event_id
                 ORDER BY i.instance_id
             """
             result = client._execute_cypher(query, params={"ontology": ontology})
         else:
             query = """
                 MATCH (i:Instance)-[:FROM_SOURCE]->(s:Source)
-                MATCH (i)<-[:EVIDENCED_BY]-(c:Concept)
-                RETURN i.instance_id as instance_id,
+                RETURN DISTINCT i.instance_id as instance_id,
                        i.quote as quote,
-                       c.concept_id as concept_id,
-                       s.source_id as source_id
+                       s.source_id as source_id,
+                       i.created_at_event_id as created_at_event_id
                 ORDER BY i.instance_id
             """
             result = client._execute_cypher(query)
@@ -270,11 +317,44 @@ class DataExporter:
             instances.append({
                 "instance_id": str(record.get("instance_id", "")).strip('"'),
                 "quote": str(record.get("quote", "")).strip('"'),
-                "concept_id": str(record.get("concept_id", "")).strip('"'),
-                "source_id": str(record.get("source_id", "")).strip('"')
+                "source_id": str(record.get("source_id", "")).strip('"'),
+                # ADR-102 §3: FK to graph_epochs.event_id (nullable, pre-ADR-203).
+                "created_at_event_id": _parse_nullable_int(record.get("created_at_event_id")),
             })
 
         return instances
+
+    @staticmethod
+    def export_evidence(client: AGEClient, ontology: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Export EVIDENCED_BY links as {concept_id, instance_id} (ADR-102, normalized).
+
+        The Concept→Instance evidence relationship is M:N. Carrying it as a separate
+        link stream keeps instance records unique (quote stored once) and lets the
+        restore reconstruct EVIDENCED_BY edges. Filtered by the instance's source
+        ontology when ``ontology`` is given.
+        """
+        if ontology:
+            query = """
+                MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance)-[:FROM_SOURCE]->(s:Source {document: $ontology})
+                RETURN c.concept_id as concept_id, i.instance_id as instance_id
+                ORDER BY c.concept_id, i.instance_id
+            """
+            result = client._execute_cypher(query, params={"ontology": ontology})
+        else:
+            query = """
+                MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance)
+                RETURN c.concept_id as concept_id, i.instance_id as instance_id
+                ORDER BY c.concept_id, i.instance_id
+            """
+            result = client._execute_cypher(query)
+
+        return [
+            {
+                "concept_id": str(r.get("concept_id", "")).strip('"'),
+                "instance_id": str(r.get("instance_id", "")).strip('"'),
+            }
+            for r in result
+        ]
 
     @staticmethod
     def export_relationships(client: AGEClient, ontology: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -540,6 +620,269 @@ class DataExporter:
                 "vocabulary": vocabulary
             }
         }
+
+    # ------------------------------------------------------------------
+    # kg-backup/2 export (ADR-102 §5; docs/reference/BACKUP_OBJECT_SPEC.md).
+    # The pure build_kg_backup_v2() assembles the self-describing object from
+    # already-fetched lists so it is unit-testable WITHOUT a database;
+    # export_kg_backup_v2() is the thin DB-fetching wrapper.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def export_embedding_profiles(client: AGEClient) -> List[Dict[str, Any]]:
+        """Fetch embedding profiles as portable header descriptors (spec §3.2).
+
+        Returns profile dicts: identity ``{provider}:{model}@{dims}``, vector_space,
+        image_vector_space, name, multimodal — active profile first (index 0).
+        Returns [] if kg_api.embedding_profile is absent (pre-migration-055).
+        """
+        conn = client.pool.getconn()
+        try:
+            import psycopg2.extras
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute("SELECT to_regclass('kg_api.embedding_profile') IS NOT NULL AS present")
+                if not cur.fetchone()["present"]:
+                    return []
+                cur.execute("""
+                    SELECT text_provider, text_model_name, text_dimensions,
+                           vector_space, image_vector_space, name, multimodal
+                    FROM kg_api.embedding_profile
+                    ORDER BY active DESC, name
+                """)
+                profiles = []
+                for row in cur.fetchall():
+                    profiles.append({
+                        "identity": f"{row['text_provider']}:{row['text_model_name']}@{row['text_dimensions']}",
+                        "vector_space": row.get("vector_space"),
+                        "image_vector_space": row.get("image_vector_space"),
+                        "name": row.get("name"),
+                        "multimodal": bool(row.get("multimodal")),
+                    })
+                return profiles
+        finally:
+            conn.commit()
+            client.pool.putconn(conn)
+
+    @staticmethod
+    def export_epoch_kinds(client: AGEClient) -> List[Dict[str, Any]]:
+        """Fetch the kg_api.graph_epoch_kinds lookup rows (migration 064)."""
+        conn = client.pool.getconn()
+        try:
+            import psycopg2.extras
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute("SELECT to_regclass('kg_api.graph_epoch_kinds') IS NOT NULL AS present")
+                if not cur.fetchone()["present"]:
+                    return []
+                cur.execute("""
+                    SELECT kind, semantic_wallclock, description
+                    FROM kg_api.graph_epoch_kinds ORDER BY kind
+                """)
+                return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.commit()
+            client.pool.putconn(conn)
+
+    @staticmethod
+    def export_graph_epochs(client: AGEClient) -> List[Dict[str, Any]]:
+        """Fetch the kg_api.graph_epochs event log (migrations 063/076).
+
+        The epoch log is PRIMARY history — it cannot be recomputed from the final
+        graph — so it is ALWAYS exported. Restore decides whether to replay it
+        (faithful) or collapse to a single restore event (simple) — ADR-102 §3.
+        """
+        conn = client.pool.getconn()
+        try:
+            import psycopg2.extras
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute("SELECT to_regclass('kg_api.graph_epochs') IS NOT NULL AS present")
+                if not cur.fetchone()["present"]:
+                    return []
+                cur.execute("""
+                    SELECT event_id, occurred_at, kind, actor, counter_after, metadata
+                    FROM kg_api.graph_epochs ORDER BY event_id
+                """)
+                rows = []
+                for r in cur.fetchall():
+                    d = dict(r)
+                    occ = d.get("occurred_at")
+                    if occ is not None and hasattr(occ, "isoformat"):
+                        d["occurred_at"] = occ.isoformat()
+                    rows.append(d)
+                return rows
+        finally:
+            conn.commit()
+            client.pool.putconn(conn)
+
+    @staticmethod
+    def build_kg_backup_v2(
+        *,
+        concepts: List[Dict[str, Any]],
+        sources: List[Dict[str, Any]],
+        instances: List[Dict[str, Any]],
+        evidence: List[Dict[str, Any]],
+        relationships: List[Dict[str, Any]],
+        vocabulary: List[Dict[str, Any]],
+        embedding_profiles: List[Dict[str, Any]],
+        epoch_kinds: List[Dict[str, Any]],
+        graph_epochs: List[Dict[str, Any]],
+        schema_version: int,
+        source_platform: str = "knowledge-graph-system",
+        source_version: str = "unknown",
+        exported_at: Optional[str] = None,
+        ontology: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Assemble a kg-backup/2 object from already-fetched lists — PURE (no I/O).
+
+        Builds the declarative header (interned dictionaries) and the bulk region
+        (references by index), per docs/reference/BACKUP_OBJECT_SPEC.md. Separated
+        from DB fetching so it is unit-testable against the offline validator.
+
+        - Relationship types / content types / epoch kinds / actors are interned
+          into header dictionaries; bulk records cite them by integer index.
+        - Concepts use the record→backup cascade (no ontology tier, ADR-102 P2):
+          with one active profile, concepts carry no per-record profile ref and
+          inherit ``header.default_embedding_profile``.
+        - Derived products are not present (caller must not pass them).
+        """
+        exported_at = exported_at or (datetime.utcnow().isoformat() + "Z")
+
+        # relationship-type dictionary: vocab types, plus any dynamic edge type
+        # actually used that is missing from the vocabulary table (so every edge
+        # `type` index resolves in the header).
+        header_vocab = list(vocabulary)
+        rel_type_index: Dict[str, int] = {}
+        for i, v in enumerate(header_vocab):
+            rt = v.get("relationship_type")
+            if rt is not None:
+                rel_type_index.setdefault(rt, i)
+        for r in relationships:
+            t = r.get("type")
+            if t is not None and t not in rel_type_index:
+                rel_type_index[t] = len(header_vocab)
+                header_vocab.append({"relationship_type": t})
+
+        # content-type dictionary (distinct, first-seen order)
+        content_types: List[str] = []
+        ct_index: Dict[str, int] = {}
+        for s in sources:
+            ct = s.get("content_type")
+            if isinstance(ct, str) and ct not in ct_index:
+                ct_index[ct] = len(content_types)
+                content_types.append(ct)
+
+        # epoch-kind dictionary (lookup rows + any kind present only in the log)
+        epoch_kinds = list(epoch_kinds)
+        kind_index: Dict[str, int] = {}
+        for i, k in enumerate(epoch_kinds):
+            if k.get("kind") is not None:
+                kind_index.setdefault(k["kind"], i)
+        # actor dictionary (distinct, from the epoch log)
+        actors: List[str] = []
+        actor_index: Dict[str, int] = {}
+        for ep in graph_epochs:
+            k = ep.get("kind")
+            if k is not None and k not in kind_index:
+                kind_index[k] = len(epoch_kinds)
+                epoch_kinds.append({"kind": k})
+            a = ep.get("actor")
+            if a is not None and a not in actor_index:
+                actor_index[a] = len(actors)
+                actors.append(a)
+
+        # ontologies (with their default profile index = active profile)
+        if ontology:
+            ontologies = [{"name": ontology, "default_embedding_profile": 0}]
+        else:
+            seen: List[str] = []
+            for s in sources:
+                doc = s.get("document")
+                if doc and doc not in seen:
+                    seen.append(doc)
+            ontologies = [{"name": d, "default_embedding_profile": 0} for d in seen]
+
+        header = {
+            "format_version": KG_BACKUP_FORMAT_VERSION,
+            "source": {"platform": source_platform, "version": source_version},
+            "exported_at": exported_at,
+            "schema_version": schema_version,
+            "embedding_profiles": embedding_profiles,
+            "default_embedding_profile": 0 if embedding_profiles else None,
+            "relationship_vocabulary": header_vocab,
+            "epoch_kinds": epoch_kinds,
+            "actors": actors,
+            "content_types": content_types,
+            "ontologies": ontologies,
+        }
+
+        # bulk: intern references by index
+        bulk_sources = []
+        for s in sources:
+            s2 = dict(s)
+            ct = s2.get("content_type")
+            if isinstance(ct, str):
+                s2["content_type"] = ct_index[ct]
+            bulk_sources.append(s2)
+
+        bulk_rels = []
+        for r in relationships:
+            r2 = dict(r)
+            t = r2.get("type")
+            if t is not None:
+                r2["type"] = rel_type_index[t]
+            bulk_rels.append(r2)
+
+        bulk_epochs = []
+        for ep in graph_epochs:
+            e2 = dict(ep)
+            k = e2.get("kind")
+            if k is not None:
+                e2["kind"] = kind_index[k]
+            a = e2.get("actor")
+            e2["actor"] = actor_index[a] if a is not None else None
+            bulk_epochs.append(e2)
+
+        return {
+            "header": header,
+            "bulk": {
+                "concepts": concepts,
+                "sources": bulk_sources,
+                "instances": instances,
+                "evidence": evidence,
+                "relationships": bulk_rels,
+                "vocabulary": vocabulary,
+                "graph_epochs": bulk_epochs,
+            },
+        }
+
+    @staticmethod
+    def export_kg_backup_v2(client: AGEClient, ontology: Optional[str] = None) -> Dict[str, Any]:
+        """Export the graph as a kg-backup/2 object (ADR-102 §5).
+
+        Thin DB wrapper: fetches every primary-input stream + the header
+        dictionaries, then delegates to the pure build_kg_backup_v2(). Derived
+        products (projections, artifacts/scores) are intentionally excluded
+        (ADR-102 §4) — they regenerate post-restore.
+        """
+        Console.info("Exporting graph as kg-backup/2...")
+        concepts = DataExporter.export_concepts(client, ontology)
+        sources = DataExporter.export_sources(client, ontology)
+        instances = DataExporter.export_instances(client, ontology)
+        evidence = DataExporter.export_evidence(client, ontology)
+        relationships = DataExporter.export_relationships(client, ontology)
+        vocabulary = DataExporter.export_vocabulary(client)
+        embedding_profiles = DataExporter.export_embedding_profiles(client)
+        epoch_kinds = DataExporter.export_epoch_kinds(client)
+        graph_epochs = DataExporter.export_graph_epochs(client)
+        DataExporter._log_vocabulary_summary(relationships, vocabulary)
+
+        return DataExporter.build_kg_backup_v2(
+            concepts=concepts, sources=sources, instances=instances,
+            evidence=evidence, relationships=relationships, vocabulary=vocabulary,
+            embedding_profiles=embedding_profiles, epoch_kinds=epoch_kinds,
+            graph_epochs=graph_epochs,
+            schema_version=BackupFormat.get_schema_version(client),
+            ontology=ontology,
+        )
 
 
 class DataImporter:

--- a/api/lib/serialization.py
+++ b/api/lib/serialization.py
@@ -6,6 +6,7 @@ preserving embeddings (1536-dim vectors), full text, and relationships.
 """
 
 import json
+import re
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 import sys
@@ -43,12 +44,14 @@ def _parse_nullable_int(raw: Any) -> Optional[int]:
 
 
 class BackupFormat:
-    """Backup data format specification"""
+    """Schema-version probe for backups (ADR-102 P3).
 
-    VERSION = "1.0"
-
-    FULL_BACKUP = "full_backup"
-    ONTOLOGY_BACKUP = "ontology_backup"
+    The legacy v1 metadata (``VERSION``/``FULL_BACKUP``/``ONTOLOGY_BACKUP`` strings
+    and ``create_metadata``) was removed in the single-path ``kg-backup/2``
+    convergence — there is now exactly one backup model. Only the schema-version
+    probe survives; it stamps ``header.schema_version`` in
+    :meth:`DataExporter.export_kg_backup_v2`.
+    """
 
     @staticmethod
     def get_schema_version(client: AGEClient) -> int:
@@ -90,32 +93,6 @@ class BackupFormat:
         finally:
             conn.commit()
             client.pool.putconn(conn)
-
-    @staticmethod
-    def create_metadata(backup_type: str, ontology: Optional[str] = None, client: AGEClient = None) -> Dict[str, Any]:
-        """
-        Create backup metadata with schema versioning
-
-        Args:
-            backup_type: Type of backup (full_backup or ontology_backup)
-            ontology: Optional ontology name
-            client: AGEClient instance (needed for schema version)
-
-        Returns:
-            Metadata dictionary with version, schema_version, type, timestamp, ontology
-        """
-        metadata = {
-            "version": BackupFormat.VERSION,
-            "type": backup_type,
-            "timestamp": datetime.utcnow().isoformat() + "Z",
-            "ontology": ontology
-        }
-
-        # Add schema version if client provided (ADR-015: Schema Versioning)
-        if client:
-            metadata["schema_version"] = BackupFormat.get_schema_version(client)
-
-        return metadata
 
 
 class DataExporter:
@@ -522,105 +499,6 @@ class DataExporter:
             top_list = ", ".join(f"{t}({c})" for t, c in top_types)
             logger.info(f"Top edge types: {top_list}")
 
-    @staticmethod
-    def export_full_backup(client: AGEClient) -> Dict[str, Any]:
-        """
-        Export entire database
-
-        Args:
-            client: AGEClient instance
-
-        Returns:
-            Full backup dictionary
-        """
-        Console.info("Exporting concepts...")
-        concepts = DataExporter.export_concepts(client)
-
-        Console.info("Exporting sources...")
-        sources = DataExporter.export_sources(client)
-
-        Console.info("Exporting instances...")
-        instances = DataExporter.export_instances(client)
-
-        Console.info("Exporting relationships...")
-        relationships = DataExporter.export_relationships(client)
-
-        Console.info("Exporting vocabulary...")
-        vocabulary = DataExporter.export_vocabulary(client)
-
-        # Calculate vocabulary statistics (ADR-032)
-        DataExporter._log_vocabulary_summary(relationships, vocabulary)
-
-        return {
-            **BackupFormat.create_metadata(BackupFormat.FULL_BACKUP, client=client),  # Fixed: pass client for schema_version
-            "statistics": {
-                "concepts": len(concepts),
-                "sources": len(sources),
-                "instances": len(instances),
-                "relationships": len(relationships),
-                "vocabulary": len(vocabulary)
-            },
-            "data": {
-                "concepts": concepts,
-                "sources": sources,
-                "instances": instances,
-                "relationships": relationships,
-                "vocabulary": vocabulary
-            }
-        }
-
-    @staticmethod
-    def export_ontology_backup(client: AGEClient, ontology: str) -> Dict[str, Any]:
-        """
-        Export specific ontology
-
-        Args:
-            client: AGEClient instance
-            ontology: Ontology name
-
-        Returns:
-            Ontology backup dictionary
-        """
-        Console.info(f"Exporting ontology: {ontology}")
-
-        Console.info("  - Concepts...")
-        concepts = DataExporter.export_concepts(client, ontology)
-
-        Console.info("  - Sources...")
-        sources = DataExporter.export_sources(client, ontology)
-
-        Console.info("  - Instances...")
-        instances = DataExporter.export_instances(client, ontology)
-
-        Console.info("  - Relationships...")
-        relationships = DataExporter.export_relationships(client, ontology)
-
-        Console.info("  - Vocabulary...")
-        # NOTE: Vocabulary is global state, export entire vocabulary table
-        # even for ontology backups to preserve extended vocabulary (ADR-032)
-        vocabulary = DataExporter.export_vocabulary(client)
-
-        # Calculate vocabulary statistics (ADR-032)
-        DataExporter._log_vocabulary_summary(relationships, vocabulary)
-
-        return {
-            **BackupFormat.create_metadata(BackupFormat.ONTOLOGY_BACKUP, ontology, client=client),  # Fixed: pass client for schema_version
-            "statistics": {
-                "concepts": len(concepts),
-                "sources": len(sources),
-                "instances": len(instances),
-                "relationships": len(relationships),
-                "vocabulary": len(vocabulary)
-            },
-            "data": {
-                "concepts": concepts,
-                "sources": sources,
-                "instances": instances,
-                "relationships": relationships,
-                "vocabulary": vocabulary
-            }
-        }
-
     # ------------------------------------------------------------------
     # kg-backup/2 export (ADR-102 §5; docs/reference/BACKUP_OBJECT_SPEC.md).
     # The pure build_kg_backup_v2() assembles the self-describing object from
@@ -885,439 +763,563 @@ class DataExporter:
         )
 
 
+def _execute_with_age_retry(client, query, params=None, *, fetch_one=False, max_retries=5):
+    """Execute a Cypher statement with AGE's first-use + MVCC retry backoff.
+
+    Apache AGE lazily creates the backing table the first time a label/edge-type
+    is used; concurrent worker threads racing that creation surface as
+    ``relation "..." already exists``. Concurrent MERGEs on the same node/edge
+    surface as ``Entity failed to be updated`` (MVCC). Both are transient — retry
+    with linear backoff. Lifted from the legacy importer so the single kg-backup/2
+    clone writer shares the same proven path (ADR-102 P3).
+    """
+    import time
+    import re
+    for attempt in range(max_retries + 1):
+        try:
+            return client._execute_cypher(query, params=params, fetch_one=fetch_one)
+        except Exception as e:
+            es = str(e)
+            transient = (
+                "already exists" in es
+                or "Entity failed to be updated" in es
+                or "SET clause expects a map" in es
+            )
+            if transient and attempt < max_retries:
+                m = re.search(r'relation "(\w+)" already exists', es)
+                if m:
+                    Console.info(f"  Initializing AGE label: {m.group(1)}")
+                time.sleep(0.1 * (attempt + 1))
+                continue
+            raise
+
+
+def _progress(progress_callback, stage, current, total, every=10):
+    """Emit console + job progress for an import stage every ``every`` items."""
+    if total and (current % every == 0 or current == total):
+        Console.progress(current, total, stage.capitalize())
+        if progress_callback:
+            progress_callback(stage, current, total, (current / total) * 100)
+
+
+def _run_parallel(items, fn, max_workers):
+    """Submit ``fn(item)`` for every item to a thread pool; raise the first error."""
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(fn, it) for it in items]
+        for future in as_completed(futures):
+            future.result()
+
+
+class KgBackupV2Reader:
+    """Read a kg-backup/2 object into normalized, de-interned records (ADR-102 P3).
+
+    Pure and DB-free: dereferences the declarative header dictionaries (relationship
+    vocabulary, content types, epoch kinds, actors) and groups the M:N evidence
+    stream, so the clone/merge writers consume plain records and the offline tests
+    exercise it without a database. It is intentionally a data-access view over one
+    object — its several accessors are all "the same backup, seen as records".
+
+    Single-path: there is exactly one backup model. The reader REFUSES anything that
+    is not ``kg-backup/<=2`` (no legacy v1 reading, no upcast — ADR-102 P3); the v1
+    JSON shape was a prototype and has been removed.
+    """
+
+    SUPPORTED_MAJOR = 2
+
+    def __init__(self, obj: Dict[str, Any]):
+        if not isinstance(obj, dict) or "header" not in obj or "bulk" not in obj:
+            raise ValueError(
+                "Not a kg-backup object: missing header/bulk "
+                "(the legacy v1 format is no longer supported — ADR-102 P3)"
+            )
+        self.header = obj["header"]
+        self.bulk = obj["bulk"]
+        self.format_version = self._negotiate(self.header.get("format_version"))
+
+        # De-intern lookup tables (header index -> value).
+        self._rel_types = [
+            v.get("relationship_type") for v in self.header.get("relationship_vocabulary", [])
+        ]
+        self._content_types = list(self.header.get("content_types", []))
+        self._epoch_kinds = [k.get("kind") for k in self.header.get("epoch_kinds", [])]
+        self._actors = list(self.header.get("actors", []))
+
+    @classmethod
+    def _negotiate(cls, fmt):
+        """Accept kg-backup/<=SUPPORTED_MAJOR; refuse unknown family / higher major (spec §7)."""
+        family, _, major = (fmt or "").partition("/")
+        if family != "kg-backup" or not major.isdigit():
+            raise ValueError(f"Unknown backup format_version: {fmt!r}")
+        if int(major) > cls.SUPPORTED_MAJOR:
+            raise ValueError(
+                f"Refusing {fmt}: newer than supported kg-backup/{cls.SUPPORTED_MAJOR} — "
+                "partially applying primary inputs is unsafe (ADR-102 §8)"
+            )
+        return fmt
+
+    def _rel_type(self, idx):
+        """Resolve an edge-type index to its relationship_type string."""
+        return self._rel_types[idx] if isinstance(idx, int) else idx
+
+    def _content_type(self, idx):
+        """Resolve a content-type index to its MIME string (None-safe)."""
+        if idx is None:
+            return None
+        return self._content_types[idx] if isinstance(idx, int) else idx
+
+    def concepts(self):
+        """Yield concept records (concept_id, label, search_terms, embedding, epoch stamps)."""
+        for c in self.bulk.get("concepts", []):
+            yield dict(c)
+
+    def sources(self):
+        """Yield source records with content_type de-interned back to its MIME string."""
+        for s in self.bulk.get("sources", []):
+            rec = dict(s)
+            rec["content_type"] = self._content_type(s.get("content_type"))
+            yield rec
+
+    def instances(self):
+        """Yield normalized instance records (unique; no concept_id — see evidence)."""
+        for i in self.bulk.get("instances", []):
+            yield dict(i)
+
+    def evidence_by_instance(self):
+        """Group the M:N evidence stream as ``{instance_id: [concept_id, ...]}``."""
+        grouped: Dict[str, List[str]] = {}
+        for e in self.bulk.get("evidence", []):
+            grouped.setdefault(e["instance_id"], []).append(e["concept_id"])
+        return grouped
+
+    def relationships(self):
+        """Yield relationship records with ``type`` de-interned to its label string."""
+        for r in self.bulk.get("relationships", []):
+            rec = dict(r)
+            rec["type"] = self._rel_type(r.get("type"))
+            rec["properties"] = r.get("properties") or {}
+            yield rec
+
+    def vocabulary(self):
+        """Return the bulk vocabulary rows (full descriptors, not interned)."""
+        return list(self.bulk.get("vocabulary", []))
+
+    def graph_epochs(self):
+        """Yield epoch-log rows with kind/actor de-interned (faithful replay — P5)."""
+        for ep in self.bulk.get("graph_epochs", []):
+            rec = dict(ep)
+            k = ep.get("kind")
+            rec["kind"] = self._epoch_kinds[k] if isinstance(k, int) else k
+            a = ep.get("actor")
+            rec["actor"] = self._actors[a] if isinstance(a, int) else a
+            yield rec
+
+    def counts(self):
+        """Return record counts per bulk stream (for stats/logging)."""
+        b = self.bulk
+        return {k: len(b.get(k, [])) for k in
+                ("concepts", "sources", "instances", "evidence", "relationships", "vocabulary")}
+
+    def external_concept_ids(self):
+        """Concept ids referenced by edges/evidence but absent from this backup.
+
+        These are cross-ontology dependencies (partial/adjacent backups). On restore
+        they create dangling edges unless the referenced concepts already exist in
+        the target — the signal the stitch/prune tooling acts on.
+        """
+        local = {c.get("concept_id") for c in self.concepts()}
+        external = {
+            endpoint
+            for rel in self.relationships()
+            for endpoint in (rel.get("from"), rel.get("to"))
+            if endpoint and endpoint not in local
+        }
+        external |= {
+            ev.get("concept_id") for ev in self.bulk.get("evidence", [])
+            if ev.get("concept_id") and ev.get("concept_id") not in local
+        }
+        return external
+
+
 class DataImporter:
-    """Import graph data from JSON format"""
+    """Import a kg-backup/2 object into the graph (ADR-102 P3).
+
+    Single-path: consumes the one backup model via :class:`KgBackupV2Reader`. The
+    clone writer (:meth:`_import_kg_backup_v2`) preserves app-assigned ids 1:1, which
+    is correct for an empty target. Adjacent-mode ID remapping and the merge modes
+    (idempotent / adjacent / integration) are added in P4.
+    """
+
+    _INSTANCE_Q = """
+        MATCH (s:Source {source_id: $source_id})
+        MERGE (i:Instance {instance_id: $instance_id})
+        SET i.quote = $quote,
+            i.created_at_event_id = $created_at_event_id
+        MERGE (i)-[:FROM_SOURCE]->(s)
+    """
+
+    # Reconstruct the M:N EVIDENCED_BY edge and the derived APPEARS edge by joining
+    # the concept to the instance's already-created source (ADR-102 §5.3.1).
+    _EVIDENCE_Q = """
+        MATCH (c:Concept {concept_id: $concept_id})
+        MATCH (i:Instance {instance_id: $instance_id})-[:FROM_SOURCE]->(s:Source)
+        MERGE (c)-[:EVIDENCED_BY]->(i)
+        MERGE (c)-[:APPEARS]->(s)
+    """
 
     @staticmethod
     def validate_backup(backup_data: Dict[str, Any]) -> bool:
+        """Validate that ``backup_data`` is a readable kg-backup object.
+
+        Constructs a :class:`KgBackupV2Reader`, which negotiates the format and
+        refuses anything that is not ``kg-backup/<=2``. Raises ``ValueError`` on
+        failure; returns ``True`` when readable. The thorough field-level oracle
+        lives in the offline validator (``scripts/development/lint/lint_backup.py``).
         """
-        Validate backup format
-
-        Args:
-            backup_data: Parsed JSON backup
-
-        Returns:
-            True if valid
-
-        Raises:
-            ValueError if invalid
-        """
-        if "version" not in backup_data:
-            raise ValueError("Missing version field in backup")
-
-        if backup_data["version"] != BackupFormat.VERSION:
-            raise ValueError(f"Unsupported backup version: {backup_data['version']}")
-
-        if "type" not in backup_data:
-            raise ValueError("Missing type field in backup")
-
-        if backup_data["type"] not in (BackupFormat.FULL_BACKUP, BackupFormat.ONTOLOGY_BACKUP):
-            raise ValueError(f"Unknown backup type: {backup_data['type']}")
-
-        if "data" not in backup_data:
-            raise ValueError("Missing data section in backup")
-
-        required_sections = ["concepts", "sources", "instances", "relationships"]
-        for section in required_sections:
-            if section not in backup_data["data"]:
-                raise ValueError(f"Missing {section} in backup data")
-
+        KgBackupV2Reader(backup_data)
         return True
 
     @staticmethod
     def import_backup(client: AGEClient, backup_data: Dict[str, Any],
-                     overwrite_existing: bool = False,
-                     progress_callback: Optional[callable] = None,
-                     max_workers: int = 2) -> Dict[str, int]:
-        """
-        Import backup data into database
+                      overwrite_existing: bool = False,
+                      progress_callback: Optional[callable] = None,
+                      max_workers: int = 2) -> Dict[str, int]:
+        """Import a kg-backup/2 object — the single backup model's front-door.
 
         Args:
             client: AGEClient instance
-            backup_data: Parsed backup JSON
-            overwrite_existing: If True, update existing nodes; if False, skip duplicates
-            progress_callback: Optional callback(stage, current, total, percent) for progress updates
-            max_workers: Maximum parallel workers for instances/relationships (default: 2)
+            backup_data: Parsed kg-backup/2 object (``{header, bulk}``)
+            overwrite_existing: If True, update existing nodes; if False, preserve them
+            progress_callback: Optional callback(stage, current, total, percent)
+            max_workers: Parallel workers for instances/evidence/relationships
 
         Returns:
-            Dictionary with import statistics
+            Stats: vocabulary_imported, concepts_created, sources_created,
+            instances_created, relationships_created.
         """
-        DataImporter.validate_backup(backup_data)
+        reader = KgBackupV2Reader(backup_data)
+        return DataImporter._import_kg_backup_v2(
+            client, reader,
+            overwrite_existing=overwrite_existing,
+            progress_callback=progress_callback,
+            max_workers=max_workers,
+        )
 
-        data = backup_data["data"]
+    @staticmethod
+    def _import_kg_backup_v2(client: AGEClient, reader: "KgBackupV2Reader", *,
+                             overwrite_existing: bool = False,
+                             progress_callback: Optional[callable] = None,
+                             max_workers: int = 2) -> Dict[str, int]:
+        """Clone-path writer: import normalized records, preserving ids 1:1.
+
+        Order matters: vocabulary (before relationships, ADR-032) → concepts →
+        sources → instances (+FROM_SOURCE) → evidence (EVIDENCED_BY + derived
+        APPEARS) → relationships. Clone preserves ids, so edge ``learned_id`` needs
+        no remap here (that is P4 adjacent mode).
+        """
         stats = {
             "vocabulary_imported": 0,
             "concepts_created": 0,
             "sources_created": 0,
             "instances_created": 0,
-            "relationships_created": 0
+            "relationships_created": 0,
         }
 
-        # Import vocabulary first (ADR-032) - needed before relationships
-        if "vocabulary" in data and len(data["vocabulary"]) > 0:
+        vocab = reader.vocabulary()
+        if vocab:
             Console.info("Importing vocabulary...")
-            total_vocab = len(data["vocabulary"])
+            DataImporter._import_vocabulary(client, vocab, progress_callback)
+            stats["vocabulary_imported"] = len(vocab)
 
-            conn = client.pool.getconn()
-            try:
-                import psycopg2.extras
-                with conn.cursor() as cur:
-                    for i, entry in enumerate(data["vocabulary"]):
-                        current = i + 1
-                        Console.progress(current, total_vocab, "Vocabulary")
-
-                        if progress_callback and current % 10 == 0:
-                            percent = (current / total_vocab) * 100
-                            progress_callback("vocabulary", current, total_vocab, percent)
-
-                        # Prepare field values
-                        # synonyms: VARCHAR[] array (not JSONB)
-                        synonyms_array = entry.get('synonyms') if entry.get('synonyms') else None
-
-                        # embedding: JSONB field
-                        embedding_json = json.dumps(entry.get('embedding')) if entry.get('embedding') else None
-
-                        # Insert or update vocabulary entry
-                        cur.execute("""
-                            INSERT INTO kg_api.relationship_vocabulary
-                                (relationship_type, description, category, added_by, added_at,
-                                 usage_count, is_active, is_builtin, synonyms, deprecation_reason,
-                                 embedding_model, embedding_generated_at, embedding)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
-                            ON CONFLICT (relationship_type) DO UPDATE SET
-                                description = EXCLUDED.description,
-                                category = EXCLUDED.category,
-                                added_by = EXCLUDED.added_by,
-                                added_at = EXCLUDED.added_at,
-                                usage_count = EXCLUDED.usage_count,
-                                is_active = EXCLUDED.is_active,
-                                is_builtin = EXCLUDED.is_builtin,
-                                synonyms = EXCLUDED.synonyms,
-                                deprecation_reason = EXCLUDED.deprecation_reason,
-                                embedding_model = EXCLUDED.embedding_model,
-                                embedding_generated_at = EXCLUDED.embedding_generated_at,
-                                embedding = EXCLUDED.embedding
-                        """, (
-                            entry.get('relationship_type'),
-                            entry.get('description'),
-                            entry.get('category'),
-                            entry.get('added_by'),
-                            entry.get('added_at'),
-                            entry.get('usage_count', 0),
-                            entry.get('is_active', True),
-                            entry.get('is_builtin', False),
-                            synonyms_array,  # Fixed: VARCHAR[] array, not JSONB
-                            entry.get('deprecation_reason'),
-                            entry.get('embedding_model'),
-                            entry.get('embedding_generated_at'),
-                            embedding_json
-                        ))
-                        stats["vocabulary_imported"] += 1
-
-                conn.commit()
-            finally:
-                client.pool.putconn(conn)
-
-            # Create :VocabType graph nodes (ADR-048)
-            # After SQL import, sync vocabulary to graph nodes
-            Console.info("  Creating vocabulary graph nodes...")
-            for i, entry in enumerate(data["vocabulary"]):
-                current = i + 1
-                relationship_type = entry.get('relationship_type')
-                category = entry.get('category', 'unknown')
-                description = entry.get('description', '')
-                is_builtin = entry.get('is_builtin', False)
-                added_by = entry.get('added_by', 'system')
-                direction_semantics = entry.get('direction_semantics')
-
-                try:
-                    # Use MERGE to be idempotent (safe for re-runs)
-                    # Creates both :VocabType node and :IN_CATEGORY relationship
-                    vocab_query = """
-                        MERGE (v:VocabType {name: $name})
-                        SET v.description = $description,
-                            v.is_builtin = $is_builtin,
-                            v.is_active = $is_active,
-                            v.added_by = $added_by,
-                            v.usage_count = $usage_count,
-                            v.direction_semantics = $direction_semantics
-                        WITH v
-                        MERGE (c:VocabCategory {name: $category})
-                        MERGE (v)-[:IN_CATEGORY]->(c)
-                        RETURN v.name as name
-                    """
-                    params = {
-                        "name": relationship_type,
-                        "category": category,
-                        "description": description,
-                        "is_builtin": 't' if is_builtin else 'f',
-                        "is_active": 't' if entry.get('is_active', True) else 'f',
-                        "added_by": added_by,
-                        "usage_count": entry.get('usage_count', 0),
-                        "direction_semantics": direction_semantics
-                    }
-                    client._execute_cypher(vocab_query, params)
-
-                    if current % 10 == 0:
-                        Console.progress(current, total_vocab, "Graph nodes")
-                except Exception as e:
-                    # Log but don't fail the restore - SQL data is already imported
-                    Console.warning(f"  Failed to create graph node for '{relationship_type}': {e}")
-
-            if progress_callback and total_vocab > 0:
-                progress_callback("vocabulary", total_vocab, total_vocab, 100.0)
-
-        # Import concepts
+        concepts = list(reader.concepts())
         Console.info("Importing concepts...")
-        total_concepts = len(data["concepts"])
-        for i, concept in enumerate(data["concepts"]):
-            current = i + 1
-            Console.progress(current, total_concepts, "Concepts")
+        DataImporter._import_concepts(client, concepts, overwrite_existing, progress_callback)
+        stats["concepts_created"] = len(concepts)
 
-            # Call progress callback every 10 items
-            if progress_callback and current % 10 == 0:
-                percent = (current / total_concepts) * 100
-                progress_callback("concepts", current, total_concepts, percent)
-
-            if overwrite_existing:
-                # Always set properties (create or update)
-                merge_query = """
-                    MERGE (c:Concept {concept_id: $concept_id})
-                    SET c.label = $label,
-                        c.search_terms = $search_terms,
-                        c.embedding = $embedding
-                """
-            else:
-                # Only set if node doesn't exist (skip if exists)
-                merge_query = """
-                    MERGE (c:Concept {concept_id: $concept_id})
-                    ON CREATE SET c.label = $label, c.search_terms = $search_terms, c.embedding = $embedding
-                """
-                # AGE workaround: Use conditional CASE in SET
-                merge_query = """
-                    OPTIONAL MATCH (existing:Concept {concept_id: $concept_id})
-                    WITH existing
-                    MERGE (c:Concept {concept_id: $concept_id})
-                    SET c.label = CASE WHEN existing IS NULL THEN $label ELSE c.label END,
-                        c.search_terms = CASE WHEN existing IS NULL THEN $search_terms ELSE c.search_terms END,
-                        c.embedding = CASE WHEN existing IS NULL THEN $embedding ELSE c.embedding END
-                """
-
-            client._execute_cypher(merge_query, params=concept)
-            stats["concepts_created"] += 1
-
-        # Final callback for concepts stage
-        if progress_callback and total_concepts > 0:
-            progress_callback("concepts", total_concepts, total_concepts, 100.0)
-
-        # Import sources
+        sources = list(reader.sources())
         Console.info("Importing sources...")
-        total_sources = len(data["sources"])
-        for i, source in enumerate(data["sources"]):
-            current = i + 1
-            Console.progress(current, total_sources, "Sources")
+        DataImporter._import_sources(client, sources, progress_callback)
+        stats["sources_created"] = len(sources)
 
-            # Call progress callback every item (sources are fewer)
-            if progress_callback:
-                percent = (current / total_sources) * 100
-                progress_callback("sources", current, total_sources, percent)
+        instances = list(reader.instances())
+        Console.info("Importing instances...")
+        DataImporter._import_instances(client, instances, progress_callback, max_workers)
+        stats["instances_created"] = len(instances)
 
-            # AGE: MERGE + SET (works for both create and update)
-            # Include garage_key, content_type, storage_key if present (ADR-081)
-            merge_query = """
+        evidence_map = reader.evidence_by_instance()
+        pairs = [(cid, iid) for iid, cids in evidence_map.items() for cid in cids]
+        if pairs:
+            Console.info(f"Reconstructing {len(pairs)} evidence links (EVIDENCED_BY + APPEARS)...")
+            DataImporter._import_evidence(client, pairs, max_workers)
+
+        rels = list(reader.relationships())
+        Console.info("Importing relationships...")
+        stats["relationships_created"] = DataImporter._import_relationships(
+            client, rels, progress_callback, max_workers
+        )
+
+        return stats
+
+    @staticmethod
+    def _import_vocabulary(client: AGEClient, vocabulary: List[Dict[str, Any]],
+                           progress_callback: Optional[callable] = None) -> None:
+        """Import relationship vocabulary: SQL rows + :VocabType graph nodes.
+
+        Ported from the original importer (ADR-032 / ADR-048): upserts
+        kg_api.relationship_vocabulary, then MERGEs the :VocabType / :VocabCategory
+        nodes. Shared by the single import path.
+        """
+        total_vocab = len(vocabulary)
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                for i, entry in enumerate(vocabulary):
+                    current = i + 1
+                    Console.progress(current, total_vocab, "Vocabulary")
+                    if progress_callback and current % 10 == 0:
+                        progress_callback("vocabulary", current, total_vocab,
+                                          (current / total_vocab) * 100)
+
+                    synonyms_array = entry.get('synonyms') if entry.get('synonyms') else None
+                    embedding_json = json.dumps(entry.get('embedding')) if entry.get('embedding') else None
+
+                    cur.execute("""
+                        INSERT INTO kg_api.relationship_vocabulary
+                            (relationship_type, description, category, added_by, added_at,
+                             usage_count, is_active, is_builtin, synonyms, deprecation_reason,
+                             embedding_model, embedding_generated_at, embedding)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                        ON CONFLICT (relationship_type) DO UPDATE SET
+                            description = EXCLUDED.description,
+                            category = EXCLUDED.category,
+                            added_by = EXCLUDED.added_by,
+                            added_at = EXCLUDED.added_at,
+                            usage_count = EXCLUDED.usage_count,
+                            is_active = EXCLUDED.is_active,
+                            is_builtin = EXCLUDED.is_builtin,
+                            synonyms = EXCLUDED.synonyms,
+                            deprecation_reason = EXCLUDED.deprecation_reason,
+                            embedding_model = EXCLUDED.embedding_model,
+                            embedding_generated_at = EXCLUDED.embedding_generated_at,
+                            embedding = EXCLUDED.embedding
+                    """, (
+                        entry.get('relationship_type'),
+                        entry.get('description'),
+                        entry.get('category'),
+                        entry.get('added_by'),
+                        entry.get('added_at'),
+                        entry.get('usage_count', 0),
+                        entry.get('is_active', True),
+                        entry.get('is_builtin', False),
+                        synonyms_array,
+                        entry.get('deprecation_reason'),
+                        entry.get('embedding_model'),
+                        entry.get('embedding_generated_at'),
+                        embedding_json
+                    ))
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
+
+        # Create :VocabType graph nodes (ADR-048) after the SQL import.
+        Console.info("  Creating vocabulary graph nodes...")
+        for i, entry in enumerate(vocabulary):
+            relationship_type = entry.get('relationship_type')
+            try:
+                vocab_query = """
+                    MERGE (v:VocabType {name: $name})
+                    SET v.description = $description,
+                        v.is_builtin = $is_builtin,
+                        v.is_active = $is_active,
+                        v.added_by = $added_by,
+                        v.usage_count = $usage_count,
+                        v.direction_semantics = $direction_semantics
+                    WITH v
+                    MERGE (c:VocabCategory {name: $category})
+                    MERGE (v)-[:IN_CATEGORY]->(c)
+                    RETURN v.name as name
+                """
+                params = {
+                    "name": relationship_type,
+                    "category": entry.get('category', 'unknown'),
+                    "description": entry.get('description', ''),
+                    "is_builtin": 't' if entry.get('is_builtin', False) else 'f',
+                    "is_active": 't' if entry.get('is_active', True) else 'f',
+                    "added_by": entry.get('added_by', 'system'),
+                    "usage_count": entry.get('usage_count', 0),
+                    "direction_semantics": entry.get('direction_semantics'),
+                }
+                client._execute_cypher(vocab_query, params)
+                if (i + 1) % 10 == 0:
+                    Console.progress(i + 1, total_vocab, "Graph nodes")
+            except Exception as e:
+                # SQL data is already imported — log but don't fail the restore.
+                Console.warning(f"  Failed to create graph node for '{relationship_type}': {e}")
+
+        if progress_callback and total_vocab > 0:
+            progress_callback("vocabulary", total_vocab, total_vocab, 100.0)
+
+    @staticmethod
+    def _import_concepts(client: AGEClient, concepts: List[Dict[str, Any]],
+                         overwrite_existing: bool, progress_callback) -> None:
+        """MERGE concepts, carrying the ADR-102 §3 epoch stamps."""
+        total = len(concepts)
+        if overwrite_existing:
+            query = """
+                MERGE (c:Concept {concept_id: $concept_id})
+                SET c.label = $label,
+                    c.search_terms = $search_terms,
+                    c.embedding = $embedding,
+                    c.created_at_epoch = $created_at_epoch,
+                    c.last_seen_epoch = $last_seen_epoch
+            """
+        else:
+            # Preserve an existing concept's properties (AGE has no ON CREATE SET).
+            query = """
+                OPTIONAL MATCH (existing:Concept {concept_id: $concept_id})
+                WITH existing
+                MERGE (c:Concept {concept_id: $concept_id})
+                SET c.label = CASE WHEN existing IS NULL THEN $label ELSE c.label END,
+                    c.search_terms = CASE WHEN existing IS NULL THEN $search_terms ELSE c.search_terms END,
+                    c.embedding = CASE WHEN existing IS NULL THEN $embedding ELSE c.embedding END,
+                    c.created_at_epoch = CASE WHEN existing IS NULL THEN $created_at_epoch ELSE c.created_at_epoch END,
+                    c.last_seen_epoch = CASE WHEN existing IS NULL THEN $last_seen_epoch ELSE c.last_seen_epoch END
+            """
+        for i, c in enumerate(concepts):
+            params = {
+                "concept_id": c["concept_id"],
+                "label": c.get("label"),
+                "search_terms": c.get("search_terms", []),
+                "embedding": c.get("embedding", []),
+                "created_at_epoch": c.get("created_at_epoch"),
+                "last_seen_epoch": c.get("last_seen_epoch"),
+            }
+            _execute_with_age_retry(client, query, params)
+            _progress(progress_callback, "concepts", i + 1, total)
+
+    @staticmethod
+    def _import_sources(client: AGEClient, sources: List[Dict[str, Any]],
+                        progress_callback) -> None:
+        """MERGE sources, including optional Garage/media keys when present (ADR-081)."""
+        total = len(sources)
+        for i, s in enumerate(sources):
+            query = """
                 MERGE (s:Source {source_id: $source_id})
                 SET s.document = $document,
                     s.file_path = $file_path,
                     s.paragraph = $paragraph,
                     s.full_text = $full_text
             """
+            params = {
+                "source_id": s["source_id"],
+                "document": s.get("document"),
+                "file_path": s.get("file_path"),
+                "paragraph": s.get("paragraph"),
+                "full_text": s.get("full_text"),
+            }
+            if s.get("garage_key"):
+                query = query.rstrip() + ",\n                    s.garage_key = $garage_key"
+                params["garage_key"] = s["garage_key"]
+            if s.get("content_type"):
+                query = query.rstrip() + ",\n                    s.content_type = $content_type"
+                params["content_type"] = s["content_type"]
+            if s.get("storage_key"):
+                query = query.rstrip() + ",\n                    s.storage_key = $storage_key"
+                params["storage_key"] = s["storage_key"]
+            _execute_with_age_retry(client, query, params)
+            _progress(progress_callback, "sources", i + 1, total, every=1)
 
-            # Add optional Garage fields to SET clause if present
-            if source.get("garage_key"):
-                merge_query = merge_query.rstrip() + ",\n                    s.garage_key = $garage_key"
-            if source.get("content_type"):
-                merge_query = merge_query.rstrip() + ",\n                    s.content_type = $content_type"
-            if source.get("storage_key"):
-                merge_query = merge_query.rstrip() + ",\n                    s.storage_key = $storage_key"
+    @staticmethod
+    def _import_instances(client: AGEClient, instances: List[Dict[str, Any]],
+                          progress_callback, max_workers: int) -> None:
+        """MERGE instances and their FROM_SOURCE edges in parallel."""
+        total = len(instances)
+        lock = threading.Lock()
+        done = {"n": 0}
 
-            client._execute_cypher(merge_query, params=source)
-            stats["sources_created"] += 1
+        def work(inst):
+            params = {
+                "instance_id": inst["instance_id"],
+                "quote": inst.get("quote", ""),
+                "source_id": inst["source_id"],
+                "created_at_event_id": inst.get("created_at_event_id"),
+            }
+            _execute_with_age_retry(client, DataImporter._INSTANCE_Q, params)
+            with lock:
+                done["n"] += 1
+                _progress(progress_callback, "instances", done["n"], total)
 
-        # Final callback for sources stage
-        if progress_callback and total_sources > 0:
-            progress_callback("sources", total_sources, total_sources, 100.0)
+        _run_parallel(instances, work, max_workers)
 
-        # Import instances (parallel processing for performance)
-        Console.info("Importing instances...")
-        total_instances = len(data["instances"])
+    @staticmethod
+    def _import_evidence(client: AGEClient, pairs: List, max_workers: int) -> None:
+        """Reconstruct EVIDENCED_BY + derived APPEARS edges from the evidence stream."""
+        total = len(pairs)
+        lock = threading.Lock()
+        done = {"n": 0}
 
+        def work(pair):
+            concept_id, instance_id = pair
+            _execute_with_age_retry(
+                client, DataImporter._EVIDENCE_Q,
+                {"concept_id": concept_id, "instance_id": instance_id},
+            )
+            with lock:
+                done["n"] += 1
+                if done["n"] % 50 == 0 or done["n"] == total:
+                    Console.progress(done["n"], total, "Evidence")
 
-        # Thread-safe counter and lock for progress tracking
-        progress_lock = threading.Lock()
-        completed = {"count": 0}
+        _run_parallel(pairs, work, max_workers)
 
-        def process_instance(instance):
-            """Process single instance with optimized single-query approach"""
-            # Optimized: Single query instead of two
-            # MATCH dependencies first, then MERGE+SET, then create relationships
-            # No WITH clause needed - all variables stay in scope
-            query = """
-                MATCH (c:Concept {concept_id: $concept_id})
-                MATCH (s:Source {source_id: $source_id})
-                MERGE (i:Instance {instance_id: $instance_id})
-                SET i.quote = $quote
-                MERGE (c)-[:EVIDENCED_BY]->(i)
-                MERGE (i)-[:FROM_SOURCE]->(s)
-                MERGE (c)-[:APPEARS]->(s)
-            """
+    @staticmethod
+    def _import_relationships(client: AGEClient, rels: List[Dict[str, Any]],
+                              progress_callback, max_workers: int) -> int:
+        """MERGE concept-concept relationships in parallel; return created count."""
+        total = len(rels)
+        lock = threading.Lock()
+        done = {"n": 0, "created": 0}
 
-            import time
-            max_retries = 5
-            for attempt in range(max_retries + 1):
-                try:
-                    client._execute_cypher(query, params=instance)
-                    break
-                except Exception as e:
-                    error_str = str(e)
-                    if "already exists" in error_str and attempt < max_retries:
-                        # AGE creates label tables on first use - parallel threads may race
-                        import re
-                        match = re.search(r'relation "(\w+)" already exists', error_str)
-                        if match:
-                            Console.info(f"  Initializing AGE label: {match.group(1)}")
-                        time.sleep(0.1 * (attempt + 1))
-                        continue
-                    elif "Entity failed to be updated" in error_str and attempt < max_retries:
-                        # AGE MVCC conflict from concurrent MERGE on same node
-                        time.sleep(0.1 * (attempt + 1))
-                        continue
-                    else:
-                        raise
+        def work(rel):
+            created = DataImporter._merge_relationship(client, rel)
+            with lock:
+                done["n"] += 1
+                done["created"] += created
+                _progress(progress_callback, "relationships", done["n"], total)
 
-            # Thread-safe progress tracking
-            with progress_lock:
-                completed["count"] += 1
-                current = completed["count"]
-                if current % 10 == 0 or current == total_instances:
-                    Console.progress(current, total_instances, "Instances")
-                    if progress_callback:
-                        percent = (current / total_instances) * 100
-                        progress_callback("instances", current, total_instances, percent)
+        _run_parallel(rels, work, max_workers)
+        return done["created"]
 
-        # Process instances in parallel (configurable workers)
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [executor.submit(process_instance, instance)
-                      for instance in data["instances"]]
+    # Edge-property keys are simple identifiers (e.g. learned_id, confidence). AGE
+    # rejects a whole-map parameter (`SET r = $props` → "SET clause expects a map"),
+    # so each property is set individually with a scalar param — mirroring how the
+    # ingestion path writes edge properties.
+    _PROP_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-            # Wait for all to complete
-            for future in as_completed(futures):
-                future.result()  # Raise any exceptions
+    @staticmethod
+    def _merge_relationship(client: AGEClient, rel: Dict[str, Any]) -> int:
+        """MERGE a single concept relationship (dynamic edge label). Returns 1 if created/matched."""
+        rel_type = rel["type"]  # de-interned label string
+        query = f"""
+            OPTIONAL MATCH (c1:Concept {{concept_id: $from_id}})
+            OPTIONAL MATCH (c2:Concept {{concept_id: $to_id}})
+            WITH c1, c2
+            WHERE c1 IS NOT NULL AND c2 IS NOT NULL
+            MERGE (c1)-[r:{rel_type}]->(c2)
+        """
+        params = {"from_id": rel["from"], "to_id": rel["to"]}
 
-        stats["instances_created"] = total_instances
+        set_items = []
+        for idx, (key, value) in enumerate((rel.get("properties") or {}).items()):
+            if not DataImporter._PROP_KEY.match(str(key)):
+                Console.warning(f"  Skipping edge property with unsafe key: {key!r}")
+                continue
+            pkey = f"p_{idx}"
+            set_items.append(f"r.{key} = ${pkey}")
+            params[pkey] = value
+        if set_items:
+            query += "                SET " + ", ".join(set_items) + "\n"
+        query += "                RETURN count(r) as created"
 
-        # Final callback for instances stage
-        if progress_callback and total_instances > 0:
-            progress_callback("instances", total_instances, total_instances, 100.0)
-
-        # Import concept-concept relationships (parallel processing for performance)
-        Console.info("Importing relationships...")
-        total_relationships = len(data["relationships"])
-
-        # Thread-safe counter and lock for progress tracking
-        rel_progress_lock = threading.Lock()
-        rel_completed = {"count": 0, "created": 0}
-
-        def process_relationship(rel):
-            """Process single relationship"""
-            # Dynamic relationship type (IMPLIES, SUPPORTS, etc.)
-            # Use OPTIONAL MATCH to handle missing nodes gracefully
-            props = rel.get("properties") or {}
-            if props:
-                query = f"""
-                    OPTIONAL MATCH (c1:Concept {{concept_id: $from_id}})
-                    OPTIONAL MATCH (c2:Concept {{concept_id: $to_id}})
-                    WITH c1, c2
-                    WHERE c1 IS NOT NULL AND c2 IS NOT NULL
-                    MERGE (c1)-[r:{rel['type']}]->(c2)
-                    SET r = $properties
-                    RETURN count(r) as created
-                """
-                params = {
-                    "from_id": rel["from"],
-                    "to_id": rel["to"],
-                    "properties": props
-                }
-            else:
-                # Skip SET for empty properties — AGE rejects SET r = {} with
-                # "SET clause expects a map"
-                query = f"""
-                    OPTIONAL MATCH (c1:Concept {{concept_id: $from_id}})
-                    OPTIONAL MATCH (c2:Concept {{concept_id: $to_id}})
-                    WITH c1, c2
-                    WHERE c1 IS NOT NULL AND c2 IS NOT NULL
-                    MERGE (c1)-[r:{rel['type']}]->(c2)
-                    RETURN count(r) as created
-                """
-                params = {
-                    "from_id": rel["from"],
-                    "to_id": rel["to"],
-                }
-
-            import time
-            max_retries = 5
-            for attempt in range(max_retries + 1):
-                try:
-                    result = client._execute_cypher(query, params=params, fetch_one=True)
-                    break
-                except Exception as e:
-                    error_str = str(e)
-
-                    if "already exists" in error_str and attempt < max_retries:
-                        # AGE creates edge type tables on first use - parallel threads may race
-                        import re
-                        match = re.search(r'relation "(\w+)" already exists', error_str)
-                        if match:
-                            Console.info(f"  Initializing edge type: {match.group(1)}")
-                        time.sleep(0.1 * (attempt + 1))
-                        continue
-                    elif "Entity failed to be updated" in error_str and attempt < max_retries:
-                        # AGE MVCC conflict from concurrent MERGE on same edge
-                        time.sleep(0.1 * (attempt + 1))
-                        continue
-                    elif "SET clause expects a map" in error_str and attempt < max_retries:
-                        time.sleep(0.1 * (attempt + 1))
-                        continue
-                    else:
-                        raise
-
-            created = 0
-            if result and int(str(result.get("created", 0))) > 0:
-                created = 1
-
-            # Thread-safe progress tracking
-            with rel_progress_lock:
-                rel_completed["count"] += 1
-                rel_completed["created"] += created
-                current = rel_completed["count"]
-                if current % 10 == 0 or current == total_relationships:
-                    Console.progress(current, total_relationships, "Relationships")
-                    if progress_callback:
-                        percent = (current / total_relationships) * 100
-                        progress_callback("relationships", current, total_relationships, percent)
-
-        # Process relationships in parallel (configurable workers)
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [executor.submit(process_relationship, rel)
-                      for rel in data["relationships"]]
-
-            # Wait for all to complete
-            for future in as_completed(futures):
-                future.result()  # Raise any exceptions
-
-        stats["relationships_created"] = rel_completed["created"]
-
-        # Final callback for relationships stage
-        if progress_callback and total_relationships > 0:
-            progress_callback("relationships", total_relationships, total_relationships, 100.0)
-
-        return stats
+        result = _execute_with_age_retry(client, query, params, fetch_one=True)
+        if result and int(str(result.get("created", 0))) > 0:
+            return 1
+        return 0

--- a/docs/reference/BACKUP_OBJECT_SPEC.md
+++ b/docs/reference/BACKUP_OBJECT_SPEC.md
@@ -445,17 +445,23 @@ contract for that version. A producer never downgrades silently.
 **Consumer.** On open, reads `header.format_version` *first* and:
 
 1. **Exact major match** (`kg-backup/2`) — accept and apply.
-2. **Known family, lower major** (`kg-backup/1` — the legacy `1.0` JSON shape:
-   flat `version`/`type`/`data`, no header, no epoch fields, inline type/MIME
-   strings) — a consumer MAY accept it through an explicit upcasting reader that
-   synthesizes a minimal HEADER (one default embedding profile, interns the
-   inline strings) and supplies the missing epoch fields as null/simple-mode
-   defaults. Acceptance of older majors is a consumer capability, never assumed.
+2. **Known family, lower major** — **refuse.** This platform is **single-path**:
+   there is exactly one backup model and **no backwards-compatibility / upcasting
+   layer** (ADR-102 P3). The pre-ADR-102 `1.0` JSON shape (flat
+   `version`/`type`/`data`, no header) was a prototype and has been **removed** —
+   no producer emits it and no consumer reads it.
 3. **Known family, higher major** — **refuse.** A `kg-backup/2` consumer MUST NOT
    attempt a `kg-backup/3` object; it may not understand new required HEADER
    dictionaries, and partially applying primary inputs is unsafe (ADR-102 §8:
    restore passes through transiently inconsistent states).
 4. **Unknown family** — refuse.
+
+> **Why no upcast.** The numbering is incidental — what matters is that the
+> running system has a single backup format end-to-end (export, archive, restore,
+> checkpoint). A compatibility shim for the removed prototype would be exactly the
+> "fallback to old methods we don't actively use" the convergence set out to
+> delete. `KgBackupV2Reader` enforces this: it refuses any object whose
+> `format_version` is not `kg-backup/<=2`.
 
 `schema_version` and `source.version` are **informational** and never gate
 acceptance — only `format_version` does. The major component bumps on any change

--- a/docs/reference/BACKUP_OBJECT_SPEC.md
+++ b/docs/reference/BACKUP_OBJECT_SPEC.md
@@ -220,37 +220,45 @@ written **once** in the header, not restated across every concept.
 
 ### 4.1 Cascading-default resolution order
 
-The embedding-profile reference for any record **cascades**. A record states
-only its *override*; absent an override it inherits from its parent scope. The
-resolution order, most-specific-wins:
+The embedding-profile reference for a record **cascades**. A record states only
+its *override*; absent an override it inherits from a parent scope. **The tiers
+available depend on whether the record is ontology-scoped:**
+
+**Ontology-scoped records (`sources`, and any media keyed by them)** — full
+3-tier cascade (most-specific-wins):
 
 ```
-1. record-level override     (concept.embedding_profile)        — if present
-2. ontology-level default    (ontologies[i].default_embedding_profile) — else
+1. record-level override     (source.embedding_profile)          — if present
+2. ontology-level default    (ontologies[i].default_embedding_profile, matched
+                              by the record's `document`)         — else
 3. backup-level default      (header.default_embedding_profile)  — else
 ```
 
+**Concepts** — 2-tier cascade, **no ontology tier**:
+
+```
+1. record-level override     (concept.embedding_profile)         — if present
+2. backup-level default      (header.default_embedding_profile)  — else
+```
+
+> **Why concepts skip the ontology tier (ADR-102 P2 decision).** A concept is
+> **cross-ontology by design**: it associates with ontologies only indirectly via
+> `APPEARS → Source{document}` and the same concept may appear in *several*
+> ontologies (that is exactly what integration/dedup produces). It therefore has no
+> single "home ontology" to inherit a profile from, and forcing one would encode a
+> lossy arbitrary pick into the format. In practice one embedding profile is active
+> per backup, so `header.default_embedding_profile` covers virtually all concepts;
+> a per-concept `embedding_profile` override handles the rare mixed-profile backup.
+
 - A backup with **one uniform** embedding profile declares it once as
   `header.default_embedding_profile` and emits **no** per-record refs.
-- A **mixed** backup declares per-ontology defaults; only records that deviate
-  from their ontology default carry an explicit `embedding_profile`.
+- A **mixed** backup declares per-ontology defaults (for sources) and per-concept
+  overrides only where a concept deviates from the backup default.
 - The same cascade pattern is the model for any future header dictionary whose
   values are scope-defaultable; today only the embedding profile cascades.
 
-> **OPEN ITEM (resolve in ADR-102 P2 — export).** The ontology tier above assumes
-> a concept can be associated with an ontology, but a concept record (§5.1) carries
-> **no** ontology field — concepts associate with an ontology only indirectly, via
-> `APPEARS → Source{document}`. P2 must pin one of: (a) add an explicit ontology
-> hint to the concept record so the ontology tier resolves, or (b) drop the ontology
-> tier for concepts entirely (concept cascade = record-override → backup-default),
-> reserving per-ontology defaults for source/media records. Until pinned, a consumer
-> resolving a concept's profile falls through to the backup-level default. The
-> offline validator (`lint_backup.py`) currently keys the ontology tier on a
-> `concept.ontology`/`concept.document` field if present and otherwise falls through
-> — it must be updated in lockstep when this is resolved.
-
-A consumer resolves a record's effective profile by walking 1 → 2 → 3 and taking
-the first index present. The resolved index then keys
+A consumer resolves a record's effective profile by walking its tiers in order and
+taking the first index present. The resolved index then keys
 `header.embedding_profiles[]` for the keep-vs-recompute decision (ADR-102 §6).
 
 ---
@@ -267,6 +275,7 @@ grounded in the current exporter (`api/lib/serialization.py`,
     "concepts":      [ ... ],
     "sources":       [ ... ],
     "instances":     [ ... ],
+    "evidence":      [ ... ],
     "relationships": [ ... ],
     "vocabulary":    [ ... ],
     "graph_epochs":  [ ... ]
@@ -301,13 +310,30 @@ grounded in the current exporter (`api/lib/serialization.py`,
 
 ### 5.3 instances
 
+Instances are **normalized**: one record per instance node, **unique by
+`instance_id`**, carrying NO `concept_id`. An instance belongs to exactly one
+source (`FROM_SOURCE`) but may be evidenced by *many* concepts (`EVIDENCED_BY` is
+M:N) — those links live in the separate `evidence` stream (§5.3.1), so the quote
+text is stored once rather than repeated per evidenced concept. (The legacy
+`kg-backup/1` exporter denormalized this, emitting one instance row per concept
+with `concept_id` inline and the quote duplicated.)
+
 | Field | Type | Notes |
 |---|---|---|
-| `instance_id` | string | App-assigned. |
+| `instance_id` | string | App-assigned, unique within the backup. Participates in ID remapping. |
 | `quote` | string | Evidence quote. |
-| `concept_id` | string | The evidenced concept (`(c)-[:EVIDENCED_BY]->(i)`). Participates in ID remapping. |
 | `source_id` | string | The originating source (`(i)-[:FROM_SOURCE]->(s)`). Participates in ID remapping. |
 | `created_at_event_id` | integer | FK into `graph_epochs.event_id` (ADR-203). New in `kg-backup/2`. In **faithful** epoch mode it is remapped through the event-ID map; in **simple** mode all instances are restamped with the single restore event (ADR-102 §3). The legacy exporter dropped this entirely. |
+
+### 5.3.1 evidence
+
+The `evidence` stream carries the M:N **Concept→Instance** `EVIDENCED_BY` links,
+one record per link. Restore reconstructs the `EVIDENCED_BY` edges from it.
+
+| Field | Type | Notes |
+|---|---|---|
+| `concept_id` | string | The evidencing concept. Must exist in `concepts[]`. Participates in ID remapping. |
+| `instance_id` | string | The evidenced instance. Must exist in `instances[]`. Participates in ID remapping. |
 
 ### 5.4 relationships
 

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -103,8 +103,10 @@ CHECK_CODES = {
     # referential integrity
     "E_REL_FROM_MISSING": "relationship.from concept_id not in concepts[].",
     "E_REL_TO_MISSING": "relationship.to concept_id not in concepts[].",
-    "E_INSTANCE_CONCEPT_MISSING": "instance.concept_id not in concepts[].",
+    "E_INSTANCE_CONCEPT_MISSING": "instance.concept_id not in concepts[] (legacy kg-backup/1 only).",
     "E_INSTANCE_SOURCE_MISSING": "instance.source_id not in sources[].",
+    "E_EVIDENCE_CONCEPT_MISSING": "evidence.concept_id not in concepts[].",
+    "E_EVIDENCE_INSTANCE_MISSING": "evidence.instance_id not in instances[].",
     "E_LEARNED_ID_MISSING": "edge properties.learned_id not an existing source_id.",
     # epochs
     "E_EVENT_ID_UNRESOLVED": "instance.created_at_event_id not in graph_epochs[].",
@@ -333,33 +335,24 @@ def _validate_header(header: Dict[str, Any], result: ValidationResult) -> None:
 
 def _resolve_concept_profile(
     concept: Dict[str, Any],
-    ontologies_by_name: Dict[str, Any],
     backup_default: Any,
 ) -> Optional[int]:
     """Resolve a concept's effective embedding-profile index via the cascade (§4.1).
 
-    Order, most-specific-wins: record override -> ontology default ->
-    backup default. Returns the first present integer index, or ``None`` if the
-    cascade yields nothing.
+    Concepts use the 2-tier cascade — record override -> backup default — with
+    NO ontology tier. A concept is cross-ontology by design (it associates with
+    ontologies only via APPEARS->Source{document} and may span several), so it has
+    no single home ontology to inherit from (BACKUP_OBJECT_SPEC §4.1, ADR-102 P2
+    decision). The ontology tier is reserved for ontology-scoped records (sources).
+
+    Returns the first present integer index, or ``None`` if neither tier yields one.
 
     @verified cffa180b
     """
     # 1. record override
     if _is_int_index(concept.get("embedding_profile")):
         return concept["embedding_profile"]
-    # 2. ontology default (concept may name its ontology via 'document'/'ontology')
-    #
-    # OPEN ITEM (BACKUP_OBJECT_SPEC §4.1): concept records carry no ontology field
-    # in the current spec — concepts associate with an ontology only indirectly via
-    # APPEARS->Source{document}. We key on a 'ontology'/'document' field IF present
-    # and otherwise fall through to the backup default. ADR-102 P2 must pin the
-    # concept->ontology association (add a hint field, or drop the ontology tier for
-    # concepts); update this resolution in lockstep when it does.
-    ont_name = concept.get("ontology") or concept.get("document")
-    ont = ontologies_by_name.get(ont_name) if ont_name else None
-    if isinstance(ont, dict) and _is_int_index(ont.get("default_embedding_profile")):
-        return ont["default_embedding_profile"]
-    # 3. backup default
+    # 2. backup default
     if _is_int_index(backup_default):
         return backup_default
     return None
@@ -398,11 +391,6 @@ def _validate_bulk(
     n_actors = len(header.get("actors") or [])
     backup_default = header.get("default_embedding_profile")
 
-    ontologies_by_name = {}
-    for ont in (header.get("ontologies") or []):
-        if isinstance(ont, dict) and "name" in ont:
-            ontologies_by_name[ont["name"]] = ont
-
     faithful = isinstance(graph_epochs, list)
 
     # ---- concepts: ids, dup, profile index, cascade, epoch fields ----
@@ -426,8 +414,8 @@ def _validate_bulk(
                        f"[0,{n_profiles}).",
                        f"$.bulk.concepts[{i}].embedding_profile")
 
-        # cascade resolves to a valid profile
-        resolved = _resolve_concept_profile(c, ontologies_by_name, backup_default)
+        # cascade resolves to a valid profile (concepts: record → backup, no ontology tier)
+        resolved = _resolve_concept_profile(c, backup_default)
         if resolved is None:
             result.add(ERROR, "E_NO_PROFILE_CASCADE",
                        f"concept {cid!r} resolves to no embedding-profile via "
@@ -492,7 +480,8 @@ def _validate_bulk(
                            f"an existing source_id (spec §5.4.1).",
                            f"$.bulk.relationships[{i}].properties.learned_id")
 
-    # ---- instances: ids, dup, concept/source integrity, event_id ----
+    # ---- instances: UNIQUE per instance_id (normalized — no concept_id; the
+    #      Concept->Instance M:N links live in the separate evidence stream) ----
     event_ids = set()
     if faithful:
         for ep in graph_epochs:
@@ -511,11 +500,6 @@ def _validate_bulk(
                            f"$.bulk.instances[{i}].instance_id")
             instance_ids.add(iid)
 
-        cid = inst.get("concept_id")
-        if cid is not None and cid not in concept_ids:
-            result.add(ERROR, "E_INSTANCE_CONCEPT_MISSING",
-                       f"instance.concept_id {cid!r} not present in concepts[].",
-                       f"$.bulk.instances[{i}].concept_id")
         sid = inst.get("source_id")
         if sid is not None and sid not in source_ids:
             result.add(ERROR, "E_INSTANCE_SOURCE_MISSING",
@@ -530,6 +514,21 @@ def _validate_bulk(
                            f"instance.created_at_event_id={ev} does not resolve to a "
                            f"graph_epochs[].event_id (spec §5.3).",
                            f"$.bulk.instances[{i}].created_at_event_id")
+
+    # ---- evidence: Concept->Instance links resolve to existing ids (§5.3.1) ----
+    for i, ev in enumerate(bulk.get("evidence") or []):
+        if not isinstance(ev, dict):
+            continue
+        cid = ev.get("concept_id")
+        if cid is not None and cid not in concept_ids:
+            result.add(ERROR, "E_EVIDENCE_CONCEPT_MISSING",
+                       f"evidence.concept_id {cid!r} not present in concepts[].",
+                       f"$.bulk.evidence[{i}].concept_id")
+        iid = ev.get("instance_id")
+        if iid is not None and iid not in instance_ids:
+            result.add(ERROR, "E_EVIDENCE_INSTANCE_MISSING",
+                       f"evidence.instance_id {iid!r} not present in instances[].",
+                       f"$.bulk.evidence[{i}].instance_id")
 
     # ---- graph_epochs: kind/actor index resolution (§5.6) ----
     if faithful:
@@ -719,7 +718,8 @@ def _selftest() -> int:
         "bulk": {
             "concepts": [{"concept_id": "c1", "label": "A"}],
             "sources": [{"source_id": "s1", "content_type": 0}],
-            "instances": [{"instance_id": "i1", "concept_id": "c1", "source_id": "s1"}],
+            "instances": [{"instance_id": "i1", "source_id": "s1"}],
+            "evidence": [{"concept_id": "c1", "instance_id": "i1"}],
             "relationships": [
                 {"from": "c1", "to": "c1", "type": 0,
                  "properties": {"learned_id": "s1"}}
@@ -744,7 +744,11 @@ def _selftest() -> int:
                 {"concept_id": "c1"}, {"concept_id": "c1"},  # dup
             ],
             "sources": [{"source_id": "s1", "content_type": 5}],  # out of range
-            "instances": [{"instance_id": "i1", "concept_id": "cX", "source_id": "sX"}],
+            "instances": [{"instance_id": "i1", "source_id": "sX"}],  # source missing
+            "evidence": [
+                {"concept_id": "cX", "instance_id": "i1"},   # concept missing
+                {"concept_id": "c1", "instance_id": "iX"},   # instance missing
+            ],
             "relationships": [
                 {"from": "cZ", "to": "c1", "type": 7,
                  "properties": {"learned_id": "sZ"}}
@@ -757,8 +761,9 @@ def _selftest() -> int:
     codes = {i.code for i in r2.issues}
     expected = {
         "E_PROFILE_IDENTITY", "E_DEFAULT_PROFILE_RANGE", "E_DUP_CONCEPT_ID",
-        "E_CONTENT_TYPE_RANGE", "E_INSTANCE_CONCEPT_MISSING",
-        "E_INSTANCE_SOURCE_MISSING", "E_REL_FROM_MISSING", "E_REL_TYPE_RANGE",
+        "E_CONTENT_TYPE_RANGE", "E_INSTANCE_SOURCE_MISSING",
+        "E_EVIDENCE_CONCEPT_MISSING", "E_EVIDENCE_INSTANCE_MISSING",
+        "E_REL_FROM_MISSING", "E_REL_TYPE_RANGE",
         "E_LEARNED_ID_MISSING", "E_DERIVED_PRESENT",
     }
     missing = expected - codes

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -19,7 +19,7 @@ any ERROR was found (CI convention, matching the sibling lint tools).
 Checks implemented (see ``CHECK_CODES`` for the stable code registry):
   - HEADER presence / well-formedness and format_version family negotiation (§7)
   - kg-backup/2 required header fields (§3.1)
-  - legacy kg-backup/1 flat shape detection (notice, then best-effort) (§7)
+  - single-path: refuse any non-kg-backup/2 object (no legacy upcast) (§7)
   - embedding-profile identity string {provider}:{model}@{dims} (§3.2)
   - dictionary index resolution: profile / rel-type / content_type / kind / actor (§4)
   - cascading embedding-profile resolution record→ontology→backup (§4.1)
@@ -85,9 +85,9 @@ CHECK_CODES = {
     "E_FORMAT_VERSION_SHAPE": "format_version is not '{family}/{major}'.",
     "E_UNKNOWN_FAMILY": "Unknown format family (refuse).",
     "E_HIGHER_MAJOR": "Higher major version than supported (refuse).",
+    "E_LOWER_MAJOR": "Lower major than supported — legacy removed, single-path (refuse).",
     "E_MISSING_HEADER_FIELD": "Required kg-backup/2 header field missing.",
     "E_NO_BULK": "Missing 'bulk' region.",
-    "N_LEGACY_FORMAT": "Legacy kg-backup/1 flat format (best-effort validation).",
     # embedding profiles
     "E_PROFILE_IDENTITY": "embedding profile identity not '{provider}:{model}@{dims}'.",
     "E_DEFAULT_PROFILE_RANGE": "default_embedding_profile index out of range.",
@@ -103,7 +103,6 @@ CHECK_CODES = {
     # referential integrity
     "E_REL_FROM_MISSING": "relationship.from concept_id not in concepts[].",
     "E_REL_TO_MISSING": "relationship.to concept_id not in concepts[].",
-    "E_INSTANCE_CONCEPT_MISSING": "instance.concept_id not in concepts[] (legacy kg-backup/1 only).",
     "E_INSTANCE_SOURCE_MISSING": "instance.source_id not in sources[].",
     "E_EVIDENCE_CONCEPT_MISSING": "evidence.concept_id not in concepts[].",
     "E_EVIDENCE_INSTANCE_MISSING": "evidence.instance_id not in instances[].",
@@ -201,11 +200,10 @@ def validate_backup(obj: Dict[str, Any]) -> ValidationResult:
     returns a :class:`ValidationResult`. Performs NO I/O — no file, network,
     database, or container access. Safe to call from pytest or an API handler.
 
-    Negotiation (§7) gates the depth of validation:
+    Negotiation (§7) — single-path, no backwards-compat:
       - ``kg-backup/2`` (exact major): full header + bulk validation.
-      - ``kg-backup/1`` (legacy flat): emits ``N_LEGACY_FORMAT`` notice and
-        validates the applicable subset (duplicates, basic referential links).
-      - higher major / unknown family: emits ERROR and stops (refuse, §7).
+      - any other major / unknown family / headerless legacy shape: ERROR, stop
+        (refuse). The legacy flat format was removed; there is no upcast path.
 
     Args:
         obj: the parsed backup object.
@@ -221,20 +219,9 @@ def validate_backup(obj: Dict[str, Any]) -> ValidationResult:
         result.add(ERROR, "E_NOT_OBJECT", "Backup object is not a JSON object.", "$")
         return result
 
-    # ---- Legacy detection (§7 case 2): flat version/type/data, no header ----
-    if "header" not in obj and "version" in obj and "data" in obj:
-        result.format_version = str(obj.get("version"))
-        result.add(
-            NOTICE,
-            "N_LEGACY_FORMAT",
-            f"Legacy kg-backup/1 flat format detected (version={obj.get('version')!r}, "
-            f"type={obj.get('type')!r}); validating applicable subset only.",
-            "$",
-        )
-        _validate_legacy(obj, result)
-        return result
-
     # ---- HEADER presence ----
+    # Single-path (§7): there is exactly one backup model. A headerless object —
+    # including the removed legacy kg-backup/1 flat shape — is refused here.
     header = obj.get("header")
     if not isinstance(header, dict):
         result.add(ERROR, "E_NO_HEADER", "Missing or non-object 'header' region.", "$.header")
@@ -277,10 +264,13 @@ def validate_backup(obj: Dict[str, Any]) -> ValidationResult:
         return result
 
     if major < NATIVE_MAJOR:
-        # Known family, lower major embedded under a header — treat as legacy notice.
-        result.add(NOTICE, "N_LEGACY_FORMAT",
-                   f"Lower-major {fmt!r}; validating applicable subset.",
+        # Single-path (§7): no backwards-compat / upcasting. A lower major is the
+        # removed prototype format — refuse rather than best-effort validate.
+        result.add(ERROR, "E_LOWER_MAJOR",
+                   f"format_version {fmt!r} is a lower major than {KNOWN_FAMILY}/{NATIVE_MAJOR}; "
+                   f"the legacy format was removed (single-path, spec §7) — refuse.",
                    "$.header.format_version")
+        return result
 
     # ---- kg-backup/2 full validation ----
     _validate_header(header, result)
@@ -547,80 +537,6 @@ def _validate_bulk(
                            f"$.bulk.graph_epochs[{i}].actor")
 
 
-def _validate_legacy(obj: Dict[str, Any], result: ValidationResult) -> None:
-    """Best-effort validation of a legacy kg-backup/1 flat object (§7 case 2).
-
-    Legacy has flat ``version``/``type``/``data`` with inline strings and no
-    header/epoch fields. Only duplicate-id and basic referential checks apply.
-
-    @verified cffa180b
-    """
-    data = obj.get("data")
-    if not isinstance(data, dict):
-        return
-    concepts = data.get("concepts") or []
-    sources = data.get("sources") or []
-    instances = data.get("instances") or []
-    relationships = data.get("relationships") or []
-
-    concept_ids = set()
-    for i, c in enumerate(concepts):
-        if not isinstance(c, dict):
-            continue
-        cid = c.get("concept_id")
-        if cid is not None:
-            if cid in concept_ids:
-                result.add(ERROR, "E_DUP_CONCEPT_ID", f"duplicate concept_id {cid!r}.",
-                           f"$.data.concepts[{i}].concept_id")
-            concept_ids.add(cid)
-
-    source_ids = set()
-    for i, s in enumerate(sources):
-        if not isinstance(s, dict):
-            continue
-        sid = s.get("source_id")
-        if sid is not None:
-            if sid in source_ids:
-                result.add(ERROR, "E_DUP_SOURCE_ID", f"duplicate source_id {sid!r}.",
-                           f"$.data.sources[{i}].source_id")
-            source_ids.add(sid)
-
-    instance_ids = set()
-    for i, inst in enumerate(instances):
-        if not isinstance(inst, dict):
-            continue
-        iid = inst.get("instance_id")
-        if iid is not None:
-            if iid in instance_ids:
-                result.add(ERROR, "E_DUP_INSTANCE_ID", f"duplicate instance_id {iid!r}.",
-                           f"$.data.instances[{i}].instance_id")
-            instance_ids.add(iid)
-        cid = inst.get("concept_id")
-        if cid is not None and cid not in concept_ids:
-            result.add(ERROR, "E_INSTANCE_CONCEPT_MISSING",
-                       f"instance.concept_id {cid!r} not present in concepts[].",
-                       f"$.data.instances[{i}].concept_id")
-        sid = inst.get("source_id")
-        if sid is not None and sid not in source_ids:
-            result.add(ERROR, "E_INSTANCE_SOURCE_MISSING",
-                       f"instance.source_id {sid!r} not present in sources[].",
-                       f"$.data.instances[{i}].source_id")
-
-    for i, r in enumerate(relationships):
-        if not isinstance(r, dict):
-            continue
-        frm = r.get("from")
-        if frm is not None and frm not in concept_ids:
-            result.add(ERROR, "E_REL_FROM_MISSING",
-                       f"relationship.from {frm!r} not present in concepts[].",
-                       f"$.data.relationships[{i}].from")
-        to = r.get("to")
-        if to is not None and to not in concept_ids:
-            result.add(ERROR, "E_REL_TO_MISSING",
-                       f"relationship.to {to!r} not present in concepts[].",
-                       f"$.data.relationships[{i}].to")
-
-
 # ---------------------------------------------------------------------------
 # I/O boundary (CLI only — kept out of the pure core)
 # ---------------------------------------------------------------------------
@@ -769,11 +685,16 @@ def _selftest() -> int:
     missing = expected - codes
     assert not missing, f"invalid sample missing expected codes: {missing}"
 
-    # legacy detection
+    # single-path: the removed legacy flat shape (no header) is refused
     legacy = {"version": "1.0", "type": "full", "data": {"concepts": [], "sources": [],
               "instances": [], "relationships": []}}
     r3 = validate_backup(legacy)
-    assert any(i.code == "N_LEGACY_FORMAT" for i in r3.issues), "legacy notice expected"
+    assert not r3.ok, "legacy flat shape must be refused"
+    assert any(i.code == "E_NO_HEADER" for i in r3.issues), "legacy flat shape → E_NO_HEADER"
+
+    # single-path: a lower-major under a header is also refused (no upcast)
+    r4 = validate_backup({"header": {"format_version": "kg-backup/1"}, "bulk": {}})
+    assert any(i.code == "E_LOWER_MAJOR" for i in r4.issues), "lower major must be refused"
 
     print("selftest: PASS")
     return 0

--- a/tests/api/test_backup_integrity.py
+++ b/tests/api/test_backup_integrity.py
@@ -1,546 +1,172 @@
 """
-Tests for Backup Integrity Check Module (ADR-015 Phase 2)
+Tests for the Backup Integrity Check Module (ADR-015 Phase 2; retargeted to
+kg-backup/2 in ADR-102 P3).
 
-Tests cover:
-- Valid backup validation
-- Missing field detection
-- Invalid format detection
-- Reference integrity checking
-- Statistics validation
-- External dependency detection
-- Edge cases and error handling
+The runtime checker now validates the single backup model (declarative header +
+bulk record streams). Tests build objects with the pure
+``DataExporter.build_kg_backup_v2`` and assert structural, reference, and
+external-dependency checks.
 """
-
-import pytest
 import json
 import tempfile
 from pathlib import Path
-from typing import Dict, Any
 
+import pytest
+
+from api.lib.serialization import DataExporter
 from api.app.lib.backup_integrity import (
     BackupIntegrityChecker,
     BackupIntegrity,
     check_backup_integrity,
-    check_backup_data
+    check_backup_data,
 )
 
 
 # ========== Fixtures ==========
 
-@pytest.fixture
-def valid_full_backup() -> Dict[str, Any]:
-    """Valid full database backup"""
-    return {
-        "version": "1.0",
-        "type": "full_backup",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "ontology": None,
-        "statistics": {
-            "concepts": 2,
-            "sources": 1,
-            "instances": 2,
-            "relationships": 1
-        },
-        "data": {
-            "concepts": [
-                {"concept_id": "concept_1", "label": "Test Concept 1", "search_terms": []},
-                {"concept_id": "concept_2", "label": "Test Concept 2", "search_terms": []}
-            ],
-            "sources": [
-                {
-                    "source_id": "source_1",
-                    "document": "Test Document",
-                    "paragraph": 1,
-                    "full_text": "Test content"
-                }
-            ],
-            "instances": [
-                {
-                    "instance_id": "inst_1",
-                    "quote": "Test quote 1",
-                    "concept_id": "concept_1",
-                    "source_id": "source_1"
-                },
-                {
-                    "instance_id": "inst_2",
-                    "quote": "Test quote 2",
-                    "concept_id": "concept_2",
-                    "source_id": "source_1"
-                }
-            ],
-            "relationships": [
-                {
-                    "from": "concept_1",
-                    "to": "concept_2",
-                    "type": "SUPPORTS",
-                    "properties": {}
-                }
-            ]
-        }
-    }
+def _lists(**overrides):
+    base = dict(
+        concepts=[
+            {"concept_id": "c1", "label": "Alpha", "search_terms": ["a"],
+             "embedding": [0.1, 0.2], "created_at_epoch": 1, "last_seen_epoch": 1},
+            {"concept_id": "c2", "label": "Beta", "search_terms": [],
+             "embedding": [0.3, 0.4], "created_at_epoch": 1, "last_seen_epoch": 1},
+        ],
+        sources=[
+            {"source_id": "s1", "document": "Corpus", "file_path": "/a.txt",
+             "paragraph": 1, "full_text": "alpha", "content_type": "text/plain"},
+        ],
+        instances=[
+            {"instance_id": "i1", "quote": "alpha", "source_id": "s1", "created_at_event_id": 1},
+        ],
+        evidence=[{"concept_id": "c1", "instance_id": "i1"}],
+        relationships=[
+            {"from": "c1", "to": "c2", "type": "IMPLIES", "properties": {}},
+        ],
+        vocabulary=[
+            {"relationship_type": "IMPLIES", "description": "x", "category": "logical",
+             "embedding_model": "openai:text-embedding-3-small@1536"},
+        ],
+        embedding_profiles=[
+            {"identity": "openai:text-embedding-3-small@1536", "vector_space": "openai-3-small",
+             "image_vector_space": None, "name": "default", "multimodal": False},
+        ],
+        epoch_kinds=[{"kind": "ingestion", "semantic_wallclock": True, "description": ""}],
+        graph_epochs=[],
+        schema_version=76,
+    )
+    base.update(overrides)
+    return base
 
 
 @pytest.fixture
-def valid_ontology_backup() -> Dict[str, Any]:
-    """Valid ontology backup with external dependencies"""
-    return {
-        "version": "1.0",
-        "type": "ontology_backup",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "ontology": "Test Ontology",
-        "statistics": {
-            "concepts": 1,
-            "sources": 1,
-            "instances": 2,
-            "relationships": 1
-        },
-        "data": {
-            "concepts": [
-                {"concept_id": "local_concept_1", "label": "Local Concept", "search_terms": []}
-            ],
-            "sources": [
-                {
-                    "source_id": "source_1",
-                    "document": "Test Document",
-                    "paragraph": 1,
-                    "full_text": "Test content"
-                }
-            ],
-            "instances": [
-                {
-                    "instance_id": "inst_1",
-                    "quote": "Local quote",
-                    "concept_id": "local_concept_1",
-                    "source_id": "source_1"
-                },
-                {
-                    "instance_id": "inst_2",
-                    "quote": "External quote",
-                    "concept_id": "external_concept_99",  # External reference
-                    "source_id": "source_1"
-                }
-            ],
-            "relationships": [
-                {
-                    "from": "local_concept_1",
-                    "to": "external_concept_77",  # External reference
-                    "type": "RELATES_TO",
-                    "properties": {}
-                }
-            ]
-        }
-    }
+def valid_full_backup():
+    return DataExporter.build_kg_backup_v2(**_lists())
 
 
-# ========== Unit Tests: Valid Backups ==========
+@pytest.fixture
+def valid_scoped_backup():
+    return DataExporter.build_kg_backup_v2(ontology="Corpus", **_lists())
 
-@pytest.mark.unit
+
+# ========== Structural format ==========
+
 def test_valid_full_backup_passes(valid_full_backup):
-    """Test that valid full backup passes all checks"""
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(valid_full_backup)
+    result = BackupIntegrityChecker().check_data(valid_full_backup)
+    assert result.valid, [e.message for e in result.errors]
+    assert result.statistics["concepts"] == 2
 
-    assert result.valid is True
-    assert len(result.errors) == 0
-    assert result.statistics == valid_full_backup["statistics"]
 
+def test_valid_scoped_backup_passes(valid_scoped_backup):
+    result = check_backup_data(valid_scoped_backup)
+    assert result.valid, [e.message for e in result.errors]
 
-@pytest.mark.unit
-def test_valid_ontology_backup_passes(valid_ontology_backup):
-    """Test that valid ontology backup passes (with warnings for external deps)"""
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(valid_ontology_backup)
 
-    assert result.valid is True
-    assert len(result.errors) == 0
-    assert result.has_external_deps is True
-    assert result.external_deps == 2  # 1 in instances, 1 in relationships
+def test_missing_header_bulk_fails():
+    result = check_backup_data({"version": "1.0", "data": {}})  # the dead v1 shape
+    assert not result.valid
+    assert any("header" in e.message.lower() or "bulk" in e.message.lower() for e in result.errors)
 
 
-# ========== Unit Tests: Format Validation ==========
-
-@pytest.mark.unit
-def test_missing_required_field_fails():
-    """Test that missing required fields are detected"""
-    invalid_data = {
-        "version": "1.0",
-        "type": "full_backup"
-        # Missing: timestamp, data, statistics
-    }
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_data)
-
-    assert result.valid is False
-    assert len(result.errors) > 0
-    assert any("Missing required fields" in e.message for e in result.errors)
-
-
-@pytest.mark.unit
-def test_invalid_backup_type_fails():
-    """Test that invalid backup type is detected"""
-    invalid_data = {
-        "version": "1.0",
-        "type": "invalid_type",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "statistics": {},
-        "data": {}
-    }
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_data)
-
-    assert result.valid is False
-    assert any("Invalid backup type" in e.message for e in result.errors)
-
-
-@pytest.mark.unit
-def test_invalid_version_fails():
-    """Test that invalid version format is detected"""
-    invalid_data = {
-        "version": None,  # Invalid
-        "type": "full_backup",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "statistics": {},
-        "data": {}
-    }
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_data)
-
-    assert result.valid is False
-    assert any("version" in e.message.lower() for e in result.errors)
-
-
-@pytest.mark.unit
-def test_missing_data_sections_fails():
-    """Test that missing data sections are detected"""
-    invalid_data = {
-        "version": "1.0",
-        "type": "full_backup",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "statistics": {},
-        "data": {
-            "concepts": [],
-            "sources": []
-            # Missing: instances, relationships
-        }
-    }
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_data)
-
-    assert result.valid is False
-    assert any("Missing data sections" in e.message for e in result.errors)
-
-
-@pytest.mark.unit
-def test_non_list_data_section_fails():
-    """Test that data sections must be lists"""
-    invalid_data = {
-        "version": "1.0",
-        "type": "full_backup",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "statistics": {},
-        "data": {
-            "concepts": "not a list",  # Invalid
-            "sources": [],
-            "instances": [],
-            "relationships": []
-        }
-    }
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_data)
-
-    assert result.valid is False
-    assert any("must be a list" in e.message for e in result.errors)
-
-
-# ========== Unit Tests: Reference Integrity ==========
-
-@pytest.mark.unit
-def test_instance_with_invalid_concept_id_fails(valid_full_backup):
-    """Test that instances referencing non-existent concepts are detected"""
-    invalid_backup = valid_full_backup.copy()
-    invalid_backup["data"]["instances"][0]["concept_id"] = "nonexistent_concept"
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_backup)
-
-    assert result.valid is False
-    assert any("concept_id" in e.message and "doesn't exist" in e.message for e in result.errors)
-
-
-@pytest.mark.unit
-def test_instance_with_invalid_source_id_fails(valid_full_backup):
-    """Test that instances referencing non-existent sources are detected"""
-    invalid_backup = valid_full_backup.copy()
-    invalid_backup["data"]["instances"][0]["source_id"] = "nonexistent_source"
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_backup)
-
-    assert result.valid is False
-    assert any("source_id" in e.message and "doesn't exist" in e.message for e in result.errors)
-
-
-@pytest.mark.unit
-def test_relationship_with_invalid_from_concept_fails(valid_full_backup):
-    """Test that relationships with invalid 'from' concept are detected"""
-    invalid_backup = valid_full_backup.copy()
-    invalid_backup["data"]["relationships"][0]["from"] = "nonexistent_concept"
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_backup)
-
-    assert result.valid is False
-    assert any("'from'" in e.message and "doesn't exist" in e.message for e in result.errors)
-
-
-@pytest.mark.unit
-def test_relationship_with_invalid_to_concept_fails(valid_full_backup):
-    """Test that relationships with invalid 'to' concept are detected"""
-    invalid_backup = valid_full_backup.copy()
-    invalid_backup["data"]["relationships"][0]["to"] = "nonexistent_concept"
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_backup)
-
-    assert result.valid is False
-    assert any("'to'" in e.message and "doesn't exist" in e.message for e in result.errors)
-
-
-@pytest.mark.unit
-def test_unusual_relationship_type_warning(valid_full_backup):
-    """Test that unusual relationship types generate warnings"""
-    backup = valid_full_backup.copy()
-    backup["data"]["relationships"][0]["type"] = "UNUSUAL_TYPE"
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(backup)
-
-    assert result.valid is True  # Warning, not error
-    assert any("not in vocabulary" in w.message for w in result.warnings)
-
-
-# ========== Unit Tests: Statistics Validation ==========
-
-@pytest.mark.unit
-def test_statistics_mismatch_warning(valid_full_backup):
-    """Test that statistics mismatches generate warnings"""
-    invalid_backup = valid_full_backup.copy()
-    invalid_backup["statistics"]["concepts"] = 999  # Wrong count
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_backup)
-
-    assert result.valid is True  # Warning, not error
-    assert any("Statistics mismatch" in w.message for w in result.warnings)
-    assert any("concepts" in w.message for w in result.warnings)
-
-
-# ========== Unit Tests: External Dependencies ==========
-
-@pytest.mark.unit
-def test_external_deps_detected_in_ontology_backup(valid_ontology_backup):
-    """Test that external dependencies are detected in ontology backups"""
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(valid_ontology_backup)
-
-    assert result.valid is True
-    assert result.has_external_deps is True
-    assert result.external_deps == 2  # 1 from instance, 1 from relationship
-    assert any("concept_ids from other ontologies" in w.message for w in result.warnings)
-
-
-@pytest.mark.unit
-def test_no_external_deps_in_full_backup(valid_full_backup):
-    """Test that full backups don't report external dependencies"""
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(valid_full_backup)
-
-    assert result.valid is True
-    assert result.has_external_deps is False
-    assert result.external_deps == 0
-
-
-# ========== Integration Tests: File Operations ==========
-
-@pytest.mark.integration
-def test_check_file_with_valid_backup(valid_full_backup):
-    """Test checking backup from file"""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-        json.dump(valid_full_backup, f)
-        temp_path = f.name
-
-    try:
-        checker = BackupIntegrityChecker()
-        result = checker.check_file(temp_path)
-
-        assert result.valid is True
-        assert len(result.errors) == 0
-    finally:
-        Path(temp_path).unlink()
-
-
-@pytest.mark.integration
-def test_check_file_with_nonexistent_file():
-    """Test checking non-existent file"""
-    checker = BackupIntegrityChecker()
-    result = checker.check_file("/nonexistent/path/backup.json")
-
-    assert result.valid is False
-    assert any("not found" in e.message for e in result.errors)
-
-
-@pytest.mark.integration
-def test_check_file_with_invalid_json():
-    """Test checking file with invalid JSON"""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-        f.write("{ invalid json }")
-        temp_path = f.name
-
-    try:
-        checker = BackupIntegrityChecker()
-        result = checker.check_file(temp_path)
-
-        assert result.valid is False
-        assert any("JSON" in e.message for e in result.errors)
-    finally:
-        Path(temp_path).unlink()
-
-
-# ========== Integration Tests: Convenience Functions ==========
-
-@pytest.mark.integration
-def test_convenience_function_check_backup_integrity(valid_full_backup):
-    """Test check_backup_integrity() convenience function"""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-        json.dump(valid_full_backup, f)
-        temp_path = f.name
-
-    try:
-        result = check_backup_integrity(temp_path)
-        assert result.valid is True
-        assert len(result.errors) == 0
-    finally:
-        Path(temp_path).unlink()
-
-
-@pytest.mark.unit
-def test_convenience_function_check_backup_data(valid_full_backup):
-    """Test check_backup_data() convenience function"""
+def test_unknown_format_version_fails(valid_full_backup):
+    valid_full_backup["header"]["format_version"] = "kg-backup/99"
     result = check_backup_data(valid_full_backup)
-
-    assert result.valid is True
-    assert len(result.errors) == 0
-    assert result.statistics == valid_full_backup["statistics"]
+    assert not result.valid
 
 
-# ========== Edge Cases ==========
+def test_missing_bulk_section_fails(valid_full_backup):
+    del valid_full_backup["bulk"]["sources"]
+    result = check_backup_data(valid_full_backup)
+    assert not result.valid
+    assert any("sources" in e.message for e in result.errors)
 
-@pytest.mark.unit
-def test_empty_backup_warning():
-    """Test that empty backup generates warning"""
-    empty_backup = {
-        "version": "1.0",
-        "type": "full_backup",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "statistics": {},
-        "data": {
-            "concepts": [],
-            "sources": [],
-            "instances": [],
-            "relationships": []
-        }
+
+def test_non_list_bulk_section_fails(valid_full_backup):
+    valid_full_backup["bulk"]["concepts"] = {"not": "a list"}
+    result = check_backup_data(valid_full_backup)
+    assert not result.valid
+
+
+# ========== Reference integrity ==========
+
+def test_instance_with_missing_source_fails(valid_full_backup):
+    valid_full_backup["bulk"]["instances"][0]["source_id"] = "nonexistent_source"
+    result = check_backup_data(valid_full_backup)
+    assert not result.valid
+    assert any("source_id" in e.message for e in result.errors)
+
+
+def test_evidence_with_missing_instance_fails(valid_full_backup):
+    valid_full_backup["bulk"]["evidence"].append({"concept_id": "c1", "instance_id": "iX"})
+    result = check_backup_data(valid_full_backup)
+    assert not result.valid
+    assert any("instance_id" in e.message for e in result.errors)
+
+
+def test_relationship_missing_endpoint_fails(valid_full_backup):
+    valid_full_backup["bulk"]["relationships"][0]["from"] = None
+    result = check_backup_data(valid_full_backup)
+    assert not result.valid
+
+
+# ========== External dependencies ==========
+
+def test_external_concept_reference_is_warning_not_error():
+    """An edge to a concept absent from the backup is an external dep (warning)."""
+    lists = _lists(relationships=[
+        {"from": "c1", "to": "external_concept", "type": "IMPLIES", "properties": {}},
+    ])
+    result = check_backup_data(DataExporter.build_kg_backup_v2(**lists))
+    assert result.valid  # external refs do not fail validation
+    assert result.has_external_deps
+    assert result.external_deps == 1
+
+
+# ========== Statistics + file path ==========
+
+def test_statistics_surface_counts(valid_full_backup):
+    result = check_backup_data(valid_full_backup)
+    assert result.statistics == {
+        "concepts": 2, "sources": 1, "instances": 1, "relationships": 1, "vocabulary": 1,
     }
 
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(empty_backup)
 
-    assert result.valid is True  # Empty is valid, just warned
-    assert any("no data" in w.message.lower() for w in result.warnings)
-
-
-@pytest.mark.unit
-def test_missing_instance_concept_id_error():
-    """Test that instances without concept_id are detected"""
-    invalid_backup = {
-        "version": "1.0",
-        "type": "full_backup",
-        "timestamp": "2025-10-09T04:00:00Z",
-        "statistics": {},
-        "data": {
-            "concepts": [{"concept_id": "concept_1", "label": "Test"}],
-            "sources": [{"source_id": "source_1", "document": "Test", "paragraph": 1, "full_text": "Test"}],
-            "instances": [
-                {
-                    "instance_id": "inst_1",
-                    "quote": "Test",
-                    # Missing: concept_id
-                    "source_id": "source_1"
-                }
-            ],
-            "relationships": []
-        }
-    }
-
-    checker = BackupIntegrityChecker()
-    result = checker.check_data(invalid_backup)
-
-    assert result.valid is False
-    assert any("missing concept_id" in e.message for e in result.errors)
+def test_check_file_round_trips(valid_full_backup):
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "backup.json"
+        p.write_text(json.dumps(valid_full_backup))
+        result = check_backup_integrity(str(p))
+        assert result.valid, [e.message for e in result.errors]
 
 
-@pytest.mark.unit
-def test_all_valid_relationship_types_pass(valid_full_backup):
-    """Test that all valid relationship types are accepted"""
-    valid_types = ["IMPLIES", "SUPPORTS", "CONTRADICTS", "RELATES_TO", "PART_OF"]
-
-    for rel_type in valid_types:
-        backup = valid_full_backup.copy()
-        backup["data"]["relationships"][0]["type"] = rel_type
-
-        checker = BackupIntegrityChecker()
-        result = checker.check_data(backup)
-
-        assert result.valid is True, f"Valid type {rel_type} should pass"
-        assert len([w for w in result.warnings if "unusual type" in w.message]) == 0
+def test_check_file_missing_path_fails():
+    result = check_backup_integrity("/no/such/backup.json")
+    assert not result.valid
 
 
-# ========== Test Coverage Report ==========
-
-def test_integrity_checker_coverage_summary():
-    """
-    Summary of test coverage for BackupIntegrityChecker
-
-    Covered:
-    - ✅ Valid full backup validation
-    - ✅ Valid ontology backup validation
-    - ✅ Missing required fields detection
-    - ✅ Invalid backup type detection
-    - ✅ Invalid version format detection
-    - ✅ Missing data sections detection
-    - ✅ Non-list data section detection
-    - ✅ Instance with invalid concept_id
-    - ✅ Instance with invalid source_id
-    - ✅ Relationship with invalid from concept
-    - ✅ Relationship with invalid to concept
-    - ✅ Unusual relationship type warnings
-    - ✅ Statistics mismatch warnings
-    - ✅ External dependency detection (ontology backups)
-    - ✅ File operations (load from disk)
-    - ✅ Non-existent file handling
-    - ✅ Invalid JSON handling
-    - ✅ Convenience functions
-    - ✅ Empty backup warnings
-    - ✅ Missing instance concept_id
-    - ✅ All valid relationship types accepted
-
-    Test Counts:
-    - Unit tests: 19
-    - Integration tests: 4
-    - Total: 23 tests
-    """
-    pass
+def test_check_file_invalid_json_fails():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "bad.json"
+        p.write_text("{not valid json")
+        result = check_backup_integrity(str(p))
+        assert not result.valid

--- a/tests/api/test_backup_streaming.py
+++ b/tests/api/test_backup_streaming.py
@@ -78,7 +78,7 @@ async def test_create_backup_stream_full_backup():
     with patch('api.app.lib.backup_streaming.DataExporter') as mock_exporter, \
          patch('api.app.lib.backup_streaming.check_backup_data') as mock_check:
 
-        mock_exporter.export_full_backup.return_value = mock_backup_data
+        mock_exporter.export_kg_backup_v2.return_value = mock_backup_data
 
         # Mock successful validation
         mock_integrity = Mock()
@@ -122,7 +122,7 @@ async def test_create_backup_stream_ontology_backup():
     with patch('api.app.lib.backup_streaming.DataExporter') as mock_exporter, \
          patch('api.app.lib.backup_streaming.check_backup_data') as mock_check:
 
-        mock_exporter.export_ontology_backup.return_value = mock_backup_data
+        mock_exporter.export_kg_backup_v2.return_value = mock_backup_data
 
         # Mock successful validation
         mock_integrity = Mock()
@@ -226,7 +226,7 @@ async def test_create_backup_stream_validates_backup_data():
     with patch('api.app.lib.backup_streaming.DataExporter') as mock_exporter, \
          patch('api.app.lib.backup_streaming.check_backup_data') as mock_check:
 
-        mock_exporter.export_full_backup.return_value = valid_backup_data
+        mock_exporter.export_kg_backup_v2.return_value = valid_backup_data
 
         # Mock successful validation
         mock_integrity = Mock()
@@ -266,7 +266,7 @@ async def test_create_backup_stream_fails_on_invalid_backup():
     with patch('api.app.lib.backup_streaming.DataExporter') as mock_exporter, \
          patch('api.app.lib.backup_streaming.check_backup_data') as mock_check:
 
-        mock_exporter.export_full_backup.return_value = invalid_backup_data
+        mock_exporter.export_kg_backup_v2.return_value = invalid_backup_data
 
         # Mock failed validation
         mock_integrity = Mock()
@@ -314,7 +314,7 @@ async def test_create_backup_stream_logs_validation_success(caplog):
     with patch('api.app.lib.backup_streaming.DataExporter') as mock_exporter, \
          patch('api.app.lib.backup_streaming.check_backup_data') as mock_check:
 
-        mock_exporter.export_full_backup.return_value = valid_backup_data
+        mock_exporter.export_kg_backup_v2.return_value = valid_backup_data
 
         # Mock successful validation
         mock_integrity = Mock()
@@ -367,7 +367,7 @@ async def test_create_backup_stream_logs_validation_warnings(caplog):
     with patch('api.app.lib.backup_streaming.DataExporter') as mock_exporter, \
          patch('api.app.lib.backup_streaming.check_backup_data') as mock_check:
 
-        mock_exporter.export_full_backup.return_value = valid_backup_data
+        mock_exporter.export_kg_backup_v2.return_value = valid_backup_data
 
         # Mock validation with warnings
         mock_integrity = Mock()
@@ -426,7 +426,7 @@ async def test_create_backup_stream_ontology_validates():
     with patch('api.app.lib.backup_streaming.DataExporter') as mock_exporter, \
          patch('api.app.lib.backup_streaming.check_backup_data') as mock_check:
 
-        mock_exporter.export_ontology_backup.return_value = valid_backup_data
+        mock_exporter.export_kg_backup_v2.return_value = valid_backup_data
 
         # Mock successful validation
         mock_integrity = Mock()

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -1,0 +1,126 @@
+"""Integration test for the kg-backup/2 clone writer (ADR-102 P3).
+
+Imports a small, TEST-NAMESPACED synthetic backup into the live dev graph via
+``DataImporter.import_backup`` and asserts the reconstructed graph shape — the
+normalized instance + M:N evidence reconstruction (EVIDENCED_BY / FROM_SOURCE /
+derived APPEARS), the dynamic relationship label, the load-bearing ``learned_id``
+edge property, and the carried epoch stamps.
+
+Honors "messy data finds bugs": it does NOT reset the working graph. All nodes use
+a ``p3rt_`` id prefix so they can't collide with real data, and the test removes
+them in a finally block.
+"""
+import pytest
+
+from api.app.lib.age_client import AGEClient
+from api.lib.serialization import DataExporter, DataImporter
+
+NS = "p3rt_"  # test namespace prefix
+
+
+def _namespaced_backup():
+    """A self-contained kg-backup/2 object with namespaced ids (built via the pure builder)."""
+    return DataExporter.build_kg_backup_v2(
+        concepts=[
+            {"concept_id": f"{NS}c1", "label": "P3 Alpha", "search_terms": ["a"],
+             "embedding": [0.1, 0.2, 0.3], "created_at_epoch": 11, "last_seen_epoch": 12},
+            {"concept_id": f"{NS}c2", "label": "P3 Beta", "search_terms": ["b"],
+             "embedding": [0.4, 0.5, 0.6], "created_at_epoch": 11, "last_seen_epoch": 11},
+        ],
+        sources=[
+            {"source_id": f"{NS}s1", "document": "P3 RoundTrip Corpus", "file_path": "/p3.txt",
+             "paragraph": 1, "full_text": "alpha implies beta", "content_type": "text/plain"},
+        ],
+        instances=[
+            {"instance_id": f"{NS}i1", "quote": "alpha implies beta",
+             "source_id": f"{NS}s1", "created_at_event_id": 11},
+        ],
+        # One instance evidenced by BOTH concepts (M:N) — exercises the evidence fan-out.
+        evidence=[
+            {"concept_id": f"{NS}c1", "instance_id": f"{NS}i1"},
+            {"concept_id": f"{NS}c2", "instance_id": f"{NS}i1"},
+        ],
+        relationships=[
+            {"from": f"{NS}c1", "to": f"{NS}c2", "type": "IMPLIES",
+             "properties": {"learned_id": f"{NS}s1", "confidence": 0.9}},
+        ],
+        vocabulary=[],          # skip vocab writes; IMPLIES is created as a dynamic edge label
+        embedding_profiles=[
+            {"identity": "openai:text-embedding-3-small@1536", "vector_space": "openai-3-small",
+             "image_vector_space": None, "name": "default", "multimodal": False},
+        ],
+        epoch_kinds=[],
+        graph_epochs=[],        # epoch-log replay is P5; clone carries only the stamps
+        schema_version=76,
+    )
+
+
+def _scalar(client, query, key="n"):
+    row = client._execute_cypher(query, fetch_one=True)
+    return int(str(row.get(key, 0)).strip('"')) if row else 0
+
+
+@pytest.fixture()
+def client_with_cleanup():
+    client = AGEClient()
+    try:
+        yield client
+    finally:
+        # Remove only the namespaced test nodes (DETACH DELETE drops their edges too).
+        for label, idfield in (("Concept", "concept_id"), ("Source", "source_id"), ("Instance", "instance_id")):
+            try:
+                client._execute_cypher(
+                    f"MATCH (n:{label}) WHERE n.{idfield} STARTS WITH '{NS}' DETACH DELETE n"
+                )
+            except Exception:
+                pass
+
+
+def test_clone_writer_reconstructs_graph(client_with_cleanup):
+    client = client_with_cleanup
+    backup = _namespaced_backup()
+
+    stats = DataImporter.import_backup(client, backup, overwrite_existing=True)
+
+    assert stats["concepts_created"] == 2
+    assert stats["sources_created"] == 1
+    assert stats["instances_created"] == 1
+    assert stats["relationships_created"] == 1
+
+    # Nodes exist with preserved ids + carried epoch stamps.
+    assert _scalar(client,
+        f"MATCH (c:Concept {{concept_id:'{NS}c1'}}) WHERE c.created_at_epoch = 11 RETURN count(c) AS n") == 1
+    assert _scalar(client,
+        f"MATCH (i:Instance {{instance_id:'{NS}i1'}}) WHERE i.created_at_event_id = 11 RETURN count(i) AS n") == 1
+
+    # Instance is normalized: one FROM_SOURCE edge to its source.
+    assert _scalar(client,
+        f"MATCH (i:Instance {{instance_id:'{NS}i1'}})-[:FROM_SOURCE]->(s:Source {{source_id:'{NS}s1'}}) RETURN count(*) AS n") == 1
+
+    # M:N EVIDENCED_BY reconstructed from the evidence stream — both concepts.
+    assert _scalar(client,
+        f"MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance {{instance_id:'{NS}i1'}}) WHERE c.concept_id STARTS WITH '{NS}' RETURN count(c) AS n") == 2
+
+    # Derived APPEARS edges (concept -> instance's source) for both concepts.
+    assert _scalar(client,
+        f"MATCH (c:Concept)-[:APPEARS]->(s:Source {{source_id:'{NS}s1'}}) WHERE c.concept_id STARTS WITH '{NS}' RETURN count(c) AS n") == 2
+
+    # Dynamic relationship with the load-bearing learned_id edge property preserved.
+    assert _scalar(client,
+        f"MATCH (:Concept {{concept_id:'{NS}c1'}})-[r:IMPLIES]->(:Concept {{concept_id:'{NS}c2'}}) "
+        f"WHERE r.learned_id = '{NS}s1' RETURN count(r) AS n") == 1
+
+
+def test_reimport_is_idempotent(client_with_cleanup):
+    """Re-importing the same backup must not duplicate edges (MERGE-by-id)."""
+    client = client_with_cleanup
+    backup = _namespaced_backup()
+
+    DataImporter.import_backup(client, backup, overwrite_existing=True)
+    DataImporter.import_backup(client, backup, overwrite_existing=True)
+
+    # Still exactly one IMPLIES edge and two EVIDENCED_BY edges after a second pass.
+    assert _scalar(client,
+        f"MATCH (:Concept {{concept_id:'{NS}c1'}})-[r:IMPLIES]->(:Concept {{concept_id:'{NS}c2'}}) RETURN count(r) AS n") == 1
+    assert _scalar(client,
+        f"MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance {{instance_id:'{NS}i1'}}) WHERE c.concept_id STARTS WITH '{NS}' RETURN count(c) AS n") == 2

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -10,6 +10,8 @@ Honors "messy data finds bugs": it does NOT reset the working graph. All nodes u
 a ``p3rt_`` id prefix so they can't collide with real data, and the test removes
 them in a finally block.
 """
+from unittest.mock import MagicMock
+
 import pytest
 
 from api.app.lib.age_client import AGEClient
@@ -75,6 +77,16 @@ def client_with_cleanup():
                 )
             except Exception:
                 pass
+
+
+def test_merge_relationship_rejects_unsafe_edge_label():
+    """A crafted edge label (untrusted backup) is skipped, never interpolated into Cypher."""
+    client = MagicMock()
+    n = DataImporter._merge_relationship(
+        client, {"from": "a", "to": "b", "type": "IMPLIES]->() DETACH DELETE n //", "properties": {}}
+    )
+    assert n == 0
+    client._execute_cypher.assert_not_called()
 
 
 def test_clone_writer_reconstructs_graph(client_with_cleanup):

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -14,6 +14,7 @@ import pytest
 
 from api.app.lib.age_client import AGEClient
 from api.lib.serialization import DataExporter, DataImporter
+from api.lib.id_remap import IdRemapper
 
 NS = "p3rt_"  # test namespace prefix
 
@@ -124,3 +125,33 @@ def test_reimport_is_idempotent(client_with_cleanup):
         f"MATCH (:Concept {{concept_id:'{NS}c1'}})-[r:IMPLIES]->(:Concept {{concept_id:'{NS}c2'}}) RETURN count(r) AS n") == 1
     assert _scalar(client,
         f"MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance {{instance_id:'{NS}i1'}}) WHERE c.concept_id STARTS WITH '{NS}' RETURN count(c) AS n") == 2
+
+
+def test_adjacent_remap_round_trips_through_clone_writer(client_with_cleanup):
+    """Adjacent mode: remap all ids, then clone — edges survive under the NEW ids."""
+    client = client_with_cleanup
+    backup = _namespaced_backup()
+
+    # New ids stay under the test namespace so cleanup catches them too.
+    remapper = IdRemapper(mode="always", id_factory=lambda kind, old: f"{NS}rm_{old}")
+    new_obj, table = remapper.remap(backup)
+
+    # Mapping table records the transposition.
+    assert table["concepts"][f"{NS}c1"] == f"{NS}rm_{NS}c1"
+    assert table["sources"][f"{NS}s1"] == f"{NS}rm_{NS}s1"
+
+    DataImporter.import_backup(client, new_obj, overwrite_existing=True)
+
+    rm_c1, rm_c2 = f"{NS}rm_{NS}c1", f"{NS}rm_{NS}c2"
+    rm_s1, rm_i1 = f"{NS}rm_{NS}s1", f"{NS}rm_{NS}i1"
+
+    # The relationship exists under remapped concept ids, with learned_id rewritten
+    # through the SOURCE map (the landmine).
+    assert _scalar(client,
+        f"MATCH (:Concept {{concept_id:'{rm_c1}'}})-[r:IMPLIES]->(:Concept {{concept_id:'{rm_c2}'}}) "
+        f"WHERE r.learned_id = '{rm_s1}' RETURN count(r) AS n") == 1
+
+    # Evidence + FROM_SOURCE reconstructed under the remapped instance/source ids.
+    assert _scalar(client,
+        f"MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance {{instance_id:'{rm_i1}'}})-[:FROM_SOURCE]->(:Source {{source_id:'{rm_s1}'}}) "
+        f"RETURN count(c) AS n") == 2

--- a/tests/unit/test_id_remap.py
+++ b/tests/unit/test_id_remap.py
@@ -1,0 +1,150 @@
+"""Unit matrix for IdRemapper — adjacent-mode ID rewrite (ADR-102 P3).
+
+One test per reference class (the LANDMINE checklist), plus the integrity guarantee
+that a remapped object still validates clean (no orphaned references). Pure/DB-free.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from api.lib.serialization import DataExporter
+from api.lib.id_remap import IdRemapper, _remap_storage_key
+
+# Offline validator (standalone script) — the no-orphan oracle.
+_REPO = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "lint_backup", _REPO / "scripts" / "development" / "lint" / "lint_backup.py"
+)
+lint_backup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_backup)
+
+
+def _backup(**overrides):
+    lists = dict(
+        concepts=[
+            {"concept_id": "c1", "label": "A", "search_terms": [], "embedding": [0.1],
+             "created_at_epoch": 1, "last_seen_epoch": 1},
+            {"concept_id": "c2", "label": "B", "search_terms": [], "embedding": [0.2],
+             "created_at_epoch": 1, "last_seen_epoch": 1},
+        ],
+        sources=[
+            {"source_id": "s1", "document": "Doc", "file_path": "/a", "paragraph": 1,
+             "full_text": "t", "content_type": "image/png",
+             "garage_key": "sources/Doc/abc123sha", "storage_key": "images/Doc/s1.png"},
+        ],
+        instances=[
+            {"instance_id": "i1", "quote": "q", "source_id": "s1", "created_at_event_id": 1},
+        ],
+        evidence=[{"concept_id": "c1", "instance_id": "i1"}],
+        relationships=[
+            {"from": "c1", "to": "c2", "type": "IMPLIES", "properties": {"learned_id": "s1"}},
+        ],
+        vocabulary=[{"relationship_type": "IMPLIES", "description": "", "category": "logical",
+                     "embedding_model": "openai:text-embedding-3-small@1536"}],
+        embedding_profiles=[{"identity": "openai:text-embedding-3-small@1536",
+                             "vector_space": "x", "image_vector_space": None,
+                             "name": "d", "multimodal": False}],
+        epoch_kinds=[{"kind": "ingestion", "semantic_wallclock": True, "description": ""}],
+        graph_epochs=[{"event_id": 1, "occurred_at": "2026-06-01T00:00:00Z",
+                       "kind": "ingestion", "actor": "system", "counter_after": 1, "metadata": {}}],
+        schema_version=76,
+    )
+    lists.update(overrides)
+    return DataExporter.build_kg_backup_v2(**lists)
+
+
+# A deterministic factory so tests can assert exact new ids.
+def _fixed_factory(kind, old):
+    return f"NEW_{old}"
+
+
+def _remap_always():
+    new, table = IdRemapper(mode="always", id_factory=_fixed_factory).remap(_backup())
+    return new, table
+
+
+def test_concept_id_rewritten_everywhere():
+    new, table = _remap_always()
+    assert table["concepts"] == {"c1": "NEW_c1", "c2": "NEW_c2"}
+    assert [c["concept_id"] for c in new["bulk"]["concepts"]] == ["NEW_c1", "NEW_c2"]
+    assert new["bulk"]["evidence"][0]["concept_id"] == "NEW_c1"
+    rel = new["bulk"]["relationships"][0]
+    assert rel["from"] == "NEW_c1" and rel["to"] == "NEW_c2"
+
+
+def test_source_id_rewritten_in_sources_and_instances():
+    new, table = _remap_always()
+    assert table["sources"] == {"s1": "NEW_s1"}
+    assert new["bulk"]["sources"][0]["source_id"] == "NEW_s1"
+    assert new["bulk"]["instances"][0]["source_id"] == "NEW_s1"
+
+
+def test_learned_id_edge_property_rewritten_via_source_map():
+    """The load-bearing landmine: learned_id is a source_id carried on an edge."""
+    new, _ = _remap_always()
+    assert new["bulk"]["relationships"][0]["properties"]["learned_id"] == "NEW_s1"
+
+
+def test_instance_id_rewritten_in_instances_and_evidence():
+    new, table = _remap_always()
+    assert table["instances"] == {"i1": "NEW_i1"}
+    assert new["bulk"]["instances"][0]["instance_id"] == "NEW_i1"
+    assert new["bulk"]["evidence"][0]["instance_id"] == "NEW_i1"
+
+
+def test_storage_key_recomputed_from_new_source_id():
+    new, _ = _remap_always()
+    src = new["bulk"]["sources"][0]
+    assert src["storage_key"] == "images/Doc/NEW_s1.png"
+
+
+def test_garage_key_is_immune():
+    """Content-addressed source-doc keys are NOT remapped."""
+    new, _ = _remap_always()
+    assert new["bulk"]["sources"][0]["garage_key"] == "sources/Doc/abc123sha"
+
+
+def test_remapped_object_validates_clean():
+    """No reference class left dangling — the integrity guarantee."""
+    new, _ = _remap_always()
+    result = lint_backup.validate_backup(new)
+    assert result.ok, [str(i) for i in result.errors]
+
+
+def test_header_carried_unchanged():
+    new, _ = _remap_always()
+    assert new["header"]["format_version"] == "kg-backup/2"
+
+
+def test_collision_mode_only_remaps_colliding_ids():
+    existing = {"concept": {"c1"}, "source": set(), "instance": set()}
+    new, table = IdRemapper(mode="collision", existing_ids=existing,
+                            id_factory=_fixed_factory).remap(_backup())
+    assert table["concepts"]["c1"] == "NEW_c1"   # collided → remapped
+    assert table["concepts"]["c2"] == "c2"        # no collision → preserved
+    assert table["sources"]["s1"] == "s1"         # no collision → preserved
+    # evidence/relationships follow the same map
+    assert new["bulk"]["relationships"][0]["from"] == "NEW_c1"
+    assert new["bulk"]["relationships"][0]["to"] == "c2"
+
+
+def test_external_reference_preserved():
+    """An edge endpoint absent from the backup keeps its id (points at target data)."""
+    obj = _backup(relationships=[
+        {"from": "c1", "to": "external_x", "type": "IMPLIES", "properties": {}},
+    ])
+    new, _ = IdRemapper(mode="always", id_factory=_fixed_factory).remap(obj)
+    rel = new["bulk"]["relationships"][0]
+    assert rel["from"] == "NEW_c1"
+    assert rel["to"] == "external_x"  # untouched
+
+
+def test_remap_storage_key_anchors_on_filename():
+    # source_id appearing only as the filename stem is replaced exactly once.
+    assert _remap_storage_key("images/Doc/s1.png", "s1", "NEW") == "images/Doc/NEW.png"
+
+
+def test_unknown_mode_rejected():
+    with pytest.raises(ValueError, match="Unknown remap mode"):
+        IdRemapper(mode="bogus")

--- a/tests/unit/test_kg_backup_v2.py
+++ b/tests/unit/test_kg_backup_v2.py
@@ -1,0 +1,144 @@
+"""Unit tests for kg-backup/2 export assembly (ADR-102 P2).
+
+Exercises the PURE ``DataExporter.build_kg_backup_v2()`` assembly — header
+construction, dictionary interning, and the concept record→backup cascade —
+and validates the result with the standalone offline validator
+(``scripts/development/lint/lint_backup.py``). No database required.
+"""
+import importlib.util
+from pathlib import Path
+
+from api.lib.serialization import DataExporter, KG_BACKUP_FORMAT_VERSION
+
+# The validator is a standalone script (not a package); import it by path.
+_REPO = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "lint_backup", _REPO / "scripts" / "development" / "lint" / "lint_backup.py"
+)
+lint_backup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_backup)
+
+
+def _fixture_lists():
+    """Minimal but representative primary-input lists for build_kg_backup_v2."""
+    return dict(
+        concepts=[
+            {"concept_id": "c1", "label": "Alpha", "search_terms": ["a"],
+             "embedding": [0.1, 0.2], "created_at_epoch": 1, "last_seen_epoch": 3},
+            {"concept_id": "c2", "label": "Beta", "search_terms": [],
+             "embedding": [0.3, 0.4], "created_at_epoch": 2, "last_seen_epoch": 2},
+        ],
+        sources=[
+            {"source_id": "s1", "document": "Corpus", "file_path": "/a.txt",
+             "paragraph": 1, "full_text": "alpha beta", "content_type": "text/plain"},
+        ],
+        instances=[
+            {"instance_id": "i1", "quote": "alpha",
+             "source_id": "s1", "created_at_event_id": 1},
+        ],
+        evidence=[
+            {"concept_id": "c1", "instance_id": "i1"},
+        ],
+        relationships=[
+            {"from": "c1", "to": "c2", "type": "IMPLIES",
+             "properties": {"learned_id": "s1"}},
+        ],
+        vocabulary=[
+            {"relationship_type": "IMPLIES", "description": "x", "category": "logical",
+             "embedding_model": "openai:text-embedding-3-small@1536"},
+        ],
+        embedding_profiles=[
+            {"identity": "openai:text-embedding-3-small@1536",
+             "vector_space": "openai-3-small", "image_vector_space": None,
+             "name": "default", "multimodal": False},
+        ],
+        epoch_kinds=[
+            {"kind": "ingestion", "semantic_wallclock": True, "description": ""},
+        ],
+        graph_epochs=[
+            {"event_id": 1, "occurred_at": "2026-06-01T00:00:00Z", "kind": "ingestion",
+             "actor": "system", "counter_after": 10, "metadata": {}},
+        ],
+        schema_version=76,
+    )
+
+
+def test_build_validates_against_offline_validator():
+    """A well-formed build passes lint_backup with no ERROR."""
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+    result = lint_backup.validate_backup(obj)
+    assert result.ok, [str(i) for i in result.errors]
+    assert obj["header"]["format_version"] == KG_BACKUP_FORMAT_VERSION
+
+
+def test_references_are_interned_by_index():
+    """Repeated descriptors live in the header; bulk cites them by integer index."""
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+
+    rel = obj["bulk"]["relationships"][0]
+    assert isinstance(rel["type"], int)
+    assert obj["header"]["relationship_vocabulary"][rel["type"]]["relationship_type"] == "IMPLIES"
+
+    src = obj["bulk"]["sources"][0]
+    assert isinstance(src["content_type"], int)
+    assert obj["header"]["content_types"][src["content_type"]] == "text/plain"
+
+    ep = obj["bulk"]["graph_epochs"][0]
+    assert isinstance(ep["kind"], int)
+    assert isinstance(ep["actor"], int)
+    assert obj["header"]["actors"][ep["actor"]] == "system"
+
+
+def test_concept_cascade_has_no_per_record_profile():
+    """With one active profile, concepts inherit the backup default (no ref emitted)."""
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+    assert obj["header"]["default_embedding_profile"] == 0
+    for c in obj["bulk"]["concepts"]:
+        assert "embedding_profile" not in c  # cascades to backup default
+
+
+def test_epoch_fields_carried():
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+    c = obj["bulk"]["concepts"][0]
+    assert c["created_at_epoch"] == 1 and c["last_seen_epoch"] == 3
+    assert obj["bulk"]["instances"][0]["created_at_event_id"] == 1
+
+
+def test_instances_normalized_with_evidence_stream():
+    """Instances are unique (no concept_id); Concept->Instance links are in evidence."""
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+    inst = obj["bulk"]["instances"][0]
+    assert "concept_id" not in inst
+    assert inst["instance_id"] == "i1"
+    ev = obj["bulk"]["evidence"][0]
+    assert ev == {"concept_id": "c1", "instance_id": "i1"}
+
+
+def test_dangling_evidence_link_is_flagged():
+    """An evidence link to a missing concept/instance fails validation."""
+    lists = _fixture_lists()
+    lists["evidence"].append({"concept_id": "cX", "instance_id": "i1"})   # cX missing
+    lists["evidence"].append({"concept_id": "c1", "instance_id": "iX"})   # iX missing
+    result = lint_backup.validate_backup(DataExporter.build_kg_backup_v2(**lists))
+    codes = {i.code for i in result.errors}
+    assert "E_EVIDENCE_CONCEPT_MISSING" in codes
+    assert "E_EVIDENCE_INSTANCE_MISSING" in codes
+
+
+def test_no_derived_products_in_bulk():
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+    for key in ("projections", "artifacts", "scores", "grounding", "catalog"):
+        assert key not in obj["bulk"]
+
+
+def test_dynamic_edge_type_missing_from_vocab_still_interns():
+    """An edge type absent from the vocabulary table is appended to the header dict."""
+    lists = _fixture_lists()
+    lists["relationships"].append(
+        {"from": "c2", "to": "c1", "type": "NOVEL_REL", "properties": {}}
+    )
+    obj = DataExporter.build_kg_backup_v2(**lists)
+    result = lint_backup.validate_backup(obj)
+    assert result.ok, [str(i) for i in result.errors]
+    types = [v.get("relationship_type") for v in obj["header"]["relationship_vocabulary"]]
+    assert "NOVEL_REL" in types

--- a/tests/unit/test_kg_backup_v2_reader.py
+++ b/tests/unit/test_kg_backup_v2_reader.py
@@ -1,0 +1,134 @@
+"""Unit tests for KgBackupV2Reader — the kg-backup/2 read/de-intern layer (ADR-102 P3).
+
+Pure and DB-free: feeds objects built by the pure ``DataExporter.build_kg_backup_v2``
+through the reader and asserts de-interning, evidence grouping, external-dependency
+detection, and single-path format negotiation (no v1 fallback).
+"""
+import pytest
+
+from api.lib.serialization import DataExporter, KgBackupV2Reader
+
+
+def _fixture_lists():
+    """Minimal representative primary-input lists for build_kg_backup_v2."""
+    return dict(
+        concepts=[
+            {"concept_id": "c1", "label": "Alpha", "search_terms": ["a"],
+             "embedding": [0.1, 0.2], "created_at_epoch": 1, "last_seen_epoch": 3},
+            {"concept_id": "c2", "label": "Beta", "search_terms": [],
+             "embedding": [0.3, 0.4], "created_at_epoch": 2, "last_seen_epoch": 2},
+        ],
+        sources=[
+            {"source_id": "s1", "document": "Corpus", "file_path": "/a.txt",
+             "paragraph": 1, "full_text": "alpha beta", "content_type": "text/plain"},
+        ],
+        instances=[
+            {"instance_id": "i1", "quote": "alpha", "source_id": "s1", "created_at_event_id": 1},
+        ],
+        evidence=[
+            {"concept_id": "c1", "instance_id": "i1"},
+            {"concept_id": "c2", "instance_id": "i1"},   # M:N — one instance, two concepts
+        ],
+        relationships=[
+            {"from": "c1", "to": "c2", "type": "IMPLIES", "properties": {"learned_id": "s1"}},
+        ],
+        vocabulary=[
+            {"relationship_type": "IMPLIES", "description": "x", "category": "logical",
+             "embedding_model": "openai:text-embedding-3-small@1536"},
+        ],
+        embedding_profiles=[
+            {"identity": "openai:text-embedding-3-small@1536", "vector_space": "openai-3-small",
+             "image_vector_space": None, "name": "default", "multimodal": False},
+        ],
+        epoch_kinds=[
+            {"kind": "ingestion", "semantic_wallclock": True, "description": ""},
+        ],
+        graph_epochs=[
+            {"event_id": 1, "occurred_at": "2026-06-01T00:00:00Z", "kind": "ingestion",
+             "actor": "system", "counter_after": 10, "metadata": {}},
+        ],
+        schema_version=76,
+    )
+
+
+def _build(**overrides):
+    lists = _fixture_lists()
+    lists.update(overrides)
+    return DataExporter.build_kg_backup_v2(**lists)
+
+
+def test_relationship_type_de_interned():
+    """Bulk relationships carry an integer type index; the reader yields the label."""
+    obj = _build()
+    assert isinstance(obj["bulk"]["relationships"][0]["type"], int)  # interned on disk
+    rels = list(KgBackupV2Reader(obj).relationships())
+    assert rels[0]["type"] == "IMPLIES"
+    assert rels[0]["properties"] == {"learned_id": "s1"}
+
+
+def test_content_type_de_interned():
+    obj = _build()
+    assert isinstance(obj["bulk"]["sources"][0]["content_type"], int)
+    src = list(KgBackupV2Reader(obj).sources())[0]
+    assert src["content_type"] == "text/plain"
+
+
+def test_evidence_grouped_by_instance():
+    """The M:N evidence stream groups to {instance_id: [concept_id, ...]}."""
+    grouped = KgBackupV2Reader(_build()).evidence_by_instance()
+    assert grouped == {"i1": ["c1", "c2"]}
+
+
+def test_instances_normalized_no_concept_id():
+    inst = list(KgBackupV2Reader(_build()).instances())[0]
+    assert "concept_id" not in inst
+    assert inst["instance_id"] == "i1" and inst["source_id"] == "s1"
+    assert inst["created_at_event_id"] == 1
+
+
+def test_graph_epochs_de_interned():
+    ep = list(KgBackupV2Reader(_build()).graph_epochs())[0]
+    assert ep["kind"] == "ingestion"
+    assert ep["actor"] == "system"
+
+
+def test_counts():
+    counts = KgBackupV2Reader(_build()).counts()
+    assert counts == {"concepts": 2, "sources": 1, "instances": 1,
+                      "evidence": 2, "relationships": 1, "vocabulary": 1}
+
+
+def test_external_concept_ids_empty_when_self_contained():
+    assert KgBackupV2Reader(_build()).external_concept_ids() == set()
+
+
+def test_external_concept_ids_detects_dangling_endpoint():
+    """An edge endpoint with no concept record is an external dependency."""
+    obj = _build(relationships=[
+        {"from": "c1", "to": "cX", "type": "IMPLIES", "properties": {}},  # cX not a concept
+    ])
+    assert KgBackupV2Reader(obj).external_concept_ids() == {"cX"}
+
+
+def test_negotiate_refuses_missing_header():
+    with pytest.raises(ValueError, match="missing header/bulk"):
+        KgBackupV2Reader({"version": "1.0", "data": {}})  # the dead v1 shape
+
+
+def test_negotiate_refuses_unknown_family():
+    obj = _build()
+    obj["header"]["format_version"] = "something-else/2"
+    with pytest.raises(ValueError, match="Unknown backup format_version"):
+        KgBackupV2Reader(obj)
+
+
+def test_negotiate_refuses_higher_major():
+    obj = _build()
+    obj["header"]["format_version"] = "kg-backup/3"
+    with pytest.raises(ValueError, match="newer than supported"):
+        KgBackupV2Reader(obj)
+
+
+def test_negotiate_accepts_current_major():
+    obj = _build()
+    assert KgBackupV2Reader(obj).format_version == "kg-backup/2"


### PR DESCRIPTION
Implements the ADR-102 spine through P3: a single portable backup model
(\`kg-backup/2\`) with export, clone restore, and adjacent-mode ID remapping.

## Commits
- **P2** \`594090bb\` — kg-backup/2 export: self-describing header (interned
  dictionaries), normalized instances + M:N evidence stream, epoch stamps,
  embedding-profile cascade. Offline validator + 8 export tests.
- **P3 converge** \`c5140445\` — single-path restore-core. \`KgBackupV2Reader\`
  (pure de-intern/evidence-group), v2-only \`DataImporter\` clone writer
  (rebuilds EVIDENCED_BY + derived APPEARS, carries epoch stamps). **Deletes
  the v1 prototype format** and converges every producer/consumer (streaming,
  archive, worker checkpoint, GEXF, integrity checker, admin routes + CLIs).
- **P3 remap** \`f7b2880c\` — adjacent-mode \`IdRemapper\`: exhaustive
  reference-class rewrite (concept/source/instance ids, the \`learned_id\` edge
  property, image \`storage_key\` recompute; content-addressed \`garage_key\`
  immune) → new valid kg-backup/2 object + mapping table.

## Behavior changes (reviewer: note these)
- **No v1 backwards-compat.** The legacy \`{version,type,data}\` format is
  removed; the reader refuses anything not \`kg-backup/<=2\`. (Single-model
  decision — the old format was a prototype.)
- **Restore clone/merge now gated by TARGET EMPTINESS**, replacing the v1
  \`full_backup\` auto-wipe. Full-restore-over-populated now MERGES (idempotent)
  instead of silently wiping; a clean replace is explicit reset → clone.
- **Edge-property fix:** AGE rejects \`SET r = \$map\`; the writer now sets each
  edge property key-by-key (was latent-broken in the legacy importer).

## Tests
67 pass / 1 pre-existing skip. Reader unit (DB-free), remap matrix (one per
reference class + no-orphan lint guarantee), clone + adjacent integration
against the live graph (namespaced, self-cleaning). Live working graph
(3988 concepts / 8295 edges) exports v2 and validates clean.

## Follow-ups (tracked)
P4 merge-mode selection (wire IdRemapper + integration ConceptMatcher + CLI
surface), P5 epochs/lanes/rehydration, P6 purge dead code (BackupAssessment,
dead admin_service subprocess methods, two-validator overlap) + split
serialization.py.

Refs ADR-102. Filed #479 (dup Source nodes / ingest race) during P2.