### PR TITLE
ADR-102 P5: epoch-simple restamp, lane quiesce, rehydration (+A13/A14)

### DIFF
--- a/api/app/lib/lane_control.py
+++ b/api/app/lib/lane_control.py
@@ -1,0 +1,162 @@
+"""Worker-lane freeze / quiesce helpers (ADR-100, ADR-102 P5 / A14).
+
+A restore wholesale rewrites the graph. If other workers keep mutating it mid
+restore (ingestion in the ``interactive`` lane, projection/annealing in the
+``maintenance`` lane) the import races those writes and the result is
+inconsistent. So before importing we *freeze* the mutating lanes and wait for
+their in-flight jobs to drain, then *thaw* them afterward.
+
+Mechanism: lane enable/disable lives in ``kg_api.worker_lanes.enabled``, which
+the LaneManager re-reads every poll cycle (ADR-100). Setting it false stops a
+lane claiming NEW jobs within one poll interval; already-running jobs finish
+naturally. Drain is detected by polling ``kg_api.jobs`` for running jobs whose
+``job_type`` belongs to a frozen lane — a cross-process signal (the in-memory
+``active_count`` on LaneManager is per-process and not visible from a worker).
+
+The restore worker itself runs in the ``system`` lane, which is NOT frozen:
+``system`` is ``max_slots=1`` (self-serializing) and also hosts the post-restore
+rehydration jobs (``source_embedding``, ``vocab_consolidate``), which must run
+*after* restore releases the slot.  @verified (new)
+"""
+import logging
+import os
+import time
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+# Lanes whose work mutates (or derives from) the graph. Frozen for the duration
+# of a restore. ``system`` is intentionally absent — see module docstring.
+RESTORE_FREEZE_LANES: List[str] = ["interactive", "maintenance"]
+
+# In-flight job statuses (ADR-100 claim sets 'running'; 'processing' is the
+# legacy in-flight marker still honored across the queue).
+_INFLIGHT_STATUSES = ("running", "processing")
+
+# How long to wait for frozen lanes to drain before proceeding anyway
+# (fail-open, ADR-102 P5 decision). Configurable for slow/long-job installs.
+DEFAULT_QUIESCE_TIMEOUT_S = int(os.getenv("KG_RESTORE_QUIESCE_TIMEOUT_S", "120"))
+_QUIESCE_POLL_INTERVAL_S = 2.0
+
+
+def freeze_lanes(job_queue, lane_names: List[str]) -> Dict[str, bool]:
+    """Disable the given lanes, returning their PRIOR enabled state.
+
+    The prior state is what ``thaw_lanes`` restores — so a lane an operator had
+    already disabled stays disabled after the restore (we never silently
+    re-enable something we did not freeze).
+    """
+    prior: Dict[str, bool] = {}
+    conn = job_queue._get_connection()
+    try:
+        with conn.cursor() as cur:
+            # Capture prior enabled, then disable — one round-trip per lane via
+            # UPDATE ... RETURNING the OLD value (a correlated subquery on the
+            # same row reads its post-update state, so read prior explicitly).
+            for name in lane_names:
+                cur.execute("SELECT enabled FROM kg_api.worker_lanes WHERE name = %s", (name,))
+                row = cur.fetchone()
+                if row is None:
+                    logger.warning("Cannot freeze unknown lane %r", name)
+                    continue
+                prior[name] = bool(row[0])
+                cur.execute(
+                    "UPDATE kg_api.worker_lanes SET enabled = FALSE, updated_at = NOW() WHERE name = %s",
+                    (name,),
+                )
+        conn.commit()
+        logger.info("Froze worker lanes %s (prior enabled: %s)", lane_names, prior)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        job_queue._return_connection(conn)
+    return prior
+
+
+def thaw_lanes(job_queue, prior_state: Dict[str, bool]) -> None:
+    """Restore lanes to their pre-freeze enabled state. Best-effort.
+
+    Called from a ``finally`` — must never raise, or a restore failure would be
+    masked by a thaw failure and leave lanes frozen with no error surfaced.
+    """
+    if not prior_state:
+        return
+    try:
+        conn = job_queue._get_connection()
+        try:
+            with conn.cursor() as cur:
+                for name, was_enabled in prior_state.items():
+                    cur.execute(
+                        "UPDATE kg_api.worker_lanes SET enabled = %s, updated_at = NOW() WHERE name = %s",
+                        (was_enabled, name),
+                    )
+            conn.commit()
+            logger.info("Thawed worker lanes (restored prior state: %s)", prior_state)
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            job_queue._return_connection(conn)
+    except Exception as e:
+        # Surface loudly — lanes left frozen is an operator-visible condition.
+        logger.error("Failed to thaw worker lanes %s: %s", list(prior_state), e, exc_info=True)
+
+
+def _lane_job_types(job_queue, lane_names: List[str]) -> List[str]:
+    """The flattened set of job_types served by the given lanes."""
+    conn = job_queue._get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT DISTINCT unnest(job_types) FROM kg_api.worker_lanes WHERE name = ANY(%s)",
+                (lane_names,),
+            )
+            return [row[0] for row in cur.fetchall()]
+    finally:
+        job_queue._return_connection(conn)
+
+
+def _count_inflight(job_queue, job_types: List[str]) -> int:
+    """Count in-flight jobs of the given types (cross-process drain signal)."""
+    if not job_types:
+        return 0
+    conn = job_queue._get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM kg_api.jobs "
+                "WHERE status = ANY(%s) AND job_type = ANY(%s)",
+                (list(_INFLIGHT_STATUSES), job_types),
+            )
+            return int(cur.fetchone()[0])
+    finally:
+        job_queue._return_connection(conn)
+
+
+def wait_for_quiesce(job_queue, lane_names: List[str],
+                     timeout_s: int = DEFAULT_QUIESCE_TIMEOUT_S,
+                     poll_interval_s: float = _QUIESCE_POLL_INTERVAL_S) -> bool:
+    """Poll until the frozen lanes' in-flight jobs drain to zero.
+
+    Fail-open (ADR-102 P5): returns True when drained, False on timeout. The
+    caller proceeds with the restore either way (a timeout is logged as a
+    warning) — we do NOT force-cancel in-flight jobs, because cancelling a
+    worker mid graph-write risks a partial mutation the restore would then
+    stomp inconsistently.
+    """
+    job_types = _lane_job_types(job_queue, lane_names)
+    deadline = time.monotonic() + timeout_s
+    while True:
+        inflight = _count_inflight(job_queue, job_types)
+        if inflight == 0:
+            return True
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "Lane quiesce timed out after %ss with %d in-flight job(s) in %s; "
+                "proceeding with restore (fail-open)",
+                timeout_s, inflight, lane_names,
+            )
+            return False
+        logger.info("Waiting for %d in-flight job(s) in %s to drain...", inflight, lane_names)
+        time.sleep(poll_interval_s)

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -20,6 +20,17 @@ from ..lib.backup_streaming import create_backup_stream
 from ..lib.backup_archive import restore_documents_to_garage, cleanup_extracted_archive
 from ...lib.serialization import DataImporter, KgBackupV2Reader
 from ..lib.restore_modes import RestoreMode, prepare_backup
