### PR TITLE
feat(restore): merge modes — idempotent / adjacent / integration (ADR-102 P4)

### DIFF
--- a/api/app/lib/restore_modes.py
+++ b/api/app/lib/restore_modes.py
@@ -56,6 +56,55 @@ def _empty_maps() -> MappingTable:
     return {"concepts": {}, "sources": {}, "instances": {}}
 
 
+def _active_identity(profiles) -> Optional[str]:
+    """The active embedding-profile identity (index 0, active-first) or None."""
+    return profiles[0].get("identity") if profiles else None
+
+
+def _backup_active_identity(obj: Dict[str, Any]) -> Optional[str]:
+    """The backup's active text embedding-profile identity (spec §3.2), or None."""
+    header = obj.get("header", {})
+    profiles = header.get("embedding_profiles") or []
+    idx = header.get("default_embedding_profile")
+    if isinstance(idx, int) and 0 <= idx < len(profiles):
+        return profiles[idx].get("identity")
+    return _active_identity(profiles)
+
+
+def _target_active_identity(client: Any) -> Optional[str]:
+    """The target graph's active embedding-profile identity, or None if unconfigured."""
+    from ...lib.serialization import DataExporter
+    return _active_identity(DataExporter.export_embedding_profiles(client))
+
+
+def _assert_compatible_embedding_space(obj: Dict[str, Any], client: Any) -> None:
+    """Guard integration matching against an embedding-space mismatch (ADR-102 §6).
+
+    Integration matches the backup's CARRIED concept vectors against the target by
+    cosine similarity. If the backup was embedded in a different space than the
+    target's active profile, those vectors are meaningless in the target space and
+    — at equal dimensions — can yield plausible-but-wrong matches that silently
+    mis-attach concepts. §6 requires recomputing embeddings before integration;
+    until that rehydration exists (P5), a known mismatch is REJECTED.
+    """
+    backup_id = _backup_active_identity(obj)
+    target_id = _target_active_identity(client)
+    if backup_id and target_id and backup_id != target_id:
+        raise ValueError(
+            f"integration mode requires matching embedding spaces: backup is "
+            f"{backup_id!r} but the target's active profile is {target_id!r}. The "
+            f"carried vectors are in a different space — recompute embeddings before "
+            f"integration matching (ADR-102 §6; embedding rehydration is P5). Use "
+            f"'adjacent' to import without matching."
+        )
+    if not (backup_id and target_id):
+        logger.warning(
+            "restore(integration): could not confirm embedding-space compatibility "
+            "(backup=%r, target=%r) — proceeding; verify your embedding configuration",
+            backup_id, target_id,
+        )
+
+
 def prepare_backup(obj: Dict[str, Any], mode: str,
                    client: Optional[Any] = None) -> Tuple[Dict[str, Any], MappingTable]:
     """Transform a kg-backup/2 object for ``mode``; return ``(prepared_obj, mapping_table)``.
@@ -91,6 +140,9 @@ def _prepare_integration(obj: Dict[str, Any], client: Any) -> Tuple[Dict[str, An
     node stays untouched); its instances/evidence/edges rewire to the target. Unmatched
     concepts — and all sources/instances — get freshly minted ids.
     """
+    # ADR-102 §6: refuse to match across embedding spaces (silent mis-attach risk).
+    _assert_compatible_embedding_space(obj, client)
+
     bulk = obj["bulk"]
     # Reuse the always-minter for fresh ids (sources, instances, unmatched concepts).
     minted = IdRemapper(mode=IdRemapper.MODE_ALWAYS).build_maps(bulk)

