### PR TITLE
fix(appliance): make the appliance build + deploy on modern Docker (first cube deploy)

### DIFF
--- a/appliance/README.md
+++ b/appliance/README.md
@@ -111,6 +111,27 @@ write_files:
 by `kg-firstboot.sh`, extensible (unknown keys ignored), and the natural channel
 a future fleet orchestrator would template per node.
 
+## Deploy gotchas (libvirt/KVM) — learned the hard way
+
+- **Attach the NoCloud seed as a VIRTIO disk, not a SATA/IDE cdrom.** The Debian
+  *cloud* kernel ships no AHCI/SATA driver, so a `sr0`/`sda` seed is invisible →
+  `ds-identify` finds no datasource → cloud-init is disabled → `provision.env`
+  never lands and the box comes up with defaults. Attach the `cidata` ISO as
+  `bus=virtio` (it shows up as `/dev/vdb`) and cloud-init finds it.
+  ```
+  virt-install ... \
+    --disk path=kg-appliance.qcow2,bus=virtio \
+    --disk path=kg-seed.iso,format=raw,bus=virtio,readonly=on
+  ```
+- **Changing the NIC MAC is safe.** The image disables cloud-init's network
+  rendering and ships a DHCP netplan matched by interface *name* (`e*`), not MAC,
+  so you can repoint the VM at a pinned DHCP reservation (`virt-xml <dom> --edit
+  --network mac=<reserved>`) and it still gets an address. (cloud-init's default,
+  MAC-pinned, would strand the NIC.)
+- **Modern Docker Engine just works.** Engine ≥25 raised its minimum served API
+  to 1.40, which Traefik v3's hard-coded 1.24 client would be rejected by; the
+  image bakes `DOCKER_MIN_API_VERSION=1.24` as a `docker.service` drop-in.
+
 ## Layout
 
 ```

--- a/appliance/build-appliance.sh
+++ b/appliance/build-appliance.sh
@@ -139,6 +139,21 @@ VC_ARGS=(
     --run-command 'apt-get update'
     --install "${DOCKER_PKGS}"
     --run-command 'systemctl enable docker qemu-guest-agent'
+    # Keep dockerd serving the legacy API version. Docker Engine >=25 raised its
+    # minimum served API to 1.40, but Traefik v3's Docker provider hard-codes
+    # 1.24 (and ignores DOCKER_API_VERSION), so it gets rejected. DOCKER_MIN_API_VERSION
+    # tells the daemon to keep accepting the old API. (Discovered on the cube deploy.)
+    --mkdir /etc/systemd/system/docker.service.d
+    --run-command 'printf "[Service]\nEnvironment=\"DOCKER_MIN_API_VERSION=1.24\"\n" > /etc/systemd/system/docker.service.d/api-compat.conf'
+    # --- MAC-agnostic networking ---
+    # cloud-init, given no network-config in the seed, generates a netplan that
+    # PINS the NIC to its first-boot MAC. Changing the MAC later (e.g. to claim a
+    # DHCP reservation) then leaves the NIC unconfigured. Disable cloud-init's
+    # network rendering and ship a static DHCP netplan matched by NAME, not MAC,
+    # so the image survives a MAC change. (Discovered on the cube deploy.)
+    --run-command 'printf "network: {config: disabled}\n" > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg'
+    --run-command 'printf "network:\n  version: 2\n  ethernets:\n    primary:\n      match:\n        name: \"e*\"\n      dhcp4: true\n" > /etc/netplan/50-cloud-init.yaml'
+    --run-command 'chmod 600 /etc/netplan/50-cloud-init.yaml'
     # --- stage the repo at /opt/kg (git archive, prefix kg/) ---
     --upload "${REPO_TAR}:/tmp/kg-repo.tar"
     --run-command 'tar -xf /tmp/kg-repo.tar -C /opt && rm -f /tmp/kg-repo.tar'

--- a/appliance/build-appliance.sh
+++ b/appliance/build-appliance.sh
@@ -108,11 +108,22 @@ qemu-img convert -O qcow2 "${BASE_IMG}" "${OUT_QCOW}"
 qemu-img resize "${OUT_QCOW}" "${DISK_SIZE}"
 
 # --- 4. Customize in place with virt-customize -------------------------------
-# Docker via the official convenience script (gives docker-ce + the v2 compose
-# plugin operator.sh needs). python3/openssl/curl/git: secret-gen + operator.
-# Cockpit (optional): host control plane on :9090.
+# Docker from the official apt repository (docker-ce + the v2 compose plugin
+# operator.sh needs). We use the repo, NOT the get.docker.com convenience script:
+# the script is fragile under virt-customize's offline/no-systemd context (it can
+# leave docker.service unregistered, so the subsequent offline `systemctl enable
+# docker` fails), and Docker themselves do not recommend it for production images.
+# The apt repo installs docker.service deterministically, so the offline enable
+# works. python3/openssl/curl/git: secret-gen + operator. Cockpit (optional): :9090.
+case "${DEBIAN_VER}" in
+    12) DEBIAN_CODENAME="bookworm" ;;
+    11) DEBIAN_CODENAME="bullseye" ;;
+    13) DEBIAN_CODENAME="trixie" ;;
+    *)  die "unknown Debian release ${DEBIAN_VER}; add its codename to build-appliance.sh" ;;
+esac
 PKGS="qemu-guest-agent,ca-certificates,curl,python3,openssl,git,jq"
 [ "${WITH_COCKPIT}" = "true" ] && PKGS="${PKGS},cockpit"
