### PR TITLE
feat(tls): in-container DNS-01 (porkbun) for letsencrypt mode

### DIFF
--- a/appliance/files/kg-firstboot.sh
+++ b/appliance/files/kg-firstboot.sh
@@ -93,6 +93,31 @@ else
     INIT_ARGS+=( --skip-ai-config )
 fi
 
+# --- TLS / ingress (ADR-105) -------------------------------------------------
+# Declarative TLS via provision.env. For a PRIVATE box with a public DNS name,
+# --tls=letsencrypt --acme-challenge=dns-01 (porkbun) is the self-renewing path:
+# DNS-01 is the only ACME challenge that works without inbound :443/:80. The DNS
+# provider credentials are exported into the operator's env (never the command
+# line) so the operator persists them to .env for Traefik/lego.
+[ -n "${KG_EXTERNAL_URL:-}" ] && INIT_ARGS+=( --external-url="${KG_EXTERNAL_URL}" )
+if [ -n "${KG_TLS_MODE:-}" ]; then
+    # In-VM TLS modes need the traefik router; default it so provision.env can
+    # just set KG_TLS_MODE.
+    INIT_ARGS+=( --router="${KG_ROUTER:-traefik}" --tls="${KG_TLS_MODE}" )
+    [ -n "${KG_LE_EMAIL:-}" ] && INIT_ARGS+=( --le-email="${KG_LE_EMAIL}" )
+    if [ -n "${KG_ACME_CHALLENGE:-}" ]; then
+        INIT_ARGS+=( --acme-challenge="${KG_ACME_CHALLENGE}" )
+        [ -n "${KG_DNS_PROVIDER:-}" ] && INIT_ARGS+=( --dns-provider="${KG_DNS_PROVIDER}" )
+        [ -n "${KG_PORKBUN_API_KEY:-}" ] && export PORKBUN_API_KEY="${KG_PORKBUN_API_KEY}"
+        [ -n "${KG_PORKBUN_SECRET_API_KEY:-}" ] && export PORKBUN_SECRET_API_KEY="${KG_PORKBUN_SECRET_API_KEY}"
+        log "TLS: ${KG_TLS_MODE} via ${KG_ACME_CHALLENGE} (${KG_DNS_PROVIDER:-porkbun})."
+    else
+        log "TLS: ${KG_TLS_MODE}."
+    fi
+elif [ -n "${KG_ROUTER:-}" ]; then
+    INIT_ARGS+=( --router="${KG_ROUTER}" )
+fi
+
 # --- Provision: mint per-instance secrets + start the standalone stack -------
 # Tee to a log so we can recover the generated admin password (operator prints
 # it once to stdout; there's no read-it-back path since it's stored encrypted).

--- a/appliance/files/provision.env.example
+++ b/appliance/files/provision.env.example
@@ -41,3 +41,30 @@
 # The appliance always generates a strong random admin password (shown on the
 # console and written to /root/kg-credentials.txt). There is no weak-password
 # mode — the startup secret-assertion (#502) would refuse to boot one anyway.
+
+# --- TLS / ingress (ADR-105) -------------------------------------------------
+# Omit this whole block → HTTP only (finish TLS in the UI / later). When set,
+# the appliance terminates TLS in-VM behind Traefik. KG_EXTERNAL_URL is the
+# public https URL; the router is enabled automatically.
+#KG_EXTERNAL_URL=https://kg.example.com
+#
+# TLS_MODE: selfsigned | manual | letsencrypt
+#   • selfsigned — Traefik's built-in cert (browser warning; fine for a LAN box)
+#   • manual     — drop your own cert+key in docker/certs/ (tls.crt + tls.key)
+#   • letsencrypt — real auto-renewing cert via Traefik ACME (needs KG_LE_EMAIL)
+#KG_TLS_MODE=letsencrypt
+#KG_LE_EMAIL=you@example.com
+#
+# ACME challenge for letsencrypt:
+#   • tls-alpn-01 (default) — secretless, but needs the box reachable from the
+#     internet on :443. Use for a public box.
+#   • dns-01 — proves control via a DNS TXT record; the ONLY challenge that works
+#     for a PRIVATE box (RFC-1918, no inbound NAT) with a public DNS name. Needs
+#     a DNS provider credential below.
+#KG_ACME_CHALLENGE=dns-01
+#KG_DNS_PROVIDER=porkbun
+#
+# porkbun DNS-01 credentials (scope the key to the one zone where possible — it
+# lives on the appliance). Read by Traefik/lego; written to .env, never argv.
+#KG_PORKBUN_API_KEY=pk1_...
+#KG_PORKBUN_SECRET_API_KEY=sk1_...