+from ..lib.lane_control import (
+    RESTORE_FREEZE_LANES,
+    freeze_lanes,
+    thaw_lanes,
+    wait_for_quiesce,
+)
+
+# ADR-102 P5: epoch-simple restore records a single graph_epochs event of this
+# kind (migration 077) so the freshness clock advances and restored nodes carry
+# a real, local event id.
+RESTORE_EPOCH_KIND = "restore"
 
 logger = logging.getLogger(__name__)
 
@@ -64,12 +75,30 @@ def run_restore_worker(
 
     checkpoint_path = None
     client = None
+    lane_prior = None       # ADR-102 A14: prior lane-enabled state, restored on exit
+    restore_event_id = None  # ADR-102 P5: the single restore graph_epochs event
 
     try:
         # ADR-100: Check for cancellation before restore
         if job_queue.is_job_cancelled(job_id):
             logger.info(f"Restore job {job_id} cancelled before start")
             return {"status": "cancelled"}
+
+        # ADR-102 A14: freeze mutating lanes (interactive/maintenance) and wait
+        # for their in-flight jobs to drain, so nothing writes the graph while we
+        # checkpoint + import. The system lane (which runs THIS job and the
+        # post-restore rehydration) stays enabled. Fail-open: proceed after the
+        # quiesce timeout with a warning rather than blocking the restore.
+        logger.info(f"[{job_id}] Freezing worker lanes {RESTORE_FREEZE_LANES} for restore")
+        job_queue.update_job(job_id, {
+            "progress": {
+                "stage": "quiescing",
+                "percent": 2,
+                "message": f"Freezing worker lanes {RESTORE_FREEZE_LANES} and draining in-flight jobs"
+            }
+        })
+        lane_prior = freeze_lanes(job_queue, RESTORE_FREEZE_LANES)
+        wait_for_quiesce(job_queue, RESTORE_FREEZE_LANES)
 
         # Stage 1: Create checkpoint backup (ADR-015 Safety Pattern)
         logger.info(f"[{job_id}] Creating checkpoint backup before restore")
@@ -107,12 +136,45 @@ def run_restore_worker(
         logger.info(f"[{job_id}] Restore mode: {mode}")
         prepared_backup, mapping_table = prepare_backup(backup_data, mode, client)
 
+        # ADR-102 P5 (epoch-simple): record ONE restore epoch event up front so its
+        # event_id can stamp every imported node. The carried bulk.graph_epochs are
+        # NOT replayed (that is P5-faithful, clone-only). record_epoch inserts an
+        # in_progress event that holds the committed watermark just below it until
+        # complete_epoch resolves it — exactly the long-job tagging pattern the
+        # ingestion worker uses.
+        #
+        # ADR-102 A13: a failed record_epoch is FATAL here (not log-and-continue).
+        # Without an event id every restored Instance would be untagged AND the
+        # post-restore watermark advance below would be meaningless — restored
+        # data could read FRESH against stale derivations. Fail loudly instead.
+        restore_event_id = client.record_epoch(
+            kind=RESTORE_EPOCH_KIND,
+            actor="restore",
+            metadata={"job_id": job_id, "mode": mode, "restore": True},
+        )
+        if restore_event_id is None:
+            raise RuntimeError(
+                "record_epoch returned None — cannot stamp restored nodes with a "
+                "graph epoch (the freshness clock would be left inconsistent). "
+                "Check kg_api.graph_epochs health (grep 'record_epoch failed')."
+            )
+        logger.info(f"[{job_id}] Restore epoch event_id={restore_event_id}")
+
+        # Concept epochs live in the separate document_ingestion_counter space
+        # (ADR-200), not the graph_epochs.event_id space — so they restamp to the
+        # target's CURRENT concept epoch, not the restore event_id.
+        restore_concept_epoch = client.get_current_epoch()
+
         # Stage 3: Execute restore with progress tracking
         restore_stats = _execute_restore(
             client=client,
             backup_data=prepared_backup,
             job_id=job_id,
-            job_queue=job_queue
+            job_queue=job_queue,
+            epoch_restamp={
+                "event_id": restore_event_id,
+                "concept_epoch": restore_concept_epoch,
+            },
         )
 
         # Stage 4: Restore documents to Garage (for archive backups)
@@ -152,27 +214,57 @@ def run_restore_worker(
             }
         })
 