--- a/api/app/lib/restore_modes.py
+++ b/api/app/lib/restore_modes.py
@@ -1,0 +1,128 @@
+"""Restore merge modes (ADR-102 P4).
+
+A backup is restored under one of three modes, chosen at restore time (a request
+param — the backup file is pure data and does not dictate its own restore policy):
+
+  - ``idempotent``  — MERGE-by-id, collisions update in place. The backup's ids are
+                      authoritative. Into an empty target this is a faithful clone
+                      (ids preserved 1:1); into a populated target it updates matching
+                      nodes and adds the rest. No id rewrite.
+  - ``adjacent``    — every id is minted fresh (``IdRemapper`` ``always``): the backup
+                      lands as a wholly independent copy alongside existing data, with
+                      a mapping table to transpose ids afterward.
+  - ``integration`` — each incoming CONCEPT is matched against the target by cosine
+                      similarity (``ConceptMatcher``, 0.85 strict / 0.75 label-boosted).
+                      A match attaches the incoming concept's instances/evidence/edges
+                      to the EXISTING target concept (the incoming concept record is
+                      dropped — the target node is left untouched); a non-match mints a
+                      new concept. Sources and instances are always minted fresh (they
+                      are raw inputs, not dedup targets). Like greenfield ingest, minus
+                      the LLM extraction step.
+
+Every mode produces a valid ``kg-backup/2`` object that flows through the normal
+clone writer (``DataImporter._import_kg_backup_v2``) plus an old→new mapping table.
+"""
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from ...lib.id_remap import IdRemapper
+from .concept_matcher import ConceptMatcher
+
+logger = logging.getLogger(__name__)
+
+MappingTable = Dict[str, Dict[str, str]]
+
+
+class RestoreMode:
+    """The three restore merge modes (ADR-102 P4)."""
+
+    IDEMPOTENT = "idempotent"
+    ADJACENT = "adjacent"
+    INTEGRATION = "integration"
+    ALL = (IDEMPOTENT, ADJACENT, INTEGRATION)
+    DEFAULT = IDEMPOTENT
+
+    @classmethod
+    def validate(cls, mode: str) -> str:
+        """Return ``mode`` if recognized, else raise ValueError."""
+        if mode not in cls.ALL:
+            raise ValueError(
+                f"Unknown restore mode {mode!r}; expected one of {', '.join(cls.ALL)}"
+            )
+        return mode
+
+
+def _empty_maps() -> MappingTable:
+    return {"concepts": {}, "sources": {}, "instances": {}}
+
+
+def prepare_backup(obj: Dict[str, Any], mode: str,
+                   client: Optional[Any] = None) -> Tuple[Dict[str, Any], MappingTable]:
+    """Transform a kg-backup/2 object for ``mode``; return ``(prepared_obj, mapping_table)``.
+
+    The prepared object is fed verbatim to the clone writer. ``client`` (an AGEClient)
+    is required only for ``integration`` (it queries the target for similar concepts).
+    """
+    RestoreMode.validate(mode)
+
+    if mode == RestoreMode.IDEMPOTENT:
+        # Authoritative ids, MERGE-by-id in the writer — no transformation.
+        return obj, _empty_maps()
+
+    if mode == RestoreMode.ADJACENT:
+        new_obj, maps = IdRemapper(mode=IdRemapper.MODE_ALWAYS).remap(obj)
+        logger.info("restore(adjacent): minted %d concept / %d source / %d instance new ids",
+                    len(maps["concepts"]), len(maps["sources"]), len(maps["instances"]))
+        return new_obj, maps
+
+    if mode == RestoreMode.INTEGRATION:
+        if client is None:
+            raise ValueError("integration mode requires a client to match against the target")
+        return _prepare_integration(obj, client)
+
+    raise ValueError(f"Unknown restore mode: {mode!r}")  # pragma: no cover (validate guards)
+
+
+def _prepare_integration(obj: Dict[str, Any], client: Any) -> Tuple[Dict[str, Any], MappingTable]:
+    """Build integration maps: concepts match-or-mint; sources/instances always mint.
+
+    A matched concept is recorded in ``concept_map`` pointing at the EXISTING target
+    concept_id and added to ``drop_concepts`` so its record is not emitted (the target
+    node stays untouched); its instances/evidence/edges rewire to the target. Unmatched
+    concepts — and all sources/instances — get freshly minted ids.
+    """
+    bulk = obj["bulk"]
+    # Reuse the always-minter for fresh ids (sources, instances, unmatched concepts).
+    minted = IdRemapper(mode=IdRemapper.MODE_ALWAYS).build_maps(bulk)
+
+    matcher = ConceptMatcher(client)
+    concept_map: Dict[str, str] = {}
+    drop_concepts = set()
+    matched_count = 0
+
+    for c in bulk.get("concepts", []):
+        cid = c["concept_id"]
+        match = matcher.match_concept_in_database(
+            {"embedding": c.get("embedding"), "label": c.get("label")}
+        )
+        if match:
+            concept_map[cid] = match["concept_id"]   # attach to existing target concept
+            drop_concepts.add(cid)                    # do not emit/overwrite the target node
+            matched_count += 1
+        else:
+            concept_map[cid] = minted["concepts"][cid]  # new concept
+
+    maps: MappingTable = {
+        "concepts": concept_map,
+        "sources": minted["sources"],
+        "instances": minted["instances"],
+    }
+    prepared = IdRemapper.apply_maps(
+        obj, concept_map, maps["sources"], maps["instances"], drop_concepts=frozenset(drop_concepts)
+    )
+    logger.info(
+        "restore(integration): %d concepts matched-and-attached to existing, %d new; "
+        "%d sources / %d instances minted",
+        matched_count, len(concept_map) - matched_count, len(maps["sources"]), len(maps["instances"]),
+    )
+    return prepared, maps

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -218,8 +218,8 @@ async def restore_backup(
     current_user: CurrentUser,
     _: None = Depends(require_permission("backups", "restore")),
     file: UploadFile = File(..., description="Backup file (.tar.gz archive or .json)"),
-    overwrite: bool = Form(False, description="Overwrite existing data"),
-    handle_external_deps: str = Form("prune", description="How to handle external dependencies: 'prune', 'stitch', or 'defer'")
+    mode: str = Form("idempotent",
+                     description="Restore merge mode: 'idempotent', 'adjacent', or 'integration'")
 ):
     """
     Restore a database backup (ADR-015 Phase 2: Multipart Upload)
@@ -229,16 +229,18 @@ async def restore_backup(
     **Multipart Upload**: Client streams backup file to server.
     Server validates, then queues restore job for background processing.
 
-    Supports two formats:
+    Supports two containers:
     - **.tar.gz** (archive): Contains manifest.json + original documents from Garage
-    - **.json** (legacy): Graph data only, no source documents
+    - **.json**: The kg-backup/2 object (graph data only, no source documents)
 
-    Restore options:
-    - **overwrite**: Whether to overwrite existing data (default: false)
-    - **handle_external_deps**: How to handle external dependencies
-      - `prune`: Remove dangling relationships (default)
-      - `stitch`: Try to reconnect to existing concepts
-      - `defer`: Leave broken (requires manual fix)
+    Restore mode (ADR-102 P4) — how the backup merges into the target:
+    - `idempotent` (default): MERGE-by-id; collisions update in place. Into an
+      empty target this is a faithful clone (ids preserved 1:1).
+    - `adjacent`: mint fresh ids for everything — land the backup as an
+      independent copy alongside existing data (returns an id mapping table).
+    - `integration`: match each incoming concept to the target by similarity and
+      attach to the existing concept where found; mint the rest. Like ingest,
+      without LLM extraction.
 
     The restore process includes:
     1. Save uploaded file to temp location
@@ -255,10 +257,15 @@ async def restore_backup(
     Example (multipart/form-data):
     ```
     file: <backup_file.tar.gz>
-    overwrite: false
-    handle_external_deps: prune
+    mode: integration
     ```
     """
+    # Validate the restore mode up front (single source of truth in restore_modes).
+    from ..lib.restore_modes import RestoreMode
+    try:
+        RestoreMode.validate(mode)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     # Validate file type
     is_archive = file.filename.endswith('.tar.gz')
@@ -332,44 +339,10 @@ async def restore_backup(
             f"Relationships: {stats.get('relationships', 0)}"
         )
 