--- a/docker/docker-compose.traefik-tls-letsencrypt-dns.yml
+++ b/docker/docker-compose.traefik-tls-letsencrypt-dns.yml
@@ -1,0 +1,67 @@
+# ============================================================================
+# Knowledge Graph System — Let's Encrypt via DNS-01 (ADR-105 §4, mode = letsencrypt + dns-01)
+# ============================================================================
+# Layers on docker-compose.traefik-tls.yml. Same as the TLS-ALPN-01 letsencrypt
+# overlay, but the ACME challenge is DNS-01 through lego's provider factory.
+# Traefik obtains and AUTO-RENEWS a real cert; `operator.sh recert` is a no-op.
+#
+# WHY DNS-01: TLS-ALPN-01 and HTTP-01 require Let's Encrypt to reach the box from
+# the internet (:443 / :80). A PRIVATE deployment (RFC-1918 address, no inbound
+# NAT) cannot satisfy them. DNS-01 proves control of the name by writing a TXT
+# record, so it works for a private box that owns a public DNS name — this is the
+# only ACME challenge that does. It is the converged, in-container equivalent of
+# the old install.sh acme.sh+porkbun flow.
+#
+# TRUST POSTURE (ADR-105 §7): DNS-01 places an account-scoped DNS API credential
+# inside the appliance. That is a real blast radius — scope the porkbun key to
+# the one zone where possible, and prefer this only for private/trusted boxes.
+# For internet-exposed boxes, the secretless TLS-ALPN-01 overlay is the default.
+#
+# PROVIDER: lego (built into Traefik) ships ~100 DNS providers; porkbun is native.
+# The provider is selected by KG_ACME_DNS_PROVIDER (default porkbun); its
+# credentials are read by lego from the traefik container environment. To add a
+# different provider, set KG_ACME_DNS_PROVIDER and pass that provider's env vars
+# in the `environment:` block below (see lego docs for the variable names).
+#
+# Requires in the environment (.env): LE_EMAIL, PORKBUN_API_KEY,
+# PORKBUN_SECRET_API_KEY. Set LE_CASERVER to staging while testing to avoid
+# rate limits: https://acme-staging-v02.api.letsencrypt.org/directory
+#
+# COMMAND IS REPLACED: restate the full TLS command and add the ACME resolver.
+# ============================================================================
+
+services:
+  traefik:
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=knowledge-graph-router
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+      - --certificatesresolvers.le.acme.dnschallenge=true
+      - --certificatesresolvers.le.acme.dnschallenge.provider=${KG_ACME_DNS_PROVIDER:-porkbun}
+      - --certificatesresolvers.le.acme.email=${LE_EMAIL}
+      - --certificatesresolvers.le.acme.storage=/etc/traefik/acme/acme.json
+      - --certificatesresolvers.le.acme.caserver=${LE_CASERVER:-https://acme-v02.api.letsencrypt.org/directory}
+    environment:
+      # lego reads the DNS provider credentials from the environment. porkbun is
+      # the default provider; other providers read their own variables (add them
+      # here when KG_ACME_DNS_PROVIDER changes).
+      - PORKBUN_API_KEY=${PORKBUN_API_KEY:-}
+      - PORKBUN_SECRET_API_KEY=${PORKBUN_SECRET_API_KEY:-}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # acme.json (account + issued certs) — Traefik creates it 0600. Persist it
+      # so renewals survive restarts and we don't re-hit ACME rate limits.
+      - ${KG_ACME_DIR:-./acme}:/etc/traefik/acme
+
+  web:
+    labels:
+      # Attach the ACME resolver to the websecure router defined in traefik-tls.yml.
+      - traefik.http.routers.kgweb-tls.tls.certresolver=le
+
+  api:
+    labels:
+      - traefik.http.routers.kgapi-tls.tls.certresolver=le

--- a/docker/docker-compose.traefik-tls-letsencrypt.yml
+++ b/docker/docker-compose.traefik-tls-letsencrypt.yml
@@ -17,13 +17,11 @@
 #     serves the ACME http challenge on the entrypoint ahead of the redirect, but
 #     the interaction is version-sensitive — if HTTP-01 fails to validate, drop
 #     the `web.http.redirections.*` lines (let :80 serve plain) while issuing.
-#   * DNS-01 via lego (e.g. porkbun) — OPT-IN, private-only. Adds an account-wide
-#     DNS credential to the appliance, so prefer `manual` (cert issued off-box).
-#     If you accept the blast radius:
-#       --certificatesresolvers.le.acme.dnschallenge=true
-#       --certificatesresolvers.le.acme.dnschallenge.provider=porkbun
-#     and pass PORKBUN_API_KEY / PORKBUN_SECRET_API_KEY into the traefik env
-#     (lego reads them). ~100 providers ship with lego; porkbun is native.
+#   * DNS-01 via lego (e.g. porkbun) — the path for a PRIVATE box (no inbound
+#     :443/:80). It is its own overlay now: docker-compose.traefik-tls-letsencrypt-dns.yml,
+#     selected by `--tls=letsencrypt --acme-challenge=dns-01`. It adds an
+#     account-scoped DNS credential to the appliance (a real blast radius — scope
+#     the key to the one zone), so it stays opt-in; tls-alpn-01 is the default.
 #
 # Requires LE_EMAIL in the environment (ACME account contact).
 # Set LE_CASERVER to the staging directory while testing to avoid rate limits:

--- a/docs/self-host/tls.md
+++ b/docs/self-host/tls.md
@@ -13,10 +13,10 @@ Kappa Graph uses Traefik as its in-VM router and TLS terminator. The cert postur
 | Scenario | Where it runs | TLS terminator | Default cert mode |
 |----------|--------------|----------------|-------------------|
 | `dev` | containers on a dev box, no VM | none | HTTP only |
-| `private` | appliance VM on a trusted LAN, private IP | in-VM Traefik | `manual` (preferred) or `selfsigned` |
-| `internet` | VM with a public IP, `:443` reachable | in-VM Traefik | `letsencrypt` |
+| `private` | appliance VM on a trusted LAN, private IP | in-VM Traefik | `letsencrypt` + `dns-01` (self-renewing), or `selfsigned` / `manual` |
+| `internet` | VM with a public IP, `:443` reachable | in-VM Traefik | `letsencrypt` (TLS-ALPN-01) |
 | `proxied` | behind an edge load balancer or proxy | edge | `offload` |
-| `public-nat` | public IP behind NAT or Cloudflare | in-VM Traefik or tunnel | DNS-01 delegation or `offload` |
+| `public-nat` | public IP behind NAT or Cloudflare | in-VM Traefik or tunnel | `letsencrypt` + `dns-01`, or `offload` |
 
 ## TLS modes
 
@@ -25,7 +25,7 @@ Four modes map to Traefik `certResolver` configurations:
 | Mode | Mechanism | Who renews |
 |------|-----------|------------|
 | `selfsigned` | Traefik's built-in default cert | Traefik (automatic) |
-| `letsencrypt` | Traefik ACME resolver — TLS-ALPN-01 by default | Traefik (automatic) |
+| `letsencrypt` | Traefik ACME resolver — TLS-ALPN-01 (default) or DNS-01 via `--acme-challenge` | Traefik (automatic) |
 | `manual` | Traefik file provider, operator-supplied cert | Operator re-supplies; Traefik hot-reloads |
 | `offload` | HTTP in-VM; edge proxy terminates TLS | Upstream (recert is a no-op) |
 
@@ -51,6 +51,17 @@ Pass `--router=traefik` and `--tls=<mode>` to `operator.sh init --headless`:
   --web-hostname=kg.example.com \
   ...
 
+# Let's Encrypt via DNS-01 (PRIVATE box, no inbound :443 — self-renewing)
+# PORKBUN_API_KEY / PORKBUN_SECRET_API_KEY must be in the environment.
+./operator.sh init --headless \
+  --router=traefik \
+  --tls=letsencrypt \
+  --acme-challenge=dns-01 \
+  --dns-provider=porkbun \
+  --le-email=admin@example.com \
+  --external-url=https://kg.example.com \
+  ...
+
 # Operator-supplied cert (manual mode)
 ./operator.sh init --headless \
   --router=traefik \
@@ -67,7 +78,7 @@ Pass `--router=traefik` and `--tls=<mode>` to `operator.sh init --headless`:
   ...
 ```
 
-`--tls=selfsigned`, `--tls=manual`, and `--tls=letsencrypt` require `--router=traefik`. `--tls=letsencrypt` requires `--le-email`. No restart is needed after init — the modes are composable overlays selected at startup.
+`--tls=selfsigned`, `--tls=manual`, and `--tls=letsencrypt` require `--router=traefik`. `--tls=letsencrypt` requires `--le-email`. `--acme-challenge=dns-01` requires `--tls=letsencrypt` and the DNS provider's credentials in the environment (porkbun: `PORKBUN_API_KEY` + `PORKBUN_SECRET_API_KEY`). No restart is needed after init — the modes are composable overlays selected at startup.
 
 `--external-url` sets the scheme+host the app uses for OAuth redirect URIs, cookie domains, and frontend links. When `--tls` is set and `--external-url` is omitted, init derives it as `https://<web-hostname>` automatically.
 
@@ -116,25 +127,41 @@ To check cert status:
 
 To replace an expiring cert, copy the new `tls.crt` and `tls.key` into `docker/certs/` (or `KG_CERT_DIR`). Traefik picks it up within seconds without a restart.
 
-## DNS-01 via lego (opt-in, private-only)
+## Let's Encrypt via DNS-01 (private box, self-renewing)
 
-Traefik ships lego, which supports ~100 DNS providers natively. DNS-01 is useful when `:80` and `:443` are not publicly reachable (e.g., NAT or Cloudflare proxy). It is **opt-in and restricted to private deployments** because it requires an account-wide DNS credential on the appliance (porkbun keys are not per-zone scoped — see ADR-105 §7 for the trust posture).
+TLS-ALPN-01 and HTTP-01 require Let's Encrypt to reach the box from the internet on `:443`/`:80`. A **private** deployment (RFC-1918 address, no inbound NAT) cannot satisfy them. DNS-01 proves control of the name by writing a TXT record, so it is the **only** ACME challenge that works for a private box with a public DNS name — and it auto-renews in-container, the converged equivalent of the old `install.sh` acme.sh+porkbun flow.
 
-To enable DNS-01, edit `docker/docker-compose.traefik-tls-letsencrypt.yml` and replace the `tlsChallenge` resolver flags with:
-
-```yaml
-- --certificatesresolvers.le.acme.dnschallenge=true
-- --certificatesresolvers.le.acme.dnschallenge.provider=porkbun
-```
-
-Then add the provider credentials to the Traefik environment:
+It is a selectable option on `letsencrypt`, not a file edit:
 
 ```bash
+# In .env (read by Traefik/lego — written here automatically by init):
 PORKBUN_API_KEY=pk1_...
 PORKBUN_SECRET_API_KEY=sk1_...
+
+./operator.sh init \
+  --router=traefik \
+  --tls=letsencrypt \
+  --acme-challenge=dns-01 \
+  --dns-provider=porkbun \
+  --le-email=you@example.com \
+  --external-url=https://kg.example.com
 ```
 
-For other providers, substitute the lego provider name and its required environment variables. The [lego documentation](https://go-acme.github.io/lego/dns/) lists all supported providers.
+The operator reads `PORKBUN_API_KEY`/`PORKBUN_SECRET_API_KEY` from the environment (never the command line) and persists them to `.env`; Traefik's lego resolver does the DNS-01 dance and renews automatically. `operator.sh recert` is a no-op.
+
+On the **appliance**, set the same via `provision.env` — declarative, no shell:
+
+```ini
+KG_EXTERNAL_URL=https://kg.example.com
+KG_TLS_MODE=letsencrypt
+KG_ACME_CHALLENGE=dns-01
+KG_DNS_PROVIDER=porkbun
+KG_LE_EMAIL=you@example.com
+KG_PORKBUN_API_KEY=pk1_...
+KG_PORKBUN_SECRET_API_KEY=sk1_...
+```
+
+**Trust posture (ADR-105 §7):** DNS-01 places an account-scoped DNS API credential inside the appliance — a real blast radius. Scope the porkbun key to the one zone where possible, and prefer DNS-01 only for private/trusted boxes; `tls-alpn-01` stays the default for internet-exposed boxes. lego ships ~100 providers ([docs](https://go-acme.github.io/lego/dns/)); porkbun is wired here. For another provider, set `--dns-provider` and add its env vars to `docker/docker-compose.traefik-tls-letsencrypt-dns.yml`.
 
 ## Offload mode
 

--- a/operator.sh
+++ b/operator.sh
@@ -113,7 +113,14 @@ get_compose_cmd() {
             selfsigned|manual|letsencrypt)
                 [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
                 [ "$TLS_MODE" = "manual" ]      && [ -f "$DOCKER_DIR/docker-compose.traefik-tls-manual.yml" ]      && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-manual.yml"
-                [ "$TLS_MODE" = "letsencrypt" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml"
+                # letsencrypt: dns-01 uses the lego DNS overlay; otherwise TLS-ALPN-01.
+                if [ "$TLS_MODE" = "letsencrypt" ]; then
+                    if [ "${ACME_CHALLENGE:-tls-alpn-01}" = "dns-01" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt-dns.yml" ]; then
+                        cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt-dns.yml"
+                    elif [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ]; then
+                        cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml"
+                    fi
+                fi
                 ;;
         esac
     fi

--- a/operator/lib/common.sh
+++ b/operator/lib/common.sh
@@ -170,7 +170,14 @@ get_compose_cmd() {
                 [ -f "$DOCKER_DIR/docker-compose.traefik-tls.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls.yml"
                 case "$TLS_MODE" in
                     manual)      [ -f "$DOCKER_DIR/docker-compose.traefik-tls-manual.yml" ]      && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-manual.yml" ;;
-                    letsencrypt) [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ;;
+                    letsencrypt)
+                        # dns-01 uses the lego DNS overlay; otherwise TLS-ALPN-01.
+                        if [ "${ACME_CHALLENGE:-tls-alpn-01}" = "dns-01" ] && [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt-dns.yml" ]; then
+                            cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt-dns.yml"
+                        elif [ -f "$DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml" ]; then
+                            cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-tls-letsencrypt.yml"
+                        fi
+                        ;;
                 esac
                 ;;
         esac

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -44,6 +44,8 @@ EXTERNAL_URL=""
 ROUTER_MODE="none"
 TLS_MODE="none"
 LE_EMAIL=""
+ACME_CHALLENGE="tls-alpn-01"
+ACME_DNS_PROVIDER="porkbun"
 SKIP_AI_CONFIG=false
 SKIP_CLI=false
 SHOW_HELP=false
@@ -107,12 +109,25 @@ ${BOLD}Web Configuration:${NC}
                           • selfsigned: Traefik's built-in self-signed cert
                           • manual: operator-supplied cert+key in docker/certs/
                             (tls.crt + tls.key); cert issued off-box
-                          • letsencrypt: Traefik ACME (TLS-ALPN-01); needs --le-email
+                          • letsencrypt: Traefik ACME, real auto-renewing cert.
+                            Challenge selected by --acme-challenge; needs --le-email
                           • offload: HTTP in-VM, edge terminates TLS (EXTERNAL_URL
                             scheme becomes https). Assumes an external reverse
                             proxy does TLS + path routing (/ -> web, /api -> api);
                             nothing in-box enforces it.
   --le-email EMAIL        ACME account contact for --tls=letsencrypt
+  --acme-challenge TYPE   ACME challenge for --tls=letsencrypt:
+                          • tls-alpn-01 (default): secretless, served on :443;
+                            requires the box reachable from the internet on :443
+                          • dns-01: proves control via a DNS TXT record — the only
+                            challenge that works for a PRIVATE box with a public
+                            name. Uses lego (built into Traefik). Set --dns-provider
+                            and supply that provider's credentials in the env.
+  --dns-provider NAME     DNS provider for --acme-challenge=dns-01 (default: porkbun;
+                          lego ships ~100). For porkbun, set PORKBUN_API_KEY and
+                          PORKBUN_SECRET_API_KEY in the environment (e.g. via the
+                          appliance provision.env); they are written to .env and
+                          read by Traefik/lego — never passed on the command line.
 
 ${BOLD}AI Configuration:${NC}
   --ai-provider PROVIDER  AI extraction provider (openai, anthropic, openrouter)
@@ -294,6 +309,22 @@ parse_args() {
                 LE_EMAIL="$2"
                 shift 2
                 ;;
+            --acme-challenge=*)
+                ACME_CHALLENGE="${1#*=}"
+                shift
+                ;;
+            --acme-challenge)
+                ACME_CHALLENGE="$2"
+                shift 2
+                ;;
+            --dns-provider=*)
+                ACME_DNS_PROVIDER="${1#*=}"
+                shift
+                ;;
+            --dns-provider)
+                ACME_DNS_PROVIDER="$2"
+                shift 2
+                ;;
             *)
                 echo -e "${RED}Unknown option: $1${NC}"
                 echo "Use --help for usage information"
@@ -362,6 +393,36 @@ validate_config() {
     if [[ "$TLS_MODE" == "letsencrypt" && -z "$LE_EMAIL" ]]; then
         echo -e "${RED}✗ --tls=letsencrypt requires --le-email (ACME account contact)${NC}"
         errors=$((errors + 1))
+    fi
+    # ACME challenge (ADR-105 §4): tls-alpn-01 (default) or dns-01 (lego).
+    case "$ACME_CHALLENGE" in
+        tls-alpn-01|dns-01) ;;
+        *)
+            echo -e "${RED}✗ Invalid --acme-challenge: $ACME_CHALLENGE (must be tls-alpn-01|dns-01)${NC}"
+            errors=$((errors + 1))
+            ;;
+    esac
+    # dns-01 only makes sense for the letsencrypt mode.
+    if [[ "$ACME_CHALLENGE" == "dns-01" && "$TLS_MODE" != "letsencrypt" ]]; then
+        echo -e "${RED}✗ --acme-challenge=dns-01 requires --tls=letsencrypt${NC}"
+        errors=$((errors + 1))
+    fi
+    # dns-01 needs the DNS provider's credentials in the environment so lego can
+    # write the TXT record. Currently porkbun is wired; other providers add their
+    # own env vars to the dns overlay.
+    if [[ "$TLS_MODE" == "letsencrypt" && "$ACME_CHALLENGE" == "dns-01" ]]; then
+        case "$ACME_DNS_PROVIDER" in
+            porkbun)
+                if [[ -z "${PORKBUN_API_KEY:-}" || -z "${PORKBUN_SECRET_API_KEY:-}" ]]; then
+                    echo -e "${RED}✗ --dns-provider=porkbun needs PORKBUN_API_KEY and PORKBUN_SECRET_API_KEY in the environment${NC}"
+                    errors=$((errors + 1))
+                fi
+                ;;
+            *)
+                echo -e "${RED}✗ Unsupported --dns-provider: $ACME_DNS_PROVIDER (wired: porkbun)${NC}"
+                errors=$((errors + 1))
+                ;;
+        esac
     fi
 
     # Validate external URL (ADR-105): must be a scheme+host, no trailing path.
@@ -576,6 +637,22 @@ main() {
         fi
     fi
 
+    # DNS-01 provider credentials → .env (read by Traefik/lego in the dns overlay).
+    # Upsert from the environment so the secret never appears in argv or logs.
+    if [[ "$TLS_MODE" == "letsencrypt" && "$ACME_CHALLENGE" == "dns-01" && "$ACME_DNS_PROVIDER" == "porkbun" ]]; then
+        _upsert_env() {  # $1=key $2=value
+            if ! grep -q "^$1=" "$PROJECT_ROOT/.env" 2>/dev/null; then
+                echo "$1=$2" >> "$PROJECT_ROOT/.env"
+            else
+                sed -i "s|^$1=.*|$1=$2|" "$PROJECT_ROOT/.env"
+            fi
+        }
+        grep -q '^# DNS-01 provider credentials' "$PROJECT_ROOT/.env" 2>/dev/null || \
+            echo "# DNS-01 provider credentials (ADR-105 §4; read by Traefik/lego)" >> "$PROJECT_ROOT/.env"
+        _upsert_env PORKBUN_API_KEY "$PORKBUN_API_KEY"
+        _upsert_env PORKBUN_SECRET_API_KEY "$PORKBUN_SECRET_API_KEY"
+    fi
+
     echo -e "${GREEN}✓ Secrets generated${NC}"
     echo -e "${GREEN}✓ Web hostname: $WEB_HOSTNAME${NC}"
     echo -e "${GREEN}✓ External URL: $EXTERNAL_URL${NC}"
@@ -596,6 +673,8 @@ COMPOSE_FILE=$COMPOSE_FILE
 IMAGE_SOURCE=$IMAGE_SOURCE
 ROUTER_MODE=$ROUTER_MODE
 TLS_MODE=$TLS_MODE
+ACME_CHALLENGE=$ACME_CHALLENGE
+ACME_DNS_PROVIDER=$ACME_DNS_PROVIDER
 EXTERNAL_URL=$EXTERNAL_URL
 INITIALIZED_AT=$(date -Iseconds)
 EOF

--- a/operator/lib/recert.sh
+++ b/operator/lib/recert.sh
@@ -27,6 +27,9 @@ ENV_FILE="$WORKSPACE/.env"
 TLS_MODE="none"
 [ -f "$CONFIG_FILE" ] && TLS_MODE="$(grep -E '^TLS_MODE=' "$CONFIG_FILE" 2>/dev/null | cut -d= -f2 || true)"
 TLS_MODE="${TLS_MODE:-none}"
+ACME_CHALLENGE="tls-alpn-01"
+[ -f "$CONFIG_FILE" ] && ACME_CHALLENGE="$(grep -E '^ACME_CHALLENGE=' "$CONFIG_FILE" 2>/dev/null | cut -d= -f2 || true)"
+ACME_CHALLENGE="${ACME_CHALLENGE:-tls-alpn-01}"
 
 # KG_CERT_DIR: read it from .env — the SAME file `docker compose --env-file`
 # substitutes into the manual overlay's cert mount — so recert checks exactly the
@@ -102,7 +105,7 @@ case "$TLS_MODE" in
         echo -e "${GREEN}✓ selfsigned: Traefik serves/regenerates its built-in cert — nothing to renew.${NC}"
         ;;
     letsencrypt)
-        echo -e "${GREEN}✓ letsencrypt: Traefik's ACME resolver auto-renews — nothing to do.${NC}"
+        echo -e "${GREEN}✓ letsencrypt (${ACME_CHALLENGE}): Traefik's ACME resolver auto-renews — nothing to do.${NC}"
         echo -e "  Inspect issued certs: docker logs <traefik> | grep -i acme"
         ;;
     offload)

