### PR TITLE
fix(serialization): serialize the :Ontology layer in kg-backup/2 round-trip

### DIFF
--- a/api/lib/id_remap.py
+++ b/api/lib/id_remap.py
@@ -7,12 +7,15 @@ rewritten through the maps. A missed class silently orphans edges (ADR-102
 Consequences: "a missed class silently orphans relationships"), so the rewrite is
 exhaustive and is covered class-by-class by the test matrix:
 
-  - ``concept_id``  → concepts, ``evidence.concept_id``, relationship ``from``/``to``
-  - ``source_id``   → sources, ``instances.source_id``, **and the ``learned_id`` EDGE
+  - ``concept_id``  → concepts, ``evidence.concept_id``, relationship ``from``/``to``,
+                      ``anchored_by.concept_id`` (:Ontology→:Concept provenance)
+  - ``source_id``   → sources, ``instances.source_id``, ``scoped_by.source_id``
+                      (:Source→:Ontology membership), **and the ``learned_id`` EDGE
                       property** (a source_id carried on agent-learned edges)
   - ``instance_id`` → instances, ``evidence.instance_id``
   - image ``storage_key`` → **recomputed** from the new source_id (derived, not an id)
   - ``garage_key`` (source document) → content-addressed (sha256): **IMMUNE**, preserved
+  - ``ontologies`` nodes / ontology ``name`` → no minted id; carried unchanged
 
 Pure and DB-free: emits a NEW valid ``kg-backup/2`` object (which flows through the
 normal clone path unchanged) plus the old→new mapping table — a restore artifact
@@ -156,6 +159,23 @@ class IdRemapper:
                 r2["properties"] = p2
             new_rels.append(r2)
         new_bulk["relationships"] = new_rels
+
+        # Ontology nodes carry no concept/source/instance id — only their own
+        # ontology_id and a stable name — so they pass through unchanged (like
+        # vocabulary). Their EDGES, however, reference app-ids and must be remapped
+        # so they land on the freshly-minted nodes rather than silently orphaning.
+        if "ontologies" in bulk:
+            new_bulk["ontologies"] = bulk["ontologies"]
+        if "scoped_by" in bulk:
+            new_bulk["scoped_by"] = [
+                {**e, "source_id": source_map.get(e["source_id"], e["source_id"])}
+                for e in bulk["scoped_by"]
+            ]
+        if "anchored_by" in bulk:
+            new_bulk["anchored_by"] = [
+                {**e, "concept_id": concept_map.get(e["concept_id"], e["concept_id"])}
+                for e in bulk["anchored_by"]
+            ]
 
         # Streams with no app-ids are carried through unchanged.
         new_bulk["vocabulary"] = bulk.get("vocabulary", [])