-        # ADR-207/#386: a restore wholesale replaces the graph — the single
-        # largest possible mutation. Announce it via record_mutation so the
-        # universal freshness tick (get_committed_epoch) advances past every
-        # derivation's stamp; otherwise the catalog index and the grounding /
-        # confidence / artifact caches keep serving pre-restore data as "fresh".
-        # record_mutation records a completed epoch event (advances the tick),
-        # invalidates graph_accel, AND refreshes the graph_change_counter
-        # snapshot — subsuming the bare refresh_graph_metrics() this replaced.
+        # ADR-207/#386 + ADR-102 P5: resolve the restore epoch as COMPLETED. Until
+        # now it held the committed watermark just below its event_id, so every
+        # derivation correctly read stale during the import. Completing it advances
+        # the universal freshness tick (get_committed_epoch) past every restored
+        # node's stamp; otherwise the catalog index and the grounding / confidence
+        # / artifact caches would keep serving pre-restore data as "fresh".
+        #
+        # The record_epoch/complete_epoch pair does NOT co-advance the in-memory
+        # graph_accel sub-counter on its own (the docstring co-advance caveat /
+        # issue #465) — only record_mutation does. So invalidate the accelerator
+        # and refresh the graph_change_counter snapshot explicitly, matching what
+        # record_mutation would have done.
+        client.complete_epoch(restore_event_id, "completed")
         try:
-            metrics_client = AGEClient()
-            try:
-                metrics_client.record_mutation(
-                    "ingestion",
-                    actor="restore",
-                    metadata={"restore": True, "job_id": job_id},
-                )
-                logger.info(f"[{job_id}] Recorded restore as a graph mutation (freshness tick advanced)")
-            finally:
-                metrics_client.close()
+            client.graph.invalidate()
+        except Exception:
+            pass  # extension may not be loaded on this connection
+        try:
+            client.refresh_epoch()
         except Exception as e:
-            logger.warning(f"[{job_id}] Failed to record restore mutation: {e}")
+            logger.warning(f"[{job_id}] refresh_epoch after restore failed: {e}")
+        logger.info(f"[{job_id}] Restore epoch {restore_event_id} completed (freshness tick advanced)")
+
+        # ADR-102 P5 rehydration: source text/visual embeddings do NOT travel in
+        # the backup (concept + vocab embeddings do, and scores/catalog/grounding
+        # self-heal off the freshness tick just advanced). Enqueue ONE bulk
+        # only-missing source-embedding job — it runs in the system lane AFTER this
+        # restore releases the slot, and skips any source that already has
+        # embeddings. Best-effort: a failure to enqueue must not fail a completed
+        # restore (the operator can run the regeneration endpoint manually).
+        rehydrate_job_id = None
+        try:
+            rehydrate_job_id = job_queue.enqueue("source_embedding", {
+                "rehydrate_missing": True,
+                "reason": "post_restore_rehydration",
+                "restore_job_id": job_id,
+            })
+            # Auto-approve as a system job (ADR-050) so the system lane claims it
+            # — enqueue() lands jobs as 'pending' (user-upload approval workflow),
+            # but this is internally triggered, not a user upload.
+            job_queue.update_job(rehydrate_job_id, {
+                "is_system_job": True,
+                "job_source": "post_restore_rehydration",
+                "created_by": f"system:restore:{job_id}",
+                "status": "approved",
+                "approved_at": datetime.now().isoformat(),
+                "approved_by": "system:restore",
+            })
+            logger.info(f"[{job_id}] Enqueued source-embedding rehydration job {rehydrate_job_id}")
+        except Exception as e:
+            logger.warning(f"[{job_id}] Failed to enqueue source-embedding rehydration: {e}")
 
         # Success: Delete checkpoint
         if checkpoint_path and checkpoint_path.exists():
