### PR TITLE
fix(appliance): web OAuth client_id/redirect in router overlay (login 400)

### DIFF
--- a/docker/docker-compose.traefik.yml
+++ b/docker/docker-compose.traefik.yml
@@ -58,8 +58,16 @@ services:
 
   web:
     # SPA calls the API same-origin through the router, not a separate port.
+    # The OAuth client_id + redirect_uri must match what operator init registers
+    # (kg-web, redirect = ${EXTERNAL_URL}/callback). The web image's baked
+    # defaults are kg-cli + http://localhost:3000/callback, and prod.yml — which
+    # normally overrides them — is NOT in the appliance/router assembly, so set
+    # them here. Without this, login fails with 400 ("OAuth client 'kg-cli' not
+    # found") at the router-fronted deployment.
     environment:
       VITE_API_URL: /api
+      VITE_OAUTH_CLIENT_ID: kg-web
+      VITE_OAUTH_REDIRECT_URI: ${EXTERNAL_URL:-http://localhost}/callback
     # Serve the SPA over plain HTTP on :80. Overrides the non-router prod mount
     # (nginx.prod.conf does :80 -> 301 https with host-specific certs, which
     # would break the HTTP-only ingress). Same container target wins on merge.


### PR DESCRIPTION
## Symptom
Web UI login on the appliance fails with **400**, independent of the password (even a freshly-reset one). The browser console shows a 400 from `POST /auth/oauth/login-and-authorize`.

## Root cause
A 400 (not 401) means login passes the password check and dies on **OAuth client validation**. The web image's baked defaults are `VITE_OAUTH_CLIENT_ID=kg-cli` + `VITE_OAUTH_REDIRECT_URI=http://localhost:3000/callback`. `docker-compose.prod.yml` overrides both to `kg-web` + `${EXTERNAL_URL}/callback` — but the **appliance / router** assembly uses `standalone.yml` + the traefik overlay, **not** `prod.yml`, so the localhost/`kg-cli` defaults leaked through. operator init registers the client as **`kg-web`**, so the SPA's `kg-cli` was never found → `400 "OAuth client 'kg-cli' not found"`.

## Fix
Set `VITE_OAUTH_CLIENT_ID=kg-web` and `VITE_OAUTH_REDIRECT_URI=${EXTERNAL_URL}/callback` on the web service in `docker-compose.traefik.yml` (the router overlay already sets `VITE_API_URL=/api`). This is the same-origin front door, so OAuth config belongs here for any router-fronted deployment, not just the appliance.

## Verified on cube
- `/config.js` (the SPA's runtime config) now serves `kg-web`.
- `POST /api/auth/oauth/login-and-authorize` with `client_id=kg-web` → **200** + auth code.
- Same request with the old `kg-cli` → **400** (the bug).