### PR TITLE
docs(adr): normalize ADR frontmatter + enforce the decision graph

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,12 +84,12 @@ jobs:
 
       - name: Lint documentation catalog (frontmatter + decision graph)
         # Validates the docs catalog (ADR-087): id/domain/mode frontmatter,
-        # the related/supersedes reference graph, and nav membership. Catalog
-        # pages are enforced (errors fail); ADR frontmatter only warns until the
-        # ADR sweep lands (#520 fast-follow), so --enforce-adrs is intentionally
-        # omitted here.
+        # the related/supersedes reference graph, and nav membership. Both
+        # catalog pages and ADRs are enforced — --enforce-adrs promotes ADR
+        # graph issues (dangling related/supersedes refs, supersede cycles) to
+        # errors now that the ADR frontmatter sweep has landed.
         run: |
-          python3 docs/scripts/doclint.py --check
+          python3 docs/scripts/doclint.py --check --enforce-adrs
 
   # TODO: Add full test infrastructure in future
   # pytest-unit:

--- a/docs/architecture/access-workflow/ADR-038-official-project-apparel.md
+++ b/docs/architecture/access-workflow/ADR-038-official-project-apparel.md
@@ -3,6 +3,7 @@ status: Proposed
 date: 2025-10-17
 deciders:
   - Solo developer with questionable fashion sense
+related: []
 ---
 
 # ADR-038: Official Project Apparel Design Specifications

--- a/docs/architecture/access-workflow/ADR-900-adr-numbering-domain-system.md
+++ b/docs/architecture/access-workflow/ADR-900-adr-numbering-domain-system.md
@@ -47,6 +47,13 @@ the "first octet" of the number. The authoritative definition lives in
 A new ADR takes the next free number in its domain band: `adr new <domain>
 "<title>"` assigns it and scaffolds the file under the domain's folder.
 
+A decision that grows into distinct parts uses **decimal sub-numbers**:
+`ADR-032.1` is the decision, `ADR-032.2` a follow-on (implementation notes, an
+appendix, later findings). The bare base number (`ADR-032`) is the *family*
+identifier: a `related: ADR-032` reference cites the decision as a whole and is
+satisfied by any of its parts, while `related: ADR-032.2` targets one part
+exactly. The graph linter (§5) resolves references this way.
+
 ### 2. Legacy range is frozen
 
 ADRs 1–99 predate the domain scheme. They are **frozen at their numbers** —

--- a/docs/architecture/ai-embeddings/ADR-068-source-text-embeddings.md
+++ b/docs/architecture/ai-embeddings/ADR-068-source-text-embeddings.md
@@ -3,6 +3,7 @@ status: Accepted
 date: 2025-11-27
 deciders:
   - System Architect
+related: []
 ---
 
 # ADR-068: Source Text Embeddings for Grounding Truth Retrieval

--- a/docs/architecture/authentication-security/ADR-054-oauth-client-management.md
+++ b/docs/architecture/authentication-security/ADR-054-oauth-client-management.md
@@ -4,6 +4,7 @@ date: 2025-11-01
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-054: OAuth 2.0 Client Management for Multi-Client Authentication

--- a/docs/architecture/authentication-security/ADR-062-mcp-file-ingestion-security.md
+++ b/docs/architecture/authentication-security/ADR-062-mcp-file-ingestion-security.md
@@ -3,6 +3,7 @@ status: Draft
 date: 2025-11-08
 deciders:
   - System Architect
+related: []
 ---
 
 # ADR-062: MCP File Ingestion Security Model

--- a/docs/architecture/database-schema/ADR-040-database-schema-migrations.md
+++ b/docs/architecture/database-schema/ADR-040-database-schema-migrations.md
@@ -3,6 +3,7 @@ status: Proposed
 date: 2025-10-20
 deciders:
   - Development Team
+related: []
 ---
 
 # ADR-040: Database Schema Migration Management

--- a/docs/architecture/database-schema/ADR-061-operator-pattern-lifecycle.md
+++ b/docs/architecture/database-schema/ADR-061-operator-pattern-lifecycle.md
@@ -4,6 +4,7 @@ date: 2025-01-07
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-061: Operator Pattern for Platform Lifecycle Management

--- a/docs/architecture/infrastructure/ADR-012-api-server-architecture.md
+++ b/docs/architecture/infrastructure/ADR-012-api-server-architecture.md
@@ -3,6 +3,7 @@ status: Accepted
 date: 2025-10-06
 deciders:
   - Development Team