-        # Safety check: If a single-ontology backup targets an existing ontology,
-        # require the --merge flag. The single kg-backup/2 model names the scope in
-        # the header (one ontology entry == a scoped backup) — ADR-102 P3.
-        with open(temp_path, 'r') as f:
-            import json
-            from ...lib.serialization import KgBackupV2Reader
-            backup_data = json.load(f)
-            _header_ontologies = [
-                o.get("name") for o in KgBackupV2Reader(backup_data).header.get("ontologies", [])
-                if o.get("name")
-            ]
-            backup_ontology = _header_ontologies[0] if len(_header_ontologies) == 1 else None
-
-            if backup_ontology and overwrite:
-                # Safety check: If ontology exists and user didn't specify --merge, error
-                try:
-                    # Use ontology list API to check existence
-                    from api.app.routes.ontology import list_ontologies
-
-                    ontologies_result = await list_ontologies()
-
-                    existing_ontologies = [ont.ontology for ont in ontologies_result.ontologies]
-                    logger.info(f"Existing ontologies: {existing_ontologies}")
-
-                    if backup_ontology in existing_ontologies:
-                        # Ontology exists - require --merge flag
-                        temp_path.unlink()
-                        raise HTTPException(
-                            status_code=status.HTTP_409_CONFLICT,
-                            detail=f"Ontology '{backup_ontology}' already exists. Use --merge flag to merge into existing ontology, or delete the existing ontology first."
-                        )
-                except HTTPException:
-                    # Re-raise HTTP exceptions (like 409)
-                    raise
-                except Exception as e:
-                    logger.error(f"Error checking ontology existence: {e}", exc_info=True)
-                    # Don't fail restore if ontology check fails - just proceed
-                    logger.warning(f"Proceeding with restore despite ontology check failure")
+        # (ADR-102 P4) No "ontology already exists" 409 guard: restoring into an
+        # existing ontology is now an explicit, intended choice expressed by the
+        # mode — idempotent updates in place, integration attaches by similarity,
+        # adjacent lands an independent copy. The mode IS the merge decision.
 
         # Queue restore job
         job_queue = get_job_queue()
@@ -390,8 +363,7 @@ async def restore_backup(
                 "ontology": "_system",  # System-level operation
                 "temp_file": str(temp_path),
                 "temp_file_id": str(temp_file_id),
-                "overwrite": overwrite,
-                "handle_external_deps": handle_external_deps,
+                "mode": mode,
                 "backup_stats": stats,
                 "integrity_warnings": len(integrity.warnings),
                 "archive_temp_dir": archive_temp_dir,  # For document restore (None if JSON)

--- a/api/app/services/admin_service.py
+++ b/api/app/services/admin_service.py
@@ -114,7 +114,13 @@ class AdminService:
         ontology_name: Optional[str] = None,
         output_filename: Optional[str] = None
     ) -> BackupResponse:
-        """Create a backup (full or ontology-specific)"""
+        """Create a backup (full or ontology-specific).
+
+        DEAD (ADR-102 P6): no caller — the live backup route uses
+        create_backup_stream / stream_backup_archive, not this subprocess. The
+        spawned ``src.admin.backup`` module path is also stale. Scheduled for
+        removal in P6; do not wire to new code.
+        """
         # Build command
         cmd = [
             str(self.project_root / "venv" / "bin" / "python"),
@@ -184,7 +190,14 @@ class AdminService:
         overwrite: bool = False,
         handle_external_deps: str = "prune"
     ) -> RestoreResponse:
-        """Restore a backup"""
+        """Restore a backup.
+
+        DEAD (ADR-102 P6): no caller — the live restore route enqueues
+        run_restore_worker (which uses the kg-backup/2 mode machinery), not this
+        subprocess. The spawned ``src.admin.restore`` path is stale and the
+        overwrite/handle_external_deps args were removed from the real flow in P4.
+        Scheduled for removal in P6; do not wire to new code.
+        """
         # Validate backup file exists
         backup_path = Path(backup_file)
         if not backup_path.exists():

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -19,6 +19,7 @@ from ..lib.age_client import AGEClient
 from ..lib.backup_streaming import create_backup_stream
 from ..lib.backup_archive import restore_documents_to_garage, cleanup_extracted_archive
 from ...lib.serialization import DataImporter, KgBackupV2Reader
