### PR TITLE
fix(restore): lift nginx 1 MB body cap that 413'd restore uploads

### DIFF
--- a/docker/nginx.prod.conf
+++ b/docker/nginx.prod.conf
@@ -51,6 +51,17 @@ server {
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
+
+        # Backup restore (ADR-015) and document/image ingest stream
+        # multipart/form-data bodies whose size scales with the data. nginx
+        # caps request bodies at 1 MB by default and rejects larger uploads
+        # with 413 *before* they reach the endpoint. Lift the cap to a bounded
+        # value — NOT 0/unlimited: this check runs before the route's auth
+        # dependency (and nginx buffers the whole body first), so it's the only
+        # thing limiting how much an *unauthenticated* client can make us
+        # receive and spool to temp disk per request. 256m clears realistic
+        # backups with headroom while bounding that pre-auth sink.
+        client_max_body_size 256m;
     }
 
     # SPA routing

--- a/install.sh
+++ b/install.sh
@@ -2193,6 +2193,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Backup restore (ADR-015) and document/image ingest stream multipart
+        # bodies that scale with the data. nginx's 1 MB default rejects them
+        # with 413 before they reach the endpoint. Bounded (not 0/unlimited):
+        # this cap runs before the route's auth dependency and nginx buffers
+        # the whole body first, so it limits what an unauthenticated client can
+        # make us receive and spool to temp disk per request.
+        client_max_body_size 256m;
     }
 
     # Frontend
@@ -2236,6 +2244,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
+
+        # Backup restore (ADR-015) and document/image ingest stream multipart
+        # bodies that scale with the data. nginx's 1 MB default rejects them
+        # with 413 before they reach the endpoint. Bounded (not 0/unlimited):
+        # this cap runs before the route's auth dependency and nginx buffers
+        # the whole body first, so it limits what an unauthenticated client can
+        # make us receive and spool to temp disk per request.
+        client_max_body_size 256m;
     }
 
     # Frontend (static files)

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -7,6 +7,14 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Parity with nginx.prod.conf and install.sh's generated configs: backup
+    # restore (ADR-015) and ingest stream multipart bodies that scale with the
+    # data, and nginx's 1 MB default body cap rejects them with 413. Bounded
+    # (not 0/unlimited) because the cap runs before route auth — see the longer
+    # note in nginx.prod.conf. This SPA config doesn't proxy /api/ today, so the
+    # directive is inert here, but it keeps the guard consistent.
+    client_max_body_size 256m;
+
     # Gzip compression for better performance
     gzip on;
     gzip_vary on;


### PR DESCRIPTION
## Problem
`kg admin restore` on cube (staging) failed with **HTTP 413** on a 16.33 MB backup. The 413 came from **nginx**, not the app: the reverse proxy fronting `/api/` has no `client_max_body_size`, so it defaulted to **1 MB** and rejected the upload before it ever reached FastAPI.

The app already streams the upload correctly (ADR-015 multipart) — the cap was purely a proxy-layer gate. Same gate would hit document/image ingest as graphs grow.

## Fix
Raise `client_max_body_size` to a bounded **256m** on the `/api/` proxy in all three nginx config sources:
- `install.sh` — both `generate_nginx_http_config` and `generate_nginx_ssl_config` (**this is what standalone/cube actually run**)
- `docker/nginx.prod.conf` (broccoli.house compose path)
- `web/nginx.conf` (baked image config; inert today, parity for the future)

## Why bounded, not `0`/unlimited
nginx checks `client_max_body_size` **before** the route's `backups:restore` auth dependency, and buffers the whole body first. So this cap is the only thing limiting how much an *unauthenticated* client can make the server receive and spool to temp disk per request. 256m clears realistic backups (16× the current one) while keeping that pre-auth sink bounded.

## Verification
Applied live to cube and reloaded nginx → restore proceeded and **completed successfully** (3994 concepts / 313 sources / 7108 instances / 8705 relationships, checkpoint auto-deleted). Graph is queryable.

## Follow-up (separate)
- Restore drops the `:Ontology` registry layer — tracked on its own branch.
- Optional: proxy-level auth on `/api/admin/*` to close the pre-auth upload sink entirely.