### PR TITLE
docs(adr-102): document the intentional two-validator layering (P6c)

### DIFF
--- a/api/app/lib/backup_integrity.py
+++ b/api/app/lib/backup_integrity.py
@@ -9,9 +9,21 @@ archived, or restored. Validates the single backup model (``kg-backup/2``):
 - External dependencies (concept references not contained in this backup — partial backups)
 - Statistics (record counts surfaced for logging)
 
-This is the *runtime* checker. The exhaustive *offline* oracle is
-``scripts/development/lint/lint_backup.py`` (used in tests/linting). Consolidating
-the two v2 validators is tracked for ADR-102 P6.
+This is the *runtime* checker, deliberately distinct from the offline oracle
+``scripts/development/lint/lint_backup.py``. They validate DIFFERENT layers and are
+intentionally NOT merged (evaluated and decided in ADR-102 P6 — do not "consolidate"
+them):
+  - THIS module checks the DE-INTERNED logical graph via :class:`KgBackupV2Reader`
+    (referential integrity, external deps, statistics) — the cheap runtime gate run
+    before a backup is streamed / archived / restored.
+  - ``lint_backup`` checks the RAW interned on-disk structure (dictionary index
+    ranges, interning integrity, §6 derived-product exclusions, format negotiation)
+    and carries NO api-package dependency by design (ADR-102 Track D), so the
+    pytest oracle can load it standalone by file path.
+
+A shared core would force one layer's representation onto the other and couple the
+standalone oracle to the api package; the narrow overlap (reference / external-dep
+checks) does not justify the cost.
 """
 
 from typing import Dict, List, Optional, Any, Set

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -16,6 +16,17 @@ suites and a future live API endpoint import that directly. The CLI is a thin
 wrapper that reads a path, calls the core, prints issues, and exits non-zero if
 any ERROR was found (CI convention, matching the sibling lint tools).
 
+Relationship to the runtime checker (ADR-102 P6 — intentionally NOT merged):
+this is the *independent* verification tool — a deliberately standalone oracle
+with NO api-package dependency, which is what makes it a convenient CI / test /
+build gate and an outside check on the serializer. It validates the RAW interned
+on-disk structure (dictionary index resolution, interning integrity, §6 exclusions,
+format negotiation). Its runtime counterpart, ``api/app/lib/backup_integrity.py``,
+validates the DE-INTERNED logical graph via :class:`KgBackupV2Reader` as the cheap
+gate before stream/archive/restore. The two check different layers for different
+consumers; consolidating them would couple this oracle to the api package and
+strip its interning-layer coverage, so they are kept separate by design.
+
 Checks implemented (see ``CHECK_CODES`` for the stable code registry):
   - HEADER presence / well-formedness and format_version family negotiation (§7)
   - kg-backup/2 required header fields (§3.1)
@@ -34,7 +45,7 @@ Usage:
     python3 scripts/development/lint/lint_backup.py <path-to-archive.tar.gz>
     python3 scripts/development/lint/lint_backup.py --selftest
 
-@verified cffa180b
+@verified b832d59d
 """
 
 import argparse


### PR DESCRIPTION
## ADR-102 P6c — chunk C resolved as document-don't-merge

Chunk C was scoped to "consolidate the two drifting kg-backup/2 validators." Verify-in-code
**inverted that premise**: they are not duplicates — they validate different layers for
different consumers, and merging them would do harm. So this PR documents the intentional
separation rather than forcing a shared core.

### The finding
| Validator | Layer it checks | Consumer | Dependency |
|---|---|---|---|
| `scripts/development/lint/lint_backup.py` | **RAW interned** on-disk structure (index ranges, interning integrity, §6 exclusions, format negotiation) | pytest oracle + CI/test/build gate; an independent outside check on the serializer | **none** (standalone by design — ADR-102 Track D) |
| `api/app/lib/backup_integrity.py` | **DE-INTERNED** logical graph via `KgBackupV2Reader` (referential integrity, external deps, stats) | runtime gate before stream/archive/restore | api package |

`lint_backup` deliberately does **not** use `KgBackupV2Reader` — the reader de-interns, which
would hide the very interning bugs the oracle exists to catch. A shared core would force one
layer's representation onto the other and couple the standalone oracle to the api package,
sacrificing the independence that makes it a useful CI/build check. The real overlap
(reference/external-dep checks) is narrow and expressed on incompatible layers.

### What changed
Docs only, no behavior change:
- Cross-reference docstrings added to **both** files making the layering explicit and warning
  against a future mistaken merge.
- Supersedes the stale `backup_integrity.py` note that said consolidation "is tracked for ADR-102 P6".
- Restamps `lint_backup` `@verified cffa180b → b832d59d` (docstring touched).

### Tests
- `lint_backup --selftest` → PASS
- `test_backup_integrity.py` + `test_kg_backup_v2.py` → 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)