### PR TITLE
feat(appliance): declarative host-management login (Cockpit/console)

### DIFF
--- a/appliance/build-appliance.sh
+++ b/appliance/build-appliance.sh
@@ -157,7 +157,7 @@ VC_ARGS=(
     # --- stage the repo at /opt/kg (git archive, prefix kg/) ---
     --upload "${REPO_TAR}:/tmp/kg-repo.tar"
     --run-command 'tar -xf /tmp/kg-repo.tar -C /opt && rm -f /tmp/kg-repo.tar'
-    --run-command 'chmod +x /opt/kg/operator.sh /opt/kg/appliance/files/kg-firstboot.sh /opt/kg/appliance/files/kg-console.sh'
+    --run-command 'chmod +x /opt/kg/operator.sh /opt/kg/appliance/files/kg-firstboot.sh /opt/kg/appliance/files/kg-console.sh /opt/kg/appliance/files/kg-host-login.sh'
     # --- first-boot provisioner ---
     --run-command 'cp /opt/kg/appliance/files/kg-firstboot.service /etc/systemd/system/kg-firstboot.service'
     --run-command 'systemctl enable kg-firstboot.service'

--- a/appliance/files/kg-firstboot.sh
+++ b/appliance/files/kg-firstboot.sh
@@ -149,6 +149,17 @@ EOF
     log "admin password saved to /root/kg-credentials.txt"
 fi
 
+# --- Host-management login (Cockpit :9090 + console "Login shell") ------------
+# Cockpit authenticates against OS accounts, so provision a sudo-enabled system
+# user. Declarative via provision.env (KG_HOST_LOGIN_USER / KG_HOST_LOGIN_PASSWORD);
+# a generated password lands in /root/kg-credentials.txt. Reusable + idempotent —
+# see appliance/files/kg-host-login.sh.
+HOST_LOGIN_USER="${KG_HOST_LOGIN_USER:-kgadmin}"
+if [ -x "${KG_DIR}/appliance/files/kg-host-login.sh" ]; then
+    log "provisioning host-management login '${HOST_LOGIN_USER}'..."
+    "${KG_DIR}/appliance/files/kg-host-login.sh" || log "WARNING: host-login provisioning failed (set it later via kg-host-login.sh)."
+fi
+
 # --- Mark done and write the login banner ------------------------------------
 touch "${SENTINEL}"
 log "provisioning complete; writing login banner."
@@ -162,6 +173,7 @@ cat > /etc/motd <<EOF
 
   Web UI:    http://${IP}:3000/
   Host mgmt: https://${IP}:9090/   (Cockpit — network, storage, logs, updates)
+             log in as '${HOST_LOGIN_USER}' (OS account — see /root/kg-credentials.txt)
 ${CRED_LINE}
 
   NEXT STEPS (in the web UI):

--- a/appliance/files/kg-host-login.sh
+++ b/appliance/files/kg-host-login.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# ============================================================================
+# kg-host-login.sh — provision the appliance's host-management login
+# ============================================================================
+#
+# Cockpit (the host console on :9090) and the tty1 "Login shell" authenticate
+# against OS accounts via PAM — NOT the Kappa Graph app's OAuth admin. A freshly
+# baked appliance has only a locked root account, so there is nothing to log in
+# with. This script provisions a sudo-enabled system user, declaratively and
+# idempotently, so host management has a credential out of the box.
+#
+# It is the single reusable definition of the host login: kg-firstboot.sh calls
+# it on first boot (after sourcing /etc/kg/provision.env), and it can be re-run
+# standalone to (re)set the login on a running appliance.
+#
+# Inputs (environment; kg-firstboot sources provision.env first):
+#   KG_HOST_LOGIN_USER      OS username to provision   (default: kgadmin)
+#   KG_HOST_LOGIN_PASSWORD  password to set; if unset, a random one is generated
+#                           and recorded in /root/kg-credentials.txt
+#
+# Standalone use on a running box (via the console "Login shell" or guest agent):
+#   sudo KG_HOST_LOGIN_PASSWORD='choose-one' /opt/kg/appliance/files/kg-host-login.sh
+#   # or let it mint + record one:
+#   sudo /opt/kg/appliance/files/kg-host-login.sh
+# ============================================================================
+set -euo pipefail
+
+USER_NAME="${KG_HOST_LOGIN_USER:-kgadmin}"
+PASSWORD="${KG_HOST_LOGIN_PASSWORD:-}"
+GENERATED=""
+
+log() { echo "[kg-host-login] $*"; }
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "[kg-host-login] must run as root (try: sudo $0)" >&2
+    exit 1
+fi
+
+# Mint a password when none was supplied. cut (not head) avoids the SIGPIPE that
+# `set -o pipefail` would turn into a fatal error.
+if [ -z "${PASSWORD}" ]; then
+    PASSWORD="$(openssl rand -base64 18 | tr -d '/+=' | cut -c1-20)"
+    GENERATED=1
+fi
+
+# Create (idempotent) and ensure sudo membership + a usable shell.
+if ! id "${USER_NAME}" >/dev/null 2>&1; then
+    useradd -m -s /bin/bash -G sudo "${USER_NAME}"
+    log "created user '${USER_NAME}' (sudo)"
+else
+    usermod -aG sudo -s /bin/bash "${USER_NAME}"
+    log "user '${USER_NAME}' already exists; ensured sudo + shell"
+fi
+
+echo "${USER_NAME}:${PASSWORD}" | chpasswd
+log "password set for '${USER_NAME}' (Cockpit :9090 / console login)"
+
+# Record a generated password so the operator can recover it (same posture as the
+# admin password). A caller-supplied password is the operator's to track, so we
+# never write it out. Replace any prior host-login block to stay idempotent.
+if [ -n "${GENERATED}" ]; then
+    umask 077
+    CRED="/root/kg-credentials.txt"
+    touch "${CRED}"
+    # Drop a previous host-login block (from a re-run) before appending a fresh one.
+    sed -i '/^# --- host-management login ---$/,/^# --- end host-management login ---$/d' "${CRED}"
+    cat >> "${CRED}" <<EOF
+# --- host-management login ---
+Host management (Cockpit :9090 / console "Login shell") — OS account:
+  username: ${USER_NAME}
+  password: ${PASSWORD}
+# --- end host-management login ---
+EOF
+    log "generated password recorded in ${CRED}"
+fi

--- a/appliance/files/provision.env.example
+++ b/appliance/files/provision.env.example
@@ -68,3 +68,11 @@
 # lives on the appliance). Read by Traefik/lego; written to .env, never argv.
 #KG_PORKBUN_API_KEY=pk1_...
 #KG_PORKBUN_SECRET_API_KEY=sk1_...
+
+# ── Host-management login (Cockpit :9090 + console "Login shell") ───────────
+# Cockpit and the tty1 console authenticate against OS accounts, not the app's
+# OAuth admin. The appliance provisions a sudo-enabled system user on first boot
+# so host management works out of the box. Defaults to 'kgadmin'; if no password
+# is set, a random one is generated and recorded in /root/kg-credentials.txt.
+#KG_HOST_LOGIN_USER=kgadmin
+#KG_HOST_LOGIN_PASSWORD=

--- a/docs/self-host/appliance-libvirt.md
+++ b/docs/self-host/appliance-libvirt.md
@@ -134,7 +134,12 @@ corrupts the base64.
 Other management surfaces:
 
 - **Cockpit** — `https://<vm-ip>:9090` (host console: services, storage, logs,
-  updates).
+  updates). Cockpit authenticates against **OS accounts**, not the app's OAuth
+  admin. First boot provisions a sudo-enabled login (`kgadmin` by default) — set
+  it declaratively with `KG_HOST_LOGIN_USER` / `KG_HOST_LOGIN_PASSWORD` in
+  `provision.env`, or let it mint a random password recorded in
+  `/root/kg-credentials.txt`. Reset it later with
+  `sudo /opt/kg/appliance/files/kg-host-login.sh`.
 - **virt-manager** — connect to `qemu+ssh://<user>@<host>/system` for lifecycle +
   the VNC console. The remote graphical console has three wiring requirements
   (see below) that each fail with an unhelpful message.


### PR DESCRIPTION
## Why
Cockpit (`:9090`) and the tty1 console authenticate against **OS accounts** via PAM — not the app's OAuth admin. A baked appliance ships only a *locked* root account, so there's nothing to log into for host management. This adds a reusable, declarative way to define that login (per Aaron: "a reusable way to define the cockpit login").

## What
- **`appliance/files/kg-host-login.sh`** — idempotent provisioner: creates a sudo-enabled system user (default `kgadmin`) from `KG_HOST_LOGIN_USER` / `KG_HOST_LOGIN_PASSWORD`; mints + records a random password in `/root/kg-credentials.txt` when none is supplied. Re-runnable standalone to reset the login on a running box.
- **`kg-firstboot.sh`** calls it after provisioning; the login banner points at it.
- **`provision.env.example`** documents the keys; **`build-appliance.sh`** bakes the script executable; the **libvirt runbook** documents the login + reset path.

## Verified on cube
Ran `kg-host-login.sh` on the live appliance: created `kgadmin` (uid 1001, sudo group), set + recorded a generated password. Cockpit/console now have a working login.

Follow-up (separate): route Cockpit through Traefik at `/cockpit` for the trusted cert (task tracked).