@@ -191,6 +283,8 @@ def run_restore_worker(
             "restore_stats": restore_stats,
             "mapping_table": mapping_table if remapped else None,
             "document_stats": doc_stats if is_archive else None,
+            "restore_epoch_event_id": restore_event_id,
+            "rehydration_job_id": rehydrate_job_id,
             "checkpoint_created": True,
             "checkpoint_deleted": checkpoint_deleted,
             "temp_file_cleaned": False  # Will be cleaned in finally block
@@ -198,6 +292,14 @@ def run_restore_worker(
 
     except Exception as e:
         logger.error(f"[{job_id}] Restore failed: {str(e)}")
+
+        # ADR-102 P5: resolve the restore epoch as FAILED so it stops holding the
+        # committed watermark below its event_id (a phantom in-flight event would
+        # stall freshness for the whole graph). The rollback below re-imports the
+        # checkpoint with its OWN carried stamps (no restamp), so this failed event
+        # tags nothing that survives.
+        if restore_event_id is not None and client is not None:
+            client.complete_epoch(restore_event_id, "failed")
 
         # Failure: Restore from checkpoint
         if checkpoint_path and checkpoint_path.exists():
@@ -227,6 +329,13 @@ def run_restore_worker(
         )
 
     finally:
+        # ADR-102 A14: ALWAYS thaw the lanes we froze, restoring their prior
+        # enabled state (a lane an operator had already disabled stays disabled).
+        # thaw_lanes is best-effort and never raises, so it cannot mask the
+        # restore's own outcome.
+        if lane_prior:
+            thaw_lanes(job_queue, lane_prior)
+
         # Cleanup: Always delete temp file
         if temp_file.exists():
             logger.info(f"[{job_id}] Cleaning up temp file {temp_file}")
@@ -298,7 +407,8 @@ def _execute_restore(
     client: AGEClient,
     backup_data: Dict[str, Any],
     job_id: str,
-    job_queue
+    job_queue,
+    epoch_restamp: Dict[str, int] = None
 ) -> Dict[str, int]:
     """
     Execute restore of an already-mode-prepared kg-backup/2 object, with progress.
@@ -307,6 +417,9 @@ def _execute_restore(
     unchanged; adjacent/integration = ids rewritten). The writer always uses
     overwrite_existing=True: idempotent updates matching nodes in place, while
     adjacent/integration ids are fresh or attach to existing targets.
+
+    ``epoch_restamp`` (ADR-102 P5 epoch-simple) overrides carried epoch stamps
+    with local clocks — see ``DataImporter.import_backup``.
 
     Returns:
         Dict with restore statistics
@@ -363,7 +476,8 @@ def _execute_restore(
         client,
         backup_data,
         overwrite_existing=True,
-        progress_callback=progress_callback
+        progress_callback=progress_callback,
+        epoch_restamp=epoch_restamp
     )
 
     return {

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -12,7 +12,7 @@ import os
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from datetime import datetime
 
 from ..lib.age_client import AGEClient
@@ -75,8 +75,9 @@ def run_restore_worker(
 
     checkpoint_path = None
     client = None
-    lane_prior = None       # ADR-102 A14: prior lane-enabled state, restored on exit
+    lane_prior = None        # ADR-102 A14: prior lane-enabled state, restored on exit
     restore_event_id = None  # ADR-102 P5: the single restore graph_epochs event
+    quiesced = True          # ADR-102 A14: did frozen lanes drain before the timeout?
 
     try:
         # ADR-100: Check for cancellation before restore
@@ -98,7 +99,9 @@ def run_restore_worker(
             }
         })
         lane_prior = freeze_lanes(job_queue, RESTORE_FREEZE_LANES)
-        wait_for_quiesce(job_queue, RESTORE_FREEZE_LANES)
+        # Fail-open: a False return means we proceeded over un-drained in-flight
+        # work. Surface it in the job result so an operator can correlate later.
+        quiesced = wait_for_quiesce(job_queue, RESTORE_FREEZE_LANES)
 
         # Stage 1: Create checkpoint backup (ADR-015 Safety Pattern)
         logger.info(f"[{job_id}] Creating checkpoint backup before restore")
@@ -162,7 +165,10 @@ def run_restore_worker(
 
         # Concept epochs live in the separate document_ingestion_counter space
         # (ADR-200), not the graph_epochs.event_id space — so they restamp to the
-        # target's CURRENT concept epoch, not the restore event_id.
+        # target's CURRENT concept epoch, not the restore event_id. NOTE: this is a
+        # DELIBERATE collapse — every restored concept gets the same created_at ==
+        # last_seen == now, so relative concept age is intentionally lost until
+        # re-annealing (epoch-simple). P5-faithful must NOT "fix" this by carrying.
         restore_concept_epoch = client.get_current_epoch()
 
         # Stage 3: Execute restore with progress tracking
@@ -229,8 +235,11 @@ def run_restore_worker(
         client.complete_epoch(restore_event_id, "completed")
         try:
             client.graph.invalidate()
-        except Exception:
-            pass  # extension may not be loaded on this connection
+        except Exception as e:
+            # Usually "extension not loaded on this connection" — benign. But this
+            # is the ONLY graph_accel co-advance (issue #465), so log it: a failure
+            # for any OTHER reason silently desyncs the accelerator.
+            logger.debug(f"[{job_id}] graph.invalidate() after restore skipped: {e}")
         try:
             client.refresh_epoch()
         except Exception as e:
@@ -285,6 +294,7 @@ def run_restore_worker(
             "document_stats": doc_stats if is_archive else None,
             "restore_epoch_event_id": restore_event_id,
             "rehydration_job_id": rehydrate_job_id,
+            "quiesce_timed_out": not quiesced,
             "checkpoint_created": True,
             "checkpoint_deleted": checkpoint_deleted,
             "temp_file_cleaned": False  # Will be cleaned in finally block
@@ -295,9 +305,13 @@ def run_restore_worker(
 
         # ADR-102 P5: resolve the restore epoch as FAILED so it stops holding the
         # committed watermark below its event_id (a phantom in-flight event would
-        # stall freshness for the whole graph). The rollback below re-imports the
-        # checkpoint with its OWN carried stamps (no restamp), so this failed event
-        # tags nothing that survives.
+        # stall freshness for the whole graph). A FAILED event still counts toward
+        # the committed watermark (migration 076), which keeps the graph reading
+        # STALE — important, because the rollback below is MERGE-only (no clear):
+        # any node the failed restore created that is absent from the checkpoint
+        # SURVIVES the rollback, stamped with this failed restore_event_id. That
+        # residue reads stale (safe), but a true-replace rollback is tracked in
+        # issue #483 (pre-existing MERGE-without-clear weakness).
         if restore_event_id is not None and client is not None:
             client.complete_epoch(restore_event_id, "failed")
 
@@ -408,7 +422,7 @@ def _execute_restore(
     backup_data: Dict[str, Any],
     job_id: str,
     job_queue,
-    epoch_restamp: Dict[str, int] = None
+    epoch_restamp: Optional[Dict[str, int]] = None
 ) -> Dict[str, int]:
     """
     Execute restore of an already-mode-prepared kg-backup/2 object, with progress.

--- a/api/app/workers/source_embedding_worker.py
+++ b/api/app/workers/source_embedding_worker.py
@@ -83,6 +83,28 @@ def run_source_embedding_worker(
             }
         })
 
+        # ADR-102 P5 rehydration: bulk only-missing mode. A restore imports source
+        # nodes WITHOUT their text/visual embeddings (those do not travel in the
+        # backup), so the restore worker enqueues one of these to fill the gaps.
+        # only_missing=True skips sources that already have embeddings — safe and
+        # idempotent, so it never re-embeds concepts/sources that arrived intact.
+        if job_data.get("rehydrate_missing"):
+            import asyncio
+            ontology = job_data.get("ontology")  # None → all ontologies
+            logger.info(
+                f"[{job_id}] Source-embedding rehydration (only_missing=True, "
+                f"ontology={ontology or 'ALL'})"
+            )
+            job_queue.update_job(job_id, {
+                "progress": {"stage": "rehydrating",
+                             "message": "Regenerating missing source embeddings"}
+            })
+            result = asyncio.run(regenerate_source_embeddings(
+                only_missing=True,
+                ontology=ontology,
+            ))
+            return {"status": "completed", "rehydrate_missing": True, **result}
+
         # Extract parameters
         source_id = job_data.get("source_id")
         if not source_id:

--- a/api/app/workers/source_embedding_worker.py
+++ b/api/app/workers/source_embedding_worker.py
@@ -11,6 +11,7 @@ Phase 1: ✅ Skeleton (migration, hash utils, chunker, worker skeleton)
 Phase 2: ✅ Full implementation with embedding generation and storage
 """
 
+import asyncio
 import logging
 import os
 import struct
@@ -89,7 +90,6 @@ def run_source_embedding_worker(
         # only_missing=True skips sources that already have embeddings — safe and
         # idempotent, so it never re-embeds concepts/sources that arrived intact.
         if job_data.get("rehydrate_missing"):
-            import asyncio
             ontology = job_data.get("ontology")  # None → all ontologies
             logger.info(
                 f"[{job_id}] Source-embedding rehydration (only_missing=True, "

--- a/api/lib/serialization.py
+++ b/api/lib/serialization.py
@@ -984,7 +984,8 @@ class DataImporter:
     def import_backup(client: AGEClient, backup_data: Dict[str, Any],
                       overwrite_existing: bool = False,
                       progress_callback: Optional[callable] = None,
-                      max_workers: int = 2) -> Dict[str, int]:
+                      max_workers: int = 2,
+                      epoch_restamp: Optional[Dict[str, int]] = None) -> Dict[str, int]:
         """Import a kg-backup/2 object — the single backup model's front-door.
 
         Args:
@@ -993,6 +994,16 @@ class DataImporter:
             overwrite_existing: If True, update existing nodes; if False, preserve them
             progress_callback: Optional callback(stage, current, total, percent)
             max_workers: Parallel workers for instances/evidence/relationships
+            epoch_restamp: ADR-102 P5 epoch-simple restamp. When provided,
+                ``{"event_id": int, "concept_epoch": int}`` overrides the carried
+                per-record epoch stamps so every restored node points at LOCAL
+                clocks: instances' ``created_at_event_id`` → the one restore
+                ``event_id`` (a real ``graph_epochs`` row in this target — carried
+                ids would dangle), and concepts' ``created_at_epoch`` /
+                ``last_seen_epoch`` → the target's current ``concept_epoch``
+                (a separate counter; carrying a foreign value future-dates concept
+                vitality). When None the carried stamps are preserved verbatim
+                (faithful — used by checkpoint rollback and P5-faithful replay).
 
         Returns:
             Stats: vocabulary_imported, concepts_created, sources_created,
@@ -1004,20 +1015,27 @@ class DataImporter:
             overwrite_existing=overwrite_existing,
             progress_callback=progress_callback,
             max_workers=max_workers,
+            epoch_restamp=epoch_restamp,
         )
 
     @staticmethod
     def _import_kg_backup_v2(client: AGEClient, reader: "KgBackupV2Reader", *,
                              overwrite_existing: bool = False,
                              progress_callback: Optional[callable] = None,
-                             max_workers: int = 2) -> Dict[str, int]:
+                             max_workers: int = 2,
+                             epoch_restamp: Optional[Dict[str, int]] = None) -> Dict[str, int]:
         """Clone-path writer: import normalized records, preserving ids 1:1.
 
         Order matters: vocabulary (before relationships, ADR-032) → concepts →
         sources → instances (+FROM_SOURCE) → evidence (EVIDENCED_BY + derived
         APPEARS) → relationships. Clone preserves ids, so edge ``learned_id`` needs
         no remap here (that is P4 adjacent mode).
+
+        ``epoch_restamp`` (ADR-102 P5 epoch-simple) overrides the carried epoch
+        stamps with local clocks — see ``import_backup`` for the contract.
         """
