### PR TITLE
ADR-102 P5-faithful: clone-only faithful epoch replay

### DIFF
--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -219,7 +219,11 @@ async def restore_backup(
     _: None = Depends(require_permission("backups", "restore")),
     file: UploadFile = File(..., description="Backup file (.tar.gz archive or .json)"),
     mode: str = Form("idempotent",
-                     description="Restore merge mode: 'idempotent', 'adjacent', or 'integration'")
+                     description="Restore merge mode: 'idempotent', 'adjacent', or 'integration'"),
+    epoch: str = Form("simple",
+                      description="Epoch reconciliation: 'simple' (one restore event) or "
+                                  "'faithful' (replay carried history; clone-only, requires "
+                                  "idempotent mode + empty target)")
 ):
     """
     Restore a database backup (ADR-015 Phase 2: Multipart Upload)
@@ -264,6 +268,14 @@ async def restore_backup(
     from ..lib.restore_modes import RestoreMode
     try:
         RestoreMode.validate(mode)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    # Validate the epoch reconciliation mode (eligibility — faithful requires
+    # idempotent + empty target — is enforced in the worker where it has a client).
+    from ..workers.restore_worker import _validate_epoch_mode
+    try:
+        epoch = _validate_epoch_mode(epoch)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
@@ -364,6 +376,7 @@ async def restore_backup(
                 "temp_file": str(temp_path),
                 "temp_file_id": str(temp_file_id),
                 "mode": mode,
+                "epoch": epoch,
                 "backup_stats": stats,
                 "integrity_warnings": len(integrity.warnings),
                 "archive_temp_dir": archive_temp_dir,  # For document restore (None if JSON)

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -84,8 +84,11 @@ def _target_is_empty(client: AGEClient) -> bool:
                 cur.execute("SELECT count(*) FROM kg_api.graph_epochs")
                 if int(cur.fetchone()[0]) > 0:
                     return False
-    finally:
         conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
         client.pool.putconn(conn)
     return True
 
@@ -231,6 +234,12 @@ def run_restore_worker(
             # events (fresh ids, carried occurred_at/kind/actor/metadata), then stamp
             # each Instance via the old→new map. Concepts carry their ORIGINAL epochs;
             # the counter is advanced after import so vitality stays consistent.
+            #
+            # Raw INSERT (not record_epoch) so we can carry occurred_at + mint N rows
+            # in one pass — watermark-equivalent to the simple path's stored-function
+            # in_progress event. A crash between this commit and the resolve below
+            # leaves N rows in_progress (the simple path leaves 1); the orphaned-epoch
+            # reconciliation sweep that fixes both is tracked in issue #485.
             reader = KgBackupV2Reader(prepared_backup)
             DataImporter._ensure_epoch_kinds(client, reader)
             event_id_map = DataImporter._replay_graph_epochs(client, reader, status="in_progress")
@@ -328,7 +337,7 @@ def run_restore_worker(
                 DataImporter._set_ingestion_counter(client, max_concept_epoch)
             logger.info(
                 f"[{job_id}] Faithful replay resolved {len(replayed_event_ids)} epochs; "
-                f"ingestion counter ≥ {max_concept_epoch}"
+                f"ingestion counter >= {max_concept_epoch}"
             )
         else:
             client.complete_epoch(restore_event_id, "completed")
@@ -418,7 +427,9 @@ def run_restore_worker(
         # any node the failed restore created that is absent from the checkpoint
         # SURVIVES the rollback, stamped with this failed restore_event_id. That
         # residue reads stale (safe), but a true-replace rollback is tracked in
-        # issue #483 (pre-existing MERGE-without-clear weakness).
+        # issue #483 (pre-existing MERGE-without-clear weakness). For faithful the
+        # same applies: the resolved-'failed' replayed epoch rows survive referencing
+        # nothing (the empty-target checkpoint rollback is a no-op), reading stale.
         if client is not None:
             if restore_event_id is not None:  # epoch-simple
                 client.complete_epoch(restore_event_id, "failed")

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -32,6 +32,63 @@ from ..lib.lane_control import (
 # a real, local event id.
 RESTORE_EPOCH_KIND = "restore"
 
+# ADR-102 P5: epoch reconciliation modes (restore-time selector).
+#   simple   — collapse the backup's history into ONE restore event (default, all modes)
+#   faithful — replay the carried graph_epochs as new local events (clone-only)
+EPOCH_SIMPLE = "simple"
+EPOCH_FAITHFUL = "faithful"
+_EPOCH_MODES = (EPOCH_SIMPLE, EPOCH_FAITHFUL)
+
+
+def _validate_epoch_mode(value) -> str:
+    """Validate the epoch reconciliation mode, defaulting to simple."""
+    v = (value or EPOCH_SIMPLE).lower()
+    if v not in _EPOCH_MODES:
+        raise ValueError(f"Unknown epoch mode {value!r}; expected one of {_EPOCH_MODES}")
+    return v
+
+
+def _max_carried_concept_epoch(backup_data: Dict[str, Any]):
+    """Max of concepts' carried created_at/last_seen epochs, or None if none.
+
+    P5-faithful sets the target's document_ingestion_counter to this so the
+    restored concepts' carried epochs do not read as 'from the future'.
+    """
+    reader = KgBackupV2Reader(backup_data)
+    hi = None
+    for c in reader.concepts():
+        for key in ("created_at_epoch", "last_seen_epoch"):
+            v = c.get(key)
+            if v is not None and (hi is None or v > hi):
+                hi = v
+    return hi
+
+
+def _target_is_empty(client: AGEClient) -> bool:
+    """True if the target holds no graph nodes AND no epoch history.
+
+    Faithful epoch replay (ADR-102) mints fresh local event_ids but only makes
+    sense when reconstructing a graph from scratch — merging a full foreign
+    history into a graph that already has its own would interleave two unrelated
+    timelines. Both the node graph and the graph_epochs log must be empty.
+    """
+    for label in ("Concept", "Source", "Instance"):
+        row = client._execute_cypher(f"MATCH (n:{label}) RETURN count(n) AS n", fetch_one=True)
+        if row and int(str(row.get("n", 0)).strip('"')) > 0:
+            return False
+    conn = client.pool.getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('kg_api.graph_epochs') IS NOT NULL")
+            if cur.fetchone()[0]:
+                cur.execute("SELECT count(*) FROM kg_api.graph_epochs")
+                if int(cur.fetchone()[0]) > 0:
+                    return False
+    finally:
+        conn.commit()
+        client.pool.putconn(conn)
+    return True
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,14 +126,16 @@ def run_restore_worker(
     temp_file = Path(job_data["temp_file"])
     temp_file_id = job_data["temp_file_id"]
     mode = RestoreMode.validate(job_data.get("mode", RestoreMode.DEFAULT))
+    epoch_mode = _validate_epoch_mode(job_data.get("epoch", EPOCH_SIMPLE))
     backup_stats = job_data.get("backup_stats", {})
     archive_temp_dir = job_data.get("archive_temp_dir")  # For archive restores
     is_archive = job_data.get("is_archive", False)
 
     checkpoint_path = None
     client = None
-    lane_prior = None        # ADR-102 A14: prior lane-enabled state, restored on exit
-    restore_event_id = None  # ADR-102 P5: the single restore graph_epochs event
+    lane_prior = None         # ADR-102 A14: prior lane-enabled state, restored on exit
+    restore_event_id = None   # ADR-102 P5 epoch-simple: the single restore event
+    replayed_event_ids = None  # ADR-102 P5-faithful: ids minted by the epoch replay
     quiesced = True          # ADR-102 A14: did frozen lanes drain before the timeout?
 
     try:
@@ -114,6 +173,27 @@ def run_restore_worker(
         })
 
         client = AGEClient()
+
+        # ADR-102 P5-faithful eligibility gate (fail fast, before checkpoint/import).
+        # Faithful epoch replay is clone-only: it requires idempotent mode AND an
+        # empty target. Reject otherwise with the actionable alternatives rather
+        # than silently downgrading (faithful is an explicit opt-in).
+        if epoch_mode == EPOCH_FAITHFUL:
+            if mode != RestoreMode.IDEMPOTENT:
+                raise ValueError(
+                    f"epoch=faithful requires --mode idempotent (got {mode!r}). "
+                    f"Faithful replay preserves per-event history against preserved "
+                    f"node ids; adjacent/integration mint new ids. Use --epoch simple, "
+                    f"or --mode idempotent into an empty target."
+                )
+            if not _target_is_empty(client):
+                raise ValueError(
+                    "epoch=faithful requires an EMPTY target (no concepts/sources/"
+                    "instances and no epoch history) — it reconstructs a graph's full "
+                    "history from scratch. For a populated target use --epoch simple, "
+                    "or --mode integration to merge into the existing graph."
+                )
+
         checkpoint_path = _create_checkpoint_backup(client, job_id)
 
         logger.info(f"[{job_id}] Checkpoint created at {checkpoint_path}")
@@ -139,37 +219,52 @@ def run_restore_worker(
         logger.info(f"[{job_id}] Restore mode: {mode}")
         prepared_backup, mapping_table = prepare_backup(backup_data, mode, client)
 
-        # ADR-102 P5 (epoch-simple): record ONE restore epoch event up front so its
-        # event_id can stamp every imported node. The carried bulk.graph_epochs are
-        # NOT replayed (that is P5-faithful, clone-only). record_epoch inserts an
-        # in_progress event that holds the committed watermark just below it until
-        # complete_epoch resolves it — exactly the long-job tagging pattern the
-        # ingestion worker uses.
-        #
-        # ADR-102 A13: a failed record_epoch is FATAL here (not log-and-continue).
-        # Without an event id every restored Instance would be untagged AND the
-        # post-restore watermark advance below would be meaningless — restored
-        # data could read FRESH against stale derivations. Fail loudly instead.
-        restore_event_id = client.record_epoch(
-            kind=RESTORE_EPOCH_KIND,
-            actor="restore",
-            metadata={"job_id": job_id, "mode": mode, "restore": True},
-        )
-        if restore_event_id is None:
-            raise RuntimeError(
-                "record_epoch returned None — cannot stamp restored nodes with a "
-                "graph epoch (the freshness clock would be left inconsistent). "
-                "Check kg_api.graph_epochs health (grep 'record_epoch failed')."
-            )
-        logger.info(f"[{job_id}] Restore epoch event_id={restore_event_id}")
+        # ADR-102 P5: epoch reconciliation. Both modes record graph_epochs as
+        # in_progress so the committed watermark sits below them and the graph reads
+        # STALE during the import; they resolve to 'completed' after the import lands.
+        logger.info(f"[{job_id}] Epoch mode: {epoch_mode}")
+        epoch_restamp = None
+        event_id_map = None
 
-        # Concept epochs live in the separate document_ingestion_counter space
-        # (ADR-200), not the graph_epochs.event_id space — so they restamp to the
-        # target's CURRENT concept epoch, not the restore event_id. NOTE: this is a
-        # DELIBERATE collapse — every restored concept gets the same created_at ==
-        # last_seen == now, so relative concept age is intentionally lost until
-        # re-annealing (epoch-simple). P5-faithful must NOT "fix" this by carrying.
-        restore_concept_epoch = client.get_current_epoch()
+        if epoch_mode == EPOCH_FAITHFUL:
+            # Faithful (clone-only): replay the carried graph_epochs as NEW local
+            # events (fresh ids, carried occurred_at/kind/actor/metadata), then stamp
+            # each Instance via the old→new map. Concepts carry their ORIGINAL epochs;
+            # the counter is advanced after import so vitality stays consistent.
+            reader = KgBackupV2Reader(prepared_backup)
+            DataImporter._ensure_epoch_kinds(client, reader)
+            event_id_map = DataImporter._replay_graph_epochs(client, reader, status="in_progress")
+            replayed_event_ids = list(event_id_map.values())
+            logger.info(f"[{job_id}] Faithful replay minted {len(replayed_event_ids)} epoch events")
+        else:
+            # epoch-simple: record ONE restore event up front so its id stamps every
+            # imported node. The carried bulk.graph_epochs are NOT replayed.
+            #
+            # ADR-102 A13: a failed record_epoch is FATAL (not log-and-continue) —
+            # without an event id, restored data could read FRESH against stale
+            # derivations and every Instance would be untagged.
+            restore_event_id = client.record_epoch(
+                kind=RESTORE_EPOCH_KIND,
+                actor="restore",
+                metadata={"job_id": job_id, "mode": mode, "restore": True},
+            )
+            if restore_event_id is None:
+                raise RuntimeError(
+                    "record_epoch returned None — cannot stamp restored nodes with a "
+                    "graph epoch (the freshness clock would be left inconsistent). "
+                    "Check kg_api.graph_epochs health (grep 'record_epoch failed')."
+                )
+            logger.info(f"[{job_id}] Restore epoch event_id={restore_event_id}")
+
+            # Concept epochs live in the separate document_ingestion_counter space
+            # (ADR-200), not graph_epochs.event_id — so they restamp to the target's
+            # CURRENT concept epoch. DELIBERATE collapse: every restored concept gets
+            # the same created_at == last_seen == now (relative age lost until
+            # re-annealing). P5-faithful preserves the original epochs instead.
+            epoch_restamp = {
+                "event_id": restore_event_id,
+                "concept_epoch": client.get_current_epoch(),
+            }
 
         # Stage 3: Execute restore with progress tracking
         restore_stats = _execute_restore(
@@ -177,10 +272,8 @@ def run_restore_worker(
             backup_data=prepared_backup,
             job_id=job_id,
             job_queue=job_queue,
-            epoch_restamp={
-                "event_id": restore_event_id,
-                "concept_epoch": restore_concept_epoch,
-            },
+            epoch_restamp=epoch_restamp,
+            event_id_map=event_id_map,
         )
 
         # Stage 4: Restore documents to Garage (for archive backups)
@@ -220,19 +313,31 @@ def run_restore_worker(
             }
         })
 
-        # ADR-207/#386 + ADR-102 P5: resolve the restore epoch as COMPLETED. Until
-        # now it held the committed watermark just below its event_id, so every
-        # derivation correctly read stale during the import. Completing it advances
-        # the universal freshness tick (get_committed_epoch) past every restored
-        # node's stamp; otherwise the catalog index and the grounding / confidence
-        # / artifact caches would keep serving pre-restore data as "fresh".
-        #
-        # The record_epoch/complete_epoch pair does NOT co-advance the in-memory
-        # graph_accel sub-counter on its own (the docstring co-advance caveat /
-        # issue #465) — only record_mutation does. So invalidate the accelerator
-        # and refresh the graph_change_counter snapshot explicitly, matching what
-        # record_mutation would have done.
-        client.complete_epoch(restore_event_id, "completed")
+        # ADR-207/#386 + ADR-102 P5: resolve the restore epoch(s) as COMPLETED. Until
+        # now they held the committed watermark just below them, so every derivation
+        # correctly read stale during the import. Completing advances the universal
+        # freshness tick (get_committed_epoch) past every restored node's stamp;
+        # otherwise the catalog index and the grounding / confidence / artifact
+        # caches would keep serving pre-restore data as "fresh".
+        if epoch_mode == EPOCH_FAITHFUL:
+            DataImporter._resolve_replayed_epochs(client, replayed_event_ids, "completed")
+            # Faithful carries concepts' ORIGINAL epochs — advance the concept counter
+            # to the max carried so vitality math + future ingestion stay monotonic.
+            max_concept_epoch = _max_carried_concept_epoch(prepared_backup)
+            if max_concept_epoch is not None:
+                DataImporter._set_ingestion_counter(client, max_concept_epoch)
+            logger.info(
+                f"[{job_id}] Faithful replay resolved {len(replayed_event_ids)} epochs; "
+                f"ingestion counter ≥ {max_concept_epoch}"
+            )
+        else:
+            client.complete_epoch(restore_event_id, "completed")
+            logger.info(f"[{job_id}] Restore epoch {restore_event_id} completed")
+
+        # The record_epoch/complete_epoch pair (and the faithful INSERT/resolve path)
+        # do NOT co-advance the in-memory graph_accel sub-counter (the docstring
+        # co-advance caveat / issue #465) — only record_mutation does. So invalidate
+        # the accelerator and refresh the graph_change_counter snapshot explicitly.
         try:
             client.graph.invalidate()
         except Exception as e:
@@ -244,7 +349,7 @@ def run_restore_worker(
             client.refresh_epoch()
         except Exception as e:
             logger.warning(f"[{job_id}] refresh_epoch after restore failed: {e}")
-        logger.info(f"[{job_id}] Restore epoch {restore_event_id} completed (freshness tick advanced)")
+        logger.info(f"[{job_id}] Freshness tick advanced ({epoch_mode} epoch reconciliation)")
 
         # ADR-102 P5 rehydration: source text/visual embeddings do NOT travel in
         # the backup (concept + vocab embeddings do, and scores/catalog/grounding
@@ -292,7 +397,9 @@ def run_restore_worker(
             "restore_stats": restore_stats,
             "mapping_table": mapping_table if remapped else None,
             "document_stats": doc_stats if is_archive else None,
+            "epoch_mode": epoch_mode,
             "restore_epoch_event_id": restore_event_id,
+            "faithful_epochs_replayed": len(replayed_event_ids) if replayed_event_ids else 0,
             "rehydration_job_id": rehydrate_job_id,
             "quiesce_timed_out": not quiesced,
             "checkpoint_created": True,
@@ -312,8 +419,14 @@ def run_restore_worker(
         # SURVIVES the rollback, stamped with this failed restore_event_id. That
         # residue reads stale (safe), but a true-replace rollback is tracked in
         # issue #483 (pre-existing MERGE-without-clear weakness).
-        if restore_event_id is not None and client is not None:
-            client.complete_epoch(restore_event_id, "failed")
+        if client is not None:
+            if restore_event_id is not None:  # epoch-simple
+                client.complete_epoch(restore_event_id, "failed")
+            if replayed_event_ids:            # P5-faithful
+                try:
+                    DataImporter._resolve_replayed_epochs(client, replayed_event_ids, "failed")
+                except Exception as ee:
+                    logger.error(f"[{job_id}] Failed to mark replayed epochs failed: {ee}")
 
         # Failure: Restore from checkpoint
         if checkpoint_path and checkpoint_path.exists():
@@ -422,7 +535,8 @@ def _execute_restore(
     backup_data: Dict[str, Any],
     job_id: str,
     job_queue,
-    epoch_restamp: Optional[Dict[str, int]] = None
+    epoch_restamp: Optional[Dict[str, int]] = None,
+    event_id_map: Optional[Dict[int, int]] = None
 ) -> Dict[str, int]:
     """
     Execute restore of an already-mode-prepared kg-backup/2 object, with progress.