+from ..lib.restore_modes import RestoreMode, prepare_backup
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +43,7 @@ def run_restore_worker(
         job_data: Job parameters
             - temp_file: str - Path to uploaded backup file
             - temp_file_id: str - UUID of temp file
-            - overwrite: bool - Overwrite existing data
-            - handle_external_deps: str - How to handle external dependencies
+            - mode: str - Restore merge mode (idempotent | adjacent | integration)
             - backup_stats: dict - Statistics from backup file
             - integrity_warnings: int - Number of validation warnings
         job_id: Job ID for progress tracking
@@ -57,8 +57,7 @@ def run_restore_worker(
     """
     temp_file = Path(job_data["temp_file"])
     temp_file_id = job_data["temp_file_id"]
-    overwrite = job_data.get("overwrite", True)  # Default: create new concepts (full restore)
-    handle_external_deps = job_data.get("handle_external_deps", "prune")
+    mode = RestoreMode.validate(job_data.get("mode", RestoreMode.DEFAULT))
     backup_stats = job_data.get("backup_stats", {})
     archive_temp_dir = job_data.get("archive_temp_dir")  # For archive restores
     is_archive = job_data.get("is_archive", False)
@@ -100,26 +99,19 @@ def run_restore_worker(
         with open(temp_file, 'r', encoding='utf-8') as f:
             backup_data = json.load(f)
 
-        # Stage 2.5: ADR-102 clone/merge gate — target emptiness, not a backup-type
-        # flag (the single kg-backup/2 model carries no v1 "full_backup" type).
-        #   empty target   → CLONE: ids preserved 1:1, props set fresh.
-        #   populated target → MERGE: MERGE-by-id in place (adjacent/integration in P4).
-        # A destructive "replace everything" is now an explicit reset (then clone),
-        # never an implicit wipe during restore.
-        if _target_is_empty(client):
-            logger.info(f"[{job_id}] Empty target — clone restore (ids preserved 1:1)")
-            overwrite = True
-        else:
-            logger.info(f"[{job_id}] Populated target — merge restore (overwrite={overwrite})")
+        # Stage 2.5: ADR-102 P4 — transform the backup for the chosen restore MODE
+        # (a restore-time request param; the backup file carries no policy).
+        #   idempotent  → MERGE-by-id in place (into an empty target: a faithful clone)
+        #   adjacent    → fresh ids everywhere (independent copy + mapping table)
+        #   integration → match concepts to existing target & attach; mint the rest
+        target_state = "empty" if _target_is_empty(client) else "populated"
+        logger.info(f"[{job_id}] Restore mode: {mode} (target {target_state})")
+        prepared_backup, mapping_table = prepare_backup(backup_data, mode, client)
 
         # Stage 3: Execute restore with progress tracking
-        logger.info(f"[{job_id}] Starting restore operation (overwrite={overwrite})")
-
         restore_stats = _execute_restore(
             client=client,
-            backup_data=backup_data,
-            overwrite=overwrite,
-            handle_external_deps=handle_external_deps,
+            backup_data=prepared_backup,
             job_id=job_id,
             job_queue=job_queue
         )
@@ -136,10 +128,13 @@ def run_restore_worker(
                 }
             })
 
+            # Use the PREPARED object: adjacent/integration recompute storage_keys,
+            # so media must land under the same keys the restored source nodes now
+            # reference. overwrite=False skips media already present (same content).
             doc_stats = restore_documents_to_garage(
                 temp_dir=archive_temp_dir,
-                manifest_data=backup_data,
-                overwrite=overwrite
+                manifest_data=prepared_backup,
+                overwrite=False
             )
 
             logger.info(
@@ -188,9 +183,14 @@ def run_restore_worker(
         else:
             checkpoint_deleted = False
 
+        # Mapping table is the transposition artifact for adjacent/integration
+        # (old→new ids). Empty for idempotent — omit it then to keep results small.
+        remapped = any(mapping_table.get(k) for k in ("concepts", "sources", "instances"))
         return {
             "status": "completed",
+            "restore_mode": mode,
             "restore_stats": restore_stats,
+            "mapping_table": mapping_table if remapped else None,
             "document_stats": doc_stats if is_archive else None,
             "checkpoint_created": True,
             "checkpoint_deleted": checkpoint_deleted,
@@ -317,13 +317,16 @@ def _target_is_empty(client: AGEClient) -> bool:
 def _execute_restore(
     client: AGEClient,
     backup_data: Dict[str, Any],
-    overwrite: bool,
-    handle_external_deps: str,
     job_id: str,
     job_queue
 ) -> Dict[str, int]:
     """
-    Execute restore operation with progress tracking.
+    Execute restore of an already-mode-prepared kg-backup/2 object, with progress.
+
+    The object has already been transformed for its restore mode (idempotent =
+    unchanged; adjacent/integration = ids rewritten). The writer always uses
+    overwrite_existing=True: idempotent updates matching nodes in place, while
+    adjacent/integration ids are fresh or attach to existing targets.
 
     Returns:
         Dict with restore statistics
@@ -379,7 +382,7 @@ def _execute_restore(
     stats = DataImporter.import_backup(
         client,
         backup_data,
-        overwrite_existing=overwrite,
+        overwrite_existing=True,
         progress_callback=progress_callback
     )
 

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -104,8 +104,7 @@ def run_restore_worker(
         #   idempotent  → MERGE-by-id in place (into an empty target: a faithful clone)
         #   adjacent    → fresh ids everywhere (independent copy + mapping table)
         #   integration → match concepts to existing target & attach; mint the rest
-        target_state = "empty" if _target_is_empty(client) else "populated"
-        logger.info(f"[{job_id}] Restore mode: {mode} (target {target_state})")
+        logger.info(f"[{job_id}] Restore mode: {mode}")
         prepared_backup, mapping_table = prepare_backup(backup_data, mode, client)
 
         # Stage 3: Execute restore with progress tracking
@@ -293,25 +292,6 @@ def _clear_database(client: AGEClient, job_id: str) -> None:
     client._execute_cypher("MATCH (n:Instance) DETACH DELETE n")
 
     logger.info(f"[{job_id}] Concept graph cleared successfully (vocabulary preserved)")
-
-
-def _target_is_empty(client: AGEClient) -> bool:
-    """Return True if the concept graph holds no Concept/Source/Instance nodes.
-
-    The ADR-102 clone/merge gate: an empty target is restored by CLONE (ids
-    preserved 1:1); a populated target is a MERGE. A label whose backing table does
-    not exist yet (fresh database) counts as empty.
-    """
-    for label in ("Concept", "Source", "Instance"):
-        try:
-            row = client._execute_cypher(
-                f"MATCH (n:{label}) RETURN count(n) AS c", fetch_one=True
-            )
-        except Exception:
-            continue  # label table absent → no such nodes
-        if row and int(str(row.get("c", 0)).strip('"')) > 0:
-            return False
-    return True
 
 
 def _execute_restore(

--- a/api/lib/id_remap.py
+++ b/api/lib/id_remap.py
@@ -73,33 +73,57 @@ class IdRemapper:
             return self._mint(kind, old_id)
         return old_id  # collision mode, no collision → preserve
 
+    def build_maps(self, bulk: Dict[str, Any]) -> Dict[str, Dict[str, str]]:
+        """Build the old→new id maps for one mode (concepts / sources / instances)."""
+        return {
+            "concepts": {c["concept_id"]: self._decide("concept", c["concept_id"])
+                         for c in bulk.get("concepts", [])},
+            "sources": {s["source_id"]: self._decide("source", s["source_id"])
+                        for s in bulk.get("sources", [])},
+            "instances": {i["instance_id"]: self._decide("instance", i["instance_id"])
+                          for i in bulk.get("instances", [])},
+        }
+
     def remap(self, obj: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Dict[str, str]]]:
-        """Return ``(new_backup_object, mapping_table)``.
+        """Return ``(new_backup_object, mapping_table)`` for this remapper's mode.
 
         The header is carried unchanged (it holds no app-ids — only ontology names,
         profile identities, and interned dictionaries). All ids live in ``bulk``.
         """
+        maps = self.build_maps(obj["bulk"])
+        new_obj = self.apply_maps(obj, maps["concepts"], maps["sources"], maps["instances"])
+        return new_obj, maps
+
+    @staticmethod
+    def apply_maps(obj: Dict[str, Any],
+                   concept_map: Dict[str, str],
+                   source_map: Dict[str, str],
+                   instance_map: Dict[str, str],
+                   drop_concepts: "frozenset[str]" = frozenset()) -> Dict[str, Any]:
+        """Rewrite every reference class in ``obj`` through the supplied maps.
+
+        Pure: same rewrite for every mode. ``drop_concepts`` names incoming
+        concept_ids whose CONCEPT RECORD must NOT be emitted (integration mode:
+        a matched concept attaches to an existing target, so its node is left
+        untouched) — references to it are still rewritten through ``concept_map``.
+        Unmapped references fall through unchanged (``.get(x, x)``): external
+        endpoints that already live in the target.
+        """
         bulk = obj["bulk"]
-
-        concept_map = {c["concept_id"]: self._decide("concept", c["concept_id"])
-                       for c in bulk.get("concepts", [])}
-        source_map = {s["source_id"]: self._decide("source", s["source_id"])
-                      for s in bulk.get("sources", [])}
-        instance_map = {i["instance_id"]: self._decide("instance", i["instance_id"])
-                        for i in bulk.get("instances", [])}
-
         new_bulk: Dict[str, Any] = {}
 
         new_bulk["concepts"] = [
-            {**c, "concept_id": concept_map[c["concept_id"]]} for c in bulk.get("concepts", [])
+            {**c, "concept_id": concept_map[c["concept_id"]]}
+            for c in bulk.get("concepts", [])
+            if c["concept_id"] not in drop_concepts
         ]
 
         new_sources = []
         for s in bulk.get("sources", []):
             old_sid = s["source_id"]
-            new_sid = source_map[old_sid]
+            new_sid = source_map.get(old_sid, old_sid)
             s2 = {**s, "source_id": new_sid}
-            if s2.get("storage_key"):
+            if s2.get("storage_key") and new_sid != old_sid:
                 s2["storage_key"] = _remap_storage_key(s2["storage_key"], old_sid, new_sid)
             # garage_key is content-addressed (sha256) — immune, left untouched.
             new_sources.append(s2)
@@ -107,7 +131,7 @@ class IdRemapper:
 
         new_bulk["instances"] = [
             {**i,
-             "instance_id": instance_map[i["instance_id"]],
+             "instance_id": instance_map.get(i["instance_id"], i["instance_id"]),
              "source_id": source_map.get(i["source_id"], i["source_id"])}
             for i in bulk.get("instances", [])
         ]
@@ -138,6 +162,4 @@ class IdRemapper:
         if "graph_epochs" in bulk:
             new_bulk["graph_epochs"] = bulk["graph_epochs"]
 
-        new_obj = {"header": obj["header"], "bulk": new_bulk}
-        mapping_table = {"concepts": concept_map, "sources": source_map, "instances": instance_map}
-        return new_obj, mapping_table
+        return {"header": obj["header"], "bulk": new_bulk}

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -1306,21 +1306,18 @@ export class KnowledgeGraphClient {
    * Uses OAuth authentication (token from login).
    *
    * @param backupFilePath Path to backup file (.tar.gz archive or .json)
-   * @param overwrite Whether to overwrite existing data
-   * @param handleExternalDeps How to handle external dependencies ('prune', 'stitch', 'defer')
+   * @param mode Restore merge mode: 'idempotent' (default), 'adjacent', or 'integration' (ADR-102 P4)
    * @param onUploadProgress Optional callback for upload progress (bytes uploaded, total bytes, percent)
    * @returns Job ID and initial status for polling restore progress
    */
   async restoreBackup(
     backupFilePath: string,
-    overwrite: boolean = false,
-    handleExternalDeps: string = 'prune',
+    mode: string = 'idempotent',
     onUploadProgress?: (uploaded: number, total: number, percent: number) => void
   ): Promise<{ job_id: string; status: string; message: string; backup_stats: any; integrity_warnings: number }> {
     const form = new FormData();
     form.append('file', fs.createReadStream(backupFilePath));
-    form.append('overwrite', String(overwrite));
-    form.append('handle_external_deps', handleExternalDeps);
+    form.append('mode', mode);
 
     const response = await this.client.post('/admin/restore', form, {
       headers: form.getHeaders(),

--- a/cli/src/cli/admin/backup.ts
+++ b/cli/src/cli/admin/backup.ts
@@ -193,8 +193,7 @@ export function createRestoreCommand(): Command {
     .description('Restore a database backup (uses OAuth authentication)')
     .option('--file <name>', 'Backup filename (from configured directory)')
     .option('--path <path>', 'Custom backup file path (overrides configured directory)')
-    .option('--merge', 'Merge into existing ontology if it exists (default: error if ontology exists)', false)
-    .option('--deps <action>', 'How to handle external dependencies: prune, stitch, defer', 'prune')
+    .option('--mode <mode>', 'Restore merge mode: "idempotent" (default; MERGE-by-id, clone into empty), "adjacent" (independent copy, fresh ids), or "integration" (attach concepts to existing graph by similarity)', 'idempotent')
     .option('--confirm', 'Confirm restore operation (required for non-interactive use)', false)
     .action(async (options) => {
       try {
@@ -291,10 +290,15 @@ export function createRestoreCommand(): Command {
         let spinner = ora('Uploading backup...').start();
 
         try {
+          const validModes = ['idempotent', 'adjacent', 'integration'];
+          if (!validModes.includes(options.mode)) {
+            spinner.fail(`Invalid --mode "${options.mode}". Expected one of: ${validModes.join(', ')}`);
+            process.exit(1);
+          }
+
           const uploadResult = await client.restoreBackup(
             backupFilePath,
-            !options.merge,
-            options.deps,
+            options.mode,
             (uploaded: number, total: number, percent: number) => {
               const uploadedMB = (uploaded / (1024 * 1024)).toFixed(2);
               const totalMB = (total / (1024 * 1024)).toFixed(2);

--- a/cli/src/cli/admin/backup.ts
+++ b/cli/src/cli/admin/backup.ts
@@ -206,6 +206,14 @@ export function createRestoreCommand(): Command {
         console.log(colors.status.warning('⚠️  Potentially destructive operation'));
         console.log(separator());
 
+        // Validate the restore mode up front (before any file I/O or upload).
+        const validModes = ['idempotent', 'adjacent', 'integration'];
+        if (!validModes.includes(options.mode)) {
+          console.error(colors.status.error(
+            `\n✗ Invalid --mode "${options.mode}". Expected one of: ${validModes.join(', ')}\n`));
+          process.exit(1);
+        }
+
         // Determine backup file path
         let backupFilePath: string;
         let backupFilename: string;
@@ -290,12 +298,6 @@ export function createRestoreCommand(): Command {
         let spinner = ora('Uploading backup...').start();
 
         try {
-          const validModes = ['idempotent', 'adjacent', 'integration'];
-          if (!validModes.includes(options.mode)) {
-            spinner.fail(`Invalid --mode "${options.mode}". Expected one of: ${validModes.join(', ')}`);
-            process.exit(1);
-          }
-
           const uploadResult = await client.restoreBackup(
             backupFilePath,
             options.mode,

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -719,8 +719,8 @@ export interface RestoreRequest {
   username: string;
   password: string;
   backup_file: string;
-  overwrite?: boolean;
-  handle_external_deps?: 'prune' | 'stitch' | 'defer';
+  // ADR-102 P4: restore merge mode (replaces overwrite + handle_external_deps).
+  mode?: 'idempotent' | 'adjacent' | 'integration';
 }
 
 export interface RestoreResponse {

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -105,7 +105,11 @@ def test_integration_mode_attaches_to_existing_concept(client_with_cleanup):
             return ({"concept_id": f"{NS}tgt", "label": "Shared", "similarity": 0.95}
                     if ext.get("label") == "P3 Alpha" else None)
 
-    with patch("api.app.lib.restore_modes.ConceptMatcher", _M):
+    # Stub the embedding-space gate (ADR-102 §6) so the test is independent of the
+    # dev graph's configured profile; the matcher is already patched.
+    with patch("api.app.lib.restore_modes.ConceptMatcher", _M), \
+         patch("api.app.lib.restore_modes._target_active_identity",
+               return_value="openai:text-embedding-3-small@1536"):
         prepared, maps = prepare_backup(incoming, RestoreMode.INTEGRATION, client)
 
     minted = [v for m in maps.values() for v in m.values() if not v.startswith(NS)]

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -10,13 +10,14 @@ Honors "messy data finds bugs": it does NOT reset the working graph. All nodes u
 a ``p3rt_`` id prefix so they can't collide with real data, and the test removes
 them in a finally block.
 """
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from api.app.lib.age_client import AGEClient
 from api.lib.serialization import DataExporter, DataImporter
 from api.lib.id_remap import IdRemapper
+from api.app.lib.restore_modes import prepare_backup, RestoreMode
 
 NS = "p3rt_"  # test namespace prefix
 
@@ -77,6 +78,60 @@ def client_with_cleanup():
                 )
             except Exception:
                 pass
+
+
+def test_integration_mode_attaches_to_existing_concept(client_with_cleanup):
+    """integration: a matched incoming concept's instance/edges attach to the
+    EXISTING target concept (not in this backup); the target node is untouched."""
+    client = client_with_cleanup
+
+    # Pre-insert the existing target concept (namespaced; caught by prefix cleanup).
+    target = DataExporter.build_kg_backup_v2(
+        concepts=[{"concept_id": f"{NS}tgt", "label": "Shared", "search_terms": [],
+                   "embedding": [0.1, 0.2, 0.3], "created_at_epoch": 1, "last_seen_epoch": 1}],
+        sources=[], instances=[], evidence=[], relationships=[], vocabulary=[],
+        embedding_profiles=[{"identity": "openai:text-embedding-3-small@1536", "vector_space": "x",
+                             "image_vector_space": None, "name": "d", "multimodal": False}],
+        epoch_kinds=[], graph_epochs=[], schema_version=76,
+    )
+    DataImporter.import_backup(client, target, overwrite_existing=True)
+
+    incoming = _namespaced_backup()  # p3rt_c1 (label "P3 Alpha") will be matched
+
+    class _M:
+        def __init__(self, *a, **k):
+            pass
+        def match_concept_in_database(self, ext, top_k=5):
+            return ({"concept_id": f"{NS}tgt", "label": "Shared", "similarity": 0.95}
+                    if ext.get("label") == "P3 Alpha" else None)
+
+    with patch("api.app.lib.restore_modes.ConceptMatcher", _M):
+        prepared, maps = prepare_backup(incoming, RestoreMode.INTEGRATION, client)
+
+    minted = [v for m in maps.values() for v in m.values() if not v.startswith(NS)]
+    try:
+        DataImporter.import_backup(client, prepared, overwrite_existing=True)
+
+        new_i1 = maps["instances"][f"{NS}i1"]
+        new_c2 = maps["concepts"][f"{NS}c2"]
+        # p3rt_c1's instance attached to the EXISTING target via EVIDENCED_BY.
+        assert _scalar(client,
+            f"MATCH (:Concept {{concept_id:'{NS}tgt'}})-[:EVIDENCED_BY]->(:Instance {{instance_id:'{new_i1}'}}) "
+            f"RETURN count(*) AS n") == 1
+        # the IMPLIES edge now runs target -> new c2 (from rewired to the match).
+        assert _scalar(client,
+            f"MATCH (:Concept {{concept_id:'{NS}tgt'}})-[r:IMPLIES]->(:Concept {{concept_id:'{new_c2}'}}) "
+            f"RETURN count(r) AS n") == 1
+    finally:
+        # Minted ids are uuid-based (outside the NS prefix) — delete them explicitly.
+        for _id in minted:
+            for label in ("Concept", "Source", "Instance"):
+                try:
+                    client._execute_cypher(
+                        f"MATCH (n:{label}) WHERE n.concept_id = $i OR n.source_id = $i "
+                        f"OR n.instance_id = $i DETACH DELETE n", params={"i": _id})
+                except Exception:
+                    pass
 
 
 def test_merge_relationship_rejects_unsafe_edge_label():

--- a/tests/unit/test_restore_modes.py
+++ b/tests/unit/test_restore_modes.py
@@ -46,6 +46,9 @@ def _backup():
     )
 
 
+_BACKUP_IDENTITY = "openai:text-embedding-3-small@1536"
+
+
 class _FakeMatcher:
     """ConceptMatcher stand-in: 'Alpha' matches an existing target; others don't."""
     def __init__(self, client, **kw):
@@ -56,6 +59,13 @@ class _FakeMatcher:
         if external_concept.get("label") == "Alpha":
             return {"concept_id": "TARGET_c1", "label": "Alpha", "similarity": 0.95}
         return None
+
+
+def _integration(obj, target_identity=_BACKUP_IDENTITY, matcher=_FakeMatcher):
+    """Run integration with a patched matcher + a controlled target embedding identity."""
+    with patch("api.app.lib.restore_modes.ConceptMatcher", matcher), \
+         patch("api.app.lib.restore_modes._target_active_identity", return_value=target_identity):
+        return prepare_backup(obj, RestoreMode.INTEGRATION, client=MagicMock())
 
 
 # ---- idempotent ----
@@ -85,8 +95,7 @@ def test_adjacent_mints_all_ids_and_stays_self_contained():
 
 def test_integration_attaches_match_and_mints_rest():
     obj = _backup()
-    with patch("api.app.lib.restore_modes.ConceptMatcher", _FakeMatcher):
-        prepared, maps = prepare_backup(obj, RestoreMode.INTEGRATION, client=MagicMock())
+    prepared, maps = _integration(obj)
 
     # c1 (Alpha) attached to the existing target; c2 minted new.
     assert maps["concepts"]["c1"] == "TARGET_c1"
@@ -108,6 +117,33 @@ def test_integration_attaches_match_and_mints_rest():
     # sources/instances always minted fresh
     assert maps["sources"]["s1"] != "s1"
     assert maps["instances"]["i1"] != "i1"
+
+
+def test_integration_two_matches_share_instance_fan_out():
+    """Two matched concepts evidencing the SAME instance both rewire (drop + fan-out)."""
+    obj = _backup()  # c1(Alpha)+c2(Beta) both evidence i1; rel c1->c2
+
+    class _BothMatch:
+        def __init__(self, *a, **k): pass
+        def match_concept_in_database(self, ext, top_k=5):
+            return {"concept_id": "T_" + ext["label"], "label": ext["label"], "similarity": 0.99}
+
+    prepared, maps = _integration(obj, matcher=_BothMatch)
+    # Both concept records dropped (attach to existing targets).
+    assert prepared["bulk"]["concepts"] == []
+    assert maps["concepts"] == {"c1": "T_Alpha", "c2": "T_Beta"}
+    # The shared instance's two evidence rows rewired to the two targets.
+    ev_concepts = {e["concept_id"] for e in prepared["bulk"]["evidence"]}
+    assert ev_concepts == {"T_Alpha", "T_Beta"}
+    # The edge between them rewired to both targets.
+    rel = prepared["bulk"]["relationships"][0]
+    assert (rel["from"], rel["to"]) == ("T_Alpha", "T_Beta")
+
+
+def test_integration_rejects_embedding_space_mismatch():
+    """ADR-102 §6: matching across embedding spaces is refused (silent mis-attach risk)."""
+    with pytest.raises(ValueError, match="matching embedding spaces"):
+        _integration(_backup(), target_identity="nomic:nomic-embed-text-v1.5@768")
 
 
 def test_integration_requires_client():

--- a/tests/unit/test_restore_modes.py
+++ b/tests/unit/test_restore_modes.py
@@ -1,0 +1,128 @@
+"""Unit tests for restore merge modes (ADR-102 P4).
+
+idempotent / adjacent are pure (no DB). integration is exercised with a patched
+ConceptMatcher so the match-or-mint + attach-and-drop behavior is asserted without
+a database.
+"""
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.lib.serialization import DataExporter
+from api.app.lib.restore_modes import RestoreMode, prepare_backup
+
+# Offline validator — adjacent output must stay self-contained (no orphans).
+_REPO = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "lint_backup", _REPO / "scripts" / "development" / "lint" / "lint_backup.py"
+)
+lint_backup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_backup)
+
+
+def _backup():
+    return DataExporter.build_kg_backup_v2(
+        concepts=[
+            {"concept_id": "c1", "label": "Alpha", "search_terms": [], "embedding": [0.1, 0.2],
+             "created_at_epoch": 1, "last_seen_epoch": 1},
+            {"concept_id": "c2", "label": "Beta", "search_terms": [], "embedding": [0.3, 0.4],
+             "created_at_epoch": 1, "last_seen_epoch": 1},
+        ],
+        sources=[{"source_id": "s1", "document": "Doc", "file_path": "/a", "paragraph": 1,
+                  "full_text": "t", "content_type": "text/plain"}],
+        instances=[{"instance_id": "i1", "quote": "q", "source_id": "s1", "created_at_event_id": 1}],
+        evidence=[{"concept_id": "c1", "instance_id": "i1"}, {"concept_id": "c2", "instance_id": "i1"}],
+        relationships=[{"from": "c1", "to": "c2", "type": "IMPLIES", "properties": {"learned_id": "s1"}}],
+        vocabulary=[{"relationship_type": "IMPLIES", "description": "", "category": "logical",
+                     "embedding_model": "openai:text-embedding-3-small@1536"}],
+        embedding_profiles=[{"identity": "openai:text-embedding-3-small@1536", "vector_space": "x",
+                             "image_vector_space": None, "name": "d", "multimodal": False}],
+        epoch_kinds=[{"kind": "ingestion", "semantic_wallclock": True, "description": ""}],
+        graph_epochs=[{"event_id": 1, "occurred_at": "2026-06-01T00:00:00Z", "kind": "ingestion",
+                       "actor": "system", "counter_after": 1, "metadata": {}}],
+        schema_version=76,
+    )
+
+
+class _FakeMatcher:
+    """ConceptMatcher stand-in: 'Alpha' matches an existing target; others don't."""
+    def __init__(self, client, **kw):
+        self.client = client
+
+    def match_concept_in_database(self, external_concept, top_k=5):
+        assert "embedding" in external_concept  # integration passes the vector
+        if external_concept.get("label") == "Alpha":
+            return {"concept_id": "TARGET_c1", "label": "Alpha", "similarity": 0.95}
+        return None
+
+
+# ---- idempotent ----
+
+def test_idempotent_passthrough():
+    obj = _backup()
+    prepared, maps = prepare_backup(obj, RestoreMode.IDEMPOTENT)
+    assert prepared is obj  # no transformation
+    assert maps == {"concepts": {}, "sources": {}, "instances": {}}
+
+
+# ---- adjacent ----
+
+def test_adjacent_mints_all_ids_and_stays_self_contained():
+    obj = _backup()
+    prepared, maps = prepare_backup(obj, RestoreMode.ADJACENT)
+    # every id remapped to something new
+    assert set(maps["concepts"]) == {"c1", "c2"}
+    assert all(new != old for old, new in maps["concepts"].items())
+    assert maps["sources"]["s1"] != "s1"
+    # self-contained → validates clean (the no-orphan guarantee)
+    assert lint_backup.validate_backup(prepared).ok, \
+        [str(i) for i in lint_backup.validate_backup(prepared).errors]
+
+
+# ---- integration ----
+
+def test_integration_attaches_match_and_mints_rest():
+    obj = _backup()
+    with patch("api.app.lib.restore_modes.ConceptMatcher", _FakeMatcher):
+        prepared, maps = prepare_backup(obj, RestoreMode.INTEGRATION, client=MagicMock())
+
+    # c1 (Alpha) attached to the existing target; c2 minted new.
+    assert maps["concepts"]["c1"] == "TARGET_c1"
+    assert maps["concepts"]["c2"] not in ("c2", "TARGET_c1")
+
+    # The matched concept's RECORD is dropped (target node left untouched);
+    # only the new concept is emitted.
+    emitted = [c["concept_id"] for c in prepared["bulk"]["concepts"]]
+    assert emitted == [maps["concepts"]["c2"]]
+    assert "TARGET_c1" not in emitted
+
+    # References to c1 rewired to the existing target.
+    assert any(e["concept_id"] == "TARGET_c1" for e in prepared["bulk"]["evidence"])
+    rel = prepared["bulk"]["relationships"][0]
+    assert rel["from"] == "TARGET_c1"
+    assert rel["to"] == maps["concepts"]["c2"]
+    assert rel["properties"]["learned_id"] == maps["sources"]["s1"]  # source remapped too
+
+    # sources/instances always minted fresh
+    assert maps["sources"]["s1"] != "s1"
+    assert maps["instances"]["i1"] != "i1"
+
+
+def test_integration_requires_client():
+    with pytest.raises(ValueError, match="requires a client"):
+        prepare_backup(_backup(), RestoreMode.INTEGRATION, client=None)
+
+
+# ---- validation ----
+
+def test_unknown_mode_rejected():
+    with pytest.raises(ValueError, match="Unknown restore mode"):
+        prepare_backup(_backup(), "bogus")
+
+
+def test_restore_mode_validate():
+    assert RestoreMode.validate("adjacent") == "adjacent"
+    with pytest.raises(ValueError):
+        RestoreMode.validate("nope")