+        restamp_event_id = epoch_restamp.get("event_id") if epoch_restamp else None
+        restamp_concept_epoch = epoch_restamp.get("concept_epoch") if epoch_restamp else None
         stats = {
             "vocabulary_imported": 0,
             "concepts_created": 0,
@@ -1034,7 +1052,8 @@ class DataImporter:
 
         concepts = list(reader.concepts())
         Console.info("Importing concepts...")
-        DataImporter._import_concepts(client, concepts, overwrite_existing, progress_callback)
+        DataImporter._import_concepts(client, concepts, overwrite_existing, progress_callback,
+                                      restamp_epoch=restamp_concept_epoch)
         stats["concepts_created"] = len(concepts)
 
         sources = list(reader.sources())
@@ -1044,7 +1063,8 @@ class DataImporter:
 
         instances = list(reader.instances())
         Console.info("Importing instances...")
-        DataImporter._import_instances(client, instances, progress_callback, max_workers)
+        DataImporter._import_instances(client, instances, progress_callback, max_workers,
+                                       restamp_event_id=restamp_event_id)
         stats["instances_created"] = len(instances)
 
         evidence_map = reader.evidence_by_instance()
@@ -1162,8 +1182,16 @@ class DataImporter:
 
     @staticmethod
     def _import_concepts(client: AGEClient, concepts: List[Dict[str, Any]],
-                         overwrite_existing: bool, progress_callback) -> None:
-        """MERGE concepts, carrying the ADR-102 §3 epoch stamps."""
+                         overwrite_existing: bool, progress_callback,
+                         restamp_epoch: Optional[int] = None) -> None:
+        """MERGE concepts, carrying the ADR-102 §3 epoch stamps.
+
+        ``restamp_epoch`` (ADR-102 P5 epoch-simple): when set, override the carried
+        ``created_at_epoch`` / ``last_seen_epoch`` with this target-local concept
+        epoch (a value in the ``document_ingestion_counter`` space). Carried foreign
+        values future-date concept vitality, so a restore into any non-pristine
+        target restamps to "now".
+        """
         total = len(concepts)
         if overwrite_existing:
             query = """
@@ -1195,6 +1223,9 @@ class DataImporter:
                 "created_at_epoch": c.get("created_at_epoch"),
                 "last_seen_epoch": c.get("last_seen_epoch"),
             }
+            if restamp_epoch is not None:
+                params["created_at_epoch"] = restamp_epoch
+                params["last_seen_epoch"] = restamp_epoch
             _execute_with_age_retry(client, query, params)
             _progress(progress_callback, "concepts", i + 1, total)
 
@@ -1232,8 +1263,15 @@ class DataImporter:
 
     @staticmethod
     def _import_instances(client: AGEClient, instances: List[Dict[str, Any]],
-                          progress_callback, max_workers: int) -> None:
-        """MERGE instances and their FROM_SOURCE edges in parallel."""
+                          progress_callback, max_workers: int,
+                          restamp_event_id: Optional[int] = None) -> None:
+        """MERGE instances and their FROM_SOURCE edges in parallel.
+
+        ``restamp_event_id`` (ADR-102 P5 epoch-simple): when set, override every
+        carried ``created_at_event_id`` with this one restore ``graph_epochs``
+        event id. Carried ids reference epoch rows that do not exist in this target
+        (the importer does not replay ``graph_epochs``), so they would dangle.
+        """
         total = len(instances)
         lock = threading.Lock()
         done = {"n": 0}
@@ -1243,7 +1281,10 @@ class DataImporter:
                 "instance_id": inst["instance_id"],
                 "quote": inst.get("quote", ""),
                 "source_id": inst["source_id"],
-                "created_at_event_id": inst.get("created_at_event_id"),
+                "created_at_event_id": (
+                    restamp_event_id if restamp_event_id is not None
+                    else inst.get("created_at_event_id")
+                ),
             }
             _execute_with_age_retry(client, DataImporter._INSTANCE_Q, params)
             with lock:

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -2326,8 +2326,7 @@ kg restore [options]
 |--------|-------------|---------|
 | `--file <name>` | Backup filename (from configured directory) | - |
 | `--path <path>` | Custom backup file path (overrides configured directory) | - |
-| `--merge` | Merge into existing ontology if it exists (default: error if ontology exists) | `false` |
-| `--deps <action>` | How to handle external dependencies: prune, stitch, defer | `"prune"` |
+| `--mode <mode>` | Restore merge mode: "idempotent" (default; MERGE-by-id, clone into empty), "adjacent" (independent copy, fresh ids), or "integration" (attach concepts to existing graph by similarity) | `"idempotent"` |
 | `--confirm` | Confirm restore operation (required for non-interactive use) | `false` |
 
 ### scheduler

--- a/docs/reference/cli/commands/admin.md
+++ b/docs/reference/cli/commands/admin.md
@@ -79,8 +79,7 @@ kg restore [options]
 |--------|-------------|---------|
 | `--file <name>` | Backup filename (from configured directory) | - |
 | `--path <path>` | Custom backup file path (overrides configured directory) | - |
-| `--merge` | Merge into existing ontology if it exists (default: error if ontology exists) | `false` |
-| `--deps <action>` | How to handle external dependencies: prune, stitch, defer | `"prune"` |
+| `--mode <mode>` | Restore merge mode: "idempotent" (default; MERGE-by-id, clone into empty), "adjacent" (independent copy, fresh ids), or "integration" (attach concepts to existing graph by similarity) | `"idempotent"` |
 | `--confirm` | Confirm restore operation (required for non-interactive use) | `false` |
 
 ### scheduler

--- a/schema/migrations/077_restore_epoch_kind.sql
+++ b/schema/migrations/077_restore_epoch_kind.sql
@@ -1,0 +1,23 @@
+-- Migration 077: Add the 'restore' graph-epoch kind (ADR-102 P5)
+--
+-- A portable-backup restore (ADR-102) is a graph mutation just like an
+-- ingestion: it creates Concept/Source/Instance nodes and must advance the
+-- ADR-207 freshness clock so every downstream derivation reads stale until the
+-- restore commits. To tag the restored nodes we record a graph_epochs event,
+-- and migration 064 made graph_epochs.kind a FOREIGN KEY into
+-- graph_epoch_kinds — so the kind must exist in the lookup before the restore
+-- worker can use it. Migration 064 was explicitly designed so new kinds are
+-- added by INSERT (here) rather than by altering a CHECK constraint.
+--
+-- semantic_wallclock = TRUE: a restore happens "now"; the restored graph state
+-- becomes current as of the restore wall-clock (epoch-simple mode collapses the
+-- backup's own history into this single event). This matches 'ingestion'/'edit'
+-- semantics, not the forensic-only 'reasoning'/'annealing' kinds.
+
+INSERT INTO kg_api.graph_epoch_kinds (kind, semantic_wallclock, description) VALUES
+    ('restore', TRUE, 'Graph state restored from a portable backup (ADR-102).')
+ON CONFLICT (kind) DO NOTHING;
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (77, 'restore_epoch_kind')
+ON CONFLICT (version) DO NOTHING;

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -183,6 +183,36 @@ def test_clone_writer_reconstructs_graph(client_with_cleanup):
         f"WHERE r.learned_id = '{NS}s1' RETURN count(r) AS n") == 1
 
 
+def test_epoch_simple_restamp_overrides_carried_stamps(client_with_cleanup):
+    """ADR-102 P5 epoch-simple: ``epoch_restamp`` overrides the carried per-record
+    epoch stamps with LOCAL clocks — every instance gets the one restore event_id,
+    every concept gets the target's current concept epoch. The backup's own
+    stamps (event_id 11, epochs 11/12) must NOT survive."""
+    client = client_with_cleanup
+    backup = _namespaced_backup()  # carries created_at_event_id=11, epochs 11/12
+
+    RESTORE_EVENT = 770077   # the single restore graph_epochs.event_id
+    CONCEPT_EPOCH = 880088   # target's current document_ingestion_counter
+
+    DataImporter.import_backup(
+        client, backup, overwrite_existing=True,
+        epoch_restamp={"event_id": RESTORE_EVENT, "concept_epoch": CONCEPT_EPOCH},
+    )
+
+    # Instance event_id restamped to the restore event (carried 11 is gone).
+    assert _scalar(client,
+        f"MATCH (i:Instance {{instance_id:'{NS}i1'}}) WHERE i.created_at_event_id = {RESTORE_EVENT} RETURN count(i) AS n") == 1
+    assert _scalar(client,
+        f"MATCH (i:Instance {{instance_id:'{NS}i1'}}) WHERE i.created_at_event_id = 11 RETURN count(i) AS n") == 0
+
+    # Both concepts restamped to the local concept epoch (carried 11/12 gone).
+    assert _scalar(client,
+        f"MATCH (c:Concept) WHERE c.concept_id STARTS WITH '{NS}' "
+        f"AND c.created_at_epoch = {CONCEPT_EPOCH} AND c.last_seen_epoch = {CONCEPT_EPOCH} RETURN count(c) AS n") == 2
+    assert _scalar(client,
+        f"MATCH (c:Concept) WHERE c.concept_id STARTS WITH '{NS}' AND c.created_at_epoch = 11 RETURN count(c) AS n") == 0
+
+
 def test_reimport_is_idempotent(client_with_cleanup):
     """Re-importing the same backup must not duplicate edges (MERGE-by-id)."""
     client = client_with_cleanup

--- a/tests/unit/test_lane_control.py
+++ b/tests/unit/test_lane_control.py
@@ -1,0 +1,159 @@
+"""Unit tests for worker-lane freeze / quiesce (ADR-102 A14 / P5).
+
+freeze_lanes / thaw_lanes are tested against a fake connection that records the
+SQL it executes and answers SELECTs from an in-memory ``worker_lanes`` model, so
+the prior-state capture + restore logic is exercised without a database. The
+wait_for_quiesce loop logic (drain vs fail-open timeout) is tested by patching
+the DB-touching helpers, isolating the control flow.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from api.app.lib import lane_control
+
+
+# --------------------------------------------------------------------------
+# A tiny fake job_queue whose connection answers the exact SQL lane_control uses.
+# --------------------------------------------------------------------------
+class _FakeCursor:
+    def __init__(self, lanes):
+        self._lanes = lanes          # {name: {"enabled": bool, "job_types": [...]}}
+        self._result = None
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        if s.startswith("SELECT enabled FROM kg_api.worker_lanes WHERE name ="):
+            name = params[0]
+            row = self._lanes.get(name)
+            self._result = [(row["enabled"],)] if row else []
+        elif s.startswith("UPDATE kg_api.worker_lanes SET enabled ="):
+            # Two shapes: freeze (literal FALSE, 1 param=name) and thaw (param enabled, name).
+            if len(params) == 1:
+                name = params[0]
+                if name in self._lanes:
+                    self._lanes[name]["enabled"] = False
+            else:
+                enabled, name = params
+                if name in self._lanes:
+                    self._lanes[name]["enabled"] = enabled
+            self._result = []
+        else:
+            self._result = []
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, lanes):
+        self._lanes = lanes
+        self.committed = False
+        self.rolled_back = False
+
+    def cursor(self, **kw):
+        return _FakeCursor(self._lanes)
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+
+class _FakeQueue:
+    def __init__(self, lanes):
+        self.lanes = lanes
+        self.returned = False
+
+    def _get_connection(self):
+        return _FakeConn(self.lanes)
+
+    def _return_connection(self, conn):
+        self.returned = True
+
+
+def _lanes():
+    return {
+        "interactive": {"enabled": True, "job_types": ["ingestion", "polarity"]},
+        "maintenance": {"enabled": True, "job_types": ["projection"]},
+        "system": {"enabled": True, "job_types": ["restore", "source_embedding"]},
+    }
+
+
+# ---- freeze / thaw ----
+
+def test_freeze_captures_prior_and_disables():
+    q = _FakeQueue(_lanes())
+    prior = lane_control.freeze_lanes(q, ["interactive", "maintenance"])
+    assert prior == {"interactive": True, "maintenance": True}
+    assert q.lanes["interactive"]["enabled"] is False
+    assert q.lanes["maintenance"]["enabled"] is False
+    # system never touched
+    assert q.lanes["system"]["enabled"] is True
+
+
+def test_thaw_restores_prior_state_not_blanket_enable():
+    # maintenance was ALREADY disabled by an operator before the restore.
+    lanes = _lanes()
+    lanes["maintenance"]["enabled"] = False
+    q = _FakeQueue(lanes)
+
+    prior = lane_control.freeze_lanes(q, ["interactive", "maintenance"])
+    assert prior == {"interactive": True, "maintenance": False}
+    assert q.lanes["interactive"]["enabled"] is False
+
+    lane_control.thaw_lanes(q, prior)
+    # interactive restored to enabled; maintenance stays disabled (its prior state).
+    assert q.lanes["interactive"]["enabled"] is True
+    assert q.lanes["maintenance"]["enabled"] is False
+
+
+def test_thaw_empty_is_noop():
+    q = _FakeQueue(_lanes())
+    lane_control.thaw_lanes(q, {})  # must not raise
+    lane_control.thaw_lanes(q, None)
+
+
+def test_thaw_never_raises_on_db_error():
+    class _BoomQueue:
+        def _get_connection(self):
+            raise RuntimeError("db down")
+    # Must swallow + log, not propagate (called from a finally).
+    lane_control.thaw_lanes(_BoomQueue(), {"interactive": True})
+
+
+# ---- wait_for_quiesce ----
+
+def test_quiesce_returns_true_when_drained():
+    q = _FakeQueue(_lanes())
+    with patch.object(lane_control, "_lane_job_types", return_value=["ingestion"]), \
+         patch.object(lane_control, "_count_inflight", return_value=0):
+        assert lane_control.wait_for_quiesce(q, ["interactive"], timeout_s=5) is True
+
+
+def test_quiesce_fail_open_on_timeout():
+    q = _FakeQueue(_lanes())
+    # Never drains → returns False (fail-open), does NOT raise.
+    with patch.object(lane_control, "_lane_job_types", return_value=["ingestion"]), \
+         patch.object(lane_control, "_count_inflight", return_value=3):
+        assert lane_control.wait_for_quiesce(
+            q, ["interactive"], timeout_s=0, poll_interval_s=0.01) is False
+
+
+def test_quiesce_drains_after_a_few_polls():
+    q = _FakeQueue(_lanes())
+    counts = iter([2, 1, 0])
+    with patch.object(lane_control, "_lane_job_types", return_value=["ingestion"]), \
+         patch.object(lane_control, "_count_inflight", side_effect=lambda *a: next(counts)):
+        assert lane_control.wait_for_quiesce(
+            q, ["interactive"], timeout_s=5, poll_interval_s=0.01) is True