--- a/operator/lib/start-platform.sh
+++ b/operator/lib/start-platform.sh
@@ -147,7 +147,14 @@ start_application() {
                 selfsigned|manual|letsencrypt)
                     [ -f docker-compose.traefik-tls.yml ] && compose_cmd="$compose_cmd -f docker-compose.traefik-tls.yml"
                     [ "$TLS_MODE" = "manual" ]      && [ -f docker-compose.traefik-tls-manual.yml ]      && compose_cmd="$compose_cmd -f docker-compose.traefik-tls-manual.yml"
-                    [ "$TLS_MODE" = "letsencrypt" ] && [ -f docker-compose.traefik-tls-letsencrypt.yml ] && compose_cmd="$compose_cmd -f docker-compose.traefik-tls-letsencrypt.yml"
+                    # letsencrypt: dns-01 uses the lego DNS overlay; otherwise TLS-ALPN-01.
+                    if [ "$TLS_MODE" = "letsencrypt" ]; then
+                        if [ "${ACME_CHALLENGE:-tls-alpn-01}" = "dns-01" ] && [ -f docker-compose.traefik-tls-letsencrypt-dns.yml ]; then
+                            compose_cmd="$compose_cmd -f docker-compose.traefik-tls-letsencrypt-dns.yml"
+                        elif [ -f docker-compose.traefik-tls-letsencrypt.yml ]; then
+                            compose_cmd="$compose_cmd -f docker-compose.traefik-tls-letsencrypt.yml"
+                        fi
+                    fi
                     ;;
             esac
         fi


