### PR TITLE
ADR-102 review follow-ups: true-replace rollback (#483) + orphaned-epoch reconciliation (#485)

### DIFF
--- a/api/app/services/job_scheduler.py
+++ b/api/app/services/job_scheduler.py
@@ -18,6 +18,14 @@ import os
 
 logger = logging.getLogger(__name__)
 
+# Terminal job statuses — a CLOSED, stable set. The orphaned-epoch sweep keys on
+# this (denylist) rather than the non-terminal set (which keeps growing:
+# pending/awaiting_approval/approved/queued/running/processing/...), so it stays
+# correct-by-construction as the pre-execution status vocabulary evolves. An epoch
+# is reconciled only when its owning job is terminal OR absent; ANY non-terminal
+# status protects it. (review #486 M1)
+TERMINAL_JOB_STATUSES = ("completed", "failed", "cancelled")
+
 
 def reconcile_orphaned_epochs(queue) -> List[int]:
     """Resolve orphaned in_progress graph_epochs to 'failed' (issue #485).
@@ -27,9 +35,11 @@ def reconcile_orphaned_epochs(queue) -> List[int]:
     row in_progress forever, pinning the committed watermark
     (kg_api.get_committed_epoch, migration 076) below it — so EVERY derivation reads
     stale indefinitely. This resolves any in_progress epoch whose owning job
-    (``metadata->>'job_id'``) is no longer active to 'failed'. A failed event still
-    counts toward the watermark, so this unblocks freshness without falsely claiming
-    the partial mutation completed.
+    (``metadata->>'job_id'``) is terminal (TERMINAL_JOB_STATUSES) or absent to
+    'failed'. A failed event still counts toward the watermark, so this unblocks
+    freshness without falsely claiming the partial mutation completed. Keying on the
+    closed terminal set (not the open non-terminal set) means ANY non-terminal
+    status protects a live epoch — correct-by-construction.
 
     Only job_id-bearing rows are swept: every long-lived in_progress epoch carries
     one (ingestion and restore-simple stamp it; P5-faithful stamps the local restore
@@ -44,6 +54,7 @@ def reconcile_orphaned_epochs(queue) -> List[int]:
             cur.execute("SELECT to_regclass('kg_api.graph_epochs') IS NOT NULL")
             if not cur.fetchone()[0]:
                 return []
+            # Resolve when NO non-terminal job owns the epoch (job terminal or absent).
             cur.execute("""
                 UPDATE kg_api.graph_epochs e
                 SET status = 'failed'
@@ -52,10 +63,10 @@ def reconcile_orphaned_epochs(queue) -> List[int]:
                   AND NOT EXISTS (
                       SELECT 1 FROM kg_api.jobs j
                       WHERE j.job_id = e.metadata->>'job_id'
-                        AND j.status IN ('pending', 'approved', 'running', 'processing')
+                        AND j.status NOT IN %s
                   )
                 RETURNING e.event_id
-            """)
+            """, (TERMINAL_JOB_STATUSES,))
             rows = cur.fetchall()
             conn.commit()
             return [r[0] for r in rows]

--- a/api/app/services/job_scheduler.py
+++ b/api/app/services/job_scheduler.py
@@ -12,11 +12,58 @@ Based on ADR-014: Job Approval Workflow
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 import logging
 import os
 
 logger = logging.getLogger(__name__)
+
+
+def reconcile_orphaned_epochs(queue) -> List[int]:
+    """Resolve orphaned in_progress graph_epochs to 'failed' (issue #485).
+
+    A crash between recording an in_progress epoch (record_epoch, or the P5-faithful
+    replay) and resolving it (complete_epoch / _resolve_replayed_epochs) leaves the
+    row in_progress forever, pinning the committed watermark
+    (kg_api.get_committed_epoch, migration 076) below it — so EVERY derivation reads
+    stale indefinitely. This resolves any in_progress epoch whose owning job
+    (``metadata->>'job_id'``) is no longer active to 'failed'. A failed event still
+    counts toward the watermark, so this unblocks freshness without falsely claiming
+    the partial mutation completed.
+
+    Only job_id-bearing rows are swept: every long-lived in_progress epoch carries
+    one (ingestion and restore-simple stamp it; P5-faithful stamps the local restore
+    job_id), so the transient in_progress window of atomic record_mutation calls
+    (which never sets job_id and self-resolves in the same call) is never touched.
+
+    Returns the list of reconciled event_ids.
+    """
+    conn = queue._get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT to_regclass('kg_api.graph_epochs') IS NOT NULL")
+            if not cur.fetchone()[0]:
+                return []
+            cur.execute("""
+                UPDATE kg_api.graph_epochs e
+                SET status = 'failed'
+                WHERE e.status = 'in_progress'
+                  AND e.metadata->>'job_id' IS NOT NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM kg_api.jobs j
+                      WHERE j.job_id = e.metadata->>'job_id'
+                        AND j.status IN ('pending', 'approved', 'running', 'processing')
+                  )
+                RETURNING e.event_id
+            """)
+            rows = cur.fetchall()
+            conn.commit()
+            return [r[0] for r in rows]
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        queue._return_connection(conn)
 
 
 class JobScheduler:
@@ -253,6 +300,19 @@ class JobScheduler:
                 queue._return_connection(conn)
         except Exception as e:
             logger.error(f"Error reaping stale jobs: {e}", exc_info=True)
+
+        # Task 4b (issue #485): reconcile orphaned in_progress graph_epochs. Runs
+        # AFTER the reaper so a just-failed job's epochs resolve the same cycle.
+        try:
+            reconciled = reconcile_orphaned_epochs(queue)
+            if reconciled:
+                logger.warning(
+                    f"Reconciled {len(reconciled)} orphaned in_progress graph_epoch(s) "
+                    f"to 'failed' (owning job terminal/absent) — unblocked the "
+                    f"committed watermark"
+                )
+        except Exception as e:
+            logger.error(f"Error reconciling orphaned epochs: {e}", exc_info=True)
 
         # Task 5: Annealing proposal lifecycle cleanup
         try:

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -641,11 +641,12 @@ def _restore_from_checkpoint(client: AGEClient, checkpoint_path: Path, job_id: s
     # Issue #483: TRUE-REPLACE rollback. A MERGE-only re-import leaves behind any
     # node the failed restore created that the checkpoint does not contain (orphans,
     # stamped with the failed restore epoch). Clear the concept graph first so the
-    # rollback reconstructs EXACTLY the pre-restore state. The checkpoint was a
-    # known-good full export captured at restore start; if the re-import below fails
-    # after the clear, the checkpoint file is preserved on disk (see below) and the
-    # caller flags "manual intervention required" — so a clear+failed-reimport is
-    # recoverable, whereas silent orphans are not. _clear_database preserves
+    # rollback reconstructs EXACTLY the pre-restore state. NOTE: clear and re-import
+    # are NOT one transaction — a process crash between them leaves the graph empty.
+    # That worst case is recoverable: the checkpoint was a known-good full export
+    # captured at restore start, it is preserved on disk (see below), and the caller
+    # flags "manual intervention required" — strictly better than silent permanent
+    # orphans. _clear_database preserves
     # vocabulary + graph_epochs (the checkpoint's instance event-id stamps still
     # resolve against the retained epoch rows).
     logger.info(f"[{job_id}] Clearing concept graph before checkpoint re-import (true replace)")

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -242,7 +242,8 @@ def run_restore_worker(
             # reconciliation sweep that fixes both is tracked in issue #485.
             reader = KgBackupV2Reader(prepared_backup)
             DataImporter._ensure_epoch_kinds(client, reader)
-            event_id_map = DataImporter._replay_graph_epochs(client, reader, status="in_progress")
+            event_id_map = DataImporter._replay_graph_epochs(
+                client, reader, status="in_progress", owner_job_id=job_id)
             replayed_event_ids = list(event_id_map.values())
             logger.info(f"[{job_id}] Faithful replay minted {len(replayed_event_ids)} epoch events")
         else:
@@ -422,14 +423,11 @@ def run_restore_worker(
         # ADR-102 P5: resolve the restore epoch as FAILED so it stops holding the
         # committed watermark below its event_id (a phantom in-flight event would
         # stall freshness for the whole graph). A FAILED event still counts toward
-        # the committed watermark (migration 076), which keeps the graph reading
-        # STALE — important, because the rollback below is MERGE-only (no clear):
-        # any node the failed restore created that is absent from the checkpoint
-        # SURVIVES the rollback, stamped with this failed restore_event_id. That
-        # residue reads stale (safe), but a true-replace rollback is tracked in
-        # issue #483 (pre-existing MERGE-without-clear weakness). For faithful the
-        # same applies: the resolved-'failed' replayed epoch rows survive referencing
-        # nothing (the empty-target checkpoint rollback is a no-op), reading stale.
+        # the committed watermark (migration 076), keeping the graph reading STALE.
+        # The rollback below is now a TRUE replace (issue #483 fixed —
+        # _restore_from_checkpoint clears before re-importing), so failed-restore
+        # node orphans are removed. The failed epoch ROWS themselves remain in
+        # graph_epochs referencing nothing (reads stale = safe; faithful leaves N).
         if client is not None:
             if restore_event_id is not None:  # epoch-simple
                 client.complete_epoch(restore_event_id, "failed")
@@ -640,8 +638,21 @@ def _restore_from_checkpoint(client: AGEClient, checkpoint_path: Path, job_id: s
     with open(checkpoint_path, 'r', encoding='utf-8') as f:
         checkpoint_data = json.load(f)
 
-    # Restore from checkpoint using DataImporter.import_backup()
-    # No need to clear database - import_backup() uses MERGE which handles overwrites
+    # Issue #483: TRUE-REPLACE rollback. A MERGE-only re-import leaves behind any
+    # node the failed restore created that the checkpoint does not contain (orphans,
+    # stamped with the failed restore epoch). Clear the concept graph first so the
+    # rollback reconstructs EXACTLY the pre-restore state. The checkpoint was a
+    # known-good full export captured at restore start; if the re-import below fails
+    # after the clear, the checkpoint file is preserved on disk (see below) and the
+    # caller flags "manual intervention required" — so a clear+failed-reimport is
+    # recoverable, whereas silent orphans are not. _clear_database preserves
+    # vocabulary + graph_epochs (the checkpoint's instance event-id stamps still
+    # resolve against the retained epoch rows).
+    logger.info(f"[{job_id}] Clearing concept graph before checkpoint re-import (true replace)")
+    _clear_database(client, job_id)
+
+    # Restore from checkpoint using DataImporter.import_backup() (MERGE-by-id into
+    # the now-cleared graph; carries the checkpoint's own epoch stamps, no restamp).
     logger.info(f"[{job_id}] Restoring checkpoint data")
     DataImporter.import_backup(client, checkpoint_data, overwrite_existing=True)
 

--- a/api/lib/serialization.py
+++ b/api/lib/serialization.py
@@ -1460,7 +1460,8 @@ class DataImporter:
 
     @staticmethod
     def _replay_graph_epochs(client: AGEClient, reader: "KgBackupV2Reader",
-                             status: str = "in_progress") -> Dict[int, int]:
+                             status: str = "in_progress",
+                             owner_job_id: Optional[str] = None) -> Dict[int, int]:
         """Replay carried graph_epochs as NEW local events (P5-faithful).
 
         Inserts each carried event in original-id order, letting BIGSERIAL mint a
@@ -1473,6 +1474,11 @@ class DataImporter:
         Inserted with ``status`` (default 'in_progress') so the committed watermark
         sits below the lowest new id and the graph reads STALE during the import;
         the worker resolves them to 'completed' once the import lands.
+
+        ``owner_job_id`` (issue #485): stamp the LOCAL restore job into each row's
+        metadata under ``job_id`` so the orphaned-epoch reconciliation sweep can tell
+        a still-running restore's in_progress rows from a crashed one's. The backup's
+        original ``job_id`` (a foreign id) is preserved under ``source_job_id``.
         """
         old_to_new: Dict[int, int] = {}
         conn = client.pool.getconn()
@@ -1480,6 +1486,13 @@ class DataImporter:
             with conn.cursor() as cur:
                 for ep in reader.graph_epochs():
                     old_id = ep.get("event_id")
+                    metadata = dict(ep.get("metadata") or {})
+                    if owner_job_id is not None:
+                        # Reserve metadata.job_id for the LOCAL owning job (the sweep
+                        # invariant); keep the backup's original under source_job_id.
+                        if "job_id" in metadata:
+                            metadata["source_job_id"] = metadata["job_id"]
+                        metadata["job_id"] = owner_job_id
                     # counter_after is carried verbatim — it snapshots the SOURCE
                     # graph's graph_change_counter, a foreign counter space. It is
                     # display-only (epoch_facade timeline), never drives the watermark
@@ -1493,7 +1506,7 @@ class DataImporter:
                             ep.get("kind"),
                             ep.get("actor"),
                             ep.get("counter_after"),
-                            json.dumps(ep.get("metadata") or {}),
+                            json.dumps(metadata),
                             status,
                         ),
                     )

--- a/tests/api/test_epoch_reconciliation.py
+++ b/tests/api/test_epoch_reconciliation.py
@@ -119,3 +119,26 @@ def test_reconcile_resolves_orphans_but_spares_active_jobs(shim):
         assert _epoch_status(shim, e_running) == "in_progress"
     finally:
         _cleanup(shim, [e_failed, e_running, e_absent], [failed_job, running_job])
+
+
+@pytest.mark.parametrize("status,spared", [
+    ("pending", True),
+    ("awaiting_approval", True),   # review #486 M1: must be spared (pre-execution, live)
+    ("approved", True),
+    ("queued", True),             # review #486 M1: must be spared
+    ("processing", True),
+    ("completed", False),          # terminal → reconciled
+    ("cancelled", False),          # terminal → reconciled
+])
+def test_reconcile_spares_all_non_terminal_statuses(shim, status, spared):
+    """The sweep keys on the closed terminal set, so EVERY non-terminal job status
+    protects its epoch — locks the M1 invariant against future status additions."""
+    job_id = f"{NS}{status}_{uuid.uuid4().hex[:8]}"
+    _seed_job(shim, job_id, status)
+    eid = _seed_epoch(shim, job_id)
+    try:
+        reconcile_orphaned_epochs(shim)
+        expected = "in_progress" if spared else "failed"
+        assert _epoch_status(shim, eid) == expected
+    finally:
+        _cleanup(shim, [eid], [job_id])

--- a/tests/api/test_epoch_reconciliation.py
+++ b/tests/api/test_epoch_reconciliation.py
@@ -1,0 +1,121 @@
+"""Live test for orphaned in_progress epoch reconciliation (issue #485).
+
+reconcile_orphaned_epochs resolves in_progress graph_epochs whose owning job
+(metadata->>'job_id') is no longer active to 'failed', unblocking the committed
+watermark after a crash. Verifies the three cases against the live DB:
+  - owning job FAILED (terminal)  → reconciled
+  - owning job absent             → reconciled
+  - owning job RUNNING (active)   → left alone (a live restore/ingestion in flight)
+
+Uses an AGEClient pool shim (the repo's live-DB pattern; the job-queue singleton
+isn't initialized in the test process). All test rows (epochs + jobs) are
+namespaced and removed in a finally.
+"""
+import json
+import uuid
+
+import pytest
+
+from api.app.lib.age_client import AGEClient
+from api.app.services.job_scheduler import reconcile_orphaned_epochs
+
+NS = "job_test485_"
+
+
+class _PoolShim:
+    """Adapts an AGEClient pool to the queue interface reconcile_orphaned_epochs uses."""
+    def __init__(self, client):
+        self._pool = client.pool
+
+    def _get_connection(self):
+        return self._pool.getconn()
+
+    def _return_connection(self, conn):
+        self._pool.putconn(conn)
+
+
+@pytest.fixture()
+def shim():
+    client = AGEClient()
+    try:
+        yield _PoolShim(client)
+    finally:
+        client.close()
+
+
+def _seed_job(shim, job_id, status):
+    conn = shim._get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO kg_api.jobs (job_id, job_type, status, job_data, user_id) "
+                "VALUES (%s, 'ingestion', %s, '{}'::jsonb, 1)",
+                (job_id, status),
+            )
+        conn.commit()
+    finally:
+        shim._return_connection(conn)
+
+
+def _seed_epoch(shim, job_id):
+    conn = shim._get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO kg_api.graph_epochs (kind, actor, status, metadata) "
+                "VALUES ('ingestion', 'test-485', 'in_progress', %s::jsonb) RETURNING event_id",
+                (json.dumps({"job_id": job_id}),),
+            )
+            eid = cur.fetchone()[0]
+        conn.commit()
+        return eid
+    finally:
+        shim._return_connection(conn)
+
+
+def _epoch_status(shim, event_id):
+    conn = shim._get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT status FROM kg_api.graph_epochs WHERE event_id = %s", (event_id,))
+            row = cur.fetchone()
+            return row[0] if row else None
+    finally:
+        conn.commit()
+        shim._return_connection(conn)
+
+
+def _cleanup(shim, event_ids, job_ids):
+    conn = shim._get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM kg_api.graph_epochs WHERE event_id = ANY(%s)", (list(event_ids),))
+            cur.execute("DELETE FROM kg_api.jobs WHERE job_id = ANY(%s)", (list(job_ids),))
+        conn.commit()
+    finally:
+        shim._return_connection(conn)
+
+
+def test_reconcile_resolves_orphans_but_spares_active_jobs(shim):
+    failed_job = f"{NS}failed_{uuid.uuid4().hex[:8]}"
+    running_job = f"{NS}running_{uuid.uuid4().hex[:8]}"
+    absent_job = f"{NS}absent_{uuid.uuid4().hex[:8]}"  # never inserted
+
+    _seed_job(shim, failed_job, "failed")
+    _seed_job(shim, running_job, "running")
+    e_failed = _seed_epoch(shim, failed_job)
+    e_running = _seed_epoch(shim, running_job)
+    e_absent = _seed_epoch(shim, absent_job)
+
+    try:
+        reconciled = reconcile_orphaned_epochs(shim)
+
+        # Orphans (failed + absent owning job) resolved; active (running) spared.
+        assert e_failed in reconciled
+        assert e_absent in reconciled
+        assert e_running not in reconciled
+        assert _epoch_status(shim, e_failed) == "failed"
+        assert _epoch_status(shim, e_absent) == "failed"
+        assert _epoch_status(shim, e_running) == "in_progress"
+    finally:
+        _cleanup(shim, [e_failed, e_running, e_absent], [failed_job, running_job])