+related: []
 ---
 
 # ADR-012: API Server Architecture for Scalable Neo4j Access

--- a/docs/architecture/infrastructure/ADR-018-server-sent-events-streaming.md
+++ b/docs/architecture/infrastructure/ADR-018-server-sent-events-streaming.md
@@ -4,6 +4,7 @@ date: 2025-10-09
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-018: Server-Sent Events for Real-Time Progress Streaming

--- a/docs/architecture/infrastructure/ADR-086-deployment-topology.md
+++ b/docs/architecture/infrastructure/ADR-086-deployment-topology.md
@@ -4,6 +4,7 @@ date: 2026-01-17
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-086: Deployment Topology (Dev/Stable Split)

--- a/docs/architecture/ingestion-content/ADR-014-job-approval-workflow.md
+++ b/docs/architecture/ingestion-content/ADR-014-job-approval-workflow.md
@@ -4,6 +4,7 @@ date: 2025-10-07
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-014: Job Approval Workflow with Pre-Ingestion Analysis

--- a/docs/architecture/ingestion-content/ADR-023-markdown-structured-content-preprocessing.md
+++ b/docs/architecture/ingestion-content/ADR-023-markdown-structured-content-preprocessing.md
@@ -4,6 +4,7 @@ date: 2025-10-10
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-023: Markdown Structured Content Preprocessing

--- a/docs/architecture/ingestion-content/ADR-057.1-multimodal-image-ingestion.md
+++ b/docs/architecture/ingestion-content/ADR-057.1-multimodal-image-ingestion.md
@@ -3,6 +3,7 @@ status: Proposed
 date: 2025-11-03
 deciders:
   - System Architects
+related: []
 ---
 
 # ADR-057: Multimodal Image Ingestion with Visual Context Injection

--- a/docs/architecture/ingestion-content/ADR-057.2-appendix-single-vs-two-stage.md
+++ b/docs/architecture/ingestion-content/ADR-057.2-appendix-single-vs-two-stage.md
@@ -4,6 +4,7 @@ date: 2025-11-03
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-057.2: Appendix: Single-Stage vs Two-Stage Image Processing

--- a/docs/architecture/ingestion-content/ADR-072-concept-matching-strategies.md
+++ b/docs/architecture/ingestion-content/ADR-072-concept-matching-strategies.md
@@ -4,6 +4,7 @@ date: 2025-12-04
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-072: Concept Matching Strategies and Configuration

--- a/docs/architecture/ingestion-content/ADR-089-deterministic-node-edge-creation.md
+++ b/docs/architecture/ingestion-content/ADR-089-deterministic-node-edge-creation.md
@@ -4,6 +4,7 @@ date: 2026-01-25
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-089: Deterministic Node and Edge Creation

--- a/docs/architecture/query-search/ADR-063-semantic-diversity-authenticity-signal.md
+++ b/docs/architecture/query-search/ADR-063-semantic-diversity-authenticity-signal.md
@@ -4,6 +4,7 @@ date: 2025-11-08
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-063: Semantic Diversity as Authenticity Signal

--- a/docs/architecture/query-search/ADR-071-parallel-graph-queries.md
+++ b/docs/architecture/query-search/ADR-071-parallel-graph-queries.md
@@ -4,6 +4,7 @@ date: 2025-12-01
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-071: Parallel Graph Query Optimization

--- a/docs/architecture/query-search/ADR-071.1-parallel-implementation-findings.md
+++ b/docs/architecture/query-search/ADR-071.1-parallel-implementation-findings.md
@@ -4,6 +4,7 @@ date: 2025-12-04
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-071.1: Parallel Graph Query Implementation Findings

--- a/docs/architecture/query-search/ADR-084-document-search.md
+++ b/docs/architecture/query-search/ADR-084-document-search.md
@@ -4,6 +4,7 @@ date: 2026-01-03
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-084: Document-Level Search

--- a/docs/architecture/user-interfaces/ADR-013-unified-typescript-client.md
+++ b/docs/architecture/user-interfaces/ADR-013-unified-typescript-client.md
@@ -3,6 +3,7 @@ status: Accepted
 date: 2025-10-06
 deciders:
   - Development Team
+related: []
 ---
 
 # ADR-013: Unified TypeScript Client (CLI + MCP Server)