### PR DESCRIPTION
Makes Let's Encrypt **DNS-01** a first-class, selectable challenge on `--tls=letsencrypt`, issued and auto-renewed **in-container** by Traefik's lego resolver (ADR-105 §4). Prerequisite for the cube deploy.

## Why

TLS-ALPN-01 / HTTP-01 require Let's Encrypt to reach the box from the internet on `:443`/`:80`. A **private** box (RFC-1918, no inbound NAT) can't satisfy them. **DNS-01 is the only ACME challenge that works for a private box with a public DNS name** — and it auto-renews in-container, the converged equivalent of the old `install.sh` acme.sh+porkbun flow that was being deprecated.

## What (threaded through the whole converged path)

- **New overlay** `docker-compose.traefik-tls-letsencrypt-dns.yml` — `dnschallenge.provider=${KG_ACME_DNS_PROVIDER:-porkbun}`, passes `PORKBUN_API_KEY`/`PORKBUN_SECRET_API_KEY` to Traefik.
- **operator**: `--acme-challenge` (`tls-alpn-01` default \| `dns-01`) + `--dns-provider` (porkbun). Validated (dns-01 ⇒ letsencrypt; creds required in env), persisted to `.operator.conf` (challenge/provider) and `.env` (creds, **never argv**).
- **Overlay selection** in `operator.sh`, `common.sh`, `start-platform.sh` picks the dns overlay when `ACME_CHALLENGE=dns-01` (defaults to alpn for pre-existing configs).
- **recert.sh**: challenge-aware (dns-01 auto-renews — no-op).
- **Appliance**: `provision.env` keys (`KG_TLS_MODE`/`KG_ACME_CHALLENGE`/`KG_DNS_PROVIDER`/`KG_LE_EMAIL`/`KG_EXTERNAL_URL`/`KG_PORKBUN_*`) → `operator init` via `kg-firstboot.sh`. **Closes the appliance TLS provisioning gap** (was hostname + AI only).
- **docs/self-host/tls.md**: DNS-01 as a flag + `provision.env`, not a manual compose edit.

## Usage

```bash
PORKBUN_API_KEY=pk1_... PORKBUN_SECRET_API_KEY=sk1_... \
./operator.sh init --router=traefik --tls=letsencrypt \
  --acme-challenge=dns-01 --dns-provider=porkbun \
  --le-email=you@example.com --external-url=https://kg.broccoli.house
```

## Trust posture (ADR-105 §7)

DNS-01 puts an account-scoped DNS key on the box — opt-in, private-only; `tls-alpn-01` stays the secretless default for internet-exposed boxes.

## Verification

`bash -n` all scripts · dns overlay valid YAML · overlay-selection correct both ways · doclint/adr lint/link_check clean. **CI can't exercise real DNS-01** (needs live DNS) — validated by selection-logic + syntax here, and on cube next.