@@ -432,8 +546,8 @@ def _execute_restore(
     overwrite_existing=True: idempotent updates matching nodes in place, while
     adjacent/integration ids are fresh or attach to existing targets.
 
-    ``epoch_restamp`` (ADR-102 P5 epoch-simple) overrides carried epoch stamps
-    with local clocks — see ``DataImporter.import_backup``.
+    ``epoch_restamp`` (epoch-simple) / ``event_id_map`` (faithful) control how
+    instance/concept epoch stamps are reconciled — see ``DataImporter.import_backup``.
 
     Returns:
         Dict with restore statistics
@@ -491,7 +605,8 @@ def _execute_restore(
         backup_data,
         overwrite_existing=True,
         progress_callback=progress_callback,
-        epoch_restamp=epoch_restamp
+        epoch_restamp=epoch_restamp,
+        event_id_map=event_id_map
     )
 
     return {

--- a/api/lib/serialization.py
+++ b/api/lib/serialization.py
@@ -1287,25 +1287,39 @@ class DataImporter:
           one restore event id (carried ids would dangle — the simple path does not
           replay ``graph_epochs``).
         - neither: carry verbatim (checkpoint rollback).
+
+        Faithful safety: a carried id absent from ``event_id_map`` (an instance
+        referencing an event the backup did not carry) is stamped NULL rather than
+        passed through — a passed-through foreign id would dangle against the target's
+        fresh epoch sequence (reads unpredictably); NULL reads stale, which is safe.
         """
         total = len(instances)
         lock = threading.Lock()
         done = {"n": 0}
+        unmapped = {"n": 0}
 
         def _event_id(inst):
             carried = inst.get("created_at_event_id")
             if event_id_map is not None:
-                return event_id_map.get(carried, carried)
+                if carried is None:
+                    return None
+                mapped = event_id_map.get(carried)
+                if mapped is None:
+                    unmapped["n"] += 1  # tracked under `lock` in work()
+                    return None
+                return mapped
             if restamp_event_id is not None:
                 return restamp_event_id
             return carried
 
         def work(inst):
+            with lock:
+                eid = _event_id(inst)
             params = {
                 "instance_id": inst["instance_id"],
                 "quote": inst.get("quote", ""),
                 "source_id": inst["source_id"],
-                "created_at_event_id": _event_id(inst),
+                "created_at_event_id": eid,
             }
             _execute_with_age_retry(client, DataImporter._INSTANCE_Q, params)
             with lock:
@@ -1313,6 +1327,11 @@ class DataImporter:
                 _progress(progress_callback, "instances", done["n"], total)
 
         _run_parallel(instances, work, max_workers)
+        if unmapped["n"]:
+            Console.warning(
+                f"  {unmapped['n']} instance(s) referenced an event_id not in the "
+                f"backup's graph_epochs — left unstamped (faithful replay)."
+            )
 
     @staticmethod
     def _import_evidence(client: AGEClient, pairs: List, max_workers: int) -> None:
@@ -1422,6 +1441,9 @@ class DataImporter:
                     name = k.get("kind") if isinstance(k, dict) else k
                     if not name:
                         continue
+                    # Log-only kinds (present in the epoch log but not the lookup
+                    # export) arrive as bare {"kind": k} with no flag — default them
+                    # to forensic (semantic_wallclock=False), the conservative choice.
                     wallclock = bool(k.get("semantic_wallclock", False)) if isinstance(k, dict) else False
                     desc = (k.get("description") if isinstance(k, dict) else None) or ""
                     cur.execute(
@@ -1458,6 +1480,10 @@ class DataImporter:
             with conn.cursor() as cur:
                 for ep in reader.graph_epochs():
                     old_id = ep.get("event_id")
+                    # counter_after is carried verbatim — it snapshots the SOURCE
+                    # graph's graph_change_counter, a foreign counter space. It is
+                    # display-only (epoch_facade timeline), never drives the watermark
+                    # or vitality, so carrying it is honest for a faithful replay.
                     cur.execute(
                         "INSERT INTO kg_api.graph_epochs "
                         "(occurred_at, kind, actor, counter_after, metadata, status) "

--- a/api/lib/serialization.py
+++ b/api/lib/serialization.py
@@ -985,7 +985,8 @@ class DataImporter:
                       overwrite_existing: bool = False,
                       progress_callback: Optional[callable] = None,
                       max_workers: int = 2,
-                      epoch_restamp: Optional[Dict[str, int]] = None) -> Dict[str, int]:
+                      epoch_restamp: Optional[Dict[str, int]] = None,
+                      event_id_map: Optional[Dict[int, int]] = None) -> Dict[str, int]:
         """Import a kg-backup/2 object — the single backup model's front-door.
 
         Args:
@@ -1004,6 +1005,13 @@ class DataImporter:
                 (a separate counter; carrying a foreign value future-dates concept
                 vitality). When None the carried stamps are preserved verbatim
                 (faithful — used by checkpoint rollback and P5-faithful replay).
+            event_id_map: ADR-102 P5-faithful replay. When provided, each
+                instance's carried ``created_at_event_id`` is remapped through this
+                ``{old_event_id: new_event_id}`` table (the freshly-minted local
+                epoch ids from the faithful replay). Mutually exclusive with
+                ``epoch_restamp`` (simple collapses to one id; faithful preserves
+                the per-event structure). Concepts are NOT remapped here — faithful
+                carries their original epochs and the worker sets the counter.
 
         Returns:
             Stats: vocabulary_imported, concepts_created, sources_created,
@@ -1016,6 +1024,7 @@ class DataImporter:
             progress_callback=progress_callback,
             max_workers=max_workers,
             epoch_restamp=epoch_restamp,
+            event_id_map=event_id_map,
         )
 
     @staticmethod
@@ -1023,7 +1032,8 @@ class DataImporter:
                              overwrite_existing: bool = False,
                              progress_callback: Optional[callable] = None,
                              max_workers: int = 2,
-                             epoch_restamp: Optional[Dict[str, int]] = None) -> Dict[str, int]:
+                             epoch_restamp: Optional[Dict[str, int]] = None,
+                             event_id_map: Optional[Dict[int, int]] = None) -> Dict[str, int]:
         """Clone-path writer: import normalized records, preserving ids 1:1.
 
         Order matters: vocabulary (before relationships, ADR-032) → concepts →
@@ -1031,8 +1041,8 @@ class DataImporter:
         APPEARS) → relationships. Clone preserves ids, so edge ``learned_id`` needs
         no remap here (that is P4 adjacent mode).
 
-        ``epoch_restamp`` (ADR-102 P5 epoch-simple) overrides the carried epoch
-        stamps with local clocks — see ``import_backup`` for the contract.
+        ``epoch_restamp`` (P5 epoch-simple) / ``event_id_map`` (P5-faithful) control
+        instance epoch stamping — see ``import_backup`` for the contract.
         """
         restamp_event_id = epoch_restamp.get("event_id") if epoch_restamp else None
         restamp_concept_epoch = epoch_restamp.get("concept_epoch") if epoch_restamp else None
