### PR TITLE
fix: restore the :Ontology + :DocumentMeta tiers + seed primordial (#505)

### DIFF
--- a/api/app/lib/age_client/__init__.py
+++ b/api/app/lib/age_client/__init__.py
@@ -21,11 +21,13 @@ from .grounding import GroundingMixin
 from .ontology import OntologyMixin
 from .ontology_scoring import OntologyScoringMixin
 from .ontology_edges import OntologyEdgesMixin
+from .rehydration import RehydrationMixin
 from .vocabulary import VocabularyMixin
 
 
 class AGEClient(
     VocabularyMixin,
+    RehydrationMixin,
     OntologyEdgesMixin,
     OntologyScoringMixin,
     OntologyMixin,
@@ -44,6 +46,7 @@ class AGEClient(
     - OntologyMixin: Ontology node CRUD and lifecycle management
     - OntologyScoringMixin: Ontology scoring, analytics, and annealing mutations
     - OntologyEdgesMixin: Inter-ontology edges and proposal execution primitives
+    - RehydrationMixin: Rebuild derived :Ontology/:DocumentMeta layers from Sources (issue #505)
     - VocabularyMixin: Relationship type config, CRUD, sync, merge, embeddings
 
     Facades attached lazily via properties on QueryMixin:

--- a/api/app/lib/age_client/rehydration.py
+++ b/api/app/lib/age_client/rehydration.py
@@ -6,25 +6,31 @@ created before the :Ontology layer was serialized (pre-v0.15.1) does not carry
 that layer, and restore otherwise never rebuilds it — so the ontology list and
 the catalog read empty even though the underlying data is intact (issue #505).
 
-This mixin reconstructs the **ontology layer** idempotently from the Sources:
-``(:Ontology)`` + ``(:Source)-[:SCOPED_BY]->(:Ontology)``, keyed by distinct
-``s.document`` (mirrors migration 044). For new backups the importer already
-MERGEs these nodes/edges (serialization), so the pass is a harmless idempotent
-no-op; for old backups it is the reconstruction fallback. It also ensures the
-reserved ``primordial`` pool exists, since a clone-style restore can replace a
-freshly-seeded graph (see migration 078 / issue #505).
+This mixin provides two restore-time rebuilds:
 
-The :DocumentMeta layer is intentionally NOT reconstructed here: its canonical
-identity (``document_id == content_hash == sha256(document bytes)``) is not
-recoverable from Source nodes (the garage_key carries only a 32-char hash
-prefix), so a Source-derived DocumentMeta would have a truncated id that breaks
-drill-down and re-ingest dedup. That layer is handled authoritatively by
-serializing it into ``kg-backup/2`` (Option B, issue #505), with a faithful
-Garage-hashed reconstruction reserved for old backups.
+- :meth:`rehydrate_projection_layers` — the **ontology layer**:
+  ``(:Ontology)`` + ``(:Source)-[:SCOPED_BY]->(:Ontology)``, keyed by distinct
+  ``s.document`` (mirrors migration 044). For new backups the importer already
+  MERGEs these nodes/edges (serialization), so the pass is a harmless idempotent
+  no-op; for old backups it is the reconstruction. It also ensures the reserved
+  ``primordial`` pool exists, since a clone-style restore can replace a
+  freshly-seeded graph (see migration 078 / issue #505).
+
+- :meth:`rehydrate_document_layer` — **restore-time durability** for the
+  :DocumentMeta tier. New backups serialize :DocumentMeta into ``kg-backup/2``
+  (Option B) and the importer rebuilds it authoritatively. Old backups carry no
+  such stream, so this reconstructs it from the restored Sources — but
+  faithfully: the canonical identity (``document_id == content_hash ==
+  sha256(document bytes)``) is unrecoverable from Source nodes alone (the
+  ``garage_key`` carries only a 32-char hash prefix), so this hashes the actual
+  document bytes (fetched from Garage) to recover the full digest rather than
+  using the truncated prefix. Garage I/O is injected so the mixin stays DB-only.
 """
 
+import hashlib
+import os
 import logging
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -84,3 +90,101 @@ class RehydrationMixin:
             )
             if linked:
                 stats["scoped_by_edges"] += int(self._parse_agtype(linked.get("c")) or 0)
+
+    def rehydrate_document_layer(
+        self,
+        fetch_bytes: Callable[[str], Optional[bytes]],
+        created_by: Optional[str] = None,
+    ) -> Dict[str, int]:
+        """Restore-time durability: rebuild :DocumentMeta from Sources + Garage bytes.
+
+        For a backup that carried no serialized ``documents`` stream (pre-Option-B),
+        reconstruct the document tier so ``kg catalog ls`` / document drill-down work
+        after restore. One :DocumentMeta per distinct ``garage_key`` (a file), linked
+        to its Source chunks via :HAS_SOURCE.
+
+        The canonical identity is recovered **faithfully**: the full document hash is
+        not on the graph (``garage_key`` holds only its first 32 chars), so this
+        fetches each document's bytes via ``fetch_bytes`` and ``sha256``-es them to
+        get the full digest, then sets ``document_id`` / ``content_hash`` to the
+        canonical ``"sha256:" + <64 hex>`` form — matching what native ingestion
+        writes, so re-ingest dedup and drill-down behave identically. A document whose
+        bytes can't be fetched is skipped (no truncated node is ever created).
+
+        Idempotent (MERGE on ``document_id``). Intended to run only when the backup
+        lacked the stream; harmless if re-run.
+
+        Args:
+            fetch_bytes: Garage accessor ``garage_key -> bytes | None`` (injected so
+                this mixin needs no storage dependency).
+            created_by: Unused for documents today; accepted for signature symmetry
+                with :meth:`rehydrate_projection_layers`.
+
+        Returns:
+            Counts: ``documents`` (nodes written), ``has_source_edges``, ``skipped``
+            (garage_keys whose bytes could not be fetched).
+        """
+        stats = {"documents": 0, "has_source_edges": 0, "skipped": 0}
+        rows = self._execute_cypher(
+            "MATCH (s:Source) WHERE s.garage_key IS NOT NULL "
+            "RETURN s.garage_key AS gk, head(collect(s.document)) AS doc, count(s) AS cnt"
+        ) or []
+        for row in rows:
+            garage_key = self._parse_agtype(row.get("gk"))
+            if not garage_key:
+                continue
+            document = self._parse_agtype(row.get("doc"))
+            chunk_count = int(self._parse_agtype(row.get("cnt")) or 0)
+
+            try:
+                content = fetch_bytes(garage_key)
+            except Exception as e:  # storage hiccup must not abort the whole rebuild
+                logger.warning("Could not fetch %s for document rehydration: %s", garage_key, e)
+                content = None
+            if not content:
+                stats["skipped"] += 1
+                continue
+
+            full_hash = hashlib.sha256(content).hexdigest()
+            # Integrity check: garage_key embeds content_hash[:32]; a mismatch means
+            # the stored bytes are not what produced the key (corruption / wrong object).
+            key_prefix = os.path.splitext(os.path.basename(garage_key))[0]
+            if key_prefix and not full_hash.startswith(key_prefix):
+                logger.warning(
+                    "garage_key prefix %s does not match recomputed hash %s (%s) — "
+                    "rebuilding DocumentMeta from the recomputed (authoritative) hash",
+                    key_prefix, full_hash[:32], garage_key,
+                )
+            document_id = f"sha256:{full_hash}"
+
+            self._execute_cypher(
+                "MERGE (d:DocumentMeta {document_id: $document_id}) "
+                "SET d.content_hash = $content_hash, d.ontology = $ontology, "
+                "    d.garage_key = $garage_key, d.filename = $filename, "
+                "    d.content_type = 'document', d.source_count = $source_count "
+                "RETURN d",
+                params={
+                    "document_id": document_id,
+                    "content_hash": document_id,  # canonical: content_hash == document_id
+                    "ontology": document,
+                    "garage_key": garage_key,
+                    # Original filename lived only on the (absent) DocumentMeta; the
+                    # garage_key basename is the best available name for old backups.
+                    "filename": os.path.basename(garage_key),
+                    "source_count": chunk_count,
+                },
+                fetch_one=True,
+            )
+            stats["documents"] += 1
+            linked = self._execute_cypher(
+                "MATCH (d:DocumentMeta {document_id: $document_id}) "
+                "MATCH (s:Source {garage_key: $garage_key}) "
+                "MERGE (d)-[:HAS_SOURCE]->(s) "
+                "RETURN count(s) AS c",
+                params={"document_id": document_id, "garage_key": garage_key},
+                fetch_one=True,
+            )
+            if linked:
+                stats["has_source_edges"] += int(self._parse_agtype(linked.get("c")) or 0)
+
+        return stats

--- a/api/app/lib/age_client/rehydration.py
+++ b/api/app/lib/age_client/rehydration.py
@@ -114,17 +114,24 @@ class RehydrationMixin:
         Idempotent (MERGE on ``document_id``). Intended to run only when the backup
         lacked the stream; harmless if re-run.
 
+        Known limitation (issue #505 multi-ontology follow-up, tracked separately): a
+        file ingested into multiple ontologies has one ``garage_key`` per ontology but
+        the SAME content hash, so the per-key MERGE collapses to one node (last
+        garage_key wins) — matching native ingest's own last-writer-wins behavior.
+
         Args:
             fetch_bytes: Garage accessor ``garage_key -> bytes | None`` (injected so
                 this mixin needs no storage dependency).
-            created_by: Unused for documents today; accepted for signature symmetry
-                with :meth:`rehydrate_projection_layers`.
+            created_by: Recorded as ``ingested_by`` provenance on rebuilt nodes (these
+                came from a restore, not a native ingest); accepted for signature
+                symmetry with :meth:`rehydrate_projection_layers`.
 
         Returns:
             Counts: ``documents`` (nodes written), ``has_source_edges``, ``skipped``
-            (garage_keys whose bytes could not be fetched).
+            (garage_keys whose bytes could not be fetched), ``mismatches``
+            (garage_key prefix != recomputed hash — corruption-grade, see logs).
         """
-        stats = {"documents": 0, "has_source_edges": 0, "skipped": 0}
+        stats = {"documents": 0, "has_source_edges": 0, "skipped": 0, "mismatches": 0}
         rows = self._execute_cypher(
             "MATCH (s:Source) WHERE s.garage_key IS NOT NULL "
             "RETURN s.garage_key AS gk, head(collect(s.document)) AS doc, count(s) AS cnt"
@@ -150,6 +157,7 @@ class RehydrationMixin:
             # the stored bytes are not what produced the key (corruption / wrong object).
             key_prefix = os.path.splitext(os.path.basename(garage_key))[0]
             if key_prefix and not full_hash.startswith(key_prefix):
+                stats["mismatches"] += 1
                 logger.warning(
                     "garage_key prefix %s does not match recomputed hash %s (%s) — "
                     "rebuilding DocumentMeta from the recomputed (authoritative) hash",
@@ -161,7 +169,8 @@ class RehydrationMixin:
                 "MERGE (d:DocumentMeta {document_id: $document_id}) "
                 "SET d.content_hash = $content_hash, d.ontology = $ontology, "
                 "    d.garage_key = $garage_key, d.filename = $filename, "
-                "    d.content_type = 'document', d.source_count = $source_count "
+                "    d.content_type = 'document', d.source_count = $source_count, "
+                "    d.ingested_by = $ingested_by "
                 "RETURN d",
                 params={
                     "document_id": document_id,
@@ -172,6 +181,8 @@ class RehydrationMixin:
                     # garage_key basename is the best available name for old backups.
                     "filename": os.path.basename(garage_key),
                     "source_count": chunk_count,
+                    # Provenance: these nodes were reconstructed at restore, not ingested.
+                    "ingested_by": created_by or "post_restore_rehydration",
                 },
                 fetch_one=True,
             )

--- a/api/app/lib/age_client/rehydration.py
+++ b/api/app/lib/age_client/rehydration.py
@@ -1,0 +1,131 @@
+"""Rehydration mixin: rebuild derived graph-projection layers from Source nodes.
+
+After a restore, the :Source nodes carry every bit of source-of-truth data
+(``document``, ``garage_key``, ``content_hash``, ``source_id``). But a backup
+created before a projection layer was serialized does not carry that layer, and
+restore otherwise never rebuilds it — so the ontology list and the catalog read
+empty even though the underlying data is intact (issue #505).
+
+This mixin reconstructs both derived layers idempotently from the Sources:
+
+- **Ontology layer** — ``(:Ontology)`` + ``(:Source)-[:SCOPED_BY]->(:Ontology)``,
+  keyed by distinct ``s.document`` (mirrors migration 044).
+- **Document layer** — ``(:DocumentMeta)`` + ``(:DocumentMeta)-[:HAS_SOURCE]->(:Source)``,
+  one ``DocumentMeta`` per file (grouped by ``s.garage_key``).
+
+Both are pure derivations of intact Source data, so the pass is idempotent
+(MERGE-based) and a no-op on post-serialization backups that already carry the
+layers. It also ensures the reserved ``primordial`` pool exists, since a
+clone-style restore can replace a freshly-seeded graph (see migration 078 /
+issue #505).
+"""
+
+import logging
+import os
+import re
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# The reserved default pool unroutable sources fall into (ADR-200). Must always
+# exist; mirrors proposal_executor._ensure_primordial_pool and migration 078.
+PRIMORDIAL_POOL_NAME = "primordial"
+
+
+class RehydrationMixin:
+    """Reconstruct the :Ontology and :DocumentMeta projection layers from Sources."""
+
+    def rehydrate_projection_layers(self, created_by: Optional[str] = None) -> Dict[str, int]:
+        """Rebuild the ontology + document projection layers from Source nodes.
+
+        Idempotent: ensures each distinct ontology and file has its node and
+        edges, creating only what is missing. Safe to run on every restore.
+
+        Args:
+            created_by: Actor recorded on any newly created Ontology nodes.
+
+        Returns:
+            Counts of work done: ``ontologies``, ``scoped_by_edges``,
+            ``documents``, ``has_source_edges``.
+        """
+        stats = {"ontologies": 0, "scoped_by_edges": 0, "documents": 0, "has_source_edges": 0}
+
+        # The primordial pool is not derivable from Sources — ensure it directly
+        # so a clone restore that wiped the seeded graph still has it.
+        self.ensure_ontology_exists(
+            PRIMORDIAL_POOL_NAME,
+            description="Default pool for unroutable sources",
+            created_by=created_by,
+        )
+
+        self._rehydrate_ontology_layer(stats, created_by)
+        self._rehydrate_document_layer(stats)
+        return stats
+
+    def _rehydrate_ontology_layer(self, stats: Dict[str, int], created_by: Optional[str]) -> None:
+        """Create an :Ontology node + :SCOPED_BY edges for each distinct s.document."""
+        rows = self._execute_cypher(
+            "MATCH (s:Source) WHERE s.document IS NOT NULL RETURN DISTINCT s.document AS name"
+        ) or []
+        for row in rows:
+            name = self._parse_agtype(row.get("name"))
+            if not name:
+                continue
+            self.ensure_ontology_exists(name, created_by=created_by)
+            stats["ontologies"] += 1
+            linked = self._execute_cypher(
+                "MATCH (s:Source {document: $name}) "
+                "MATCH (o:Ontology {name: $name}) "
+                "MERGE (s)-[:SCOPED_BY]->(o) "
+                "RETURN count(s) AS c",
+                params={"name": name},
+                fetch_one=True,
+            )
+            if linked:
+                stats["scoped_by_edges"] += int(self._parse_agtype(linked.get("c")) or 0)
+
+    def _rehydrate_document_layer(self, stats: Dict[str, int]) -> None:
+        """Create one :DocumentMeta per file (grouped by garage_key) + :HAS_SOURCE edges."""
+        rows = self._execute_cypher(
+            "MATCH (s:Source) WHERE s.garage_key IS NOT NULL "
+            "RETURN s.garage_key AS gk, s.document AS doc, count(s) AS cnt"
+        ) or []
+        # A file (garage_key) may carry chunks tagged to different ontologies, so
+        # the same gk can appear on multiple rows; process each gk once.
+        seen: set = set()
+        for row in rows:
+            garage_key = self._parse_agtype(row.get("gk"))
+            if not garage_key or garage_key in seen:
+                continue
+            seen.add(garage_key)
+            document = self._parse_agtype(row.get("doc"))
+            chunk_count = int(self._parse_agtype(row.get("cnt")) or 0)
+
+            # Stable document_id + display name from the file hash in the garage_key.
+            file_hash = re.sub(r"^.*/([^/]+)\.md$", r"\1", garage_key)
+            document_id = f"sha256:{file_hash}"
+
+            self._execute_cypher(
+                "MERGE (d:DocumentMeta {document_id: $document_id}) "
+                "SET d.filename = $filename, d.ontology = $ontology, "
+                "    d.content_type = 'document', d.source_count = $source_count "
+                "RETURN d",
+                params={
+                    "document_id": document_id,
+                    "filename": os.path.basename(garage_key),
+                    "ontology": document,
+                    "source_count": chunk_count,
+                },
+                fetch_one=True,
+            )
+            stats["documents"] += 1
+            linked = self._execute_cypher(
+                "MATCH (d:DocumentMeta {document_id: $document_id}) "
+                "MATCH (s:Source {garage_key: $garage_key}) "
+                "MERGE (d)-[:HAS_SOURCE]->(s) "
+                "RETURN count(s) AS c",
+                params={"document_id": document_id, "garage_key": garage_key},
+                fetch_one=True,
+            )
+            if linked:
+                stats["has_source_edges"] += int(self._parse_agtype(linked.get("c")) or 0)

--- a/api/app/lib/age_client/rehydration.py
+++ b/api/app/lib/age_client/rehydration.py
@@ -1,29 +1,30 @@
-"""Rehydration mixin: rebuild derived graph-projection layers from Source nodes.
+"""Rehydration mixin: rebuild the derived :Ontology layer from Source nodes.
 
 After a restore, the :Source nodes carry every bit of source-of-truth data
 (``document``, ``garage_key``, ``content_hash``, ``source_id``). But a backup
-created before a projection layer was serialized does not carry that layer, and
-restore otherwise never rebuilds it — so the ontology list and the catalog read
-empty even though the underlying data is intact (issue #505).
+created before the :Ontology layer was serialized (pre-v0.15.1) does not carry
+that layer, and restore otherwise never rebuilds it — so the ontology list and
+the catalog read empty even though the underlying data is intact (issue #505).
 
-This mixin reconstructs both derived layers idempotently from the Sources:
+This mixin reconstructs the **ontology layer** idempotently from the Sources:
+``(:Ontology)`` + ``(:Source)-[:SCOPED_BY]->(:Ontology)``, keyed by distinct
+``s.document`` (mirrors migration 044). For new backups the importer already
+MERGEs these nodes/edges (serialization), so the pass is a harmless idempotent
+no-op; for old backups it is the reconstruction fallback. It also ensures the
+reserved ``primordial`` pool exists, since a clone-style restore can replace a
+freshly-seeded graph (see migration 078 / issue #505).
 
-- **Ontology layer** — ``(:Ontology)`` + ``(:Source)-[:SCOPED_BY]->(:Ontology)``,
-  keyed by distinct ``s.document`` (mirrors migration 044).
-- **Document layer** — ``(:DocumentMeta)`` + ``(:DocumentMeta)-[:HAS_SOURCE]->(:Source)``,
-  one ``DocumentMeta`` per file (grouped by ``s.garage_key``).
-
-Both are pure derivations of intact Source data, so the pass is idempotent
-(MERGE-based) and a no-op on post-serialization backups that already carry the
-layers. It also ensures the reserved ``primordial`` pool exists, since a
-clone-style restore can replace a freshly-seeded graph (see migration 078 /
-issue #505).
+The :DocumentMeta layer is intentionally NOT reconstructed here: its canonical
+identity (``document_id == content_hash == sha256(document bytes)``) is not
+recoverable from Source nodes (the garage_key carries only a 32-char hash
+prefix), so a Source-derived DocumentMeta would have a truncated id that breaks
+drill-down and re-ingest dedup. That layer is handled authoritatively by
+serializing it into ``kg-backup/2`` (Option B, issue #505), with a faithful
+Garage-hashed reconstruction reserved for old backups.
 """
 
 import logging
-import os
-import re
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -33,22 +34,23 @@ PRIMORDIAL_POOL_NAME = "primordial"
 
 
 class RehydrationMixin:
-    """Reconstruct the :Ontology and :DocumentMeta projection layers from Sources."""
+    """Reconstruct the :Ontology projection layer from Sources (issue #505)."""
 
     def rehydrate_projection_layers(self, created_by: Optional[str] = None) -> Dict[str, int]:
-        """Rebuild the ontology + document projection layers from Source nodes.
+        """Rebuild the ontology projection layer from Source nodes.
 
-        Idempotent: ensures each distinct ontology and file has its node and
-        edges, creating only what is missing. Safe to run on every restore.
+        Idempotent: ensures each distinct ontology has its node and SCOPED_BY
+        edges, creating only what is missing. Safe to run on every restore — a
+        no-op on backups that already carry the serialized ontology layer, the
+        reconstruction fallback on pre-serialization backups.
 
         Args:
             created_by: Actor recorded on any newly created Ontology nodes.
 
         Returns:
-            Counts of work done: ``ontologies``, ``scoped_by_edges``,
-            ``documents``, ``has_source_edges``.
+            Counts of work done: ``ontologies``, ``scoped_by_edges``.
         """
-        stats = {"ontologies": 0, "scoped_by_edges": 0, "documents": 0, "has_source_edges": 0}
+        stats = {"ontologies": 0, "scoped_by_edges": 0}
 
         # The primordial pool is not derivable from Sources — ensure it directly
         # so a clone restore that wiped the seeded graph still has it.
@@ -59,7 +61,6 @@ class RehydrationMixin:
         )
 
         self._rehydrate_ontology_layer(stats, created_by)
-        self._rehydrate_document_layer(stats)
         return stats
 
     def _rehydrate_ontology_layer(self, stats: Dict[str, int], created_by: Optional[str]) -> None:
@@ -83,49 +84,3 @@ class RehydrationMixin:
             )
             if linked:
                 stats["scoped_by_edges"] += int(self._parse_agtype(linked.get("c")) or 0)
-
-    def _rehydrate_document_layer(self, stats: Dict[str, int]) -> None:
-        """Create one :DocumentMeta per file (grouped by garage_key) + :HAS_SOURCE edges."""
-        rows = self._execute_cypher(
-            "MATCH (s:Source) WHERE s.garage_key IS NOT NULL "
-            "RETURN s.garage_key AS gk, s.document AS doc, count(s) AS cnt"
-        ) or []
-        # A file (garage_key) may carry chunks tagged to different ontologies, so
-        # the same gk can appear on multiple rows; process each gk once.
-        seen: set = set()
-        for row in rows:
-            garage_key = self._parse_agtype(row.get("gk"))
-            if not garage_key or garage_key in seen:
-                continue
-            seen.add(garage_key)
-            document = self._parse_agtype(row.get("doc"))
-            chunk_count = int(self._parse_agtype(row.get("cnt")) or 0)
-
-            # Stable document_id + display name from the file hash in the garage_key.
-            file_hash = re.sub(r"^.*/([^/]+)\.md$", r"\1", garage_key)
-            document_id = f"sha256:{file_hash}"
-
-            self._execute_cypher(
-                "MERGE (d:DocumentMeta {document_id: $document_id}) "
-                "SET d.filename = $filename, d.ontology = $ontology, "
-                "    d.content_type = 'document', d.source_count = $source_count "
-                "RETURN d",
-                params={
-                    "document_id": document_id,
-                    "filename": os.path.basename(garage_key),
-                    "ontology": document,
-                    "source_count": chunk_count,
-                },
-                fetch_one=True,
-            )
-            stats["documents"] += 1
-            linked = self._execute_cypher(
-                "MATCH (d:DocumentMeta {document_id: $document_id}) "
-                "MATCH (s:Source {garage_key: $garage_key}) "
-                "MERGE (d)-[:HAS_SOURCE]->(s) "
-                "RETURN count(s) AS c",
-                params={"document_id": document_id, "garage_key": garage_key},
-                fetch_one=True,
-            )
-            if linked:
-                stats["has_source_edges"] += int(self._parse_agtype(linked.get("c")) or 0)

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -342,6 +342,38 @@ def run_restore_worker(
         except Exception as e:
             logger.warning(f"[{job_id}] Graph-projection rehydration failed (non-fatal): {e}")
 
+        # Issue #505: restore-time durability for the :DocumentMeta tier. New backups
+        # carry a serialized `documents` stream that the importer rebuilds
+        # authoritatively; OLD backups don't, leaving the catalog document tier empty.
+        # When no DocumentMeta survived the import, reconstruct it from the restored
+        # Sources by hashing the document bytes now in Garage (uploaded in Stage 4
+        # above) to recover the canonical full hash. Guarded on the empty-tier check
+        # so it is a no-op for new backups; idempotent + best-effort.
+        try:
+            have = client._execute_cypher(
+                "MATCH (d:DocumentMeta) RETURN count(d) AS c", fetch_one=True
+            )
+            doc_count = int(client._parse_agtype(have.get("c")) or 0) if have else 0
+            if doc_count == 0:
+                from ..lib.garage import get_source_storage
+                source_storage = get_source_storage()
+                dh = client.rehydrate_document_layer(
+                    fetch_bytes=source_storage.get,
+                    created_by="post_restore_rehydration",
+                )
+                logger.info(
+                    f"[{job_id}] Restore-time durability rebuilt document tier: "
+                    f"{dh['documents']} documents / {dh['has_source_edges']} HAS_SOURCE "
+                    f"({dh['skipped']} skipped — bytes unavailable)"
+                )
+            else:
+                logger.info(
+                    f"[{job_id}] Document tier present ({doc_count} DocumentMeta) — "
+                    "serialized stream restored authoritatively, durability rebuild skipped"
+                )
+        except Exception as e:
+            logger.warning(f"[{job_id}] Document-tier durability rebuild failed (non-fatal): {e}")
+
         # ADR-207/#386 + ADR-102 P5: resolve the restore epoch(s) as COMPLETED. Until
         # now they held the committed watermark just below them, so every derivation
         # correctly read stale during the import. Completing advances the universal

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -323,6 +323,24 @@ def run_restore_worker(
             }
         })
 
+        # Issue #505: rebuild the derived graph-projection layers from the
+        # restored Sources. Backups predating ADR-200 (:Ontology) / the
+        # :DocumentMeta layer do not carry those nodes, and the Sources retain
+        # all source-of-truth data — without this the ontology list and catalog
+        # read empty after a restore. Runs BEFORE the epoch completes below, so
+        # the freshness tick that triggers the catalog's first post-restore
+        # rebuild already sees the rebuilt layers. Idempotent + best-effort: a
+        # failure must not fail an otherwise-completed restore.
+        try:
+            rh = client.rehydrate_projection_layers(created_by="post_restore_rehydration")
+            logger.info(
+                f"[{job_id}] Rehydrated graph projections: "
+                f"{rh['ontologies']} ontologies / {rh['scoped_by_edges']} SCOPED_BY, "
+                f"{rh['documents']} documents / {rh['has_source_edges']} HAS_SOURCE"
+            )
+        except Exception as e:
+            logger.warning(f"[{job_id}] Graph-projection rehydration failed (non-fatal): {e}")
+
         # ADR-207/#386 + ADR-102 P5: resolve the restore epoch(s) as COMPLETED. Until
         # now they held the committed watermark just below them, so every derivation
         # correctly read stale during the import. Completing advances the universal

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -323,20 +323,21 @@ def run_restore_worker(
             }
         })
 
-        # Issue #505: rebuild the derived graph-projection layers from the
-        # restored Sources. Backups predating ADR-200 (:Ontology) / the
-        # :DocumentMeta layer do not carry those nodes, and the Sources retain
-        # all source-of-truth data — without this the ontology list and catalog
-        # read empty after a restore. Runs BEFORE the epoch completes below, so
-        # the freshness tick that triggers the catalog's first post-restore
-        # rebuild already sees the rebuilt layers. Idempotent + best-effort: a
-        # failure must not fail an otherwise-completed restore.
+        # Issue #505: rebuild the derived :Ontology layer from the restored
+        # Sources. Backups predating the ontology serialization (pre-v0.15.1) do
+        # not carry :Ontology / :SCOPED_BY, and the Sources retain all
+        # source-of-truth data — without this the ontology list and catalog read
+        # empty after a restore. Runs BEFORE the epoch completes below, so the
+        # freshness tick that triggers the catalog's first post-restore rebuild
+        # already sees the rebuilt layer. Idempotent + best-effort: a failure
+        # must not fail an otherwise-completed restore. (The :DocumentMeta layer
+        # is rebuilt from its own serialized section, not reconstructed here —
+        # see issue #505 Option B.)
         try:
             rh = client.rehydrate_projection_layers(created_by="post_restore_rehydration")
             logger.info(
-                f"[{job_id}] Rehydrated graph projections: "
-                f"{rh['ontologies']} ontologies / {rh['scoped_by_edges']} SCOPED_BY, "
-                f"{rh['documents']} documents / {rh['has_source_edges']} HAS_SOURCE"
+                f"[{job_id}] Rehydrated ontology layer: "
+                f"{rh['ontologies']} ontologies / {rh['scoped_by_edges']} SCOPED_BY"
             )
         except Exception as e:
             logger.warning(f"[{job_id}] Graph-projection rehydration failed (non-fatal): {e}")

--- a/api/app/workers/restore_worker.py
+++ b/api/app/workers/restore_worker.py
@@ -348,7 +348,10 @@ def run_restore_worker(
         # When no DocumentMeta survived the import, reconstruct it from the restored
         # Sources by hashing the document bytes now in Garage (uploaded in Stage 4
         # above) to recover the canonical full hash. Guarded on the empty-tier check
-        # so it is a no-op for new backups; idempotent + best-effort.
+        # so it is a no-op for new backups; idempotent + best-effort. (All-or-nothing
+        # by design: a serialized restore that produced *some* DocumentMeta is trusted
+        # whole — a partial import is not self-healed here, to avoid re-hashing all of
+        # Garage on every healthy restore. Issue #505.)
         try:
             have = client._execute_cypher(
                 "MATCH (d:DocumentMeta) RETURN count(d) AS c", fetch_one=True
@@ -361,10 +364,14 @@ def run_restore_worker(
                     fetch_bytes=source_storage.get,
                     created_by="post_restore_rehydration",
                 )
+                mismatch_note = (
+                    f", {dh['mismatches']} HASH MISMATCH — check Garage integrity"
+                    if dh.get("mismatches") else ""
+                )
                 logger.info(
                     f"[{job_id}] Restore-time durability rebuilt document tier: "
                     f"{dh['documents']} documents / {dh['has_source_edges']} HAS_SOURCE "
-                    f"({dh['skipped']} skipped — bytes unavailable)"
+                    f"({dh['skipped']} skipped — bytes unavailable{mismatch_note})"
                 )
             else:
                 logger.info(

--- a/api/lib/serialization/exporter.py
+++ b/api/lib/serialization/exporter.py
@@ -466,6 +466,106 @@ class DataExporter:
         ]
 
     @staticmethod
+    def export_documents(client: AGEClient, ontology: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Export :DocumentMeta nodes as first-class records (the catalog document tier).
+
+        The document layer is NOT reconstructable from Sources: the canonical
+        identity (``document_id == content_hash == sha256(document bytes)``, the
+        full 71-char ``sha256:``-prefixed digest) survives on Sources only as the
+        32-char ``garage_key`` prefix, so a Source-derived DocumentMeta would have a
+        truncated id that breaks drill-down and re-ingest dedup (issue #505). We
+        therefore serialize the layer and carry every field verbatim — especially
+        ``document_id``/``content_hash`` (with prefix) and ``garage_key`` (no prefix);
+        no recomputation on either side. Round-trips with :func:`export_has_source`
+        and the importer's ``_import_documents``.
+
+        Args:
+            client: AGEClient instance
+            ontology: Optional name filter (None = all documents)
+
+        Returns:
+            List of DocumentMeta node dictionaries.
+        """
+        if ontology:
+            query = """
+                MATCH (d:DocumentMeta {ontology: $ontology})
+                RETURN d.document_id as document_id, d.content_hash as content_hash,
+                       d.ontology as ontology, d.filename as filename,
+                       d.garage_key as garage_key, d.content_type as content_type,
+                       d.source_count as source_count, d.ingested_at as ingested_at,
+                       d.ingested_by as ingested_by, d.job_id as job_id,
+                       d.file_path as file_path, d.source_type as source_type,
+                       d.hostname as hostname, d.storage_key as storage_key
+                ORDER BY d.document_id
+            """
+            result = client._execute_cypher(query, params={"ontology": ontology})
+        else:
+            query = """
+                MATCH (d:DocumentMeta)
+                RETURN d.document_id as document_id, d.content_hash as content_hash,
+                       d.ontology as ontology, d.filename as filename,
+                       d.garage_key as garage_key, d.content_type as content_type,
+                       d.source_count as source_count, d.ingested_at as ingested_at,
+                       d.ingested_by as ingested_by, d.job_id as job_id,
+                       d.file_path as file_path, d.source_type as source_type,
+                       d.hostname as hostname, d.storage_key as storage_key
+                ORDER BY d.document_id
+            """
+            result = client._execute_cypher(query)
+
+        documents = []
+        for record in result:
+            documents.append({
+                # Canonical identity — carried verbatim (with the sha256: prefix),
+                # never recomputed. This is what makes restore authoritative.
+                "document_id": _parse_nullable_str(record.get("document_id")),
+                "content_hash": _parse_nullable_str(record.get("content_hash")),
+                "ontology": _parse_nullable_str(record.get("ontology")),
+                "filename": _parse_nullable_str(record.get("filename")),
+                "garage_key": _parse_nullable_str(record.get("garage_key")),
+                "content_type": _parse_nullable_str(record.get("content_type")),
+                "source_count": _parse_nullable_int(record.get("source_count")),
+                "ingested_at": _parse_nullable_str(record.get("ingested_at")),
+                "ingested_by": _parse_nullable_str(record.get("ingested_by")),
+                "job_id": _parse_nullable_str(record.get("job_id")),
+                "file_path": _parse_nullable_str(record.get("file_path")),
+                "source_type": _parse_nullable_str(record.get("source_type")),
+                "hostname": _parse_nullable_str(record.get("hostname")),
+                "storage_key": _parse_nullable_str(record.get("storage_key")),
+            })
+
+        return documents
+
+    @staticmethod
+    def export_has_source(client: AGEClient, ontology: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Export (:DocumentMeta)-[:HAS_SOURCE]->(:Source) edges — the file→chunk grouping.
+
+        One DocumentMeta groups all the Source chunks of a file. Exported explicitly
+        (keyed on the canonical ``document_id``) so the grouping round-trips rather
+        than being re-derived from ``garage_key`` heuristics (issue #505).
+        """
+        if ontology:
+            query = """
+                MATCH (d:DocumentMeta {ontology: $ontology})-[:HAS_SOURCE]->(s:Source)
+                RETURN d.document_id as document_id, s.source_id as source_id
+                ORDER BY d.document_id, s.source_id
+            """
+            result = client._execute_cypher(query, params={"ontology": ontology})
+        else:
+            query = """
+                MATCH (d:DocumentMeta)-[:HAS_SOURCE]->(s:Source)
+                RETURN d.document_id as document_id, s.source_id as source_id
+                ORDER BY d.document_id, s.source_id
+            """
+            result = client._execute_cypher(query)
+
+        return [
+            {"document_id": str(r.get("document_id", "")).strip('"'),
+             "source_id": str(r.get("source_id", "")).strip('"')}
+            for r in result
+        ]
+
+    @staticmethod
     def export_vocabulary(client: AGEClient) -> List[Dict[str, Any]]:
         """
         Export relationship vocabulary table (ADR-032)
@@ -685,6 +785,8 @@ class DataExporter:
         ontologies: Optional[List[Dict[str, Any]]] = None,
         scoped_by: Optional[List[Dict[str, Any]]] = None,
         anchored_by: Optional[List[Dict[str, Any]]] = None,
+        documents: Optional[List[Dict[str, Any]]] = None,
+        has_source: Optional[List[Dict[str, Any]]] = None,
         source_platform: str = "knowledge-graph-system",
         source_version: str = "unknown",
         exported_at: Optional[str] = None,
@@ -819,6 +921,12 @@ class DataExporter:
                 "ontologies": list(ontologies or []),
                 "scoped_by": list(scoped_by or []),
                 "anchored_by": list(anchored_by or []),
+                # :DocumentMeta nodes + their HAS_SOURCE grouping (the catalog
+                # document tier). Carried verbatim — canonical document_id /
+                # content_hash are unrecoverable from Sources (issue #505). Empty
+                # for pre-stream backups; the reader tolerates absence.
+                "documents": list(documents or []),
+                "has_source": list(has_source or []),
             },
         }
 
@@ -844,6 +952,8 @@ class DataExporter:
         ontologies = DataExporter.export_ontologies(client, ontology)
         scoped_by = DataExporter.export_scoped_by(client, ontology)
         anchored_by = DataExporter.export_anchored_by(client, ontology)
+        documents = DataExporter.export_documents(client, ontology)
+        has_source = DataExporter.export_has_source(client, ontology)
         DataExporter._log_vocabulary_summary(relationships, vocabulary)
 
         return DataExporter.build_kg_backup_v2(
@@ -852,6 +962,7 @@ class DataExporter:
             embedding_profiles=embedding_profiles, epoch_kinds=epoch_kinds,
             graph_epochs=graph_epochs,
             ontologies=ontologies, scoped_by=scoped_by, anchored_by=anchored_by,
+            documents=documents, has_source=has_source,
             schema_version=BackupFormat.get_schema_version(client),
             ontology=ontology,
         )

--- a/api/lib/serialization/exporter.py
+++ b/api/lib/serialization/exporter.py
@@ -479,6 +479,12 @@ class DataExporter:
         no recomputation on either side. Round-trips with :func:`export_has_source`
         and the importer's ``_import_documents``.
 
+        NOTE (multi-ontology, issue #505 follow-up): a scoped export filters on
+        ``d.ontology``, so a document ingested into several ontologies (one
+        DocumentMeta, one ontology value) is only carried by the export of *that*
+        ontology. The dominant full-DB export (``ontology=None``) carries every
+        DocumentMeta and is unaffected.
+
         Args:
             client: AGEClient instance
             ontology: Optional name filter (None = all documents)
@@ -560,8 +566,8 @@ class DataExporter:
             result = client._execute_cypher(query)
 
         return [
-            {"document_id": str(r.get("document_id", "")).strip('"'),
-             "source_id": str(r.get("source_id", "")).strip('"')}
+            {"document_id": _parse_nullable_str(r.get("document_id")),
+             "source_id": _parse_nullable_str(r.get("source_id"))}
             for r in result
         ]
 

--- a/api/lib/serialization/format.py
+++ b/api/lib/serialization/format.py
@@ -186,12 +186,30 @@ class KgBackupV2Reader:
         """Return (:Ontology)-[:ANCHORED_BY]->(:Concept) edges as ``{ontology, concept_id}``."""
         return list(self.bulk.get("anchored_by", []))
 
+    def documents(self):
+        """Yield :DocumentMeta node records (the catalog's document tier — issue #505).
+
+        Carries the canonical document identity (``document_id``/``content_hash`` —
+        the full ``sha256:``-prefixed digest) and Garage location, so restore
+        rebuilds the layer authoritatively rather than re-deriving it from Sources
+        (where the full document hash is unrecoverable). Empty for backups taken
+        before this stream existed — restoring such a backup falls back to the
+        Garage-hashed reconstruction in restore (Option B fallback).
+        """
+        for d in self.bulk.get("documents", []):
+            yield dict(d)
+
+    def has_source(self):
+        """Return (:DocumentMeta)-[:HAS_SOURCE]->(:Source) edges as ``{document_id, source_id}``."""
+        return list(self.bulk.get("has_source", []))
+
     def counts(self):
         """Return record counts per bulk stream (for stats/logging)."""
         b = self.bulk
         return {k: len(b.get(k, [])) for k in
                 ("concepts", "sources", "instances", "evidence", "relationships",
-                 "vocabulary", "ontologies", "scoped_by", "anchored_by")}
+                 "vocabulary", "ontologies", "scoped_by", "anchored_by",
+                 "documents", "has_source")}
 
     def external_concept_ids(self):
         """Concept ids referenced by edges/evidence but absent from this backup.

--- a/api/lib/serialization/importer.py
+++ b/api/lib/serialization/importer.py
@@ -176,6 +176,7 @@ class DataImporter:
             "concepts_created": 0,
             "sources_created": 0,
             "ontologies_created": 0,
+            "documents_created": 0,
             "instances_created": 0,
             "relationships_created": 0,
         }
@@ -204,6 +205,17 @@ class DataImporter:
             Console.info(f"Importing {len(ontologies)} ontologies (+SCOPED_BY/ANCHORED_BY)...")
             stats["ontologies_created"] = DataImporter._import_ontologies(
                 client, ontologies, reader.scoped_by(), reader.anchored_by(), progress_callback
+            )
+
+        # DocumentMeta after sources: HAS_SOURCE needs the Source nodes (imported
+        # above). Authoritative restore of the catalog document tier (issue #505).
+        # Absent in pre-stream backups → falls back to the restore-worker's
+        # Garage-hashed reconstruction.
+        documents = list(reader.documents())
+        if documents:
+            Console.info(f"Importing {len(documents)} documents (+HAS_SOURCE)...")
+            stats["documents_created"] = DataImporter._import_documents(
+                client, documents, reader.has_source(), progress_callback
             )
 
         instances = list(reader.instances())
@@ -475,6 +487,63 @@ class DataImporter:
             _execute_with_age_retry(client, anchored_query, {
                 "ontology": edge.get("ontology"),
                 "concept_id": edge.get("concept_id"),
+            })
+
+        return total
+
+    # DocumentMeta properties carried in the backup, besides the document_id MERGE
+    # key. Only non-None values are SET so a restore never wipes a field that the
+    # backup happens not to carry (mirrors create_document_meta's build).
+    _DOCUMENT_PROPS = (
+        "content_hash", "ontology", "filename", "garage_key", "content_type",
+        "source_count", "ingested_at", "ingested_by", "job_id", "file_path",
+        "source_type", "hostname", "storage_key",
+    )
+
+    @staticmethod
+    def _import_documents(client: AGEClient,
+                          documents: List[Dict[str, Any]],
+                          has_source: List[Dict[str, Any]],
+                          progress_callback) -> int:
+        """MERGE :DocumentMeta nodes and their HAS_SOURCE edges (issue #505).
+
+        Authoritative restore of the catalog document tier. Idempotent and keyed on
+        the canonical ``document_id`` (the full ``sha256:``-prefixed digest), carried
+        **verbatim** from the backup — never recomputed. MERGE-on-``document_id``
+        means restoring the same backup twice, or restoring a document already
+        present in the target, converges to a single node (robustness requirement #1:
+        no duplicate DocumentMeta). ``content_hash``/``garage_key`` are likewise
+        carried verbatim, so byte-identical content keeps its deterministic Garage
+        key and re-ingest dedup still short-circuits (requirement #2).
+
+        Nodes are written first so the HAS_SOURCE MERGEs can match both endpoints;
+        an edge whose Source endpoint is absent matches nothing and is skipped (no
+        dangling edge). Returns the number of DocumentMeta nodes written.
+        """
+        total = len(documents)
+        for i, d in enumerate(documents):
+            document_id = d.get("document_id")
+            if not document_id:
+                continue
+            # Build SET only from carried, non-None props (don't wipe on restore).
+            set_props = {k: d[k] for k in DataImporter._DOCUMENT_PROPS
+                         if d.get(k) is not None}
+            set_clause = ", ".join(f"d.{k} = ${k}" for k in set_props)
+            node_query = "MERGE (d:DocumentMeta {document_id: $document_id})"
+            if set_clause:
+                node_query += f" SET {set_clause}"
+            _execute_with_age_retry(client, node_query, {"document_id": document_id, **set_props})
+            _progress(progress_callback, "documents", i + 1, total, every=1)
+
+        # HAS_SOURCE: (DocumentMeta)-[:HAS_SOURCE]->(Source), keyed on document_id.
+        has_source_query = """
+            MATCH (d:DocumentMeta {document_id: $document_id}), (s:Source {source_id: $source_id})
+            MERGE (d)-[:HAS_SOURCE]->(s)
+        """
+        for edge in has_source:
+            _execute_with_age_retry(client, has_source_query, {
+                "document_id": edge.get("document_id"),
+                "source_id": edge.get("source_id"),
             })
 
         return total

--- a/schema/migrations/078_seed_primordial_ontology.sql
+++ b/schema/migrations/078_seed_primordial_ontology.sql
@@ -1,0 +1,57 @@
+-- Migration: 078_seed_primordial_ontology
+-- Description: Seed the reserved 'primordial' ontology pool on clean install
+-- Issue: #505
+-- ADR: ADR-200 (Annealing Ontologies)
+--
+-- The 'primordial' pool is the reserved default ontology that unroutable
+-- sources fall into. It was only created LAZILY — the first time an annealing
+-- cycle ran (proposal_executor._ensure_primordial_pool) — so a fresh instance
+-- had no primordial pool until then. Seed it eagerly at install so it always
+-- exists. Idempotent: creates the node only if absent.
+--
+-- (Restore also ensures primordial via AGEClient.rehydrate_projection_layers,
+-- since a clone-style restore can replace this freshly-seeded graph.)
+
+LOAD 'age';
+SET search_path = ag_catalog, kg_api, public;
+
+DO $migration$
+DECLARE
+    exists_count INTEGER;
+    new_id TEXT;
+BEGIN
+    -- The :Ontology label is precreated by migration 058, so this MATCH is safe
+    -- on a fresh graph (empty, not missing).
+    EXECUTE 'SELECT count(*)::int FROM cypher(''knowledge_graph'', $cypher$
+        MATCH (o:Ontology {name: ''primordial''})
+        RETURN o
+    $cypher$) as (o agtype)' INTO exists_count;
+
+    IF exists_count = 0 THEN
+        new_id := 'ont_' || gen_random_uuid()::text;
+        EXECUTE format(
+            'SELECT * FROM cypher(''knowledge_graph'', $cypher$
+                CREATE (o:Ontology {
+                    ontology_id: ''%s'',
+                    name: ''primordial'',
+                    description: ''Default pool for unroutable sources'',
+                    lifecycle_state: ''active'',
+                    creation_epoch: 0,
+                    created_by: ''system''
+                })
+            $cypher$) as (o agtype)',
+            new_id
+        );
+        RAISE NOTICE 'Seeded primordial ontology (id: %)', new_id;
+    ELSE
+        RAISE NOTICE 'primordial ontology already exists, skipping';
+    END IF;
+END $migration$;
+
+-- ---------------------------------------------------------------------------
+-- Migration Tracking
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (78, 'seed_primordial_ontology')
+ON CONFLICT (version) DO NOTHING;

--- a/scripts/development/lint/lint_backup.py
+++ b/scripts/development/lint/lint_backup.py
@@ -137,6 +137,11 @@ CHECK_CODES = {
     "E_SCOPED_ONTOLOGY_MISSING": "scoped_by.ontology not in ontologies[].",
     "E_ANCHORED_CONCEPT_MISSING": "anchored_by.concept_id not in concepts[].",
     "E_ANCHORED_ONTOLOGY_MISSING": "anchored_by.ontology not in ontologies[].",
+    # document streams (first-class :DocumentMeta nodes + their HAS_SOURCE edges, #505)
+    "E_DUP_DOCUMENT_ID": "duplicate document_id in documents[].",
+    "E_HAS_SOURCE_DOC_MISSING": "has_source.document_id not in documents[].",
+    "E_HAS_SOURCE_SOURCE_MISSING": "has_source.source_id not in sources[].",
+    "E_DUP_HAS_SOURCE": "duplicate (document_id, source_id) HAS_SOURCE edge.",
     # exclusions
     "E_DERIVED_PRESENT": "derived product present in bulk (must be excluded).",
 }
@@ -679,6 +684,41 @@ def _validate_bulk(
                            f"duplicate ANCHORED_BY edge ({on!r} -> {cid!r}).",
                            f"$.bulk.anchored_by[{i}]")
             seen_anchored.add(pair)
+
+    # ---- documents / has_source: unique ids, endpoints resolve, no dup edges (#505) ----
+    document_ids = set()
+    for i, d in enumerate(bulk.get("documents") or []):
+        if not isinstance(d, dict):
+            continue
+        did = d.get("document_id")
+        if did is not None:
+            if did in document_ids:
+                result.add(ERROR, "E_DUP_DOCUMENT_ID",
+                           f"duplicate document_id {did!r} in documents[].",
+                           f"$.bulk.documents[{i}].document_id")
+            document_ids.add(did)
+
+    seen_has_source = set()
+    for i, e in enumerate(bulk.get("has_source") or []):
+        if not isinstance(e, dict):
+            continue
+        did = e.get("document_id")
+        if did is not None and did not in document_ids:
+            result.add(ERROR, "E_HAS_SOURCE_DOC_MISSING",
+                       f"has_source.document_id {did!r} not present in documents[].",
+                       f"$.bulk.has_source[{i}].document_id")
+        sid = e.get("source_id")
+        if sid is not None and sid not in source_ids:
+            result.add(ERROR, "E_HAS_SOURCE_SOURCE_MISSING",
+                       f"has_source.source_id {sid!r} not present in sources[].",
+                       f"$.bulk.has_source[{i}].source_id")
+        pair = (did, sid)
+        if did is not None and sid is not None:
+            if pair in seen_has_source:
+                result.add(ERROR, "E_DUP_HAS_SOURCE",
+                           f"duplicate HAS_SOURCE edge ({did!r} -> {sid!r}).",
+                           f"$.bulk.has_source[{i}]")
+            seen_has_source.add(pair)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_kg_backup_v2_restore.py
+++ b/tests/api/test_kg_backup_v2_restore.py
@@ -72,7 +72,8 @@ def client_with_cleanup():
     finally:
         # Remove only the namespaced test nodes (DETACH DELETE drops their edges too).
         for label, idfield in (("Concept", "concept_id"), ("Source", "source_id"),
-                               ("Instance", "instance_id"), ("Ontology", "ontology_id")):
+                               ("Instance", "instance_id"), ("Ontology", "ontology_id"),
+                               ("DocumentMeta", "document_id")):
             try:
                 client._execute_cypher(
                     f"MATCH (n:{label}) WHERE n.{idfield} STARTS WITH '{NS}' DETACH DELETE n"
@@ -440,3 +441,120 @@ def test_adjacent_remap_round_trips_through_clone_writer(client_with_cleanup):
     assert _scalar(client,
         f"MATCH (c:Concept)-[:EVIDENCED_BY]->(i:Instance {{instance_id:'{rm_i1}'}})-[:FROM_SOURCE]->(:Source {{source_id:'{rm_s1}'}}) "
         f"RETURN count(c) AS n") == 2
+
+
+def _document_backup():
+    """A namespaced backup carrying one :DocumentMeta grouping one Source (issue #505)."""
+    doc_id = f"{NS}sha256_doc1"   # NS-prefixed so the cleanup fixture removes it
+    return DataExporter.build_kg_backup_v2(
+        concepts=[],
+        sources=[{"source_id": f"{NS}ds1", "document": f"{NS}DocOnto", "file_path": "/d",
+                  "paragraph": 1, "full_text": "body", "content_type": "text/plain",
+                  "garage_key": f"sources/{NS}DocOnto/{'a' * 32}.md"}],
+        instances=[], evidence=[], relationships=[], vocabulary=[],
+        embedding_profiles=[{"identity": "openai:text-embedding-3-small@1536", "vector_space": "x",
+                             "image_vector_space": None, "name": "d", "multimodal": False}],
+        epoch_kinds=[], graph_epochs=[],
+        documents=[{"document_id": doc_id, "content_hash": doc_id, "ontology": f"{NS}DocOnto",
+                    "filename": "doc1.md", "garage_key": f"sources/{NS}DocOnto/{'a' * 32}.md",
+                    "content_type": "document", "source_count": 1}],
+        has_source=[{"document_id": doc_id, "source_id": f"{NS}ds1"}],
+        schema_version=78,
+    ), doc_id
+
+
+def test_document_layer_round_trips_and_is_idempotent(client_with_cleanup):
+    """The serialized :DocumentMeta layer restores authoritatively and dedups on re-restore.
+
+    Covers issue #505 Option B requirement #1: restoring the SAME backup twice must
+    MERGE on the canonical document_id, never creating a duplicate DocumentMeta. Also
+    asserts the canonical id/content_hash come back byte-identical (carried verbatim,
+    not re-derived from the Source's truncated garage_key prefix).
+    """
+    client = client_with_cleanup
+    backup, doc_id = _document_backup()
+
+    # Restore twice — idempotency is the whole point.
+    DataImporter.import_backup(client, backup, overwrite_existing=True)
+    DataImporter.import_backup(client, backup, overwrite_existing=True)
+
+    # Exactly ONE DocumentMeta despite two restores (requirement #1: no duplicate).
+    assert _scalar(client,
+        f"MATCH (d:DocumentMeta {{document_id:'{doc_id}'}}) RETURN count(d) AS n") == 1
+    # Canonical identity carried verbatim (content_hash == document_id, full string).
+    assert _scalar(client,
+        f"MATCH (d:DocumentMeta {{document_id:'{doc_id}'}}) "
+        f"WHERE d.content_hash = '{doc_id}' RETURN count(d) AS n") == 1
+    # HAS_SOURCE grouping reconstructed, and also idempotent (one edge, not two).
+    assert _scalar(client,
+        f"MATCH (:DocumentMeta {{document_id:'{doc_id}'}})-[:HAS_SOURCE]->(:Source {{source_id:'{NS}ds1'}}) "
+        f"RETURN count(*) AS n") == 1
+
+
+def test_pre_b_backup_imports_no_document_layer(client_with_cleanup):
+    """A backup without the documents stream creates no :DocumentMeta on import.
+
+    (The restore worker's Garage-hashed durability path — covered separately — is
+    what rebuilds the tier for such backups; the importer itself must not invent one.)
+    """
+    client = client_with_cleanup
+    backup, doc_id = _document_backup()
+    backup["bulk"].pop("documents", None)
+    backup["bulk"].pop("has_source", None)
+
+    DataImporter.import_backup(client, backup, overwrite_existing=True)
+    assert _scalar(client,
+        f"MATCH (d:DocumentMeta {{document_id:'{doc_id}'}}) RETURN count(d) AS n") == 0
+
+
+def test_durability_reconstructs_canonical_documentmeta_from_garage_bytes(client_with_cleanup):
+    """Restore-time durability rebuilds :DocumentMeta with the CANONICAL full hash (#505).
+
+    For a pre-B backup there is no documents stream, so the worker hashes the actual
+    document bytes (from Garage) to recover the full digest rather than the truncated
+    32-char garage_key prefix. This injects a fake byte-fetcher and asserts the
+    reconstructed document_id == "sha256:" + sha256(bytes) — the full 71-char form,
+    not the truncated id the naive Source-derived approach produced.
+
+    rehydrate_document_layer scans ALL Sources, so the fetcher returns bytes ONLY for
+    our namespaced garage_key and None for everything else — real sources are skipped
+    (never mutated), keeping this test honest against the "messy data" live graph.
+    """
+    import hashlib
+    client = client_with_cleanup
+
+    content = b"the quick brown fox"
+    full = hashlib.sha256(content).hexdigest()
+    expected_id = f"sha256:{full}"
+    garage_key = f"sources/{NS}DurOnto/{full[:32]}.md"   # prefix matches → no integrity warning
+
+    # Two namespaced Source chunks of the same file (same garage_key), no DocumentMeta yet.
+    for n in (1, 2):
+        client._execute_cypher(
+            "CREATE (s:Source {source_id: $sid, document: $doc, garage_key: $gk, "
+            "full_text: $ft, paragraph: $p})",
+            params={"sid": f"{NS}durs{n}", "doc": f"{NS}DurOnto", "gk": garage_key,
+                    "ft": "chunk", "p": n})
+
+    # Bytes for our file only; None for every real source so they are skipped, not touched.
+    fetch = lambda gk: content if gk == garage_key else None
+    try:
+        client.rehydrate_document_layer(fetch_bytes=fetch)
+
+        # Canonical full-length id reconstructed (NOT the 32-char truncation).
+        assert _scalar(client,
+            f"MATCH (d:DocumentMeta {{document_id:'{expected_id}'}}) "
+            f"WHERE d.content_hash = '{expected_id}' AND d.garage_key = '{garage_key}' "
+            f"RETURN count(d) AS n") == 1
+        # Both chunks grouped under the one DocumentMeta.
+        assert _scalar(client,
+            f"MATCH (:DocumentMeta {{document_id:'{expected_id}'}})-[:HAS_SOURCE]->(s:Source) "
+            f"WHERE s.source_id STARTS WITH '{NS}dur' RETURN count(s) AS n") == 2
+        # Idempotent: a second pass creates no duplicate node or edge.
+        client.rehydrate_document_layer(fetch_bytes=fetch)
+        assert _scalar(client,
+            f"MATCH (d:DocumentMeta {{document_id:'{expected_id}'}}) RETURN count(d) AS n") == 1
+    finally:
+        # Hash-based id isn't NS-prefixed, so remove it explicitly (the fixture can't).
+        client._execute_cypher(
+            f"MATCH (d:DocumentMeta {{document_id:'{expected_id}'}}) DETACH DELETE d")

--- a/tests/unit/test_kg_backup_v2.py
+++ b/tests/unit/test_kg_backup_v2.py
@@ -255,3 +255,74 @@ def test_dynamic_edge_type_missing_from_vocab_still_interns():
     assert result.ok, [str(i) for i in result.errors]
     types = [v.get("relationship_type") for v in obj["header"]["relationship_vocabulary"]]
     assert "NOVEL_REL" in types
+
+
+# ---------------------------------------------------------------------------
+# Document streams (:DocumentMeta + HAS_SOURCE) — issue #505 Option B
+# ---------------------------------------------------------------------------
+
+_DOC_ID = "sha256:" + "a" * 64
+
+
+def _document(document_id=_DOC_ID, ontology="Corpus"):
+    return {"document_id": document_id, "content_hash": document_id,
+            "ontology": ontology, "filename": "intro.md",
+            "garage_key": "sources/Corpus/" + "a" * 32 + ".md",
+            "content_type": "document", "source_count": 1}
+
+
+def test_document_streams_land_in_bulk_and_validate():
+    """First-class :DocumentMeta nodes + HAS_SOURCE edges are emitted and validate."""
+    lists = _fixture_lists()
+    lists["documents"] = [_document()]
+    lists["has_source"] = [{"document_id": _DOC_ID, "source_id": "s1"}]
+    obj = DataExporter.build_kg_backup_v2(**lists)
+
+    assert obj["bulk"]["documents"][0]["document_id"] == _DOC_ID
+    # Canonical id carried verbatim (with sha256: prefix) — the heart of Option B.
+    assert obj["bulk"]["documents"][0]["content_hash"] == _DOC_ID
+    assert obj["bulk"]["has_source"] == [{"document_id": _DOC_ID, "source_id": "s1"}]
+    result = lint_backup.validate_backup(obj)
+    assert result.ok, [str(i) for i in result.errors]
+
+
+def test_document_streams_default_empty_when_omitted():
+    """Callers that don't pass the streams get empty lists, not missing keys."""
+    obj = DataExporter.build_kg_backup_v2(**_fixture_lists())
+    assert obj["bulk"]["documents"] == []
+    assert obj["bulk"]["has_source"] == []
+
+
+def test_has_source_orphans_are_flagged():
+    """The validator catches HAS_SOURCE edges whose endpoints are missing."""
+    lists = _fixture_lists()
+    lists["documents"] = [_document()]
+    lists["has_source"] = [
+        {"document_id": _DOC_ID, "source_id": "s1"},          # ok
+        {"document_id": _DOC_ID, "source_id": "sX"},          # sX: no such source
+        {"document_id": "sha256:" + "b" * 64, "source_id": "s1"},  # doc: not in documents[]
+    ]
+    codes = {i.code for i in lint_backup.validate_backup(
+        DataExporter.build_kg_backup_v2(**lists)).errors}
+    assert "E_HAS_SOURCE_SOURCE_MISSING" in codes
+    assert "E_HAS_SOURCE_DOC_MISSING" in codes
+
+
+def test_duplicate_document_and_has_source_flagged():
+    lists = _fixture_lists()
+    lists["documents"] = [_document(), _document()]            # same document_id twice
+    lists["has_source"] = [{"document_id": _DOC_ID, "source_id": "s1"},
+                           {"document_id": _DOC_ID, "source_id": "s1"}]  # dup edge
+    codes = {i.code for i in lint_backup.validate_backup(
+        DataExporter.build_kg_backup_v2(**lists)).errors}
+    assert "E_DUP_DOCUMENT_ID" in codes
+    assert "E_DUP_HAS_SOURCE" in codes
+
+
+def test_well_formed_document_streams_validate_clean():
+    """A faithful document layer passes the validator with no new errors."""
+    lists = _fixture_lists()
+    lists["documents"] = [_document()]
+    lists["has_source"] = [{"document_id": _DOC_ID, "source_id": "s1"}]
+    result = lint_backup.validate_backup(DataExporter.build_kg_backup_v2(**lists))
+    assert result.ok, [str(i) for i in result.errors]

--- a/tests/unit/test_kg_backup_v2_reader.py
+++ b/tests/unit/test_kg_backup_v2_reader.py
@@ -96,7 +96,8 @@ def test_counts():
     counts = KgBackupV2Reader(_build()).counts()
     assert counts == {"concepts": 2, "sources": 1, "instances": 1,
                       "evidence": 2, "relationships": 1, "vocabulary": 1,
-                      "ontologies": 0, "scoped_by": 0, "anchored_by": 0}
+                      "ontologies": 0, "scoped_by": 0, "anchored_by": 0,
+                      "documents": 0, "has_source": 0}
 
 
 def test_ontology_streams_round_trip_through_reader():
@@ -130,6 +131,43 @@ def test_ontology_streams_absent_in_pre_stream_backup():
     reader = KgBackupV2Reader(obj)
     assert list(reader.ontologies()) == []
     assert reader.scoped_by() == [] and reader.anchored_by() == []
+
+
+def test_document_streams_round_trip_through_reader():
+    """:DocumentMeta nodes + HAS_SOURCE edges survive build → read intact (#505).
+
+    The canonical identity (the full ``sha256:``-prefixed digest) must come back
+    byte-for-byte — that is what makes restore authoritative rather than a lossy
+    re-derivation from Sources.
+    """
+    full_id = "sha256:" + "a" * 64
+    obj = _build(
+        documents=[
+            {"document_id": full_id, "content_hash": full_id, "ontology": "Corpus",
+             "filename": "intro.md", "garage_key": "sources/Corpus/" + "a" * 32 + ".md",
+             "content_type": "document", "source_count": 3},
+        ],
+        has_source=[{"document_id": full_id, "source_id": "s1"}],
+    )
+    reader = KgBackupV2Reader(obj)
+    docs = list(reader.documents())
+    assert len(docs) == 1
+    assert docs[0]["document_id"] == full_id          # full 71-char id, not truncated
+    assert docs[0]["content_hash"] == full_id
+    assert docs[0]["garage_key"] == "sources/Corpus/" + "a" * 32 + ".md"
+    assert reader.has_source() == [{"document_id": full_id, "source_id": "s1"}]
+    assert reader.counts()["documents"] == 1
+    assert reader.counts()["has_source"] == 1
+
+
+def test_document_streams_absent_in_pre_stream_backup():
+    """A pre-Option-B backup (no documents stream) reads as empty (back-compat)."""
+    obj = _build()
+    obj["bulk"].pop("documents", None)
+    obj["bulk"].pop("has_source", None)
+    reader = KgBackupV2Reader(obj)
+    assert list(reader.documents()) == []
+    assert reader.has_source() == []
 
 
 def test_external_concept_ids_empty_when_self_contained():


### PR DESCRIPTION
Toward #505 — closes after the maintainer's end-to-end verification (wipe → rebuild → restore).

Restoring a backup left the catalog's **document tier** empty (`kg catalog ls`, document drill-down) and — for pre-serialization backups — the **ontology tier** too (`kg ontology list`). This PR restores both authoritatively, and seeds the reserved `primordial` pool on clean install.

## What's in here (4 commits)

1. **`feat(restore)` + `refactor(restore)` — ontology-layer rehydration.** `RehydrationMixin.rehydrate_projection_layers()` rebuilds `:Ontology` + `:SCOPED_BY` from distinct `s.document`. For new backups the importer already MERGEs these (serialization), so it's an idempotent no-op; for **old** backups it's the reconstruction. (The original document-half of this rehydration was removed — it produced a truncated 32-char `document_id` that broke drill-down + dedup; replaced by serialization below.)

2. **`feat(install)` — primordial seed.** Migration `078` seeds the `primordial` pool eagerly + idempotently (was only created lazily during annealing).

3. **`feat(serialization)` — serialize the `:DocumentMeta` layer + restore-time durability (Option B).**
   - **Exporter** emits `:DocumentMeta` nodes + `HAS_SOURCE` edges, carrying `document_id`/`content_hash` **verbatim** (canonical `sha256:`-prefixed digest) and `garage_key` (no prefix) — no recomputation.
   - **Importer** `_import_documents` MERGEs on the canonical `document_id` → restoring the same backup twice never duplicates a `:DocumentMeta` (**robustness req #1**).
   - **Restore-time durability**: pre-B backups (no `documents` stream) reconstruct the tier from the document bytes in Garage, hashing them to recover the **canonical full digest** (not the truncated `garage_key` prefix). Garage I/O injected; mixin stays DB-only; guarded on an empty tier (no-op for new backups).
   - **Determinism (req #2):** hashes/keys are carried, never recomputed at restore; the durability path hashes raw bytes and asserts the result matches the existing `garage_key` prefix.
   - **Validator**: `documents`/`has_source` referential + duplicate checks, mirroring the ontology streams.

## Why serialize instead of reconstruct

The canonical identity `document_id == content_hash == sha256(document bytes)` is **not recoverable** from `:Source` nodes — `garage_key` carries only `content_hash[:32]`, and `Source.content_hash` is the per-chunk hash. A Source-derived id is truncated and breaks `GET /documents/{id}` (reads `d.garage_key`) and re-ingest dedup. Confirmed against the live graph; full analysis in `.claude/todo-issue-505-restore-fidelity.md`.

## Validation

- **Non-destructive probe on the live graph:** 120/120 Garage objects hash back to their `garage_key` prefix (0 mismatch) — the durability path recovers canonical hashes exactly.
- **Tests (77 passing in the backup/restore set):** build→read round-trip preserving the full id; importer idempotency (double restore → one node); pre-B backup imports no tier; durability reconstructs the canonical hash + is idempotent; validator orphan/dup cases.
- **End-to-end** (wipe → rebuild → fresh restore) is the maintainer's acceptance test, run after review.

## Notes

- Data-quality observation (some `garage_key`s tagged to multiple `s.document` ontologies) tracked as a separate follow-up.
- A restore endpoint that imports *pre-extracted graph interchange* (vs. raw content) is a possible future feature — deliberately **not** in scope here; restore stays faithful rehydration, ingestion stays extraction.