### PR DESCRIPTION
Wires the restore *modes* on top of the P2/P3 single backup model. Mode is a
restore-time request param; the backup file stays pure data.

## Modes
- **idempotent** (default) — MERGE-by-id, collisions update in place. Into an
  empty target: a faithful clone (ids 1:1).
- **adjacent** — `IdRemapper("always")`: fresh ids everywhere, an independent copy
  + an old→new mapping table.
- **integration** — match each incoming concept to the target by cosine similarity
  (`ConceptMatcher` 0.85 / 0.75 label-boosted); a match **attaches** the incoming
  concept's instances/evidence/edges to the EXISTING target concept (its record is
  dropped — target node untouched), a non-match mints a new concept. Sources/
  instances always mint fresh. Like ingest, minus LLM extraction.

## Changes
- `IdRemapper` split into `build_maps()` + pure `apply_maps(..., drop_concepts)`.
- `api/app/lib/restore_modes.py` (new): `RestoreMode` + `prepare_backup(obj, mode,
  client) -> (prepared_obj, mapping_table)`; every mode yields a kg-backup/2 object
  fed to the existing clone writer.
- `restore_worker`: `job_data["mode"]` dispatch (replaces the emptiness→overwrite
  toggle); surfaces `restore_mode` + `mapping_table`; archive media restore uses the
  prepared object + `overwrite=False`.
- `/restore`: `mode` Form param (400 on bad value); **removes** `overwrite` +
  `handle_external_deps` and the obsolete "ontology exists" 409 guard (mode is the
  explicit merge intent now).
- CLI: `kg admin restore --mode {idempotent,adjacent,integration}` replaces
  `--merge`/`--deps`; `client.restoreBackup(path, mode, …)`. MCP has no restore tool.

## Tests
restore_modes unit (idempotent passthrough; adjacent self-contained via lint;
integration attach+drop+rewire via patched matcher) + a live integration test
attaching to a pre-inserted concept in AGE. 75 backend pass / 1 skip; CLI builds,
46 CLI tests pass.

## Behavior note
Restoring a full backup into a populated graph no longer auto-wipes or 409s — the
mode decides (idempotent updates, integration attaches, adjacent copies). Clean
replace = explicit reset, then restore.

Refs ADR-102.