### PR TITLE
feat(appliance): Traefik TLS cert path — EXTERNAL_URL + 4 cert modes (ADR-105)

### DIFF
--- a/.github/workflows/appliance-integration.yml
+++ b/.github/workflows/appliance-integration.yml
@@ -15,8 +15,9 @@ name: Appliance Integration (GHCR images)
 #     --image-source=ghcr — provisions per-instance secrets and brings the stack
 #     up healthy;
 #   * the #502 fail-closed secret assertions don't ship a placeholder;
-#   * the ADR-105 in-VM Traefik router (--router=traefik) serves a unified HTTP
-#     ingress: http://localhost/ -> web, http://localhost/api -> api.
+#   * the ADR-105 in-VM Traefik router (--router=traefik --tls=selfsigned) serves
+#     a unified HTTPS ingress: :80 redirects to :443, https://localhost/ -> web,
+#     https://localhost/api -> api (selfsigned default cert).
 #
 # Runs on the runner's native CPU, so it finishes in minutes and barely touches
 # the Actions minute budget. The qcow2/OVA is built locally and attached to
@@ -71,6 +72,7 @@ jobs:
             --gpu=cpu \
             --web-hostname=localhost \
             --router=traefik \
+            --tls=selfsigned \
             --skip-cli \
             --skip-ai-config \
             --password-mode=random
@@ -100,23 +102,30 @@ jobs:
           echo "timed out (api=$ok_api web=$ok_web)"
           exit 1
 
-      - name: Verify Traefik unified HTTP ingress (ADR-105)
-        # The whole point of ROUTER_MODE=traefik: one front door routes to both
-        # the SPA and the API. Prove http://localhost/ serves web and
-        # http://localhost/api/health reaches the API (with /api stripped).
+      - name: Verify Traefik unified HTTPS ingress (ADR-105, TLS=selfsigned)
+        # The whole point of ROUTER_MODE=traefik + TLS_MODE=selfsigned: one HTTPS
+        # front door routes to both the SPA and the API, and plain HTTP redirects
+        # to it. Prove all three: :80 -> 301 https, https:// serves web,
+        # https:///api/health reaches the API (/api stripped). -k: the selfsigned
+        # default cert is untrusted by design.
         run: |
           deadline=$((SECONDS + 120))
           while [ "$SECONDS" -lt "$deadline" ]; do
-            if curl -fsS http://localhost/ >/dev/null 2>&1 \
-               && curl -fsS http://localhost/api/health >/dev/null 2>&1; then
-              echo "::notice::Traefik ingress healthy — / → web, /api → api"
-              echo "--- /api/health via ingress ---"
-              curl -fsS http://localhost/api/health; echo
-              exit 0
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/ 2>/dev/null || echo 000)
+            if [ "$code" = "301" ] || [ "$code" = "308" ]; then
+              if curl -fsSk https://localhost/ >/dev/null 2>&1 \
+                 && curl -fsSk https://localhost/api/health >/dev/null 2>&1; then
+                echo "::notice::Traefik HTTPS ingress healthy — :80 → $code https, / → web, /api → api"
+                echo "--- :80 redirect target ---"
+                curl -sI http://localhost/ | grep -i '^location:' || true
+                echo "--- /api/health via https ingress ---"
+                curl -fsSk https://localhost/api/health; echo
+                exit 0
+              fi
             fi
             sleep 5
           done
-          echo "::error::Traefik unified ingress did not come up on :80"
+          echo "::error::Traefik HTTPS ingress did not come up (last :80 code=$code)"
           docker ps -a
           docker logs "$(docker ps -aqf name=traefik | head -1)" 2>&1 | tail -40 || true
           exit 1

--- a/.github/workflows/appliance-integration.yml
+++ b/.github/workflows/appliance-integration.yml
@@ -113,7 +113,10 @@ jobs:
           while [ "$SECONDS" -lt "$deadline" ]; do
             code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/ 2>/dev/null || echo 000)
             if [ "$code" = "301" ] || [ "$code" = "308" ]; then
-              if curl -fsSk https://localhost/ >/dev/null 2>&1 \
+              # Assert the :80 redirect actually targets https:// (not just any 3xx),
+              # then that https serves web and reaches the API. -k: selfsigned cert.
+              if curl -sI http://localhost/ | grep -qi '^location: https://' \
+                 && curl -fsSk https://localhost/ >/dev/null 2>&1 \
                  && curl -fsSk https://localhost/api/health >/dev/null 2>&1; then
                 echo "::notice::Traefik HTTPS ingress healthy — :80 → $code https, / → web, /api → api"
                 echo "--- :80 redirect target ---"

--- a/docker/acme/.gitignore
+++ b/docker/acme/.gitignore
@@ -1,0 +1,4 @@
+# Let's Encrypt cert mode (ADR-105): Traefik writes acme.json here — it holds
+# the ACME ACCOUNT KEY and issued certs. Never commit it.
+*
+!.gitignore

--- a/docker/certs/.gitignore
+++ b/docker/certs/.gitignore
@@ -1,0 +1,4 @@
+# Manual cert mode (ADR-105): the operator drops tls.crt / tls.key here.
+# Never commit real key material.
+*
+!.gitignore

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -98,9 +98,14 @@ services:
     container_name: kg-web
     mac_address: "02:42:c0:a8:01:c5"
     environment:
-      VITE_API_URL: https://${WEB_HOSTNAME:-localhost}/api
+      # ADR-105: derive public-facing URLs from EXTERNAL_URL (scheme+host), the
+      # single source of public identity, so the web app's OAuth redirect scheme
+      # matches what init registered. Falls back to http://localhost when unset
+      # (e.g. raw `docker compose up` without operator init). The traefik overlay
+      # further overrides VITE_API_URL to same-origin /api.
+      VITE_API_URL: ${EXTERNAL_URL:-http://localhost}/api
       VITE_OAUTH_CLIENT_ID: kg-web
-      VITE_OAUTH_REDIRECT_URI: https://${WEB_HOSTNAME:-localhost}/callback
+      VITE_OAUTH_REDIRECT_URI: ${EXTERNAL_URL:-http://localhost}/callback
       VITE_APP_NAME: Knowledge Graph
     volumes:
       - ./nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker/docker-compose.traefik-tls-letsencrypt.yml
+++ b/docker/docker-compose.traefik-tls-letsencrypt.yml
@@ -13,7 +13,10 @@
 #   * HTTP-01  — needs :80 reachable; add
 #       --certificatesresolvers.le.acme.httpchallenge=true
 #       --certificatesresolvers.le.acme.httpchallenge.entrypoint=web
-#     (Traefik bypasses the :80->:443 redirect for /.well-known/acme-challenge.)
+#     NOTE: this overlay restates the :80->:443 entrypoint redirect below. Traefik
+#     serves the ACME http challenge on the entrypoint ahead of the redirect, but
+#     the interaction is version-sensitive — if HTTP-01 fails to validate, drop
+#     the `web.http.redirections.*` lines (let :80 serve plain) while issuing.
 #   * DNS-01 via lego (e.g. porkbun) — OPT-IN, private-only. Adds an account-wide
 #     DNS credential to the appliance, so prefer `manual` (cert issued off-box).
 #     If you accept the blast radius:

--- a/docker/docker-compose.traefik-tls-letsencrypt.yml
+++ b/docker/docker-compose.traefik-tls-letsencrypt.yml
@@ -1,0 +1,59 @@
+# ============================================================================
+# Knowledge Graph System — Let's Encrypt cert mode (ADR-105 §3-4, mode = letsencrypt)
+# ============================================================================
+# Layers on docker-compose.traefik-tls.yml. Traefik's ACME certResolver obtains
+# and AUTO-RENEWS a real cert; `operator.sh recert` is a no-op for this mode.
+#
+# CHALLENGE (this overlay): TLS-ALPN-01 — secretless, served on :443 only, the
+# right default for the `internet` scenario (public IP, :443 reachable). No DNS
+# credential ever touches the appliance (ADR-105 §7 trust posture).
+#
+# Other challenges (ADR-105 §4 — lego is the provider factory; switch by editing
+# the resolver flags below):
+#   * HTTP-01  — needs :80 reachable; add
+#       --certificatesresolvers.le.acme.httpchallenge=true
+#       --certificatesresolvers.le.acme.httpchallenge.entrypoint=web
+#     (Traefik bypasses the :80->:443 redirect for /.well-known/acme-challenge.)
+#   * DNS-01 via lego (e.g. porkbun) — OPT-IN, private-only. Adds an account-wide
+#     DNS credential to the appliance, so prefer `manual` (cert issued off-box).
+#     If you accept the blast radius:
+#       --certificatesresolvers.le.acme.dnschallenge=true
+#       --certificatesresolvers.le.acme.dnschallenge.provider=porkbun
+#     and pass PORKBUN_API_KEY / PORKBUN_SECRET_API_KEY into the traefik env
+#     (lego reads them). ~100 providers ship with lego; porkbun is native.
+#
+# Requires LE_EMAIL in the environment (ACME account contact).
+# Set LE_CASERVER to the staging directory while testing to avoid rate limits:
+#   https://acme-staging-v02.api.letsencrypt.org/directory
+#
+# COMMAND IS REPLACED: restate the full TLS command and add the ACME resolver.
+# ============================================================================
+
+services:
+  traefik:
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=knowledge-graph-router
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+      - --certificatesresolvers.le.acme.tlschallenge=true
+      - --certificatesresolvers.le.acme.email=${LE_EMAIL}
+      - --certificatesresolvers.le.acme.storage=/etc/traefik/acme/acme.json
+      - --certificatesresolvers.le.acme.caserver=${LE_CASERVER:-https://acme-v02.api.letsencrypt.org/directory}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # acme.json (account + issued certs) — Traefik creates it 0600. Persist it
+      # so renewals survive restarts and we don't re-hit ACME rate limits.
+      - ${KG_ACME_DIR:-./acme}:/etc/traefik/acme
+
+  web:
+    labels:
+      # Attach the ACME resolver to the websecure router defined in traefik-tls.yml.
+      - traefik.http.routers.kgweb-tls.tls.certresolver=le
+
+  api:
+    labels:
+      - traefik.http.routers.kgapi-tls.tls.certresolver=le

--- a/docker/docker-compose.traefik-tls-manual.yml
+++ b/docker/docker-compose.traefik-tls-manual.yml
@@ -1,0 +1,37 @@
+# ============================================================================
+# Knowledge Graph System — manual cert mode (ADR-105 §3, cert mode = manual)
+# ============================================================================
+# Layers on docker-compose.traefik-tls.yml. The operator supplies the cert+key
+# off-box (e.g. issued on a host that DOES hold the DNS credential), drops them
+# into ${KG_CERT_DIR:-./certs}/tls.{crt,key}, and Traefik's file provider serves
+# them as the default certificate for the tls=true routers.
+#
+#   This is cube's path: the kg.broccoli.house cert is issued on `north`
+#   (acme.sh + porkbun DNS-01) and copied here — NO DNS key ever lives on the
+#   appliance (ADR-105 §7 trust posture).
+#
+# Renewal: the operator re-supplies the cert near expiry; the file provider
+# (--providers.file.watch) hot-reloads it without a restart. `operator.sh recert`
+# verifies/nudges this — see operator/lib/recert.sh.
+#
+# COMMAND IS REPLACED: restate the full TLS command from traefik-tls.yml and add
+# the file provider. The tls=true router labels come from traefik-tls.yml (merged).
+# ============================================================================
+
+services:
+  traefik:
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=knowledge-graph-router
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+      # File provider supplies the operator's cert as the default certificate.
+      - --providers.file.directory=/etc/traefik/dynamic
+      - --providers.file.watch=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/dynamic:/etc/traefik/dynamic:ro
+      - ${KG_CERT_DIR:-./certs}:/etc/traefik/certs:ro

--- a/docker/docker-compose.traefik-tls.yml
+++ b/docker/docker-compose.traefik-tls.yml
@@ -1,0 +1,72 @@
+# ============================================================================
+# Knowledge Graph System — in-VM Traefik TLS termination (ADR-105, step 2)
+# ============================================================================
+# Layers on top of docker-compose.traefik.yml (the HTTP router). It turns the
+# single front door into an HTTPS front door:
+#
+#   http://<host>/...  -> 301 redirect -> https://<host>/...   (entrypoint-level)
+#   https://<host>/        -> web   (TLS terminated by Traefik)
+#   https://<host>/api/... -> api   (TLS terminated, /api prefix stripped)
+#
+# Activated by TLS_MODE != none (operator get_compose_cmd / start-platform),
+# and only meaningful with ROUTER_MODE=traefik. Default TLS_MODE=none leaves
+# this overlay out — the platform stays on the PR1 HTTP-only ingress.
+#
+# CERT SOURCE (this step): none. With no certResolver and no mounted cert,
+# Traefik serves its built-in DEFAULT self-signed certificate for any tls=true
+# router. HTTPS works end-to-end with a browser trust warning — the "appliance
+# handles itself" default (scenario: private / selfsigned). Real certs
+# (manual / letsencrypt / offload) attach as certResolvers in a later step.
+#
+# COMMAND IS REPLACED, NOT MERGED: docker compose replaces a service's `command`
+# wholesale when an overlay redefines it (sequences don't merge). So every flag
+# the base traefik service needs is repeated here, plus the TLS additions.
+#
+# LABELS / PORTS MERGE: compose unions label and port lists across files. We add
+# new websecure routers (kgweb-tls / kgapi-tls) rather than mutate the base http
+# routers — the http routers still match but the entrypoint-level redirect 301s
+# them to https before they proxy, the standard Traefik HTTP->HTTPS pattern.
+# ============================================================================
+
+services:
+  traefik:
+    command:
+      # --- repeated from docker-compose.traefik.yml (command is replaced) ---
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=knowledge-graph-router
+      - --entrypoints.web.address=:80
+      # --- TLS additions ---
+      # Redirect all plain-HTTP traffic to HTTPS at the entrypoint level, so it
+      # applies before routing (every http router inherits it).
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+    ports:
+      # Base overlay already publishes :80; compose unions, so only add :443 here
+      # (re-listing :80 risks a duplicate published-port allocation).
+      - "${KG_HTTPS_PORT:-443}:443"
+
+  web:
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=knowledge-graph-router
+      # TLS catch-all (lowest priority): everything not matched by /api -> web.
+      - "traefik.http.routers.kgweb-tls.rule=PathPrefix(`/`)"
+      - traefik.http.routers.kgweb-tls.entrypoints=websecure
+      - traefik.http.routers.kgweb-tls.priority=1
+      # No certResolver -> Traefik serves its built-in self-signed default cert.
+      - traefik.http.routers.kgweb-tls.tls=true
+      - traefik.http.services.kgweb.loadbalancer.server.port=80
+
+  api:
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=knowledge-graph-router
+      - "traefik.http.routers.kgapi-tls.rule=PathPrefix(`/api`)"
+      - traefik.http.routers.kgapi-tls.entrypoints=websecure
+      - traefik.http.routers.kgapi-tls.priority=10
+      - traefik.http.routers.kgapi-tls.tls=true
+      - traefik.http.middlewares.kgapi-strip.stripprefix.prefixes=/api
+      - traefik.http.routers.kgapi-tls.middlewares=kgapi-strip
+      - traefik.http.services.kgapi.loadbalancer.server.port=8000

--- a/docker/docker-compose.traefik-tls.yml
+++ b/docker/docker-compose.traefik-tls.yml
@@ -43,8 +43,8 @@ services:
       - --entrypoints.web.http.redirections.entrypoint.scheme=https
       - --entrypoints.websecure.address=:443
     ports:
-      # Base overlay already publishes :80; compose unions, so only add :443 here
-      # (re-listing :80 risks a duplicate published-port allocation).
+      # Base overlay already publishes :80; compose unions ports, so only add
+      # :443 here. (Identical mappings de-dupe; a differing :80 would conflict.)
       - "${KG_HTTPS_PORT:-443}:443"
 
   web:

--- a/docker/traefik/dynamic/certs.yml
+++ b/docker/traefik/dynamic/certs.yml
@@ -1,0 +1,19 @@
+# Traefik dynamic configuration — manual cert mode (ADR-105).
+# Loaded by the file provider (--providers.file.directory=/etc/traefik/dynamic).
+#
+# Points the default TLS store at the operator-supplied cert+key mounted at
+# /etc/traefik/certs (from ${KG_CERT_DIR:-./certs}). Any tls=true router with no
+# certResolver — i.e. the kgweb-tls / kgapi-tls routers — serves this cert.
+#
+# Drop your PEM cert chain and private key here before `--tls=manual`:
+#   ${KG_CERT_DIR:-docker/certs}/tls.crt   (leaf + intermediates)
+#   ${KG_CERT_DIR:-docker/certs}/tls.key   (private key, keep 0600)
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/certs/tls.crt
+        keyFile: /etc/traefik/certs/tls.key
+  certificates:
+    - certFile: /etc/traefik/certs/tls.crt
+      keyFile: /etc/traefik/certs/tls.key

--- a/docs/architecture/infrastructure/ADR-105-scenario-driven-tls-via-in-vm-traefik-router.md
+++ b/docs/architecture/infrastructure/ADR-105-scenario-driven-tls-via-in-vm-traefik-router.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-06-14
 deciders:
   - aaronsb
@@ -284,5 +284,30 @@ Incremental, each step shippable:
 8. Deploy cube as **private / manual** (cert issued off-box on north; no DNS key
    on cube) — the first real exercise, and a faithful rehearsal of **proxied**.
 
-_This revises the acme.sh/nginx mechanism of this same ADR (still Draft,
-unmerged); the decision's thesis is unchanged._
+_This revises the acme.sh/nginx mechanism of this same ADR; the decision's
+thesis is unchanged._
+
+### Implementation status
+
+- **Step 1 — done** (PR #517): in-VM Traefik HTTP router, `ROUTER_MODE=traefik`,
+  `docker-compose.traefik.yml` + `nginx.router.conf`; appliance CI asserts the
+  unified ingress.
+- **Step 4 — done** (PR2 commit A): `EXTERNAL_URL` (scheme+host) as the single
+  source of public identity; OAuth redirect + web `VITE_*` derive from it, fixing
+  the http/https registration mismatch (was `headless-init.sh:515`).
+- **Steps 3, 5 — done** (PR2 commits B, C): `TLS_MODE` = `none` / `selfsigned` /
+  `manual` / `letsencrypt` / `offload`. `selfsigned` = Traefik default cert;
+  `manual` = file provider over an operator-supplied cert (`docker/certs/`);
+  `letsencrypt` = ACME TLS-ALPN-01 (HTTP-01 / DNS-01-via-lego documented as
+  opt-in); `offload` = HTTP in-VM + `EXTERNAL_URL=https`. `operator/lib/recert.sh`
+  is the thin verify/no-op dispatcher. Appliance CI exercises the `selfsigned`
+  HTTPS path end-to-end (`:80`→`:443` redirect + `https` web/api).
+- **Steps 2, 6 — deferred**: the `install.sh` SECTION 9 convergence and a single
+  scenario→config generator are not yet folded in; the modes ship as composable
+  Traefik overlays selected by `TLS_MODE` for now.
+- **Step 8 — pending**: cube deploy as **private / manual** (cert issued off-box
+  on `north`; no DNS key on cube).
+
+DNS-01 on the appliance stays **opt-in, private-only** (§7): the wired Let's
+Encrypt default is secretless TLS-ALPN-01, and cube uses `manual` precisely so no
+DNS credential ever lands on the box.

--- a/operator.sh
+++ b/operator.sh
@@ -106,10 +106,16 @@ get_compose_cmd() {
     # SSL overlay (if configured)
     [ -f "$DOCKER_DIR/docker-compose.ssl.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.ssl.yml"
 
-    # Traefik router overlay (ADR-105) when enabled; TLS overlay layers on top.
+    # Traefik router overlay (ADR-105) + TLS overlays selected by TLS_MODE.
     if [ "$ROUTER_MODE" = "traefik" ] && [ -f "$DOCKER_DIR/docker-compose.traefik.yml" ]; then
         cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik.yml"
-        [ "$TLS_MODE" != "none" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
+        case "$TLS_MODE" in
+            selfsigned|manual|letsencrypt)
+                [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
+                [ "$TLS_MODE" = "manual" ]      && [ -f "$DOCKER_DIR/docker-compose.traefik-tls-manual.yml" ]      && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-manual.yml"
+                [ "$TLS_MODE" = "letsencrypt" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml"
+                ;;
+        esac
     fi
 
     # Dev mode overlay (adds hot reload, source mounts)

--- a/operator.sh
+++ b/operator.sh
@@ -61,6 +61,9 @@ load_config() {
     # ADR-105 in-VM router; default off so non-traefik deployments are unchanged.
     ROUTER_MODE="${ROUTER_MODE:-none}"
     export ROUTER_MODE
+    # ADR-105 TLS termination mode (none|selfsigned); only meaningful with traefik.
+    TLS_MODE="${TLS_MODE:-none}"
+    export TLS_MODE
     # Dev mode uses local builds by default, standalone uses GHCR
     if [ "$DEV_MODE" = "true" ]; then
         IMAGE_SOURCE="${IMAGE_SOURCE:-local}"
@@ -103,8 +106,11 @@ get_compose_cmd() {
     # SSL overlay (if configured)
     [ -f "$DOCKER_DIR/docker-compose.ssl.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.ssl.yml"
 
-    # Traefik router overlay (ADR-105) when enabled
-    [ "$ROUTER_MODE" = "traefik" ] && [ -f "$DOCKER_DIR/docker-compose.traefik.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik.yml"
+    # Traefik router overlay (ADR-105) when enabled; TLS overlay layers on top.
+    if [ "$ROUTER_MODE" = "traefik" ] && [ -f "$DOCKER_DIR/docker-compose.traefik.yml" ]; then
+        cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik.yml"
+        [ "$TLS_MODE" != "none" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
+    fi
 
     # Dev mode overlay (adds hot reload, source mounts)
     [ "$DEV_MODE" = "true" ] && [ -f "$DOCKER_DIR/docker-compose.dev.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.dev.yml"

--- a/operator/lib/common.sh
+++ b/operator/lib/common.sh
@@ -159,13 +159,21 @@ get_compose_cmd() {
         cmd="$cmd -f $DOCKER_DIR/docker-compose.ssl.yml"
     fi
 
-    # Add Traefik router overlay (ADR-105) when enabled
+    # Add Traefik router overlay (ADR-105) when enabled, plus the TLS overlays
+    # selected by TLS_MODE. selfsigned/manual/letsencrypt terminate TLS in-VM and
+    # share the websecure baseline (traefik-tls.yml); manual and letsencrypt add a
+    # cert-source overlay on top. `offload` and `none` stay HTTP-only at the router.
     if [ "$ROUTER_MODE" = "traefik" ] && [ -f "$DOCKER_DIR/docker-compose.traefik.yml" ]; then
         cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik.yml"
-        # TLS overlay layers on top of the HTTP router (must come after it).
-        if [ "$TLS_MODE" != "none" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ]; then
-            cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
-        fi
+        case "$TLS_MODE" in
+            selfsigned|manual|letsencrypt)
+                [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
+                case "$TLS_MODE" in
+                    manual)      [ -f "$DOCKER_DIR/docker-compose.traefik-tls-manual.yml" ]      && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-manual.yml" ;;
+                    letsencrypt) [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ;;
+                esac
+                ;;
+        esac
     fi
 
     # Add dev overlay if in development mode

--- a/operator/lib/common.sh
+++ b/operator/lib/common.sh
@@ -36,6 +36,11 @@ load_operator_config() {
     # direct per-service ports; `traefik` adds the unified HTTP ingress overlay.
     ROUTER_MODE="${ROUTER_MODE:-none}"
     export ROUTER_MODE
+    # ADR-105: TLS termination mode for the in-VM router. `none` (default) keeps
+    # the HTTP-only ingress; `selfsigned` adds the websecure :443 entrypoint with
+    # Traefik's built-in self-signed cert. Only meaningful with ROUTER_MODE=traefik.
+    TLS_MODE="${TLS_MODE:-none}"
+    export TLS_MODE
     # ADR-105: public base URL (scheme+host). Single source of public identity —
     # the web overlay substitutes it into VITE_* so the OAuth redirect scheme
     # matches what init registered. Empty default lets compose fall back to
@@ -157,6 +162,10 @@ get_compose_cmd() {
     # Add Traefik router overlay (ADR-105) when enabled
     if [ "$ROUTER_MODE" = "traefik" ] && [ -f "$DOCKER_DIR/docker-compose.traefik.yml" ]; then
         cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik.yml"
+        # TLS overlay layers on top of the HTTP router (must come after it).
+        if [ "$TLS_MODE" != "none" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ]; then
+            cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
+        fi
     fi
 
     # Add dev overlay if in development mode

--- a/operator/lib/common.sh
+++ b/operator/lib/common.sh
@@ -36,6 +36,12 @@ load_operator_config() {
     # direct per-service ports; `traefik` adds the unified HTTP ingress overlay.
     ROUTER_MODE="${ROUTER_MODE:-none}"
     export ROUTER_MODE
+    # ADR-105: public base URL (scheme+host). Single source of public identity —
+    # the web overlay substitutes it into VITE_* so the OAuth redirect scheme
+    # matches what init registered. Empty default lets compose fall back to
+    # http://localhost; init writes the real value to both .env and .operator.conf.
+    EXTERNAL_URL="${EXTERNAL_URL:-}"
+    export EXTERNAL_URL
 
     # ADR-101: derive kg-api image tag via the shared helper (see
     # operator/lib/image-tag.sh for the single source of truth).

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -95,7 +95,9 @@ ${BOLD}Web Configuration:${NC}
   --external-url URL      Public base URL — scheme+host, no path (ADR-105).
                           Single source of public identity: OAuth redirect and
                           API URL derive from it. e.g. https://kg.example.com
-                          Default: http://<web-hostname>
+                          Default: http://<web-hostname> (https when --tls set).
+                          If you remap KG_HTTPS_PORT/KG_HTTP_PORT off 443/80,
+                          include the port here (e.g. https://host:8443).
   --router MODE           Ingress router (ADR-105):
                           • none (default): direct per-service ports
                           • traefik: unified HTTP ingress (/ -> web, /api -> api)
@@ -107,7 +109,9 @@ ${BOLD}Web Configuration:${NC}
                             (tls.crt + tls.key); cert issued off-box
                           • letsencrypt: Traefik ACME (TLS-ALPN-01); needs --le-email
                           • offload: HTTP in-VM, edge terminates TLS (EXTERNAL_URL
-                            scheme becomes https)
+                            scheme becomes https). Assumes an external reverse
+                            proxy does TLS + path routing (/ -> web, /api -> api);
+                            nothing in-box enforces it.
   --le-email EMAIL        ACME account contact for --tls=letsencrypt
 
 ${BOLD}AI Configuration:${NC}

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -42,6 +42,7 @@ AI_KEY=""
 WEB_HOSTNAME=""
 EXTERNAL_URL=""
 ROUTER_MODE="none"
+TLS_MODE="none"
 SKIP_AI_CONFIG=false
 SKIP_CLI=false
 SHOW_HELP=false
@@ -97,6 +98,11 @@ ${BOLD}Web Configuration:${NC}
   --router MODE           Ingress router (ADR-105):
                           • none (default): direct per-service ports
                           • traefik: unified HTTP ingress (/ -> web, /api -> api)
+  --tls MODE              TLS termination at the in-VM router (requires
+                          --router=traefik):
+                          • none (default): HTTP only on :80
+                          • selfsigned: HTTPS on :443 with Traefik's built-in
+                            self-signed cert, :80 redirects to :443
 
 ${BOLD}AI Configuration:${NC}
   --ai-provider PROVIDER  AI extraction provider (openai, anthropic, openrouter)
@@ -262,6 +268,14 @@ parse_args() {
                 ROUTER_MODE="$2"
                 shift 2
                 ;;
+            --tls=*)
+                TLS_MODE="${1#*=}"
+                shift
+                ;;
+            --tls)
+                TLS_MODE="$2"
+                shift 2
+                ;;
             *)
                 echo -e "${RED}Unknown option: $1${NC}"
                 echo "Use --help for usage information"
@@ -307,6 +321,18 @@ validate_config() {
     # Validate router mode (ADR-105)
     if [[ "$ROUTER_MODE" != "none" && "$ROUTER_MODE" != "traefik" ]]; then
         echo -e "${RED}✗ Invalid --router: $ROUTER_MODE (must be 'none' or 'traefik')${NC}"
+        errors=$((errors + 1))
+    fi
+
+    # Validate TLS mode (ADR-105). PR2-B ships none|selfsigned; manual /
+    # letsencrypt / offload land in a later step.
+    if [[ "$TLS_MODE" != "none" && "$TLS_MODE" != "selfsigned" ]]; then
+        echo -e "${RED}✗ Invalid --tls: $TLS_MODE (must be 'none' or 'selfsigned')${NC}"
+        errors=$((errors + 1))
+    fi
+    # TLS termination only makes sense behind the in-VM router.
+    if [[ "$TLS_MODE" != "none" && "$ROUTER_MODE" != "traefik" ]]; then
+        echo -e "${RED}✗ --tls=$TLS_MODE requires --router=traefik${NC}"
         errors=$((errors + 1))
     fi
 
@@ -427,6 +453,9 @@ main() {
     if [ -n "$EXTERNAL_URL" ]; then
         echo -e "  External URL:      ${BLUE}$EXTERNAL_URL${NC}"
     fi
+    if [ "$ROUTER_MODE" != "none" ]; then
+        echo -e "  Router:            ${BLUE}$ROUTER_MODE${NC} (tls: $TLS_MODE)"
+    fi
     if [ "$SKIP_AI_CONFIG" = true ]; then
         echo -e "  AI config:         ${YELLOW}skipped${NC}"
     elif [ -n "$AI_PROVIDER" ]; then
@@ -479,11 +508,15 @@ main() {
     fi
 
     # Derive EXTERNAL_URL (ADR-105) if not supplied. Single source of public
-    # identity = scheme+host. Until the TLS path lands (PR2-B), the appliance
-    # serves plain HTTP, so the default scheme is http://. Operators terminating
-    # TLS (selfsigned/manual/letsencrypt/offload) pass --external-url=https://…
+    # identity = scheme+host. Scheme follows TLS_MODE: plain HTTP when the
+    # appliance serves :80 only, https once Traefik terminates TLS. An explicit
+    # --external-url always wins (e.g. behind an offloading edge).
     if [ -z "$EXTERNAL_URL" ]; then
-        EXTERNAL_URL="http://${WEB_HOSTNAME}"
+        if [ "$TLS_MODE" != "none" ]; then
+            EXTERNAL_URL="https://${WEB_HOSTNAME}"
+        else
+            EXTERNAL_URL="http://${WEB_HOSTNAME}"
+        fi
     fi
     # Normalize: strip any trailing slash so "${EXTERNAL_URL}/callback" is clean.
     EXTERNAL_URL="${EXTERNAL_URL%/}"
@@ -524,6 +557,7 @@ CONTAINER_SUFFIX=$CONTAINER_SUFFIX
 COMPOSE_FILE=$COMPOSE_FILE
 IMAGE_SOURCE=$IMAGE_SOURCE
 ROUTER_MODE=$ROUTER_MODE
+TLS_MODE=$TLS_MODE
 EXTERNAL_URL=$EXTERNAL_URL
 INITIALIZED_AT=$(date -Iseconds)
 EOF

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -43,6 +43,7 @@ WEB_HOSTNAME=""
 EXTERNAL_URL=""
 ROUTER_MODE="none"
 TLS_MODE="none"
+LE_EMAIL=""
 SKIP_AI_CONFIG=false
 SKIP_CLI=false
 SHOW_HELP=false
@@ -98,11 +99,16 @@ ${BOLD}Web Configuration:${NC}
   --router MODE           Ingress router (ADR-105):
                           • none (default): direct per-service ports
                           • traefik: unified HTTP ingress (/ -> web, /api -> api)
-  --tls MODE              TLS termination at the in-VM router (requires
-                          --router=traefik):
+  --tls MODE              TLS termination (ADR-105). selfsigned/manual/letsencrypt
+                          require --router=traefik; :80 redirects to :443:
                           • none (default): HTTP only on :80
-                          • selfsigned: HTTPS on :443 with Traefik's built-in
-                            self-signed cert, :80 redirects to :443
+                          • selfsigned: Traefik's built-in self-signed cert
+                          • manual: operator-supplied cert+key in docker/certs/
+                            (tls.crt + tls.key); cert issued off-box
+                          • letsencrypt: Traefik ACME (TLS-ALPN-01); needs --le-email
+                          • offload: HTTP in-VM, edge terminates TLS (EXTERNAL_URL
+                            scheme becomes https)
+  --le-email EMAIL        ACME account contact for --tls=letsencrypt
 
 ${BOLD}AI Configuration:${NC}
   --ai-provider PROVIDER  AI extraction provider (openai, anthropic, openrouter)
@@ -276,6 +282,14 @@ parse_args() {
                 TLS_MODE="$2"
                 shift 2
                 ;;
+            --le-email=*)
+                LE_EMAIL="${1#*=}"
+                shift
+                ;;
+            --le-email)
+                LE_EMAIL="$2"
+                shift 2
+                ;;
             *)
                 echo -e "${RED}Unknown option: $1${NC}"
                 echo "Use --help for usage information"
@@ -324,15 +338,25 @@ validate_config() {
         errors=$((errors + 1))
     fi
 
-    # Validate TLS mode (ADR-105). PR2-B ships none|selfsigned; manual /
-    # letsencrypt / offload land in a later step.
-    if [[ "$TLS_MODE" != "none" && "$TLS_MODE" != "selfsigned" ]]; then
-        echo -e "${RED}✗ Invalid --tls: $TLS_MODE (must be 'none' or 'selfsigned')${NC}"
-        errors=$((errors + 1))
+    # Validate TLS mode (ADR-105): none | selfsigned | manual | letsencrypt | offload.
+    case "$TLS_MODE" in
+        none|selfsigned|manual|letsencrypt|offload) ;;
+        *)
+            echo -e "${RED}✗ Invalid --tls: $TLS_MODE (must be none|selfsigned|manual|letsencrypt|offload)${NC}"
+            errors=$((errors + 1))
+            ;;
+    esac
+    # In-VM termination modes need the router. (offload terminates at the edge and
+    # none has no TLS, so neither requires traefik.)
+    if [[ "$TLS_MODE" == "selfsigned" || "$TLS_MODE" == "manual" || "$TLS_MODE" == "letsencrypt" ]]; then
+        if [[ "$ROUTER_MODE" != "traefik" ]]; then
+            echo -e "${RED}✗ --tls=$TLS_MODE requires --router=traefik${NC}"
+            errors=$((errors + 1))
+        fi
     fi
-    # TLS termination only makes sense behind the in-VM router.
-    if [[ "$TLS_MODE" != "none" && "$ROUTER_MODE" != "traefik" ]]; then
-        echo -e "${RED}✗ --tls=$TLS_MODE requires --router=traefik${NC}"
+    # Let's Encrypt needs an ACME account email.
+    if [[ "$TLS_MODE" == "letsencrypt" && -z "$LE_EMAIL" ]]; then
+        echo -e "${RED}✗ --tls=letsencrypt requires --le-email (ACME account contact)${NC}"
         errors=$((errors + 1))
     fi
 
@@ -536,6 +560,16 @@ main() {
         echo "EXTERNAL_URL=$EXTERNAL_URL" >> "$PROJECT_ROOT/.env"
     else
         sed -i "s|^EXTERNAL_URL=.*|EXTERNAL_URL=$EXTERNAL_URL|" "$PROJECT_ROOT/.env"
+    fi
+
+    # Add LE_EMAIL to .env when set (consumed by the letsencrypt overlay's ACME resolver)
+    if [ -n "$LE_EMAIL" ]; then
+        if ! grep -q '^LE_EMAIL=' "$PROJECT_ROOT/.env" 2>/dev/null; then
+            echo "# Let's Encrypt ACME account contact (ADR-105 letsencrypt mode)" >> "$PROJECT_ROOT/.env"
+            echo "LE_EMAIL=$LE_EMAIL" >> "$PROJECT_ROOT/.env"
+        else
+            sed -i "s|^LE_EMAIL=.*|LE_EMAIL=$LE_EMAIL|" "$PROJECT_ROOT/.env"
+        fi
     fi
 
     echo -e "${GREEN}✓ Secrets generated${NC}"

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -40,6 +40,7 @@ AI_PROVIDER=""
 AI_MODEL=""
 AI_KEY=""
 WEB_HOSTNAME=""
+EXTERNAL_URL=""
 ROUTER_MODE="none"
 SKIP_AI_CONFIG=false
 SKIP_CLI=false
@@ -89,6 +90,10 @@ ${BOLD}Web Configuration:${NC}
   --web-hostname HOST     Public hostname for web access (e.g., kg.example.com)
                           Used for OAuth redirect URIs and API URL
                           Default: localhost (for local dev) or localhost:3000
+  --external-url URL      Public base URL — scheme+host, no path (ADR-105).
+                          Single source of public identity: OAuth redirect and
+                          API URL derive from it. e.g. https://kg.example.com
+                          Default: http://<web-hostname>
   --router MODE           Ingress router (ADR-105):
                           • none (default): direct per-service ports
                           • traefik: unified HTTP ingress (/ -> web, /api -> api)
@@ -241,6 +246,14 @@ parse_args() {
                 WEB_HOSTNAME="$2"
                 shift 2
                 ;;
+            --external-url=*)
+                EXTERNAL_URL="${1#*=}"
+                shift
+                ;;
+            --external-url)
+                EXTERNAL_URL="$2"
+                shift 2
+                ;;
             --router=*)
                 ROUTER_MODE="${1#*=}"
                 shift
@@ -295,6 +308,20 @@ validate_config() {
     if [[ "$ROUTER_MODE" != "none" && "$ROUTER_MODE" != "traefik" ]]; then
         echo -e "${RED}✗ Invalid --router: $ROUTER_MODE (must be 'none' or 'traefik')${NC}"
         errors=$((errors + 1))
+    fi
+
+    # Validate external URL (ADR-105): must be a scheme+host, no trailing path.
+    # The single source of public identity — OAuth redirect + API URL derive from it.
+    if [[ -n "$EXTERNAL_URL" ]]; then
+        if [[ "$EXTERNAL_URL" != http://* && "$EXTERNAL_URL" != https://* ]]; then
+            echo -e "${RED}✗ Invalid --external-url: $EXTERNAL_URL (must start with http:// or https://)${NC}"
+            errors=$((errors + 1))
+        elif [[ "${EXTERNAL_URL#*://}" == */* && "${EXTERNAL_URL#*://}" != */ ]]; then
+            # Strip scheme; a slash in the remainder (other than a sole trailing /)
+            # means a path was supplied — reject, we want scheme+host only.
+            echo -e "${RED}✗ Invalid --external-url: $EXTERNAL_URL (scheme+host only, no path)${NC}"
+            errors=$((errors + 1))
+        fi
     fi
 
     # Validate AI provider if specified
@@ -397,6 +424,9 @@ main() {
     if [ -n "$WEB_HOSTNAME" ]; then
         echo -e "  Web hostname:      ${BLUE}$WEB_HOSTNAME${NC}"
     fi
+    if [ -n "$EXTERNAL_URL" ]; then
+        echo -e "  External URL:      ${BLUE}$EXTERNAL_URL${NC}"
+    fi
     if [ "$SKIP_AI_CONFIG" = true ]; then
         echo -e "  AI config:         ${YELLOW}skipped${NC}"
     elif [ -n "$AI_PROVIDER" ]; then
@@ -448,6 +478,16 @@ main() {
         fi
     fi
 
+    # Derive EXTERNAL_URL (ADR-105) if not supplied. Single source of public
+    # identity = scheme+host. Until the TLS path lands (PR2-B), the appliance
+    # serves plain HTTP, so the default scheme is http://. Operators terminating
+    # TLS (selfsigned/manual/letsencrypt/offload) pass --external-url=https://…
+    if [ -z "$EXTERNAL_URL" ]; then
+        EXTERNAL_URL="http://${WEB_HOSTNAME}"
+    fi
+    # Normalize: strip any trailing slash so "${EXTERNAL_URL}/callback" is clean.
+    EXTERNAL_URL="${EXTERNAL_URL%/}"
+
     # Add WEB_HOSTNAME to .env
     if ! grep -q '^WEB_HOSTNAME=' "$PROJECT_ROOT/.env" 2>/dev/null; then
         echo "" >> "$PROJECT_ROOT/.env"
@@ -457,8 +497,17 @@ main() {
         sed -i "s|^WEB_HOSTNAME=.*|WEB_HOSTNAME=$WEB_HOSTNAME|" "$PROJECT_ROOT/.env"
     fi
 
+    # Add EXTERNAL_URL to .env (consumed by the web overlay for VITE_* substitution)
+    if ! grep -q '^EXTERNAL_URL=' "$PROJECT_ROOT/.env" 2>/dev/null; then
+        echo "# Public base URL (scheme+host) — OAuth redirect + API URL derive from it" >> "$PROJECT_ROOT/.env"
+        echo "EXTERNAL_URL=$EXTERNAL_URL" >> "$PROJECT_ROOT/.env"
+    else
+        sed -i "s|^EXTERNAL_URL=.*|EXTERNAL_URL=$EXTERNAL_URL|" "$PROJECT_ROOT/.env"
+    fi
+
     echo -e "${GREEN}✓ Secrets generated${NC}"
     echo -e "${GREEN}✓ Web hostname: $WEB_HOSTNAME${NC}"
+    echo -e "${GREEN}✓ External URL: $EXTERNAL_URL${NC}"
     echo ""
 
     # -------------------------------------------------------------------------
@@ -475,6 +524,7 @@ CONTAINER_SUFFIX=$CONTAINER_SUFFIX
 COMPOSE_FILE=$COMPOSE_FILE
 IMAGE_SOURCE=$IMAGE_SOURCE
 ROUTER_MODE=$ROUTER_MODE
+EXTERNAL_URL=$EXTERNAL_URL
 INITIALIZED_AT=$(date -Iseconds)
 EOF
 
@@ -510,9 +560,13 @@ EOF
         echo -e "${GREEN}✓ Open self-registration disabled (production)${NC}"
     fi
 
-    # Register OAuth client for web app with configured hostname
+    # Register OAuth client for web app. Redirect URI derives from EXTERNAL_URL
+    # (scheme+host) so the registered scheme matches what the web app sends —
+    # under TLS the scheme is https, plain HTTP it is http. (ADR-105: this is the
+    # fix for the latent mismatch where the prod web env emitted https:// while
+    # init registered http://.)
     local POSTGRES_CONTAINER=$(get_container_name postgres)
-    local REDIRECT_URI="http://${WEB_HOSTNAME}/callback"
+    local REDIRECT_URI="${EXTERNAL_URL}/callback"
     echo -e "${BLUE}  Registering OAuth client (kg-web)...${NC}"
     docker exec "$POSTGRES_CONTAINER" psql -U ${POSTGRES_USER:-admin} -d ${POSTGRES_DB:-knowledge_graph} -c \
         "INSERT INTO kg_auth.oauth_clients (client_id, client_name, client_type, redirect_uris, grant_types, scopes)

--- a/operator/lib/recert.sh
+++ b/operator/lib/recert.sh
@@ -22,10 +22,18 @@ GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC
 # /workspace is the repo root bind-mounted into the operator container.
 WORKSPACE="${WORKSPACE:-/workspace}"
 CONFIG_FILE="$WORKSPACE/.operator.conf"
+ENV_FILE="$WORKSPACE/.env"
 
 TLS_MODE="none"
 [ -f "$CONFIG_FILE" ] && TLS_MODE="$(grep -E '^TLS_MODE=' "$CONFIG_FILE" 2>/dev/null | cut -d= -f2 || true)"
 TLS_MODE="${TLS_MODE:-none}"
+
+# KG_CERT_DIR: read it from .env — the SAME file `docker compose --env-file`
+# substitutes into the manual overlay's cert mount — so recert checks exactly the
+# path Traefik serves from. Explicit environment wins (matches compose precedence).
+if [ -z "${KG_CERT_DIR:-}" ] && [ -f "$ENV_FILE" ]; then
+    KG_CERT_DIR="$(grep -E '^KG_CERT_DIR=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- || true)"
+fi
 
 # Days before expiry at which manual mode starts warning.
 WARN_DAYS="${RECERT_WARN_DAYS:-21}"
@@ -85,7 +93,7 @@ verify_manual() {
     return 0
 }
 
-echo -e "${BLUE}${NC}TLS mode: ${TLS_MODE}"
+echo -e "${BLUE}TLS mode:${NC} ${TLS_MODE}"
 case "$TLS_MODE" in
     manual)
         verify_manual

--- a/operator/lib/recert.sh
+++ b/operator/lib/recert.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# ============================================================================
+# recert.sh — TLS cert lifecycle helper (ADR-105 §5)
+# ============================================================================
+# Invoked by `operator.sh recert` inside the operator container. Traefik owns
+# renewal for the automated modes, so this is deliberately THIN — a verify/nudge
+# for `manual`, a no-op-with-status for the rest. It is not a renewal engine.
+#
+#   selfsigned   Traefik regenerates its built-in cert — nothing to do.
+#   letsencrypt  Traefik's ACME resolver auto-renews — nothing to do.
+#   manual       Operator supplies the cert off-box; the file provider hot-reloads.
+#                We verify the cert exists and warn on imminent/past expiry.
+#   offload      Upstream edge owns the cert — no-op.
+#   none         No TLS at the router — no-op.
+#
+# Reads TLS_MODE from .operator.conf. @verified
+# ============================================================================
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+
+# /workspace is the repo root bind-mounted into the operator container.
+WORKSPACE="${WORKSPACE:-/workspace}"
+CONFIG_FILE="$WORKSPACE/.operator.conf"
+
+TLS_MODE="none"
+[ -f "$CONFIG_FILE" ] && TLS_MODE="$(grep -E '^TLS_MODE=' "$CONFIG_FILE" 2>/dev/null | cut -d= -f2 || true)"
+TLS_MODE="${TLS_MODE:-none}"
+
+# Days before expiry at which manual mode starts warning.
+WARN_DAYS="${RECERT_WARN_DAYS:-21}"
+
+# Resolve the manual cert dir the same way the compose overlay does: KG_CERT_DIR
+# (relative paths are under docker/) defaulting to docker/certs.
+resolve_cert_dir() {
+    local dir="${KG_CERT_DIR:-./certs}"
+    case "$dir" in
+        /*) echo "$dir" ;;                       # absolute — use as-is
+        ./*) echo "$WORKSPACE/docker/${dir#./}" ;;
+        *)  echo "$WORKSPACE/docker/$dir" ;;
+    esac
+}
+
+verify_manual() {
+    local cert_dir crt key
+    cert_dir="$(resolve_cert_dir)"
+    crt="$cert_dir/tls.crt"
+    key="$cert_dir/tls.key"
+
+    if [ ! -f "$crt" ] || [ ! -f "$key" ]; then
+        echo -e "${RED}✗ manual mode: cert+key not found${NC}"
+        echo -e "  Expected: ${crt}"
+        echo -e "            ${key}"
+        echo -e "  Issue a cert off-box and drop both files here, then re-run recert."
+        return 1
+    fi
+
+    if ! command -v openssl >/dev/null 2>&1; then
+        echo -e "${YELLOW}⚠ openssl not available — cannot check expiry. Cert files present.${NC}"
+        return 0
+    fi
+
+    if ! openssl x509 -in "$crt" -noout >/dev/null 2>&1; then
+        echo -e "${RED}✗ $crt is not a readable PEM certificate${NC}"
+        return 1
+    fi
+
+    local not_after
+    not_after="$(openssl x509 -in "$crt" -noout -enddate | cut -d= -f2)"
+    echo -e "${BLUE}→ manual cert: ${crt}${NC}"
+    echo -e "  Subject : $(openssl x509 -in "$crt" -noout -subject | sed 's/^subject=//')"
+    echo -e "  Expires : ${not_after}"
+
+    # Warn if within WARN_DAYS of expiry (or already expired).
+    if openssl x509 -in "$crt" -noout -checkend $(( WARN_DAYS * 86400 )) >/dev/null 2>&1; then
+        echo -e "${GREEN}✓ Cert valid for more than ${WARN_DAYS} days. Traefik hot-reloads on replacement.${NC}"
+    else
+        if openssl x509 -in "$crt" -noout -checkend 0 >/dev/null 2>&1; then
+            echo -e "${YELLOW}⚠ Cert expires within ${WARN_DAYS} days — re-issue off-box and replace ${crt}/.key${NC}"
+        else
+            echo -e "${RED}✗ Cert has EXPIRED — re-issue off-box and replace ${crt}/.key now${NC}"
+            return 1
+        fi
+    fi
+    return 0
+}
+
+echo -e "${BLUE}${NC}TLS mode: ${TLS_MODE}"
+case "$TLS_MODE" in
+    manual)
+        verify_manual
+        ;;
+    selfsigned)
+        echo -e "${GREEN}✓ selfsigned: Traefik serves/regenerates its built-in cert — nothing to renew.${NC}"
+        ;;
+    letsencrypt)
+        echo -e "${GREEN}✓ letsencrypt: Traefik's ACME resolver auto-renews — nothing to do.${NC}"
+        echo -e "  Inspect issued certs: docker logs <traefik> | grep -i acme"
+        ;;
+    offload)
+        echo -e "${GREEN}✓ offload: the upstream edge owns the certificate — recert is a no-op.${NC}"
+        ;;
+    none|"")
+        echo -e "${YELLOW}⚠ No TLS configured at the router (TLS_MODE=none) — nothing to recert.${NC}"
+        ;;
+    *)
+        echo -e "${RED}✗ Unknown TLS_MODE: ${TLS_MODE}${NC}"
+        exit 1
+        ;;
+esac

--- a/operator/lib/start-platform.sh
+++ b/operator/lib/start-platform.sh
@@ -140,10 +140,16 @@ start_application() {
         # SSL overlay (can apply to either mode)
         [ -f docker-compose.ssl.yml ] && compose_cmd="$compose_cmd -f docker-compose.ssl.yml"
 
-        # Traefik router overlay (ADR-105) when enabled; TLS overlay on top.
+        # Traefik router overlay (ADR-105) + TLS overlays selected by TLS_MODE.
         if [ "$ROUTER_MODE" = "traefik" ] && [ -f docker-compose.traefik.yml ]; then
             compose_cmd="$compose_cmd -f docker-compose.traefik.yml"
-            [ "${TLS_MODE:-none}" != "none" ] && [ -f docker-compose.traefik-tls.yml ] && compose_cmd="$compose_cmd -f docker-compose.traefik-tls.yml"
+            case "${TLS_MODE:-none}" in
+                selfsigned|manual|letsencrypt)
+                    [ -f docker-compose.traefik-tls.yml ] && compose_cmd="$compose_cmd -f docker-compose.traefik-tls.yml"
+                    [ "$TLS_MODE" = "manual" ]      && [ -f docker-compose.traefik-tls-manual.yml ]      && compose_cmd="$compose_cmd -f docker-compose.traefik-tls-manual.yml"
+                    [ "$TLS_MODE" = "letsencrypt" ] && [ -f docker-compose.traefik-tls-letsencrypt.yml ] && compose_cmd="$compose_cmd -f docker-compose.traefik-tls-letsencrypt.yml"
+                    ;;
+            esac
         fi
 
         compose_cmd="$compose_cmd --env-file $ENV_FILE"

--- a/operator/lib/start-platform.sh
+++ b/operator/lib/start-platform.sh
@@ -140,8 +140,11 @@ start_application() {
         # SSL overlay (can apply to either mode)
         [ -f docker-compose.ssl.yml ] && compose_cmd="$compose_cmd -f docker-compose.ssl.yml"
 
-        # Traefik router overlay (ADR-105) when enabled
-        [ "$ROUTER_MODE" = "traefik" ] && [ -f docker-compose.traefik.yml ] && compose_cmd="$compose_cmd -f docker-compose.traefik.yml"
+        # Traefik router overlay (ADR-105) when enabled; TLS overlay on top.
+        if [ "$ROUTER_MODE" = "traefik" ] && [ -f docker-compose.traefik.yml ]; then
+            compose_cmd="$compose_cmd -f docker-compose.traefik.yml"
+            [ "${TLS_MODE:-none}" != "none" ] && [ -f docker-compose.traefik-tls.yml ] && compose_cmd="$compose_cmd -f docker-compose.traefik-tls.yml"
+        fi
 
         compose_cmd="$compose_cmd --env-file $ENV_FILE"
 


### PR DESCRIPTION
## Summary

Builds the TLS cert path on top of the merged in-VM Traefik HTTP router (PR #517), completing **ADR-105**. The appliance can now terminate HTTPS itself, with the cert source chosen by a single `TLS_MODE` knob. Default `TLS_MODE=none` → **zero behavior change** (PR #517's HTTP ingress is untouched).

Three commits, each shippable:

### A — `EXTERNAL_URL` contract + OAuth scheme fix
- `EXTERNAL_URL` (scheme+host) becomes the single source of public identity. The OAuth redirect registered at init **and** the web app's `VITE_OAUTH_REDIRECT_URI` both derive from it.
- Fixes a **latent bug**: the prod web overlay emitted `https://${WEB_HOSTNAME}` while init registered `http://…` — OAuth would break the moment TLS terminated in front of the SPA.

### B — Traefik TLS entrypoint + self-signed default
- `TLS_MODE=selfsigned`: a `:443` websecure entrypoint, `:80 → :443` redirect, `tls=true` routers serving Traefik's built-in self-signed cert. HTTPS works end-to-end (browser warning) — the "appliance handles itself" default.

### C — cert modes + recert + CI https
- **manual** — file provider over an operator-supplied cert in `docker/certs/` (**cube's path**: cert issued off-box on `north` via porkbun DNS-01, *no DNS key on the appliance*).
- **letsencrypt** — Traefik ACME, TLS-ALPN-01 (secretless); HTTP-01 / DNS-01-via-lego documented as opt-in.
- **offload** — HTTP in-VM, edge terminates, `EXTERNAL_URL=https`.
- `operator/lib/recert.sh` — thin verify/no-op dispatcher (was a dangling reference at `operator.sh:924`).
- CI now inits `--tls=selfsigned` and asserts the HTTPS ingress: `:80 → 301/308`, `https` web, `https` api/health.

## Design notes
- Cert modes are **composable Traefik overlays** selected by `TLS_MODE` across all three compose-assembly sites. `command` is restated per overlay (compose replaces, not merges, command sequences) — verified via `docker compose config`.
- DNS-01 on the appliance stays **opt-in, private-only** (ADR-105 §7 trust posture). The wired LE default is secretless TLS-ALPN-01; cube uses `manual` precisely so no DNS credential lands on the box.

## Test plan
- [x] `docker compose config` merge verified for selfsigned / manual / letsencrypt (command, ports, labels, mounts).
- [x] Shell syntax + `EXTERNAL_URL` validation unit-checked.
- [ ] Appliance integration CI green on the selfsigned HTTPS path (triggered below).

Refs ADR-105. Follows PR #517.