--- a/api/lib/serialization/exporter.py
+++ b/api/lib/serialization/exporter.py
@@ -395,6 +395,8 @@ class DataExporter:
             ontologies.append({
                 "ontology_id": _parse_nullable_str(record.get("ontology_id")),
                 "name": str(record.get("name", "")).strip('"'),
+                # description normalizes null→"" (production defaults it to "" at
+                # create time; the null/empty distinction carries no meaning here).
                 "description": _parse_nullable_str(record.get("description")) or "",
                 "embedding": embedding,
                 "search_terms": search_terms,

--- a/api/lib/serialization/exporter.py
+++ b/api/lib/serialization/exporter.py
@@ -35,6 +35,21 @@ def _parse_nullable_int(raw: Any) -> Optional[int]:
         return None
 
 
+def _parse_nullable_str(raw: Any) -> Optional[str]:
+    """Parse a nullable string from an AGE agtype scalar.
+
+    Distinguishes a genuinely absent/NULL property (``None`` or the literal
+    ``"null"``) from an empty string, which AGE returns as ``'""'``. Used for
+    optional node properties like ``Ontology.created_by``.
+    """
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if s.lower() == "null":
+        return None
+    return s.strip('"')
+
+
 class DataExporter:
     """Export graph data to JSON format"""
 
@@ -328,6 +343,127 @@ class DataExporter:
         return relationships
 
     @staticmethod
+    def export_ontologies(client: AGEClient, ontology: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Export :Ontology nodes as first-class records (full fidelity).
+
+        Ontologies are first-class graph entities in the concept embedding space,
+        not derivable from sources — the ``s.document`` string is only a
+        denormalized cache of membership. A backup that drops them loses the
+        registry that ``kg ontology list`` / the catalog browse tree depend on,
+        plus the ``lifecycle_state`` (``frozen`` ontologies would silently become
+        writable on restore). Round-trips with :func:`export_scoped_by` /
+        :func:`export_anchored_by` and the importer's ``_import_ontologies``.
+
+        Args:
+            client: AGEClient instance
+            ontology: Optional name filter (None = all ontologies)
+
+        Returns:
+            List of ontology node dictionaries with full embeddings.
+        """
+        if ontology:
+            query = """
+                MATCH (o:Ontology {name: $ontology})
+                RETURN o.ontology_id as ontology_id, o.name as name,
+                       o.description as description, o.embedding as embedding,
+                       o.search_terms as search_terms, o.lifecycle_state as lifecycle_state,
+                       o.creation_epoch as creation_epoch, o.created_by as created_by
+                ORDER BY o.name
+            """
+            result = client._execute_cypher(query, params={"ontology": ontology})
+        else:
+            query = """
+                MATCH (o:Ontology)
+                RETURN o.ontology_id as ontology_id, o.name as name,
+                       o.description as description, o.embedding as embedding,
+                       o.search_terms as search_terms, o.lifecycle_state as lifecycle_state,
+                       o.creation_epoch as creation_epoch, o.created_by as created_by
+                ORDER BY o.name
+            """
+            result = client._execute_cypher(query)
+
+        ontologies = []
+        for record in result:
+            try:
+                search_terms = json.loads(str(record.get("search_terms", "[]")))
+            except json.JSONDecodeError:
+                search_terms = []
+            try:
+                embedding = json.loads(str(record.get("embedding", "[]")))
+            except json.JSONDecodeError:
+                embedding = []
+            ontologies.append({
+                "ontology_id": _parse_nullable_str(record.get("ontology_id")),
+                "name": str(record.get("name", "")).strip('"'),
+                "description": _parse_nullable_str(record.get("description")) or "",
+                "embedding": embedding,
+                "search_terms": search_terms,
+                "lifecycle_state": _parse_nullable_str(record.get("lifecycle_state")) or "active",
+                "creation_epoch": _parse_nullable_int(record.get("creation_epoch")),
+                "created_by": _parse_nullable_str(record.get("created_by")),
+            })
+
+        return ontologies
+
+    @staticmethod
+    def export_scoped_by(client: AGEClient, ontology: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Export (:Source)-[:SCOPED_BY]->(:Ontology) edges — ontology membership.
+
+        ``:SCOPED_BY`` is the source of truth for which ontology a source belongs
+        to (``s.document`` is the denormalized cache). Exported explicitly so the
+        membership graph round-trips rather than being re-derived heuristically.
+        """
+        if ontology:
+            query = """
+                MATCH (s:Source)-[:SCOPED_BY]->(o:Ontology {name: $ontology})
+                RETURN s.source_id as source_id, o.name as ontology
+                ORDER BY s.source_id
+            """
+            result = client._execute_cypher(query, params={"ontology": ontology})
+        else:
+            query = """
+                MATCH (s:Source)-[:SCOPED_BY]->(o:Ontology)
+                RETURN s.source_id as source_id, o.name as ontology
+                ORDER BY s.source_id, o.name
+            """
+            result = client._execute_cypher(query)
+
+        return [
+            {"source_id": str(r.get("source_id", "")).strip('"'),
+             "ontology": str(r.get("ontology", "")).strip('"')}
+            for r in result
+        ]
+
+    @staticmethod
+    def export_anchored_by(client: AGEClient, ontology: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Export (:Ontology)-[:ANCHORED_BY]->(:Concept) edges — founding concepts.
+
+        Links a promoted ontology to the concept it grew from (ADR-200). The
+        concept exists independently; this edge records provenance and must
+        survive a clone so promotion history is not lost.
+        """
+        if ontology:
+            query = """
+                MATCH (o:Ontology {name: $ontology})-[:ANCHORED_BY]->(c:Concept)
+                RETURN o.name as ontology, c.concept_id as concept_id
+                ORDER BY c.concept_id
+            """
+            result = client._execute_cypher(query, params={"ontology": ontology})
+        else:
+            query = """
+                MATCH (o:Ontology)-[:ANCHORED_BY]->(c:Concept)
+                RETURN o.name as ontology, c.concept_id as concept_id
+                ORDER BY o.name, c.concept_id
+            """
+            result = client._execute_cypher(query)
+
+        return [
+            {"ontology": str(r.get("ontology", "")).strip('"'),
+             "concept_id": str(r.get("concept_id", "")).strip('"')}
+            for r in result
+        ]
+
+    @staticmethod
     def export_vocabulary(client: AGEClient) -> List[Dict[str, Any]]:
         """
         Export relationship vocabulary table (ADR-032)
@@ -544,6 +680,9 @@ class DataExporter:
         epoch_kinds: List[Dict[str, Any]],
         graph_epochs: List[Dict[str, Any]],
         schema_version: int,
+        ontologies: Optional[List[Dict[str, Any]]] = None,
+        scoped_by: Optional[List[Dict[str, Any]]] = None,
+        anchored_by: Optional[List[Dict[str, Any]]] = None,
         source_platform: str = "knowledge-graph-system",
         source_version: str = "unknown",
         exported_at: Optional[str] = None,
@@ -607,16 +746,19 @@ class DataExporter:
                 actor_index[a] = len(actors)
                 actors.append(a)
 
-        # ontologies (with their default profile index = active profile)
+        # header.ontologies: the per-ontology embedding-profile registry (the
+        # name→active-profile map the §4.1 cascade reads). Distinct from the
+        # bulk.ontologies NODE stream (the ``ontologies`` parameter) — a separate
+        # local so it does not shadow that parameter.
         if ontology:
-            ontologies = [{"name": ontology, "default_embedding_profile": 0}]
+            header_ontologies = [{"name": ontology, "default_embedding_profile": 0}]
         else:
             seen: List[str] = []
             for s in sources:
                 doc = s.get("document")
                 if doc and doc not in seen:
                     seen.append(doc)
-            ontologies = [{"name": d, "default_embedding_profile": 0} for d in seen]
+            header_ontologies = [{"name": d, "default_embedding_profile": 0} for d in seen]
 
         header = {
             "format_version": KG_BACKUP_FORMAT_VERSION,
@@ -629,7 +771,7 @@ class DataExporter:
             "epoch_kinds": epoch_kinds,
             "actors": actors,
             "content_types": content_types,
-            "ontologies": ontologies,
+            "ontologies": header_ontologies,
         }
 
         # bulk: intern references by index
@@ -669,6 +811,12 @@ class DataExporter:
                 "relationships": bulk_rels,
                 "vocabulary": vocabulary,
                 "graph_epochs": bulk_epochs,
+                # First-class :Ontology nodes + their membership/provenance edges.
+                # Not interned (small cardinality); empty for backups taken before
+                # this stream existed (the reader tolerates absence).
+                "ontologies": list(ontologies or []),
+                "scoped_by": list(scoped_by or []),
+                "anchored_by": list(anchored_by or []),
             },
         }
 
@@ -691,6 +839,9 @@ class DataExporter:
         embedding_profiles = DataExporter.export_embedding_profiles(client)
         epoch_kinds = DataExporter.export_epoch_kinds(client)
         graph_epochs = DataExporter.export_graph_epochs(client)
+        ontologies = DataExporter.export_ontologies(client, ontology)
+        scoped_by = DataExporter.export_scoped_by(client, ontology)
+        anchored_by = DataExporter.export_anchored_by(client, ontology)
         DataExporter._log_vocabulary_summary(relationships, vocabulary)
 
         return DataExporter.build_kg_backup_v2(
@@ -698,6 +849,7 @@ class DataExporter:
             evidence=evidence, relationships=relationships, vocabulary=vocabulary,
             embedding_profiles=embedding_profiles, epoch_kinds=epoch_kinds,
             graph_epochs=graph_epochs,
+            ontologies=ontologies, scoped_by=scoped_by, anchored_by=anchored_by,
             schema_version=BackupFormat.get_schema_version(client),
             ontology=ontology,
         )

--- a/api/lib/serialization/format.py
+++ b/api/lib/serialization/format.py
@@ -169,11 +169,29 @@ class KgBackupV2Reader:
             rec["actor"] = self._actors[a] if isinstance(a, int) else a
             yield rec
 
+    def ontologies(self):
+        """Yield :Ontology node records (name, embedding, lifecycle_state, ...).
+
+        Empty for backups taken before the ontology stream existed — restoring
+        such a backup simply creates no ontology nodes (the prior behavior).
+        """
+        for o in self.bulk.get("ontologies", []):
+            yield dict(o)
+
+    def scoped_by(self):
+        """Return (:Source)-[:SCOPED_BY]->(:Ontology) edges as ``{source_id, ontology}``."""
+        return list(self.bulk.get("scoped_by", []))
+
+    def anchored_by(self):
+        """Return (:Ontology)-[:ANCHORED_BY]->(:Concept) edges as ``{ontology, concept_id}``."""
+        return list(self.bulk.get("anchored_by", []))
+
     def counts(self):
         """Return record counts per bulk stream (for stats/logging)."""
         b = self.bulk
         return {k: len(b.get(k, [])) for k in
-                ("concepts", "sources", "instances", "evidence", "relationships", "vocabulary")}
+                ("concepts", "sources", "instances", "evidence", "relationships",
+                 "vocabulary", "ontologies", "scoped_by", "anchored_by")}
 
     def external_concept_ids(self):
         """Concept ids referenced by edges/evidence but absent from this backup.

--- a/api/lib/serialization/importer.py
+++ b/api/lib/serialization/importer.py
@@ -175,6 +175,7 @@ class DataImporter:
             "vocabulary_imported": 0,
             "concepts_created": 0,
             "sources_created": 0,
+            "ontologies_created": 0,
             "instances_created": 0,
             "relationships_created": 0,
         }
@@ -195,6 +196,15 @@ class DataImporter:
         Console.info("Importing sources...")
         DataImporter._import_sources(client, sources, progress_callback)
         stats["sources_created"] = len(sources)
+
+        # Ontologies after concepts + sources: SCOPED_BY needs sources, ANCHORED_BY
+        # needs concepts (both already imported above). Absent in pre-stream backups.
+        ontologies = list(reader.ontologies())
+        if ontologies:
+            Console.info(f"Importing {len(ontologies)} ontologies (+SCOPED_BY/ANCHORED_BY)...")
+            stats["ontologies_created"] = DataImporter._import_ontologies(
+                client, ontologies, reader.scoped_by(), reader.anchored_by(), progress_callback
+            )
 
         instances = list(reader.instances())
         Console.info("Importing instances...")
@@ -396,6 +406,70 @@ class DataImporter:
                 params["storage_key"] = s["storage_key"]
             _execute_with_age_retry(client, query, params)
             _progress(progress_callback, "sources", i + 1, total, every=1)
+
+    @staticmethod
+    def _import_ontologies(client: AGEClient,
+                           ontologies: List[Dict[str, Any]],
+                           scoped_by: List[Dict[str, Any]],
+                           anchored_by: List[Dict[str, Any]],
+                           progress_callback) -> int:
+        """MERGE :Ontology nodes and their SCOPED_BY / ANCHORED_BY edges.
+
+        Clone-faithful and idempotent (MERGE + SET), so re-running a restore
+        re-converges. Nodes are written first so the edge MERGEs can match both
+        endpoints; an edge whose other endpoint (source/concept) is absent simply
+        matches nothing and is skipped — no dangling edge is created.
+
+        Returns the number of ontology nodes written.
+        """
+        total = len(ontologies)
+        node_query = """
+            MERGE (o:Ontology {ontology_id: $ontology_id})
+            SET o.name = $name,
+                o.description = $description,
+                o.embedding = $embedding,
+                o.search_terms = $search_terms,
+                o.lifecycle_state = $lifecycle_state,
+                o.creation_epoch = $creation_epoch,
+                o.created_by = $created_by
+        """
+        for i, o in enumerate(ontologies):
+            params = {
+                "ontology_id": o.get("ontology_id"),
+                "name": o.get("name"),
+                "description": o.get("description", ""),
+                "embedding": o.get("embedding", []),
+                "search_terms": o.get("search_terms", []),
+                "lifecycle_state": o.get("lifecycle_state", "active"),
+                "creation_epoch": o.get("creation_epoch"),
+                "created_by": o.get("created_by"),
+            }
+            _execute_with_age_retry(client, node_query, params)
+            _progress(progress_callback, "ontologies", i + 1, total, every=1)
+
+        # SCOPED_BY: (Source)-[:SCOPED_BY]->(Ontology), keyed by ontology name.
+        scoped_query = """
+            MATCH (s:Source {source_id: $source_id}), (o:Ontology {name: $ontology})
+            MERGE (s)-[:SCOPED_BY]->(o)
+        """
+        for edge in scoped_by:
+            _execute_with_age_retry(client, scoped_query, {
+                "source_id": edge.get("source_id"),
+                "ontology": edge.get("ontology"),
+            })
+
+        # ANCHORED_BY: (Ontology)-[:ANCHORED_BY]->(Concept), founding-concept provenance.
+        anchored_query = """
+            MATCH (o:Ontology {name: $ontology}), (c:Concept {concept_id: $concept_id})
+            MERGE (o)-[:ANCHORED_BY]->(c)
+        """
+        for edge in anchored_by:
+            _execute_with_age_retry(client, anchored_query, {
+                "ontology": edge.get("ontology"),
+                "concept_id": edge.get("concept_id"),
+            })
+
+        return total
 
     @staticmethod
     def _import_instances(client: AGEClient, instances: List[Dict[str, Any]],

--- a/api/lib/serialization/importer.py
+++ b/api/lib/serialization/importer.py
@@ -420,12 +420,20 @@ class DataImporter:
         endpoints; an edge whose other endpoint (source/concept) is absent simply
         matches nothing and is skipped — no dangling edge is created.
 
+        Identity is keyed on ``name``, NOT ``ontology_id`` — ``name`` is the
+        natural key the rest of the system uses (``ensure_ontology_exists`` /
+        ``get_ontology_node`` / both edge MATCHes key on it, and the SCOPED_BY /
+        ANCHORED_BY edges below cite ontologies by name). MERGE-on-name keeps a
+        single node per name across merge modes (where ``ontology_id`` is carried
+        verbatim and could otherwise collide-by-id or, when null, collapse every
+        id-less ontology into one node); ``ontology_id`` is restored as a property.
+
         Returns the number of ontology nodes written.
         """
         total = len(ontologies)
         node_query = """
-            MERGE (o:Ontology {ontology_id: $ontology_id})
-            SET o.name = $name,
+            MERGE (o:Ontology {name: $name})
+            SET o.ontology_id = $ontology_id,
                 o.description = $description,
                 o.embedding = $embedding,
                 o.search_terms = $search_terms,

--- a/docs/reference/BACKUP_OBJECT_SPEC.md
+++ b/docs/reference/BACKUP_OBJECT_SPEC.md
@@ -278,10 +278,17 @@ grounded in the current exporter (`api/lib/serialization.py`,
     "evidence":      [ ... ],
     "relationships": [ ... ],
     "vocabulary":    [ ... ],
-    "graph_epochs":  [ ... ]
+    "graph_epochs":  [ ... ],
+    "ontologies":    [ ... ],
+    "scoped_by":     [ ... ],
+    "anchored_by":   [ ... ]
   }
 }
 ```
+
+> **`ontologies` / `scoped_by` / `anchored_by` are additive streams.** A reader
+> tolerates their absence (older backups predate them and simply restore no
+> ontology layer). They are NOT interned (small cardinality) — see §5.7.
 
 ### 5.1 concepts
 
@@ -404,6 +411,54 @@ Present **only** when the backup is produced for faithful epoch replay
 > **Why CLONE-only.** Faithful replay is coherent only when identity is
 > preserved 1:1 (empty target). In MERGE the epoch collapses to one restore
 > event (simple mode), so the source's `graph_epochs` rows are not carried.
+
+### 5.7 ontologies, scoped_by, anchored_by — the ontology layer
+
+`:Ontology` nodes are **first-class primary inputs**, not derived: they carry
+their own `embedding` (in the concept space), `lifecycle_state`, and curator
+metadata that nothing post-restore can reconstruct. A backup that omitted them
+silently dropped `kg ontology list` / the catalog browse tree on restore, and
+turned a `frozen` ontology back into a writable one. These three streams carry
+the nodes and their two edge classes so the layer round-trips faithfully.
+
+They are **not interned** (ontology cardinality is tiny — tens, not tens of
+thousands) and are **additive**: a backup taken before they existed simply lacks
+the keys, and the reader yields empty.
+
+**`ontologies`** — one record per `:Ontology` node:
+
+| Field | Type | Notes |
+|---|---|---|
+| `ontology_id` | string | App-assigned (`ont_<uuid>`). Carried unchanged by ID remapping (its own id space — not a concept/source/instance id). MERGE key on restore. |
+| `name` | string | The ontology name; matches `sources[].document` and is the key the edges below cite. Stable identifier — never minted/remapped. |
+| `description` | string | Curator description (may be empty). |
+| `embedding` | array of floats | Ontology vector, same space as concepts. |
+| `search_terms` | array of strings | Alternative names for similarity matching. |
+| `lifecycle_state` | string | `active` \| `pinned` \| `frozen`. **Load-bearing** — a lost `frozen` silently re-opens an ontology to writes. |
+| `creation_epoch` | integer or null | Global epoch when created. |
+| `created_by` | string or null | Creating user (ADR-200). |
+
+**`scoped_by`** — `(:Source)-[:SCOPED_BY]->(:Ontology)` membership (the source of
+truth; `Source.document` is a denormalized cache):
+
+| Field | Type | Notes |
+|---|---|---|
+| `source_id` | string | Participates in ID remapping (source map). |
+| `ontology` | string | The `ontologies[].name` it belongs to. Not remapped. |
+
+**`anchored_by`** — `(:Ontology)-[:ANCHORED_BY]->(:Concept)` founding-concept
+provenance (ADR-200):
+
+| Field | Type | Notes |
+|---|---|---|
+| `ontology` | string | The `ontologies[].name`. Not remapped. |
+| `concept_id` | string | Participates in ID remapping (concept map). |
+
+The independent validator (`lint_backup.py`) enforces referential integrity for
+all three: duplicate `ontology_id`/`name`, and `scoped_by`/`anchored_by`
+endpoints that resolve to an existing source/concept/ontology
+(`E_SCOPED_*` / `E_ANCHORED_*` / `E_DUP_ONTOLOGY_*`). This is why `kg admin
+verify` round-trip-checks the ontology layer without a restore.
 
 ---
 

--- a/docs/reference/BACKUP_OBJECT_SPEC.md
+++ b/docs/reference/BACKUP_OBJECT_SPEC.md
@@ -429,8 +429,8 @@ the keys, and the reader yields empty.
 
 | Field | Type | Notes |
 |---|---|---|
-| `ontology_id` | string | App-assigned (`ont_<uuid>`). Carried unchanged by ID remapping (its own id space — not a concept/source/instance id). MERGE key on restore. |
-| `name` | string | The ontology name; matches `sources[].document` and is the key the edges below cite. Stable identifier — never minted/remapped. |
+| `ontology_id` | string | App-assigned (`ont_<uuid>`). Carried unchanged by ID remapping (its own id space — not a concept/source/instance id). Restored as a property, NOT the MERGE key. |
+| `name` | string | The ontology name; matches `sources[].document` and is the key the edges below cite. **The natural key**: restore MERGEs the node on `name` (consistent with `ensure_ontology_exists` and the edge MATCHes), so a same-named ontology with a different `ontology_id` converges to one node across merge modes rather than duplicating. Stable identifier — never minted/remapped. |
 | `description` | string | Curator description (may be empty). |
 | `embedding` | array of floats | Ontology vector, same space as concepts. |
 | `search_terms` | array of strings | Alternative names for similarity matching. |
@@ -454,11 +454,13 @@ provenance (ADR-200):
 | `ontology` | string | The `ontologies[].name`. Not remapped. |
 | `concept_id` | string | Participates in ID remapping (concept map). |
 
-The independent validator (`lint_backup.py`) enforces referential integrity for
-all three: duplicate `ontology_id`/`name`, and `scoped_by`/`anchored_by`
-endpoints that resolve to an existing source/concept/ontology
-(`E_SCOPED_*` / `E_ANCHORED_*` / `E_DUP_ONTOLOGY_*`). This is why `kg admin
-verify` round-trip-checks the ontology layer without a restore.
+The independent validator (`lint_backup.py`) enforces integrity for all three:
+duplicate `ontology_id`/`name`, duplicate edges, `scoped_by`/`anchored_by`
+endpoints that resolve to an existing source/concept/ontology, and the ontology
+embedding dimension against the backup-default profile (`E_DUP_ONTOLOGY_*` /
+`E_DUP_SCOPED_BY` / `E_DUP_ANCHORED_BY` / `E_SCOPED_*` / `E_ANCHORED_*` /
+`E_ONTOLOGY_EMBEDDING_DIM`). This is why `kg admin verify` round-trip-checks the
+ontology layer without a restore.
 
 ---
 

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -127,6 +127,13 @@ CHECK_CODES = {
     "E_DUP_CONCEPT_ID": "duplicate concept_id.",
     "E_DUP_SOURCE_ID": "duplicate source_id.",
     "E_DUP_INSTANCE_ID": "duplicate instance_id.",
+    "E_DUP_ONTOLOGY_ID": "duplicate ontology_id.",
+    "E_DUP_ONTOLOGY_NAME": "duplicate ontology name.",
+    # ontology streams (first-class :Ontology nodes + their edges)
+    "E_SCOPED_SOURCE_MISSING": "scoped_by.source_id not in sources[].",
+    "E_SCOPED_ONTOLOGY_MISSING": "scoped_by.ontology not in ontologies[].",
+    "E_ANCHORED_CONCEPT_MISSING": "anchored_by.concept_id not in concepts[].",
+    "E_ANCHORED_ONTOLOGY_MISSING": "anchored_by.ontology not in ontologies[].",
     # exclusions
     "E_DERIVED_PRESENT": "derived product present in bulk (must be excluded).",
 }
@@ -587,6 +594,58 @@ def _validate_bulk(
                 result.add(ERROR, "E_EPOCH_ACTOR_RANGE",
                            f"graph_epoch.actor={actor} out of range [0,{n_actors}).",
                            f"$.bulk.graph_epochs[{i}].actor")
+
+    # ---- ontologies: first-class :Ontology nodes; dup ids/names ----
+    # Absent in pre-stream backups (the .get defaults to []), so this whole block
+    # is a no-op there — the streams are additive and back-compatible.
+    ontology_ids = set()
+    ontology_names = set()
+    for i, o in enumerate(bulk.get("ontologies") or []):
+        if not isinstance(o, dict):
+            continue
+        oid = o.get("ontology_id")
+        if oid is not None:
+            if oid in ontology_ids:
+                result.add(ERROR, "E_DUP_ONTOLOGY_ID",
+                           f"duplicate ontology_id {oid!r}.",
+                           f"$.bulk.ontologies[{i}].ontology_id")
+            ontology_ids.add(oid)
+        name = o.get("name")
+        if name is not None:
+            if name in ontology_names:
+                result.add(ERROR, "E_DUP_ONTOLOGY_NAME",
+                           f"duplicate ontology name {name!r}.",
+                           f"$.bulk.ontologies[{i}].name")
+            ontology_names.add(name)
+
+    # ---- scoped_by / anchored_by: edge endpoints must resolve (no silent orphans) ----
+    for i, e in enumerate(bulk.get("scoped_by") or []):
+        if not isinstance(e, dict):
+            continue
+        sid = e.get("source_id")
+        if sid is not None and sid not in source_ids:
+            result.add(ERROR, "E_SCOPED_SOURCE_MISSING",
+                       f"scoped_by.source_id {sid!r} not present in sources[].",
+                       f"$.bulk.scoped_by[{i}].source_id")
+        on = e.get("ontology")
+        if on is not None and on not in ontology_names:
+            result.add(ERROR, "E_SCOPED_ONTOLOGY_MISSING",
+                       f"scoped_by.ontology {on!r} not present in ontologies[].",
+                       f"$.bulk.scoped_by[{i}].ontology")
+
+    for i, e in enumerate(bulk.get("anchored_by") or []):
+        if not isinstance(e, dict):
+            continue
+        cid = e.get("concept_id")
+        if cid is not None and cid not in concept_ids:
+            result.add(ERROR, "E_ANCHORED_CONCEPT_MISSING",
+                       f"anchored_by.concept_id {cid!r} not present in concepts[].",
+                       f"$.bulk.anchored_by[{i}].concept_id")
+        on = e.get("ontology")
+        if on is not None and on not in ontology_names:
+            result.add(ERROR, "E_ANCHORED_ONTOLOGY_MISSING",
+                       f"anchored_by.ontology {on!r} not present in ontologies[].",
+                       f"$.bulk.anchored_by[{i}].ontology")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -129,7 +129,10 @@ CHECK_CODES = {
     "E_DUP_INSTANCE_ID": "duplicate instance_id.",
     "E_DUP_ONTOLOGY_ID": "duplicate ontology_id.",
     "E_DUP_ONTOLOGY_NAME": "duplicate ontology name.",
+    "E_DUP_SCOPED_BY": "duplicate (source_id, ontology) SCOPED_BY edge.",
+    "E_DUP_ANCHORED_BY": "duplicate (ontology, concept_id) ANCHORED_BY edge.",
     # ontology streams (first-class :Ontology nodes + their edges)
+    "E_ONTOLOGY_EMBEDDING_DIM": "ontology embedding length != resolved profile @dims.",
     "E_SCOPED_SOURCE_MISSING": "scoped_by.source_id not in sources[].",
     "E_SCOPED_ONTOLOGY_MISSING": "scoped_by.ontology not in ontologies[].",
     "E_ANCHORED_CONCEPT_MISSING": "anchored_by.concept_id not in concepts[].",
@@ -618,7 +621,22 @@ def _validate_bulk(
                            f"$.bulk.ontologies[{i}].name")
             ontology_names.add(name)
 
-    # ---- scoped_by / anchored_by: edge endpoints must resolve (no silent orphans) ----
+        # Embedding-dimension check (§3.2), mirroring concepts. Ontologies live in
+        # the concept space and have no per-record profile override, so they resolve
+        # to the backup-default profile. Only checked when a NON-EMPTY vector is
+        # present — an ontology created without an embedding carries [] legitimately.
+        embedding = o.get("embedding")
+        if isinstance(embedding, list) and embedding:
+            dims = _profile_dims(profiles, backup_default)
+            if dims is not None and len(embedding) != dims:
+                ident = profiles[backup_default].get("identity")
+                result.add(ERROR, "E_ONTOLOGY_EMBEDDING_DIM",
+                           f"ontology {name!r} embedding has {len(embedding)} dims but "
+                           f"backup-default profile ({ident!r}) declares {dims}.",
+                           f"$.bulk.ontologies[{i}].embedding")
+
+    # ---- scoped_by / anchored_by: endpoints resolve (no silent orphans) + no dup edges ----
+    seen_scoped = set()
     for i, e in enumerate(bulk.get("scoped_by") or []):
         if not isinstance(e, dict):
             continue
@@ -632,7 +650,15 @@ def _validate_bulk(
             result.add(ERROR, "E_SCOPED_ONTOLOGY_MISSING",
                        f"scoped_by.ontology {on!r} not present in ontologies[].",
                        f"$.bulk.scoped_by[{i}].ontology")
+        pair = (sid, on)
+        if sid is not None and on is not None:
+            if pair in seen_scoped:
+                result.add(ERROR, "E_DUP_SCOPED_BY",
+                           f"duplicate SCOPED_BY edge ({sid!r} -> {on!r}).",
+                           f"$.bulk.scoped_by[{i}]")
+            seen_scoped.add(pair)
 
+    seen_anchored = set()
     for i, e in enumerate(bulk.get("anchored_by") or []):
         if not isinstance(e, dict):
             continue
@@ -646,6 +672,13 @@ def _validate_bulk(
             result.add(ERROR, "E_ANCHORED_ONTOLOGY_MISSING",
                        f"anchored_by.ontology {on!r} not present in ontologies[].",
                        f"$.bulk.anchored_by[{i}].ontology")
+        pair = (on, cid)
+        if on is not None and cid is not None:
+            if pair in seen_anchored:
+                result.add(ERROR, "E_DUP_ANCHORED_BY",
+                           f"duplicate ANCHORED_BY edge ({on!r} -> {cid!r}).",
+                           f"$.bulk.anchored_by[{i}]")
+            seen_anchored.add(pair)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -122,6 +122,50 @@ def test_ontology_nodes_and_edges_round_trip(client_with_cleanup):
         f"RETURN count(*) AS n") == 1
 
 
+def test_ontology_merges_on_name_not_id(client_with_cleanup):
+    """Merge safety: an incoming ontology with the same NAME but a different
+    ontology_id converges onto the one node (keyed by name), not a duplicate.
+
+    The rest of the system keys ontologies by name; MERGE-on-name keeps a single
+    node and lets the SCOPED_BY/ANCHORED_BY MATCHes (which bind by name) resolve
+    unambiguously. Regression guard for the adjacent/integration collision case.
+    """
+    client = client_with_cleanup
+    # Pre-existing ontology in the target: same name, DIFFERENT id.
+    client._execute_cypher(
+        "CREATE (o:Ontology {name: $name, ontology_id: $oid, lifecycle_state: 'active'})",
+        params={"name": f"{NS}Onto", "oid": f"{NS}ontA"})
+
+    backup = DataExporter.build_kg_backup_v2(
+        concepts=[{"concept_id": f"{NS}oc1", "label": "Anchor", "search_terms": [],
+                   "embedding": [0.1, 0.2, 0.3], "created_at_epoch": 1, "last_seen_epoch": 1}],
+        sources=[{"source_id": f"{NS}os1", "document": f"{NS}Onto", "file_path": "/o",
+                  "paragraph": 1, "full_text": "t", "content_type": "text/plain"}],
+        instances=[], evidence=[], relationships=[], vocabulary=[],
+        embedding_profiles=[{"identity": "openai:text-embedding-3-small@1536", "vector_space": "x",
+                             "image_vector_space": None, "name": "d", "multimodal": False}],
+        epoch_kinds=[], graph_epochs=[],
+        ontologies=[{"ontology_id": f"{NS}ontB", "name": f"{NS}Onto",  # SAME name, different id
+                     "description": "", "embedding": [0.4, 0.5, 0.6], "search_terms": [],
+                     "lifecycle_state": "frozen", "creation_epoch": 2, "created_by": None}],
+        scoped_by=[{"source_id": f"{NS}os1", "ontology": f"{NS}Onto"}],
+        anchored_by=[{"ontology": f"{NS}Onto", "concept_id": f"{NS}oc1"}],
+        schema_version=76,
+    )
+    DataImporter.import_backup(client, backup, overwrite_existing=True)
+
+    # Exactly ONE node with that name — the id mismatch did NOT spawn a duplicate.
+    assert _scalar(client,
+        f"MATCH (o:Ontology {{name:'{NS}Onto'}}) RETURN count(o) AS n") == 1
+    # Edges attach unambiguously to that single node.
+    assert _scalar(client,
+        f"MATCH (:Source {{source_id:'{NS}os1'}})-[:SCOPED_BY]->(:Ontology {{name:'{NS}Onto'}}) "
+        f"RETURN count(*) AS n") == 1
+    assert _scalar(client,
+        f"MATCH (:Ontology {{name:'{NS}Onto'}})-[:ANCHORED_BY]->(:Concept {{concept_id:'{NS}oc1'}}) "
+        f"RETURN count(*) AS n") == 1
+
+
 def test_integration_mode_attaches_to_existing_concept(client_with_cleanup):
     """integration: a matched incoming concept's instance/edges attach to the
     EXISTING target concept (not in this backup); the target node is untouched."""

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -71,13 +71,55 @@ def client_with_cleanup():
         yield client
     finally:
         # Remove only the namespaced test nodes (DETACH DELETE drops their edges too).
-        for label, idfield in (("Concept", "concept_id"), ("Source", "source_id"), ("Instance", "instance_id")):
+        for label, idfield in (("Concept", "concept_id"), ("Source", "source_id"),
+                               ("Instance", "instance_id"), ("Ontology", "ontology_id")):
             try:
                 client._execute_cypher(
                     f"MATCH (n:{label}) WHERE n.{idfield} STARTS WITH '{NS}' DETACH DELETE n"
                 )
             except Exception:
                 pass
+
+
+def test_ontology_nodes_and_edges_round_trip(client_with_cleanup):
+    """Faithful clone restores the :Ontology layer that the format previously dropped.
+
+    Exports an ontology node (with a non-default ``lifecycle_state``), a source
+    scoped to it, and a concept it anchors, then imports into the live graph and
+    asserts the node + SCOPED_BY + ANCHORED_BY all reconstruct. ``lifecycle_state``
+    is the tell that a *lossy* reconstruction (name-only) would have lost.
+    """
+    client = client_with_cleanup
+    backup = DataExporter.build_kg_backup_v2(
+        concepts=[{"concept_id": f"{NS}oc1", "label": "Anchor", "search_terms": [],
+                   "embedding": [0.1, 0.2, 0.3], "created_at_epoch": 1, "last_seen_epoch": 1}],
+        sources=[{"source_id": f"{NS}os1", "document": f"{NS}Onto", "file_path": "/o",
+                  "paragraph": 1, "full_text": "t", "content_type": "text/plain"}],
+        instances=[], evidence=[], relationships=[], vocabulary=[],
+        embedding_profiles=[{"identity": "openai:text-embedding-3-small@1536", "vector_space": "x",
+                             "image_vector_space": None, "name": "d", "multimodal": False}],
+        epoch_kinds=[], graph_epochs=[],
+        ontologies=[{"ontology_id": f"{NS}ont1", "name": f"{NS}Onto",
+                     "description": "round-trip", "embedding": [0.4, 0.5, 0.6],
+                     "search_terms": ["o"], "lifecycle_state": "frozen",
+                     "creation_epoch": 2, "created_by": "tester"}],
+        scoped_by=[{"source_id": f"{NS}os1", "ontology": f"{NS}Onto"}],
+        anchored_by=[{"ontology": f"{NS}Onto", "concept_id": f"{NS}oc1"}],
+        schema_version=76,
+    )
+    DataImporter.import_backup(client, backup, overwrite_existing=True)
+
+    # :Ontology node restored WITH lifecycle_state intact (a name-only fix loses this).
+    assert _scalar(client,
+        f"MATCH (o:Ontology {{name:'{NS}Onto'}}) WHERE o.lifecycle_state = 'frozen' "
+        f"RETURN count(o) AS n") == 1
+    # SCOPED_BY membership + ANCHORED_BY provenance edges reconstructed.
+    assert _scalar(client,
+        f"MATCH (:Source {{source_id:'{NS}os1'}})-[:SCOPED_BY]->(:Ontology {{name:'{NS}Onto'}}) "
+        f"RETURN count(*) AS n") == 1
+    assert _scalar(client,
+        f"MATCH (:Ontology {{name:'{NS}Onto'}})-[:ANCHORED_BY]->(:Concept {{concept_id:'{NS}oc1'}}) "
+        f"RETURN count(*) AS n") == 1
 
 
 def test_integration_mode_attaches_to_existing_concept(client_with_cleanup):

--- a/tests/unit/test_id_remap.py
+++ b/tests/unit/test_id_remap.py
@@ -105,6 +105,27 @@ def test_garage_key_is_immune():
     assert new["bulk"]["sources"][0]["garage_key"] == "sources/Doc/abc123sha"
 
 
+def test_ontology_edges_rewritten_via_id_maps():
+    """SCOPED_BY/ANCHORED_BY edge ids follow their source/concept maps; nodes pass through.
+
+    Without this, adjacent-mode restore would silently orphan ontology membership
+    and provenance — exactly the "missed class" failure the remapper guards against.
+    """
+    obj = _backup(
+        ontologies=[{"ontology_id": "ont_1", "name": "Doc", "description": "",
+                     "embedding": [0.1], "search_terms": [], "lifecycle_state": "active",
+                     "creation_epoch": 1, "created_by": None}],
+        scoped_by=[{"source_id": "s1", "ontology": "Doc"}],
+        anchored_by=[{"ontology": "Doc", "concept_id": "c1"}],
+    )
+    new, _ = IdRemapper(mode="always", id_factory=_fixed_factory).remap(obj)
+    # Edge endpoints follow the minted ids; the ontology NAME is a stable key, unchanged.
+    assert new["bulk"]["scoped_by"] == [{"source_id": "NEW_s1", "ontology": "Doc"}]
+    assert new["bulk"]["anchored_by"] == [{"ontology": "Doc", "concept_id": "NEW_c1"}]
+    # The ontology node itself carries no minted id — passed through verbatim.
+    assert new["bulk"]["ontologies"][0]["ontology_id"] == "ont_1"
+
+
 def test_remapped_object_validates_clean():
     """No reference class left dangling — the integrity guarantee."""
     new, _ = _remap_always()

--- a/tests/unit/test_kg_backup_v2.py
+++ b/tests/unit/test_kg_backup_v2.py
@@ -131,6 +131,84 @@ def test_no_derived_products_in_bulk():
         assert key not in obj["bulk"]
 
 
+def test_ontology_streams_land_in_bulk_and_validate():
+    """First-class :Ontology nodes + edges are emitted to bulk and pass the validator."""
+    lists = _fixture_lists()
+    lists["ontologies"] = [
+        {"ontology_id": "ont_1", "name": "Corpus", "description": "d",
+         "embedding": [0.1, 0.2], "search_terms": [], "lifecycle_state": "active",
+         "creation_epoch": 1, "created_by": None},
+    ]
+    lists["scoped_by"] = [{"source_id": "s1", "ontology": "Corpus"}]
+    lists["anchored_by"] = [{"ontology": "Corpus", "concept_id": "c1"}]
+    obj = DataExporter.build_kg_backup_v2(**lists)
+
+    assert obj["bulk"]["ontologies"][0]["name"] == "Corpus"
+    assert obj["bulk"]["scoped_by"] == [{"source_id": "s1", "ontology": "Corpus"}]
+    assert obj["bulk"]["anchored_by"] == [{"ontology": "Corpus", "concept_id": "c1"}]
+    # The new streams are not interned (small cardinality) and must not break validation.
+    result = lint_backup.validate_backup(obj)
+    assert result.ok, [str(i) for i in result.errors]
+
+
+def test_ontology_streams_default_empty_when_omitted():
+    """Callers that don't pass the streams get empty lists, not missing keys."""
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+    assert obj["bulk"]["ontologies"] == []
+    assert obj["bulk"]["scoped_by"] == []
+    assert obj["bulk"]["anchored_by"] == []
+
+
+def _ontology(name="Corpus", oid="o1"):
+    return {"ontology_id": oid, "name": name, "description": "", "embedding": [],
+            "search_terms": [], "lifecycle_state": "active", "creation_epoch": 1,
+            "created_by": None}
+
+
+def test_ontology_edge_orphans_are_flagged():
+    """The independent validator catches scoped_by/anchored_by edges with missing endpoints.
+
+    This is what makes `kg admin verify` a real round-trip check: a backup whose
+    ontology membership/provenance edges dangle is rejected WITHOUT a restore.
+    """
+    lists = _fixture_lists()
+    lists["ontologies"] = [_ontology()]
+    lists["scoped_by"] = [
+        {"source_id": "s1", "ontology": "Corpus"},   # ok
+        {"source_id": "sX", "ontology": "Corpus"},   # sX: no such source
+        {"source_id": "s1", "ontology": "Nope"},     # Nope: no such ontology
+    ]
+    lists["anchored_by"] = [
+        {"ontology": "Corpus", "concept_id": "cX"},  # cX: no such concept
+        {"ontology": "Ghost", "concept_id": "c1"},   # Ghost: no such ontology
+    ]
+    codes = {i.code for i in lint_backup.validate_backup(
+        DataExporter.build_kg_backup_v2(**lists)).errors}
+    assert "E_SCOPED_SOURCE_MISSING" in codes
+    assert "E_SCOPED_ONTOLOGY_MISSING" in codes
+    assert "E_ANCHORED_CONCEPT_MISSING" in codes
+    assert "E_ANCHORED_ONTOLOGY_MISSING" in codes
+
+
+def test_duplicate_ontology_is_flagged():
+    lists = _fixture_lists()
+    lists["ontologies"] = [_ontology(), _ontology()]   # same id + name twice
+    codes = {i.code for i in lint_backup.validate_backup(
+        DataExporter.build_kg_backup_v2(**lists)).errors}
+    assert "E_DUP_ONTOLOGY_ID" in codes
+    assert "E_DUP_ONTOLOGY_NAME" in codes
+
+
+def test_well_formed_ontology_streams_validate_clean():
+    """A faithful ontology layer passes the validator with no new errors."""
+    lists = _fixture_lists()
+    lists["ontologies"] = [_ontology()]
+    lists["scoped_by"] = [{"source_id": "s1", "ontology": "Corpus"}]
+    lists["anchored_by"] = [{"ontology": "Corpus", "concept_id": "c1"}]
+    result = lint_backup.validate_backup(DataExporter.build_kg_backup_v2(**lists))
+    assert result.ok, [str(i) for i in result.errors]
+
+
 def test_dynamic_edge_type_missing_from_vocab_still_interns():
     """An edge type absent from the vocabulary table is appended to the header dict."""
     lists = _fixture_lists()

--- a/tests/unit/test_kg_backup_v2.py
+++ b/tests/unit/test_kg_backup_v2.py
@@ -209,6 +209,41 @@ def test_well_formed_ontology_streams_validate_clean():
     assert result.ok, [str(i) for i in result.errors]
 
 
+def test_ontology_embedding_dim_mismatch_flagged():
+    """An ontology vector whose length != the backup-default profile @dims is caught
+    (mirrors the concept dim check — ontologies live in the same space)."""
+    lists = _fixture_lists()                       # default profile is @2 (dims=2)
+    o = _ontology()
+    o["embedding"] = [0.1, 0.2, 0.3]               # 3 dims — wrong
+    lists["ontologies"] = [o]
+    codes = {i.code for i in lint_backup.validate_backup(
+        DataExporter.build_kg_backup_v2(**lists)).errors}
+    assert "E_ONTOLOGY_EMBEDDING_DIM" in codes
+
+
+def test_ontology_empty_embedding_not_dim_checked():
+    """An ontology created without an embedding (``[]``) is not dim-checked."""
+    lists = _fixture_lists()
+    lists["ontologies"] = [_ontology()]            # embedding [] — legitimately absent
+    codes = {i.code for i in lint_backup.validate_backup(
+        DataExporter.build_kg_backup_v2(**lists)).errors}
+    assert "E_ONTOLOGY_EMBEDDING_DIM" not in codes
+
+
+def test_duplicate_ontology_edges_flagged():
+    """Duplicate SCOPED_BY/ANCHORED_BY edges are flagged (integrity parity with nodes)."""
+    lists = _fixture_lists()
+    lists["ontologies"] = [_ontology()]
+    lists["scoped_by"] = [{"source_id": "s1", "ontology": "Corpus"},
+                          {"source_id": "s1", "ontology": "Corpus"}]    # dup
+    lists["anchored_by"] = [{"ontology": "Corpus", "concept_id": "c1"},
+                            {"ontology": "Corpus", "concept_id": "c1"}]  # dup
+    codes = {i.code for i in lint_backup.validate_backup(
+        DataExporter.build_kg_backup_v2(**lists)).errors}
+    assert "E_DUP_SCOPED_BY" in codes
+    assert "E_DUP_ANCHORED_BY" in codes
+
+
 def test_dynamic_edge_type_missing_from_vocab_still_interns():
     """An edge type absent from the vocabulary table is appended to the header dict."""
     lists = _fixture_lists()

--- a/tests/unit/test_kg_backup_v2_reader.py
+++ b/tests/unit/test_kg_backup_v2_reader.py
@@ -95,7 +95,41 @@ def test_graph_epochs_de_interned():
 def test_counts():
     counts = KgBackupV2Reader(_build()).counts()
     assert counts == {"concepts": 2, "sources": 1, "instances": 1,
-                      "evidence": 2, "relationships": 1, "vocabulary": 1}
+                      "evidence": 2, "relationships": 1, "vocabulary": 1,
+                      "ontologies": 0, "scoped_by": 0, "anchored_by": 0}
+
+
+def test_ontology_streams_round_trip_through_reader():
+    """Ontology nodes + SCOPED_BY/ANCHORED_BY edges survive build → read intact."""
+    obj = _build(
+        ontologies=[
+            {"ontology_id": "ont_1", "name": "Corpus", "description": "d",
+             "embedding": [0.1, 0.2], "search_terms": ["c"],
+             "lifecycle_state": "frozen", "creation_epoch": 5, "created_by": "alice"},
+        ],
+        scoped_by=[{"source_id": "s1", "ontology": "Corpus"}],
+        anchored_by=[{"ontology": "Corpus", "concept_id": "c1"}],
+    )
+    reader = KgBackupV2Reader(obj)
+    onts = list(reader.ontologies())
+    assert len(onts) == 1
+    assert onts[0]["name"] == "Corpus"
+    assert onts[0]["lifecycle_state"] == "frozen"      # the property a lossy fix would drop
+    assert onts[0]["embedding"] == [0.1, 0.2]
+    assert reader.scoped_by() == [{"source_id": "s1", "ontology": "Corpus"}]
+    assert reader.anchored_by() == [{"ontology": "Corpus", "concept_id": "c1"}]
+    assert reader.counts()["ontologies"] == 1
+
+
+def test_ontology_streams_absent_in_pre_stream_backup():
+    """A backup without the ontology streams reads as empty (back-compat)."""
+    obj = _build()
+    obj["bulk"].pop("ontologies", None)
+    obj["bulk"].pop("scoped_by", None)
+    obj["bulk"].pop("anchored_by", None)
+    reader = KgBackupV2Reader(obj)
+    assert list(reader.ontologies()) == []
+    assert reader.scoped_by() == [] and reader.anchored_by() == []
 
 
 def test_external_concept_ids_empty_when_self_contained():