--- a/tests/unit/test_restore_worker_epoch.py
+++ b/tests/unit/test_restore_worker_epoch.py
@@ -1,0 +1,52 @@
+"""Unit test for the ADR-102 A13 fix: a failed restore epoch is FATAL.
+
+Before P5, ``record_mutation`` ran AFTER the restore wrapped in a try/except that
+logged-and-continued (and ignored a None return) — a restore could complete with
+no epoch event, leaving restored data readable as FRESH against stale derivations
+and every Instance untagged. P5 records the epoch BEFORE import and raises when
+record_epoch returns None. This test pins that behavior with everything else
+mocked (no DB, no real graph).
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.app.workers import restore_worker
+
+
+def _minimal_backup():
+    return {"header": {"format": "kg-backup/2"}, "bulk": {}}
+
+
+def test_restore_raises_when_record_epoch_returns_none(tmp_path):
+    temp_file = tmp_path / "backup.json"
+    temp_file.write_text(json.dumps(_minimal_backup()))
+
+    job_queue = MagicMock()
+    job_queue.is_job_cancelled.return_value = False
+
+    client = MagicMock()
+    client.record_epoch.return_value = None  # A13: the failure under test
+
+    # Checkpoint path that does NOT exist → the except block's rollback is skipped,
+    # so the original error surfaces cleanly.
+    missing_checkpoint = tmp_path / "nope.json"
+
+    with patch.object(restore_worker, "AGEClient", return_value=client), \
+         patch.object(restore_worker, "freeze_lanes", return_value={"interactive": True}), \
+         patch.object(restore_worker, "wait_for_quiesce", return_value=True), \
+         patch.object(restore_worker, "thaw_lanes") as thaw, \
+         patch.object(restore_worker, "_create_checkpoint_backup", return_value=missing_checkpoint), \
+         patch.object(restore_worker, "prepare_backup", return_value=(_minimal_backup(), {})):
+        with pytest.raises(Exception, match="record_epoch returned None"):
+            restore_worker.run_restore_worker(
+                {"temp_file": str(temp_file), "temp_file_id": "t1", "mode": "idempotent"},
+                "job_test_a13",
+                job_queue,
+            )
+
+    # No completed epoch was recorded (event id was None).
+    client.complete_epoch.assert_not_called()
+    # Lanes were still thawed in the finally despite the fatal error (A14).
+    thaw.assert_called_once()


### PR DESCRIPTION
## ADR-102 P5 — epoch reconciliation, lane quiesce, rehydration

Builds on P4 (#481). Makes a restore a first-class graph mutation: it reconciles epochs to local clocks, quiesces competing workers, advances the freshness clock, and rehydrates the one derived product that doesn't travel.

### Verified-in-code first — two tracking-note assumptions were wrong
- **Lane topology:** only 3 lanes exist (migration 057): `interactive`, `maintenance`, `system`. **Restore runs in `system`**, alongside the rehydration jobs. So we freeze `interactive`+`maintenance` and KEEP `system` (self-serializing, max_slots=1). The notes' `artifact_cleanup`/`embedding` lanes don't exist.
- **Epoch number-spaces:** `instances.created_at_event_id` is `graph_epochs.event_id`; `concepts.created_at_epoch/last_seen_epoch` is the **separate** `document_ingestion_counter` (`get_current_epoch()`). They can't share a value.

### What ships
1. **Epoch-simple restamp** (default, all modes) — `import_backup(epoch_restamp={event_id, concept_epoch})`. Instances → the one restore event id (carried ids dangle — the importer doesn't replay `graph_epochs`); concepts → the target's current concept epoch (carried foreign values future-date vitality). `None` preserves carried stamps (checkpoint rollback / future P5-faithful). Migration **077** adds the `restore` epoch kind.
2. **Lane freeze/quiesce (A14)** — `api/app/lib/lane_control.py`. Freeze `interactive`+`maintenance` via `worker_lanes.enabled`, drain in-flight via `kg_api.jobs` (cross-process), thaw to **prior** state in `finally`. Fail-open (120s, `KG_RESTORE_QUIESCE_TIMEOUT_S`), no force-cancel.
3. **Epoch lifecycle + A13** — `record_epoch('restore')` before import, `complete_epoch` after (+ explicit `graph.invalidate()`/`refresh_epoch()` co-advance, issue #465), `failed` on error. A None `record_epoch` is now **fatal** (was log-and-continue).
4. **Rehydration** — only source text/visual embeddings don't travel (concept+vocab embeddings do; scores/catalog/grounding self-heal off the tick). Restore enqueues **one** bulk only-missing `source_embedding` job (new `rehydrate_missing` mode on the existing worker — no new job_type/migration; auto-approved system job).

### Decisions (gated with maintainer)
quiesce fail-open (no force-cancel) · restamp Option A · rehydration = only-missing source embeddings · §6 cross-space integration → keep P4 reject, **defer** rehydrate-then-match (follow-up).

### Tests
`test_lane_control.py` (7), `test_restore_worker_epoch.py` (A13 raise + thaw-in-finally), epoch-simple restamp live test in `test_kg_backup_v2_restore.py`. Full suite **1316 passed / 16 skipped / 1 failed** — the failure is pre-existing vision-config dev-DB state pollution (migration 074, untouched by P5).

### Not in this PR
P5-faithful epoch replay (clone-only, next branch); §6 rehydrate-then-match.