--- a/docs/architecture/user-interfaces/ADR-029-cli-theory-of-operation.md
+++ b/docs/architecture/user-interfaces/ADR-029-cli-theory-of-operation.md
@@ -4,6 +4,7 @@ date: 2025-10-12
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-029: CLI Theory of Operation - Hybrid Unix/Domain-Specific Design

--- a/docs/architecture/user-interfaces/ADR-075-postmodern-theme.md
+++ b/docs/architecture/user-interfaces/ADR-075-postmodern-theme.md
@@ -4,6 +4,7 @@ date: 2025-01-09
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-075: Postmodern Theme System

--- a/docs/architecture/vocabulary-relationships/ADR-052-vocabulary-expansion-consolidation-cycle.md
+++ b/docs/architecture/vocabulary-relationships/ADR-052-vocabulary-expansion-consolidation-cycle.md
@@ -4,6 +4,7 @@ date: 2025-10-31
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-052: Vocabulary Expansion-Consolidation Cycle (The "Dreaming" Pattern)

--- a/docs/architecture/vocabulary-relationships/ADR-077-vocabulary-explorers.md
+++ b/docs/architecture/vocabulary-relationships/ADR-077-vocabulary-explorers.md
@@ -4,6 +4,7 @@ date: 2025-12-10
 deciders:
   - aaronsb
   - claude
+related: []
 ---
 
 # ADR-077: Vocabulary Explorers

--- a/docs/scripts/doclint.py
+++ b/docs/scripts/doclint.py
@@ -232,16 +232,32 @@ def collect_nav_pages() -> set:
 
 
 def check_references(nodes: list):
-    """Flag related/supersedes targets that resolve to no known node."""
+    """Flag related/supersedes targets that resolve to no known node.
+
+    Decimal-ADR convention (ADR-900): a decision may be split into parts
+    (ADR-032.1, ADR-032.2). A bare base reference (`ADR-032`) is the family
+    identifier and is satisfied by any of its parts — references cite the
+    decision, not a specific part. An exact part reference (`ADR-032.2`) must
+    match exactly.
+    """
     keys = {n.key for n in nodes}
+    base_parts = set()
+    for k in keys:
+        m = re.match(r"^(ADR-\d+)\.\d+$", k)
+        if m:
+            base_parts.add(m.group(1))
+
     for node in nodes:
         for fname, target in node.refs:
             t = target.strip()
-            if ADR_REF_RE.match(t) or ID_RE.match(t):
-                if t not in keys:
-                    node.issues.append(
-                        ("error", f"dangling {fname} reference: {t} (no such record)"))
-            # Non-ref strings (e.g. prose `amends:`) are ignored by the graph.
+            if not (ADR_REF_RE.match(t) or ID_RE.match(t)):
+                continue   # prose `amends:` and other non-refs are not edges
+            if t in keys:
+                continue
+            if "." not in t and t in base_parts:
+                continue   # base reference satisfied by a part (ADR-032 -> ADR-032.1)
+            node.issues.append(
+                ("error", f"dangling {fname} reference: {t} (no such record)"))
 
 
 def check_supersede_cycles(nodes: list):


### PR DESCRIPTION
Fast-follow to PR #519 (documentation catalog, ADR-087/900). Makes the ADR corpus pass the graph linter under enforcement.

## What

- **doclint — decimal-ADR resolution.** A bare base reference (`related: ADR-032`) is the *family* identifier and is satisfied by any of its parts (`ADR-032.1`, `ADR-032.2`); an exact part reference (`ADR-032.2`) still matches exactly. This clears the **11 dangling related-refs** (ADR-032/051/057) — they were references to split decisions whose base lives at the `.1` part, not broken links.
- **ADR-900** now documents the decimal-ADR convention the linter encodes.
- **Normalized 24 ADRs** that lacked a `related:` key — every ADR now carries the uniform `status`/`date`/`deciders`/`related` frontmatter block. (0 ADRs had the body-duplicate-status anti-pattern; ADR-087 was the only one, fixed in #519.)
- **Flipped ADR enforcement on.** The `Docs Catalog Lint` CI job now runs `doclint.py --check --enforce-adrs`, so ADR graph issues (dangling refs, supersede cycles) fail the build like catalog-page issues.

## Verification

- `adr lint` — 0 errors, 0 warnings
- `doclint.py --enforce-adrs --check` — 0 errors, 0 warnings (was 11 errors)
- `link_check` — clean

No ADR was renumbered (ADR-900 freeze policy); the fix lives in the linter's reference model, not in mass edits.