### PR DESCRIPTION
## Problem
A **full** backup silently dropped the entire ontology layer. Restoring a full backup onto cube (staging) restored 3994 concepts / 313 sources / 7108 instances / 8705 relationships perfectly — but `kg ontology list` and `kg catalog` came back **empty**.

Root cause: ontologies were second-class in `kg-backup/2` on **both** sides.
- **Export** wrote only ontology *names* into `header.ontologies` (derived from `source.document`, for the embedding-profile cascade) and never serialized the `:Ontology` nodes.
- **Import** never recreated `:Ontology` nodes or their `SCOPED_BY`/`ANCHORED_BY` edges.

Beyond the empty catalog, this lost `lifecycle_state` — a **`frozen` ontology silently became writable** after restore.

## Fix — faithful serialization (3 additive bulk streams)
`:Ontology` nodes are first-class primary inputs (own embedding, lifecycle, curator metadata) — nothing post-restore reconstructs them. Carry them faithfully:

| Stream | Content |
|---|---|
| `bulk.ontologies` | `:Ontology` nodes, full properties |
| `bulk.scoped_by` | `(:Source)-[:SCOPED_BY]->(:Ontology)` membership |
| `bulk.anchored_by` | `(:Ontology)-[:ANCHORED_BY]->(:Concept)` provenance |