--- a/tests/unit/test_restore_worker_epoch.py
+++ b/tests/unit/test_restore_worker_epoch.py
@@ -145,3 +145,26 @@ def test_faithful_orchestration_replays_and_resolves(tmp_path):
     assert result["epoch_mode"] == "faithful"
     assert result["faithful_epochs_replayed"] == 2
     assert result["restore_epoch_event_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# #483: rollback is a true replace (clear before checkpoint re-import)
+# ---------------------------------------------------------------------------
+def test_rollback_clears_before_reimport(tmp_path):
+    """_restore_from_checkpoint must _clear_database BEFORE re-importing so a failed
+    restore's orphan nodes (absent from the checkpoint) don't survive the rollback."""
+    checkpoint = tmp_path / "ckpt.json"
+    checkpoint.write_text(json.dumps(_minimal_backup()))
+
+    client = MagicMock()
+    calls = []
+    with patch.object(restore_worker, "_clear_database",
+                      side_effect=lambda *a, **k: calls.append("clear")) as clear, \
+         patch.object(DataImporter, "import_backup",
+                      side_effect=lambda *a, **k: calls.append("import")) as imp:
+        restore_worker._restore_from_checkpoint(client, checkpoint, "job_rb", MagicMock())
+
+    clear.assert_called_once()
+    imp.assert_called_once()
+    # Order matters: clear must precede the checkpoint re-import.
+    assert calls == ["clear", "import"]


### PR DESCRIPTION
Closes #483, closes #485. Both deferred from the P5 / P5-faithful reviews.

## #483 — true-replace restore rollback
`_restore_from_checkpoint` was MERGE-only, so nodes a failed restore created that the checkpoint doesn't contain survived rollback (stamped with the failed epoch). It now `_clear_database()`s the concept graph **before** re-importing the checkpoint = true replace.
- The checkpoint is a known-good full export from restore start. If the post-clear re-import also fails, the checkpoint file is preserved on disk and the caller already flags "manual intervention required" — recoverable, vs. silent orphans which weren't.
- `_clear_database` preserves vocabulary + `graph_epochs`, so the checkpoint's instance event-id stamps still resolve.

## #485 — orphaned in_progress epoch reconciliation
A crash between recording an `in_progress` graph_epoch and resolving it left the row `in_progress` forever, pinning the committed watermark (`get_committed_epoch`) → every derivation reads stale indefinitely. Affects ingestion + restore-simple (1 row) + faithful (N).
- New `reconcile_orphaned_epochs(queue)` (run in `JobScheduler.cleanup_jobs`, right after the stale-job reaper) resolves `in_progress` epochs whose owning job (`metadata->>'job_id'`) is no longer active → `failed` (still counts toward the watermark, so it unblocks without claiming the partial mutation completed).
- Only `job_id`-bearing rows are swept, so atomic `record_mutation`'s transient in_progress window is never touched.
- P5-faithful now stamps the **local** restore `job_id` into replayed rows (the backup's original is preserved under `source_job_id`), so a live restore's rows aren't swept mid-flight.

## Tests
- `#483`: rollback clears-before-reimport (call order asserted).
- `#485`: live reconciliation — failed/absent owning job → resolved to `failed`, running → spared.
- Full suite: 1323 passed / 16 skipped / 1 failed (pre-existing vision-config dev-DB pollution, unrelated).