@@ -1064,7 +1074,8 @@ class DataImporter:
         instances = list(reader.instances())
         Console.info("Importing instances...")
         DataImporter._import_instances(client, instances, progress_callback, max_workers,
-                                       restamp_event_id=restamp_event_id)
+                                       restamp_event_id=restamp_event_id,
+                                       event_id_map=event_id_map)
         stats["instances_created"] = len(instances)
 
         evidence_map = reader.evidence_by_instance()
@@ -1264,27 +1275,37 @@ class DataImporter:
     @staticmethod
     def _import_instances(client: AGEClient, instances: List[Dict[str, Any]],
                           progress_callback, max_workers: int,
-                          restamp_event_id: Optional[int] = None) -> None:
+                          restamp_event_id: Optional[int] = None,
+                          event_id_map: Optional[Dict[int, int]] = None) -> None:
         """MERGE instances and their FROM_SOURCE edges in parallel.
 
-        ``restamp_event_id`` (ADR-102 P5 epoch-simple): when set, override every
-        carried ``created_at_event_id`` with this one restore ``graph_epochs``
-        event id. Carried ids reference epoch rows that do not exist in this target
-        (the importer does not replay ``graph_epochs``), so they would dangle.
+        Instance ``created_at_event_id`` resolution (mutually exclusive):
+        - ``event_id_map`` (P5-faithful): remap the carried id through the
+          {old: new} faithful-replay table (``.get(old, old)`` — an unmapped or
+          null carried id passes through).
+        - ``restamp_event_id`` (P5 epoch-simple): override every instance with this
+          one restore event id (carried ids would dangle — the simple path does not
+          replay ``graph_epochs``).
+        - neither: carry verbatim (checkpoint rollback).
         """
         total = len(instances)
         lock = threading.Lock()
         done = {"n": 0}