- **Export** (`export_ontologies/scoped_by/anchored_by`) threaded through `build_kg_backup_v2`, so the **streaming backup path** picks them up too.
- **Reader** accessors + an idempotent **importer** step (`_import_ontologies`: MERGE nodes, then edges) reconstruct the layer 1:1 on clone.
- **IdRemapper** carries the nodes through and remaps `scoped_by.source_id` / `anchored_by.concept_id`, so **adjacent/integration** modes don't silently orphan the edges (the "missed class" failure the remapper exists to prevent).
- **Independent validator** (`lint_backup.py` — also the engine behind `kg admin verify`) now enforces referential integrity (`E_SCOPED_*` / `E_ANCHORED_*` / `E_DUP_ONTOLOGY_*`), so a malformed ontology layer is caught **on verify, without a restore**.

## Compatibility
Streams are **additive**: backups taken before them lack the keys and the reader yields empty (prior behavior) — older backups still restore. **Faithful-only**: the existing cube backup has no node data to recover, but fresh backups round-trip in full (this is the agreed path — re-take a backup from dev with the fixed exporter, then restore on cube).

## Tests (858 passed)
- Unit: build emits streams + validates; reader round-trip incl. `lifecycle_state`; back-compat absence; validator orphan/dup detection; IdRemapper edge remap.
- DB: `test_ontology_nodes_and_edges_round_trip` — export→import against live AGE, asserts `:Ontology` (frozen) + `SCOPED_BY` + `ANCHORED_BY`.
- `BACKUP_OBJECT_SPEC.md` §5.7 documents the streams.

## Related
Found alongside the 413 restore-upload fix (#494). Independent subsystems, separate PRs.