+DOCKER_PKGS="docker-ce,docker-ce-cli,containerd.io,docker-buildx-plugin,docker-compose-plugin"
 
 VC_ARGS=(
     -a "${OUT_QCOW}"
@@ -120,7 +131,13 @@ VC_ARGS=(
     --hostname "kg-appliance"
     --run-command 'apt-get update'
     --install "${PKGS}"
-    --run-command 'curl -fsSL https://get.docker.com | sh'
+    # Docker's official apt repo (keyring + source), then install docker-ce.
+    --run-command 'install -m 0755 -d /etc/apt/keyrings'
+    --run-command 'curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc'
+    --run-command 'chmod a+r /etc/apt/keyrings/docker.asc'
+    --run-command "printf 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${DEBIAN_CODENAME} stable\n' > /etc/apt/sources.list.d/docker.list"
+    --run-command 'apt-get update'
+    --install "${DOCKER_PKGS}"
     --run-command 'systemctl enable docker qemu-guest-agent'
     # --- stage the repo at /opt/kg (git archive, prefix kg/) ---
     --upload "${REPO_TAR}:/tmp/kg-repo.tar"
@@ -142,7 +159,7 @@ VC_ARGS=(
 )
 [ "${WITH_COCKPIT}" = "true" ] && VC_ARGS+=( --run-command 'systemctl enable cockpit.socket' )
 
-log "customizing image (no VM boot; --network lets apt + get.docker.com fetch)..."
+log "customizing image (no VM boot; --network lets apt fetch base + docker repo)..."
 [ "${WITH_COCKPIT}" = "true" ] && log "  including Cockpit host console (:9090)" || log "  Cockpit disabled (--no-cockpit)"
 virt-customize "${VC_ARGS[@]}"
 

--- a/docker/docker-compose.traefik-tls-letsencrypt-dns.yml
+++ b/docker/docker-compose.traefik-tls-letsencrypt-dns.yml
@@ -61,7 +61,13 @@ services:
     labels:
       # Attach the ACME resolver to the websecure router defined in traefik-tls.yml.
       - traefik.http.routers.kgweb-tls.tls.certresolver=le
+      # Pin the cert hostname. The router rule is host-agnostic PathPrefix(`/`), so
+      # without an explicit domain Traefik has nothing to request a cert for and
+      # ACME never fires (acme.json stays empty). TLS_DOMAIN is the bare host the
+      # operator derived from EXTERNAL_URL.
+      - traefik.http.routers.kgweb-tls.tls.domains[0].main=${TLS_DOMAIN}
 
   api:
     labels:
       - traefik.http.routers.kgapi-tls.tls.certresolver=le
+      - traefik.http.routers.kgapi-tls.tls.domains[0].main=${TLS_DOMAIN}

--- a/docker/docker-compose.traefik-tls-letsencrypt.yml
+++ b/docker/docker-compose.traefik-tls-letsencrypt.yml
@@ -54,7 +54,13 @@ services:
     labels:
       # Attach the ACME resolver to the websecure router defined in traefik-tls.yml.
       - traefik.http.routers.kgweb-tls.tls.certresolver=le
+      # Pin the cert hostname. The router rule is host-agnostic PathPrefix(`/`), so
+      # without an explicit domain Traefik has nothing to request a cert for and
+      # ACME never fires (acme.json stays empty). TLS_DOMAIN is the bare host the
+      # operator derived from EXTERNAL_URL.
+      - traefik.http.routers.kgweb-tls.tls.domains[0].main=${TLS_DOMAIN}
 
   api:
     labels:
       - traefik.http.routers.kgapi-tls.tls.certresolver=le
+      - traefik.http.routers.kgapi-tls.tls.domains[0].main=${TLS_DOMAIN}

--- a/docker/docker-compose.traefik.yml
+++ b/docker/docker-compose.traefik.yml
@@ -32,14 +32,13 @@ services:
     image: traefik:v3.3.1
     container_name: ${CONTAINER_PREFIX:-knowledge-graph}-traefik
     restart: unless-stopped
-    environment:
-      # Pin the Docker API version the provider uses. Traefik v3.3.1's Docker
-      # client otherwise negotiates down to 1.24, which modern Docker Engine
-      # (>=25; the appliance bakes the latest docker-ce) rejects with "client
-      # version 1.24 is too old. Minimum supported API version is 1.40". 1.44 is
-      # within every current daemon's [min,max] window and supported by Traefik's
-      # bundled SDK. Override via .env if a future daemon raises its minimum.
-      - DOCKER_API_VERSION=${DOCKER_API_VERSION:-1.44}
+    # NOTE on modern Docker Engine: Traefik v3.3.1's Docker provider HARD-CODES
+    # API version 1.24 and ignores the DOCKER_API_VERSION env (it builds its
+    # client with an explicit WithVersion("1.24")). Engine >=25 raised its
+    # minimum served API to 1.40, so it rejects 1.24 with "client version 1.24
+    # is too old". The fix lives on the DAEMON, not here: set
+    # DOCKER_MIN_API_VERSION=1.24 on dockerd to keep serving the old API. The
+    # appliance bakes that as a docker.service drop-in (appliance/build-appliance.sh).
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false

--- a/docker/docker-compose.traefik.yml
+++ b/docker/docker-compose.traefik.yml
@@ -32,6 +32,14 @@ services:
     image: traefik:v3.3.1
     container_name: ${CONTAINER_PREFIX:-knowledge-graph}-traefik
     restart: unless-stopped
+    environment:
+      # Pin the Docker API version the provider uses. Traefik v3.3.1's Docker
+      # client otherwise negotiates down to 1.24, which modern Docker Engine
+      # (>=25; the appliance bakes the latest docker-ce) rejects with "client
+      # version 1.24 is too old. Minimum supported API version is 1.40". 1.44 is
+      # within every current daemon's [min,max] window and supported by Traefik's
+      # bundled SDK. Override via .env if a future daemon raises its minimum.
+      - DOCKER_API_VERSION=${DOCKER_API_VERSION:-1.44}
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false

--- a/docs/self-host/appliance-libvirt.md
+++ b/docs/self-host/appliance-libvirt.md
@@ -1,0 +1,194 @@
+---
+id: 1.O.10
+domain: infra
+mode: operations
+---
+
+# Appliance on libvirt/KVM
+
+How to deploy and manage the [x86 thin appliance](../../appliance/README.md)
+([ADR-103](../architecture/infrastructure/ADR-103-distribution-strategy-nomic-first-thin-appliance-with-app-store-tenancy.md))
+as a libvirt/KVM guest, with a self-renewing TLS certificate and no inbound
+ports. The worked example is the `cube` deployment (`kg.broccoli.house`), but the
+procedure is generic.
+
+The appliance is **thin**: container images pull on first boot, secrets are
+minted per-instance, and the box carries no baked `.env`. The image is built by
+`appliance/build-appliance.sh`; this page covers everything *after* you have a
+`kg-appliance-*.qcow2`.
+
+## What you get
+
+- A single VM that boots, mints its own secrets, pulls images, and starts the
+  full stack (traefik / web / api / postgres / garage / operator).
+- **Self-renewing TLS** via in-container ACME DNS-01 (lego + a DNS provider such
+  as porkbun) — the [TLS guide](tls.md) and
+  [ADR-105](../architecture/infrastructure/ADR-105-scenario-driven-tls-via-in-vm-traefik-router.md)
+  cover the cert design. DNS-01 is the only ACME challenge that works for a
+  private box (RFC-1918, no inbound `:80`/`:443`) that owns a public DNS name.
+- Management without SSH — the appliance ships **no sshd**. You drive it through
+  the qemu-guest-agent, the Cockpit host console (`:9090`), or the tty1 console
+  TUI over VNC.
+
+## 1. The NoCloud seed — attach it as a VIRTIO disk
+
+Provisioning config (`provision.env`) reaches the VM through a cloud-init
+NoCloud seed: a small ISO with the `cidata` volume label holding `user-data` +
+`meta-data`.
+
+> **Critical:** attach the seed as a **virtio** disk, not a SATA/IDE cdrom. The
+> Debian *cloud* kernel has no AHCI/SATA driver, so a `sr0`/`sda` seed is
+> invisible → `ds-identify` finds no datasource → cloud-init is disabled → the
+> box boots with defaults and your `provision.env` is silently ignored.
+
+Build the seed (run where you can write, then copy into the libvirt pool):
+
+```bash
+mkdir -p ~/kg-seed && cd ~/kg-seed
+cat > meta-data <<EOF
+instance-id: kg-appliance-01
+local-hostname: kg-appliance
+EOF
+cat > user-data <<'EOF'
+#cloud-config
+write_files:
+  - path: /etc/kg/provision.env
+    permissions: '0600'
+    content: |
+      KG_EXTERNAL_URL=https://kg.example.com
+      KG_TLS_MODE=letsencrypt
+      KG_ACME_CHALLENGE=dns-01
+      KG_DNS_PROVIDER=porkbun
+      KG_LE_EMAIL=you@example.com
+      KG_PORKBUN_API_KEY=pk1_...
+      KG_PORKBUN_SECRET_API_KEY=sk1_...
+EOF
+# label MUST be cidata for NoCloud
+xorriso -as mkisofs -V cidata -J -r -o kg-seed.iso user-data meta-data
+sudo cp kg-seed.iso /srv/storage/libvirt/images/   # xorriso can't write a root-owned pool dir directly
+```
+
+`provision.env` is the appliance's single declarative control surface; unknown
+keys are ignored. See [`appliance/files/provision.env.example`](../../appliance/files/provision.env.example).
+
+## 2. Define the VM
+
+```bash
+sudo virt-install \
+  --name kg-appliance \
+  --memory 4096 --vcpus 2 \
+  --os-variant debian12 \
+  --import \
+  --disk path=/srv/storage/libvirt/images/kg-appliance.qcow2,bus=virtio \
+  --disk path=/srv/storage/libvirt/images/kg-seed.iso,format=raw,bus=virtio,readonly=on \
+  --network bridge=br0,model=virtio,mac=52:54:00:6e:4a:82 \
+  --graphics vnc \
+  --channel unix,target_type=virtio,name=org.qemu.guest_agent.0 \
+  --noautoconsole
+```
+
+- **Bridge, not NAT** — put the VM on a real Linux bridge (`br0 ← <nic>`) so it
+  gets a routable address and multiple guests can share the NIC.
+- **Pin the MAC** to claim a DHCP reservation (and your public DNS A record).
+  Changing the MAC later is safe — the image matches its NIC by *name*, not MAC
+  (see Troubleshooting). To repoint an existing VM:
+  `virsh shutdown kg-appliance && virt-xml kg-appliance --edit --network mac=<reserved> && virsh start kg-appliance`.
+- The `org.qemu.guest_agent.0` channel is what lets you manage the box without
+  SSH.
+
+First boot pulls images and provisions — watch with `journalctl -u kg-firstboot -f`
+(via the console). The admin password is written to `/root/kg-credentials.txt`
+inside the VM.
+
+## 3. Managing the box without SSH
+
+The appliance has no sshd. Run commands inside the guest through the
+qemu-guest-agent from the libvirt host. This helper executes a command in the VM
+and prints its output:
+
+```bash
+vmx() {  # usage: vmx "shell command" [wait_seconds]
+  local pid
+  pid=$(sudo virsh qemu-agent-command kg-appliance \
+    "{\"execute\":\"guest-exec\",\"arguments\":{\"path\":\"/bin/sh\",\"arg\":[\"-c\",\"$1\"],\"capture-output\":true}}" \
+    | grep -oE '"pid":[0-9]+' | cut -d: -f2)
+  [ -z "$pid" ] && { echo "(agent busy / not ready)"; return; }
+  sleep "${2:-3}"
+  sudo virsh qemu-agent-command kg-appliance \
+    "{\"execute\":\"guest-exec-status\",\"arguments\":{\"pid\":$pid}}" \
+    | python3 -c 'import sys,json,base64
+d=json.load(sys.stdin)["return"]
+for k in ("out-data","err-data"):
+    if d.get(k): sys.stdout.write(base64.b64decode(d[k]).decode("utf-8","replace"))'
+}
+
+vmx "docker ps --format '{{.Names}}: {{.Status}}'"
+vmx "cd /opt/kg && ./operator.sh status"
+```
+
+For commands with awkward quoting (heredocs, JSON), base64-encode them:
+`vmx "echo <base64> | base64 -d | sh"`. Decode `out-data` and `err-data`
+*separately* — they are padded independently, so concatenating before decoding
+corrupts the base64.
+
+Other management surfaces:
+
+- **Cockpit** — `https://<vm-ip>:9090` (host console: services, storage, logs,
+  updates).
+- **virt-manager** — connect to `qemu+ssh://<user>@<host>/system` for lifecycle +
+  the VNC console. (On the client you may need `x11-ssh-askpass` and an
+  `ssh-copy-id` to the libvirt host.)
+- **Console TUI** — tty1 over VNC offers status / logs / restart / credentials /
+  operator shell.
+
+## 4. The certificate
+
+With `KG_TLS_MODE=letsencrypt` + `KG_ACME_CHALLENGE=dns-01`, Traefik obtains and
+**auto-renews** a real Let's Encrypt cert; `operator.sh recert` is a no-op. The
+cert and ACME account live in a persisted bind-mount (`/opt/kg/docker/acme/acme.json`)
+so renewals survive restarts. Verify from the libvirt host:
+
+```bash
+echo | openssl s_client -connect <vm-ip>:443 -servername kg.example.com 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+```
+
+## Worked example: `cube`
+
+| Property | Value |
+|----------|-------|
+| Host | `cube` (libvirt `qemu:///system`), bridge `br0 ← enp2s0` |
+| VM | `kg-appliance` — 2 vCPU / 4 GiB, virtio qcow2 + virtio seed |
+| NIC MAC | `52:54:00:6e:4a:82` → DHCP reservation `192.168.1.82` |
+| DNS | `kg.broccoli.house` → `192.168.1.82` (UniFi) |
+| TLS | in-container DNS-01 via porkbun; self-renewing Let's Encrypt cert |
+| Manage | qemu-guest-agent (`vmx`), Cockpit `:9090`, VNC console |
+
+## Troubleshooting
+
+- **`provision.env` ignored / box came up with defaults** — the seed was almost
+  certainly attached as a SATA cdrom. The cloud kernel can't see it; reattach as
+  a virtio disk (§1). Confirm cloud-init found it: `vmx "cloud-init status --long"`
+  should name a `config-disk` datasource.
+- **NIC has no address after a MAC change** — only affects images predating the
+  MAC-agnostic networking fix. Current images disable cloud-init's network
+  rendering and ship a DHCP netplan matched by interface name (`e*`), so MAC
+  changes are safe. If stranded, rewrite `/etc/netplan/50-cloud-init.yaml` to
+  match by name and `netplan apply`.
+- **Traefik can't reach Docker (`client version 1.24 is too old`)** — Traefik v3
+  hard-codes Docker API 1.24 while Engine ≥25 serves a minimum of 1.40. Current
+  images bake `DOCKER_MIN_API_VERSION=1.24` as a `docker.service` drop-in. To fix
+  a running box: write that drop-in and `systemctl restart docker`.
+- **TLS stuck on the self-signed default / `acme.json` empty** — Traefik only
+  requests a cert for a declared domain; it does not mint on-demand from SNI.
+  Ensure `EXTERNAL_URL`/`TLS_DOMAIN` is a public FQDN (not `localhost`) so the
+  letsencrypt overlay's `tls.domains` is populated. `operator.sh start` warns when
+  it isn't.
+
+## See also
+
+- [Appliance build](../../appliance/README.md) — building the image
+- [TLS and Certificates](tls.md) — cert modes and scenarios
+- [Troubleshooting](troubleshooting.md) — general platform issues
+- [ADR-103](../architecture/infrastructure/ADR-103-distribution-strategy-nomic-first-thin-appliance-with-app-store-tenancy.md),
+  [ADR-105](../architecture/infrastructure/ADR-105-scenario-driven-tls-via-in-vm-traefik-router.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - "Configuration Reference": self-host/configuration.md
       - "Dedicated IP (macvlan)": self-host/macvlan.md
       - "TLS and Certificates": self-host/tls.md
+      - "Appliance on libvirt/KVM": self-host/appliance-libvirt.md
       - "Security and Access": self-host/security.md
       - "Backup and Restore": self-host/backup-restore.md
       - "Scheduled Jobs": self-host/scheduled-jobs.md

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -610,6 +610,15 @@ main() {
     # Normalize: strip any trailing slash so "${EXTERNAL_URL}/callback" is clean.
     EXTERNAL_URL="${EXTERNAL_URL%/}"
 
+    # Derive TLS_DOMAIN — the bare hostname (no scheme, no port, no path) that
+    # Let's Encrypt issues the certificate FOR. Traefik only requests an ACME
+    # cert for a domain it finds in a router Host() rule or in tls.domains; the
+    # appliance keeps routers host-agnostic (PathPrefix), so the letsencrypt
+    # overlays pin tls.domains[0].main=${TLS_DOMAIN}. Without it, ACME never fires
+    # and acme.json stays empty (ADR-105 §4). Strip scheme, then port/path.
+    TLS_DOMAIN="${EXTERNAL_URL#*://}"
+    TLS_DOMAIN="${TLS_DOMAIN%%[:/]*}"
+
     # Add WEB_HOSTNAME to .env
     if ! grep -q '^WEB_HOSTNAME=' "$PROJECT_ROOT/.env" 2>/dev/null; then
         echo "" >> "$PROJECT_ROOT/.env"
@@ -625,6 +634,15 @@ main() {
         echo "EXTERNAL_URL=$EXTERNAL_URL" >> "$PROJECT_ROOT/.env"
     else
         sed -i "s|^EXTERNAL_URL=.*|EXTERNAL_URL=$EXTERNAL_URL|" "$PROJECT_ROOT/.env"
+    fi
+
+    # Add TLS_DOMAIN to .env (the letsencrypt overlays pin tls.domains to it so
+    # Traefik knows which hostname to obtain the ACME cert for).
+    if ! grep -q '^TLS_DOMAIN=' "$PROJECT_ROOT/.env" 2>/dev/null; then
+        echo "# Cert hostname — Traefik tls.domains for the letsencrypt ACME resolver" >> "$PROJECT_ROOT/.env"
+        echo "TLS_DOMAIN=$TLS_DOMAIN" >> "$PROJECT_ROOT/.env"
+    else
+        sed -i "s|^TLS_DOMAIN=.*|TLS_DOMAIN=$TLS_DOMAIN|" "$PROJECT_ROOT/.env"
     fi
 
     # Add LE_EMAIL to .env when set (consumed by the letsencrypt overlay's ACME resolver)

--- a/operator/lib/start-platform.sh
+++ b/operator/lib/start-platform.sh
@@ -149,6 +149,18 @@ start_application() {
                     [ "$TLS_MODE" = "manual" ]      && [ -f docker-compose.traefik-tls-manual.yml ]      && compose_cmd="$compose_cmd -f docker-compose.traefik-tls-manual.yml"
                     # letsencrypt: dns-01 uses the lego DNS overlay; otherwise TLS-ALPN-01.
                     if [ "$TLS_MODE" = "letsencrypt" ]; then
+                        # The letsencrypt overlays pin tls.domains[0].main=${TLS_DOMAIN}
+                        # so ACME knows which host to issue for. headless-init writes
+                        # TLS_DOMAIN to .env, but a hand-edited or pre-upgrade .env may
+                        # lack it — derive a launch-time fallback from EXTERNAL_URL so an
+                        # empty label never silently disables cert issuance.
+                        if [ -z "${TLS_DOMAIN:-}" ] && [ -n "${EXTERNAL_URL:-}" ]; then
+                            TLS_DOMAIN="${EXTERNAL_URL#*://}"; TLS_DOMAIN="${TLS_DOMAIN%%[:/]*}"
+                            export TLS_DOMAIN
+                        fi
+                        if [ -z "${TLS_DOMAIN:-}" ] || [ "$TLS_DOMAIN" = "localhost" ]; then
+                            echo -e "${YELLOW}⚠ TLS_MODE=letsencrypt but TLS_DOMAIN='${TLS_DOMAIN:-}' is not a public FQDN — Let's Encrypt cannot issue a cert. Set a public hostname via --external-url / EXTERNAL_URL.${NC}"
+                        fi
                         if [ "${ACME_CHALLENGE:-tls-alpn-01}" = "dns-01" ] && [ -f docker-compose.traefik-tls-letsencrypt-dns.yml ]; then
                             compose_cmd="$compose_cmd -f docker-compose.traefik-tls-letsencrypt-dns.yml"
                         elif [ -f docker-compose.traefik-tls-letsencrypt.yml ]; then


### PR DESCRIPTION
Fixes surfaced (and validated end-to-end) while doing the **first real libvirt/KVM
deploy of the thin appliance to `cube`** — `https://kg.broccoli.house` now serves a
real Let's Encrypt cert via in-container DNS-01/porkbun, web + `/api` reachable.

## Commits

1. **`fix(appliance): install Docker from apt repo, not get.docker.com`** — the
   convenience script is fragile under `virt-customize`'s offline/no-systemd
   context (leaves `docker.service` unregistered → offline enable fails). Use
   Docker's official apt repo so `systemctl enable docker` is deterministic.

2. ~~`fix(traefik): pin DOCKER_API_VERSION`~~ → **superseded by #3.** Kept in
   history as the documented dead-end: Traefik v3.3.1's Docker provider
   hard-codes API `1.24` and **ignores** `DOCKER_API_VERSION`, so the compose
   env was inert.

3. **`fix(appliance): survive modern Docker + MAC changes`**
   - **Modern Docker API floor.** Engine ≥25 serves a minimum API of 1.40;
     Traefik's hard-coded 1.24 client gets rejected ("client version 1.24 is too
     old"), so it can't enumerate containers → no routing, no ACME. Real fix is
     daemon-side: bake `DOCKER_MIN_API_VERSION=1.24` as a `docker.service`
     drop-in. Removes the inert compose env from #2.
   - **MAC-agnostic networking.** cloud-init (no seed network-config) pins the
     NIC to its first-boot MAC; repointing the VM at a pinned DHCP reservation
     then strands the NIC. Disable cloud-init net rendering, ship a DHCP netplan
     matched by interface **name** (`e*`).
   - **README gotchas**, incl. the virtio-seed requirement (cloud kernel has no
     AHCI → a SATA-cdrom seed is invisible and cloud-init never runs).

4. **`fix(tls): pin tls.domains so ACME knows which host to issue for`** (ADR-105)
   — the letsencrypt overlays attached `certresolver=le` to host-agnostic
   `PathPrefix(/)` routers but never declared a domain, so Traefik never
   requested a cert (`acme.json` stayed empty; it does **not** mint on-demand
   from SNI). Operator now derives `TLS_DOMAIN` from `EXTERNAL_URL`; both
   letsencrypt overlays pin `tls.domains[0].main=${TLS_DOMAIN}`.

## Validation (on cube)

| Check | Result |
|---|---|
| DNS `kg.broccoli.house` | → 192.168.1.82 |
| Web | HTTP 200, cert validates (`ssl_verify=0`) |
| `/api/health` | 200 |
| Cert | CN=kg.broccoli.house, Let's Encrypt YR1, 90d |
| HTTP→HTTPS | 301 |