+
+        def _event_id(inst):
+            carried = inst.get("created_at_event_id")
+            if event_id_map is not None:
+                return event_id_map.get(carried, carried)
+            if restamp_event_id is not None:
+                return restamp_event_id
+            return carried
 
         def work(inst):
             params = {
                 "instance_id": inst["instance_id"],
                 "quote": inst.get("quote", ""),
                 "source_id": inst["source_id"],
-                "created_at_event_id": (
-                    restamp_event_id if restamp_event_id is not None
-                    else inst.get("created_at_event_id")
-                ),
+                "created_at_event_id": _event_id(inst),
             }
             _execute_with_age_retry(client, DataImporter._INSTANCE_Q, params)
             with lock:
@@ -1374,3 +1395,140 @@ class DataImporter:
         if result and int(str(result.get("created", 0))) > 0:
             return 1
         return 0
+
+    # ------------------------------------------------------------------
+    # P5-faithful epoch replay (ADR-102) — clone-only. The worker gates this
+    # to an empty target + idempotent mode and orchestrates the order:
+    #   _ensure_epoch_kinds -> _replay_graph_epochs(in_progress) -> import(map)
+    #   -> _resolve_replayed_epochs(completed) -> _set_ingestion_counter.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _ensure_epoch_kinds(client: AGEClient, reader: "KgBackupV2Reader") -> None:
+        """Upsert the backup's epoch kinds into kg_api.graph_epoch_kinds.
+
+        Faithful replay inserts graph_epochs rows whose ``kind`` is FK-constrained
+        (migration 064) to this lookup, so any carried kind not already present must
+        exist first. ON CONFLICT DO NOTHING preserves the target's own definition
+        for kinds that already exist.
+        """
+        kinds = reader.header.get("epoch_kinds", [])
+        if not kinds:
+            return
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                for k in kinds:
+                    name = k.get("kind") if isinstance(k, dict) else k
+                    if not name:
+                        continue
+                    wallclock = bool(k.get("semantic_wallclock", False)) if isinstance(k, dict) else False
+                    desc = (k.get("description") if isinstance(k, dict) else None) or ""
+                    cur.execute(
+                        "INSERT INTO kg_api.graph_epoch_kinds (kind, semantic_wallclock, description) "
+                        "VALUES (%s, %s, %s) ON CONFLICT (kind) DO NOTHING",
+                        (name, wallclock, desc),
+                    )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            client.pool.putconn(conn)
+
+    @staticmethod
+    def _replay_graph_epochs(client: AGEClient, reader: "KgBackupV2Reader",
+                             status: str = "in_progress") -> Dict[int, int]:
+        """Replay carried graph_epochs as NEW local events (P5-faithful).
+
+        Inserts each carried event in original-id order, letting BIGSERIAL mint a
+        fresh local event_id while carrying occurred_at/kind/actor/counter_after/
+        metadata — so the replayed history's structure (count, order, node→event
+        groupings, wallclock) is faithful even though the ids are new (new ids never
+        collide; no sequence surgery). Returns {old_event_id: new_event_id} for
+        remapping Instance.created_at_event_id.
+
+        Inserted with ``status`` (default 'in_progress') so the committed watermark
+        sits below the lowest new id and the graph reads STALE during the import;
+        the worker resolves them to 'completed' once the import lands.
+        """
+        old_to_new: Dict[int, int] = {}
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                for ep in reader.graph_epochs():
+                    old_id = ep.get("event_id")
+                    cur.execute(
+                        "INSERT INTO kg_api.graph_epochs "
+                        "(occurred_at, kind, actor, counter_after, metadata, status) "
+                        "VALUES (%s::timestamptz, %s, %s, %s, %s::jsonb, %s) RETURNING event_id",
+                        (
+                            ep.get("occurred_at"),
+                            ep.get("kind"),
+                            ep.get("actor"),
+                            ep.get("counter_after"),
+                            json.dumps(ep.get("metadata") or {}),
+                            status,
+                        ),
+                    )
+                    new_id = cur.fetchone()[0]
+                    if old_id is not None:
+                        old_to_new[old_id] = new_id
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            client.pool.putconn(conn)
+        return old_to_new
+
+    @staticmethod
+    def _resolve_replayed_epochs(client: AGEClient, new_event_ids: List[int],
+                                 status: str = "completed") -> None:
+        """Resolve replayed epoch rows to a terminal status (P5-faithful).
+
+        Called after the import lands ('completed') or fails ('failed'). Both count
+        toward the committed watermark (migration 076); completing advances the
+        freshness clock to the max replayed id, failing keeps the graph stale.
+        """
+        if not new_event_ids:
+            return
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE kg_api.graph_epochs SET status = %s WHERE event_id = ANY(%s)",
+                    (status, list(new_event_ids)),
+                )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            client.pool.putconn(conn)
+
+    @staticmethod
+    def _set_ingestion_counter(client: AGEClient, value: int) -> None:
+        """Advance document_ingestion_counter to at least ``value`` (P5-faithful).
+
+        Faithful carries concepts' original created_at/last_seen epochs; the counter
+        must be >= the max carried epoch or restored concepts read as 'from the
+        future' against a lower counter (the P5 hazard) and future ingestion would
+        reissue colliding epoch numbers. GREATEST keeps it monotonic.
+        """
+        if value is None:
+            return
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE graph_metrics SET counter = GREATEST(counter, %s), updated_at = NOW() "
+                    "WHERE metric_name = 'document_ingestion_counter'",
+                    (value,),
+                )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            client.pool.putconn(conn)

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -1308,16 +1308,19 @@ export class KnowledgeGraphClient {
    * @param backupFilePath Path to backup file (.tar.gz archive or .json)
    * @param mode Restore merge mode: 'idempotent' (default), 'adjacent', or 'integration' (ADR-102 P4)
    * @param onUploadProgress Optional callback for upload progress (bytes uploaded, total bytes, percent)
+   * @param epoch Epoch reconciliation: 'simple' (default) or 'faithful' (clone-only) (ADR-102 P5)
    * @returns Job ID and initial status for polling restore progress
    */
   async restoreBackup(
     backupFilePath: string,
     mode: string = 'idempotent',
-    onUploadProgress?: (uploaded: number, total: number, percent: number) => void
+    onUploadProgress?: (uploaded: number, total: number, percent: number) => void,
+    epoch: string = 'simple'
   ): Promise<{ job_id: string; status: string; message: string; backup_stats: any; integrity_warnings: number }> {
     const form = new FormData();
     form.append('file', fs.createReadStream(backupFilePath));
     form.append('mode', mode);
+    form.append('epoch', epoch);
 
     const response = await this.client.post('/admin/restore', form, {
       headers: form.getHeaders(),

--- a/cli/src/cli/admin/backup.ts
+++ b/cli/src/cli/admin/backup.ts
@@ -194,6 +194,7 @@ export function createRestoreCommand(): Command {
     .option('--file <name>', 'Backup filename (from configured directory)')
     .option('--path <path>', 'Custom backup file path (overrides configured directory)')
     .option('--mode <mode>', 'Restore merge mode: "idempotent" (default; MERGE-by-id, clone into empty), "adjacent" (independent copy, fresh ids), or "integration" (attach concepts to existing graph by similarity)', 'idempotent')
+    .option('--epoch <epoch>', 'Epoch reconciliation: "simple" (default; one restore event) or "faithful" (replay the backup\'s history; clone-only — requires --mode idempotent into an empty target)', 'simple')
     .option('--confirm', 'Confirm restore operation (required for non-interactive use)', false)
     .action(async (options) => {
       try {
@@ -206,11 +207,23 @@ export function createRestoreCommand(): Command {
         console.log(colors.status.warning('⚠️  Potentially destructive operation'));
         console.log(separator());
 
-        // Validate the restore mode up front (before any file I/O or upload).
+        // Validate the restore mode + epoch mode up front (before any file I/O or upload).
         const validModes = ['idempotent', 'adjacent', 'integration'];
         if (!validModes.includes(options.mode)) {
           console.error(colors.status.error(
             `\n✗ Invalid --mode "${options.mode}". Expected one of: ${validModes.join(', ')}\n`));
+          process.exit(1);
+        }
+        const validEpochs = ['simple', 'faithful'];
+        if (!validEpochs.includes(options.epoch)) {
+          console.error(colors.status.error(
+            `\n✗ Invalid --epoch "${options.epoch}". Expected one of: ${validEpochs.join(', ')}\n`));
+          process.exit(1);
+        }
+        if (options.epoch === 'faithful' && options.mode !== 'idempotent') {
+          console.error(colors.status.error(
+            `\n✗ --epoch faithful requires --mode idempotent (clone-only). ` +
+            `Use --epoch simple for ${options.mode}, or --mode integration to merge.\n`));
           process.exit(1);
         }
 
@@ -305,7 +318,8 @@ export function createRestoreCommand(): Command {
               const uploadedMB = (uploaded / (1024 * 1024)).toFixed(2);
               const totalMB = (total / (1024 * 1024)).toFixed(2);
               spinner.text = `Uploading backup... ${percent}% (${uploadedMB}/${totalMB} MB)`;
-            }
+            },
+            options.epoch
           );
 
           spinner.succeed('Backup uploaded successfully!');

--- a/cli/src/types/index.ts
+++ b/cli/src/types/index.ts
@@ -721,6 +721,8 @@ export interface RestoreRequest {
   backup_file: string;
   // ADR-102 P4: restore merge mode (replaces overwrite + handle_external_deps).
   mode?: 'idempotent' | 'adjacent' | 'integration';
+  // ADR-102 P5: epoch reconciliation. 'faithful' is clone-only (idempotent + empty target).
+  epoch?: 'simple' | 'faithful';
 }
 
 export interface RestoreResponse {

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -2327,6 +2327,7 @@ kg restore [options]
 | `--file <name>` | Backup filename (from configured directory) | - |
 | `--path <path>` | Custom backup file path (overrides configured directory) | - |
 | `--mode <mode>` | Restore merge mode: "idempotent" (default; MERGE-by-id, clone into empty), "adjacent" (independent copy, fresh ids), or "integration" (attach concepts to existing graph by similarity) | `"idempotent"` |
+| `--epoch <epoch>` | Epoch reconciliation: "simple" (default; one restore event) or "faithful" (replay the backup's history; clone-only — requires --mode idempotent into an empty target) | `"simple"` |
 | `--confirm` | Confirm restore operation (required for non-interactive use) | `false` |
 
 ### scheduler

--- a/docs/reference/cli/commands/admin.md
+++ b/docs/reference/cli/commands/admin.md
@@ -80,6 +80,7 @@ kg restore [options]
 | `--file <name>` | Backup filename (from configured directory) | - |
 | `--path <path>` | Custom backup file path (overrides configured directory) | - |
 | `--mode <mode>` | Restore merge mode: "idempotent" (default; MERGE-by-id, clone into empty), "adjacent" (independent copy, fresh ids), or "integration" (attach concepts to existing graph by similarity) | `"idempotent"` |
+| `--epoch <epoch>` | Epoch reconciliation: "simple" (default; one restore event) or "faithful" (replay the backup's history; clone-only — requires --mode idempotent into an empty target) | `"simple"` |
 | `--confirm` | Confirm restore operation (required for non-interactive use) | `false` |
 
 ### scheduler

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from api.app.lib.age_client import AGEClient
-from api.lib.serialization import DataExporter, DataImporter
+from api.lib.serialization import DataExporter, DataImporter, KgBackupV2Reader
 from api.lib.id_remap import IdRemapper
 from api.app.lib.restore_modes import prepare_backup, RestoreMode
 
@@ -136,6 +136,73 @@ def test_integration_mode_attaches_to_existing_concept(client_with_cleanup):
                         f"OR n.instance_id = $i DETACH DELETE n", params={"i": _id})
                 except Exception:
                     pass
+
+
+def test_faithful_replay_mints_ordered_ids_and_maps_instances(client_with_cleanup):
+    """P5-faithful primitives against the live DB: _replay_graph_epochs mints fresh
+    ordered event_ids carrying occurred_at/kind, and import with event_id_map stamps
+    the restored instance through old→new. Inserts as 'completed' (watermark-safe)
+    and deletes the test epoch rows in a finally."""
+    client = client_with_cleanup
+    backup = DataExporter.build_kg_backup_v2(
+        concepts=[{"concept_id": f"{NS}fc1", "label": "F", "search_terms": [],
+                   "embedding": [0.1, 0.2, 0.3], "created_at_epoch": 5, "last_seen_epoch": 7}],
+        sources=[{"source_id": f"{NS}fs1", "document": "F", "file_path": "/f", "paragraph": 1,
+                  "full_text": "t", "content_type": "text/plain"}],
+        instances=[{"instance_id": f"{NS}fi1", "quote": "q", "source_id": f"{NS}fs1",
+                    "created_at_event_id": 41}],   # carried id → must remap to a new local id
+        evidence=[{"concept_id": f"{NS}fc1", "instance_id": f"{NS}fi1"}],
+        relationships=[], vocabulary=[],
+        embedding_profiles=[{"identity": "x", "vector_space": "x", "image_vector_space": None,
+                             "name": "d", "multimodal": False}],
+        epoch_kinds=[{"kind": "ingestion", "semantic_wallclock": True, "description": ""}],
+        graph_epochs=[
+            {"event_id": 40, "occurred_at": "2026-01-01T00:00:00Z", "kind": "ingestion",
+             "actor": "system", "counter_after": 40, "metadata": {"k": "v"}},
+            {"event_id": 41, "occurred_at": "2026-02-01T00:00:00Z", "kind": "ingestion",
+             "actor": "system", "counter_after": 41, "metadata": {}},
+        ],
+        schema_version=76,
+    )
+    reader = KgBackupV2Reader(backup)
+
+    DataImporter._ensure_epoch_kinds(client, reader)
+    event_id_map = DataImporter._replay_graph_epochs(client, reader, status="completed")
+    new_ids = sorted(event_id_map.values())
+    try:
+        # Two events minted, fresh + ordered (preserve original 40<41 order).
+        assert set(event_id_map.keys()) == {40, 41}
+        assert new_ids[0] < new_ids[1]
+        assert event_id_map[40] < event_id_map[41]
+        # Rows exist carrying the original kind + wallclock.
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT kind, occurred_at FROM kg_api.graph_epochs WHERE event_id = %s",
+                    (event_id_map[40],))
+                row = cur.fetchone()
+                assert row[0] == "ingestion"
+                assert row[1].year == 2026 and row[1].month == 1
+        finally:
+            conn.commit(); client.pool.putconn(conn)
+
+        # Import with the map: the instance's carried event_id 41 → the new local id.
+        DataImporter.import_backup(client, backup, overwrite_existing=True, event_id_map=event_id_map)
+        assert _scalar(client,
+            f"MATCH (i:Instance {{instance_id:'{NS}fi1'}}) "
+            f"WHERE i.created_at_event_id = {event_id_map[41]} RETURN count(i) AS n") == 1
+        assert _scalar(client,
+            f"MATCH (i:Instance {{instance_id:'{NS}fi1'}}) "
+            f"WHERE i.created_at_event_id = 41 RETURN count(i) AS n") == 0
+    finally:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM kg_api.graph_epochs WHERE event_id = ANY(%s)", (new_ids,))
+            conn.commit()
+        finally:
+            client.pool.putconn(conn)
 
 
 def test_merge_relationship_rejects_unsafe_edge_label():

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -205,6 +205,37 @@ def test_faithful_replay_mints_ordered_ids_and_maps_instances(client_with_cleanu
             client.pool.putconn(conn)
 
 
+def test_faithful_unmapped_event_id_is_unstamped_not_dangling(client_with_cleanup):
+    """P5-faithful safety (review M2): an instance referencing an event_id absent
+    from the backup's graph_epochs must be stamped NULL, not passed through to a
+    foreign id that would dangle against the target's fresh epoch sequence."""
+    client = client_with_cleanup
+    backup = DataExporter.build_kg_backup_v2(
+        concepts=[{"concept_id": f"{NS}uc1", "label": "U", "search_terms": [],
+                   "embedding": [0.1, 0.2, 0.3], "created_at_epoch": 1, "last_seen_epoch": 1}],
+        sources=[{"source_id": f"{NS}us1", "document": "U", "file_path": "/u", "paragraph": 1,
+                  "full_text": "t", "content_type": "text/plain"}],
+        # Instance references event 999 — NOT present in graph_epochs below.
+        instances=[{"instance_id": f"{NS}ui1", "quote": "q", "source_id": f"{NS}us1",
+                    "created_at_event_id": 999}],
+        evidence=[{"concept_id": f"{NS}uc1", "instance_id": f"{NS}ui1"}],
+        relationships=[], vocabulary=[],
+        embedding_profiles=[{"identity": "x", "vector_space": "x", "image_vector_space": None,
+                             "name": "d", "multimodal": False}],
+        epoch_kinds=[], graph_epochs=[], schema_version=76,
+    )
+    # event_id_map is empty (no carried epochs) → 999 is unmapped.
+    DataImporter.import_backup(client, backup, overwrite_existing=True, event_id_map={})
+
+    # Stamped NULL (unstamped), NOT the dangling foreign id 999.
+    assert _scalar(client,
+        f"MATCH (i:Instance {{instance_id:'{NS}ui1'}}) "
+        f"WHERE i.created_at_event_id = 999 RETURN count(i) AS n") == 0
+    assert _scalar(client,
+        f"MATCH (i:Instance {{instance_id:'{NS}ui1'}}) "
+        f"WHERE i.created_at_event_id IS NULL RETURN count(i) AS n") == 1
+
+
 def test_merge_relationship_rejects_unsafe_edge_label():
     """A crafted edge label (untrusted backup) is skipped, never interpolated into Cypher."""
     client = MagicMock()

--- a/tests/unit/test_restore_worker_epoch.py
+++ b/tests/unit/test_restore_worker_epoch.py
@@ -50,3 +50,98 @@ def test_restore_raises_when_record_epoch_returns_none(tmp_path):
     client.complete_epoch.assert_not_called()
     # Lanes were still thawed in the finally despite the fatal error (A14).
     thaw.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# P5-faithful eligibility gate + orchestration
+# ---------------------------------------------------------------------------
+from api.lib.serialization import DataExporter, DataImporter  # noqa: E402
+
+
+def _valid_backup(concept_epochs=(11, 12)):
+    """A spec-valid kg-backup/2 object with two carried epoch events."""
+    return DataExporter.build_kg_backup_v2(
+        concepts=[{"concept_id": "c1", "label": "A", "search_terms": [], "embedding": [0.1],
+                   "created_at_epoch": concept_epochs[0], "last_seen_epoch": concept_epochs[1]}],
+        sources=[{"source_id": "s1", "document": "D", "file_path": "/d", "paragraph": 1,
+                  "full_text": "t", "content_type": "text/plain"}],
+        instances=[{"instance_id": "i1", "quote": "q", "source_id": "s1", "created_at_event_id": 1}],
+        evidence=[{"concept_id": "c1", "instance_id": "i1"}],
+        relationships=[],
+        vocabulary=[],
+        embedding_profiles=[{"identity": "x", "vector_space": "x", "image_vector_space": None,
+                             "name": "d", "multimodal": False}],
+        epoch_kinds=[{"kind": "ingestion", "semantic_wallclock": True, "description": ""}],
+        graph_epochs=[
+            {"event_id": 1, "occurred_at": "2026-01-01T00:00:00Z", "kind": "ingestion",
+             "actor": "system", "counter_after": 1, "metadata": {}},
+            {"event_id": 2, "occurred_at": "2026-02-01T00:00:00Z", "kind": "ingestion",
+             "actor": "system", "counter_after": 2, "metadata": {}},
+        ],
+        schema_version=76,
+    )
+
+
+def _run_faithful(tmp_path, mode="idempotent", target_empty=True, backup=None):
+    """Drive run_restore_worker in faithful mode with all DB/lane I/O mocked."""
+    backup = backup or _valid_backup()
+    temp_file = tmp_path / "b.json"
+    temp_file.write_text(json.dumps(backup))
+
+    job_queue = MagicMock()
+    job_queue.is_job_cancelled.return_value = False
+    client = MagicMock()
+
+    with patch.object(restore_worker, "AGEClient", return_value=client), \
+         patch.object(restore_worker, "freeze_lanes", return_value={"interactive": True}), \
+         patch.object(restore_worker, "wait_for_quiesce", return_value=True), \
+         patch.object(restore_worker, "thaw_lanes"), \
+         patch.object(restore_worker, "_create_checkpoint_backup", return_value=(tmp_path / "nope.json")), \
+         patch.object(restore_worker, "_target_is_empty", return_value=target_empty), \
+         patch.object(restore_worker, "prepare_backup", return_value=(backup, {})), \
+         patch.object(DataImporter, "_ensure_epoch_kinds") as ensure, \
+         patch.object(DataImporter, "_replay_graph_epochs", return_value={1: 101, 2: 102}) as replay, \
+         patch.object(DataImporter, "_resolve_replayed_epochs") as resolve, \
+         patch.object(DataImporter, "_set_ingestion_counter") as set_counter, \
+         patch.object(restore_worker, "_execute_restore", return_value={"concepts": 1}) as execute:
+        result = restore_worker.run_restore_worker(
+            {"temp_file": str(temp_file), "temp_file_id": "t", "mode": mode, "epoch": "faithful"},
+            "job_faithful", job_queue,
+        )
+    return result, dict(ensure=ensure, replay=replay, resolve=resolve,
+                        set_counter=set_counter, execute=execute)
+
+
+def test_faithful_rejects_non_idempotent_mode(tmp_path):
+    with pytest.raises(Exception, match="requires --mode idempotent"):
+        _run_faithful(tmp_path, mode="adjacent")
+
+
+def test_faithful_rejects_non_empty_target(tmp_path):
+    with pytest.raises(Exception, match="requires an EMPTY target"):
+        _run_faithful(tmp_path, mode="idempotent", target_empty=False)
+
+
+def test_faithful_orchestration_replays_and_resolves(tmp_path):
+    result, m = _run_faithful(tmp_path)
+
+    # Replay happened in_progress; instances stamped via the old→new map; concepts
+    # NOT restamped (epoch_restamp is None for faithful).
+    m["ensure"].assert_called_once()
+    m["replay"].assert_called_once()
+    assert m["replay"].call_args.kwargs.get("status") == "in_progress"
+    _, exec_kwargs = m["execute"].call_args
+    assert exec_kwargs["event_id_map"] == {1: 101, 2: 102}
+    assert exec_kwargs["epoch_restamp"] is None
+
+    # Resolved completed; counter advanced to max carried concept epoch (12).
+    # _resolve_replayed_epochs(client, new_event_ids, status) — positional.
+    m["resolve"].assert_called_once()
+    assert sorted(m["resolve"].call_args[0][1]) == [101, 102]
+    assert m["resolve"].call_args[0][2] == "completed"
+    m["set_counter"].assert_called_once()
+    assert m["set_counter"].call_args[0][1] == 12
+
+    assert result["epoch_mode"] == "faithful"
+    assert result["faithful_epochs_replayed"] == 2
+    assert result["restore_epoch_event_id"] is None


### PR DESCRIPTION
## ADR-102 P5-faithful — faithful epoch replay (clone-only)

Fast-follow to P5 (#482). Adds `epoch=faithful` to the restore: instead of collapsing the backup's history into one restore event (epoch-simple), it **replays the carried `graph_epochs` as a new local sequence that mirrors the backup's structure**.

### The mechanism (decided with maintainer)
`graph_epochs.event_id` is `BIGSERIAL`, so we do NOT force the backup's literal ids. We replay each carried event in original-id order, letting the sequence mint a **fresh local id** while carrying `occurred_at/kind/actor/counter_after/metadata` — so the *shape* (event count, order, node→event groupings, wallclock) is faithful even though ids are new. Fresh ids never collide → no `setval` surgery.

- **Gate (clone-only):** `faithful` ⟹ `idempotent` mode + **empty** target (no nodes, no `graph_epochs`). Otherwise **reject** with actionable alternatives (`--epoch simple`, or `--mode integration`). No silent downgrade — faithful is an explicit opt-in.
- **Stale-during-import:** replayed rows insert `status='in_progress'` (watermark sits below them → graph reads stale during import), resolve to `'completed'` after the import lands (`'failed'` on error — still counts toward the watermark, keeping things stale).
- **Instances:** `created_at_event_id` remapped through the `{old: new}` table (`import_backup(event_id_map=…)`).
- **Concepts:** carry their *original* `created_at_epoch/last_seen_epoch` (the separate `document_ingestion_counter` space); the worker advances the counter to `max(carried)` so vitality + future ingestion stay monotonic.
- **Selection:** `epoch={simple|faithful}` request param + `kg restore --epoch` flag (default `simple`).

### Primitives (DataImporter)
`_ensure_epoch_kinds` (FK upsert) · `_replay_graph_epochs` · `_resolve_replayed_epochs` · `_set_ingestion_counter` · `event_id_map` threading through the import path.

### Tests
- Gate rejections (non-idempotent, non-empty target).
- Mocked orchestration: replay→map→resolve(completed)→counter ordering + result fields.
- **Live importer-primitive test**: `_replay_graph_epochs` mints fresh *ordered* ids carrying `occurred_at/kind`, and the import remaps the instance through old→new (epoch rows cleaned up in a finally; inserted `completed` so the dev watermark is untouched).

Full suite: **1320 passed / 16 skipped / 1 failed** — the failure is the pre-existing vision-config dev-DB pollution (unrelated).

### Note
The eligibility gate means faithful can't be exercised end-to-end through the queue on the populated dev graph (by design); the live test covers the replay SQL directly, mocked tests cover the worker wiring + gate.