### PR TITLE
feat(appliance): Cockpit behind Traefik at /cockpit (trusted cert)

### DIFF
--- a/appliance/build-appliance.sh
+++ b/appliance/build-appliance.sh
@@ -157,7 +157,7 @@ VC_ARGS=(
     # --- stage the repo at /opt/kg (git archive, prefix kg/) ---
     --upload "${REPO_TAR}:/tmp/kg-repo.tar"
     --run-command 'tar -xf /tmp/kg-repo.tar -C /opt && rm -f /tmp/kg-repo.tar'
-    --run-command 'chmod +x /opt/kg/operator.sh /opt/kg/appliance/files/kg-firstboot.sh /opt/kg/appliance/files/kg-console.sh /opt/kg/appliance/files/kg-host-login.sh'
+    --run-command 'chmod +x /opt/kg/operator.sh /opt/kg/appliance/files/kg-firstboot.sh /opt/kg/appliance/files/kg-console.sh /opt/kg/appliance/files/kg-host-login.sh /opt/kg/appliance/files/kg-cockpit-proxy.sh'
     # --- first-boot provisioner ---
     --run-command 'cp /opt/kg/appliance/files/kg-firstboot.service /etc/systemd/system/kg-firstboot.service'
     --run-command 'systemctl enable kg-firstboot.service'

--- a/appliance/files/kg-cockpit-proxy.sh
+++ b/appliance/files/kg-cockpit-proxy.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# ============================================================================
+# kg-cockpit-proxy.sh — configure Cockpit to sit behind Traefik at /cockpit
+# ============================================================================
+#
+# Cockpit defaults to serving at the root of :9090 with its own self-signed cert.
+# To front it through Traefik at https://<host>/cockpit/ (sharing the trusted
+# Let's Encrypt cert), Cockpit must be told its URL root and the external origin
+# it will be reached from. This writes /etc/cockpit/cockpit.conf accordingly.
+#
+# Pairs with docker-compose.traefik-cockpit.yml (the socat sidecar + Traefik
+# route). kg-firstboot.sh calls this; it is idempotent and re-runnable standalone
+# to (re)point Cockpit at a new external URL on a running appliance.
+#
+# Input (environment; kg-firstboot sources /etc/kg/provision.env first):
+#   KG_EXTERNAL_URL   public https URL, e.g. https://kg.example.com. Required —
+#                     the Origins/cert hostname derives from it. No-op if unset.
+# ============================================================================
+set -euo pipefail
+
+log() { echo "[kg-cockpit-proxy] $*"; }
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "[kg-cockpit-proxy] must run as root (try: sudo $0)" >&2
+    exit 1
+fi
+
+EXTERNAL="${KG_EXTERNAL_URL:-}"
+if [ -z "${EXTERNAL}" ]; then
+    log "KG_EXTERNAL_URL unset; nothing to do (Cockpit stays on :9090)."
+    exit 0
+fi
+
+# Bare host (no scheme/port/path) — Cockpit's Origins + the cert hostname.
+HOST="${EXTERNAL#*://}"
+HOST="${HOST%%[:/]*}"
+
+mkdir -p /etc/cockpit
+cat > /etc/cockpit/cockpit.conf <<EOF
+# Managed by kg-cockpit-proxy.sh — Cockpit behind Traefik at /cockpit.
+[WebService]
+# Serve under the /cockpit path so Traefik can route to it by prefix.
+UrlRoot = /cockpit
+# Allow the external origin for the login WebSocket / CSRF check.
+Origins = https://${HOST} wss://${HOST}
+# Trust Traefik's X-Forwarded-Proto so Cockpit knows the edge is https.
+ProtocolHeader = X-Forwarded-Proto
+# Traefik terminates TLS and speaks plain HTTP to the sidecar; accept it.
+AllowUnencrypted = true
+EOF
+
+# Apply: Cockpit reads cockpit.conf per ws process; restart the socket+service.
+systemctl restart cockpit.socket cockpit 2>/dev/null || true
+log "Cockpit configured under /cockpit for ${HOST}."

--- a/appliance/files/kg-firstboot.sh
+++ b/appliance/files/kg-firstboot.sh
@@ -118,6 +118,24 @@ elif [ -n "${KG_ROUTER:-}" ]; then
     INIT_ARGS+=( --router="${KG_ROUTER}" )
 fi
 
+# --- Cockpit behind Traefik at /cockpit (ADR-105) ----------------------------
+# Front the host console through Traefik so it shares the trusted cert (instead
+# of Cockpit's self-signed cert on :9090, which HSTS on the main host won't let a
+# browser click through). Needs the letsencrypt path (the cockpit router uses the
+# `le` resolver) + an external URL. Default on; KG_COCKPIT_PROXY=false opts out.
+# Note: provision.env values are sourced (not exported), so pass what the child
+# script reads explicitly.
+if [ "${KG_COCKPIT_PROXY:-true}" = "true" ] && [ -n "${KG_EXTERNAL_URL:-}" ] \
+        && [ "${KG_TLS_MODE:-}" = "letsencrypt" ] \
+        && [ -x "${KG_DIR}/appliance/files/kg-cockpit-proxy.sh" ]; then
+    log "configuring Cockpit behind Traefik at /cockpit..."
+    if KG_EXTERNAL_URL="${KG_EXTERNAL_URL}" "${KG_DIR}/appliance/files/kg-cockpit-proxy.sh"; then
+        INIT_ARGS+=( --cockpit-proxy )
+    else
+        log "WARNING: cockpit-proxy config failed; Cockpit stays on :9090."
+    fi
+fi
+
 # --- Provision: mint per-instance secrets + start the standalone stack -------
 # Tee to a log so we can recover the generated admin password (operator prints
 # it once to stdout; there's no read-it-back path since it's stored encrypted).
@@ -157,7 +175,10 @@ fi
 HOST_LOGIN_USER="${KG_HOST_LOGIN_USER:-kgadmin}"
 if [ -x "${KG_DIR}/appliance/files/kg-host-login.sh" ]; then
     log "provisioning host-management login '${HOST_LOGIN_USER}'..."
-    "${KG_DIR}/appliance/files/kg-host-login.sh" || log "WARNING: host-login provisioning failed (set it later via kg-host-login.sh)."
+    # provision.env values are sourced, not exported — pass them explicitly.
+    KG_HOST_LOGIN_USER="${KG_HOST_LOGIN_USER:-}" KG_HOST_LOGIN_PASSWORD="${KG_HOST_LOGIN_PASSWORD:-}" \
+        "${KG_DIR}/appliance/files/kg-host-login.sh" \
+        || log "WARNING: host-login provisioning failed (set it later via kg-host-login.sh)."
 fi
 
 # --- Mark done and write the login banner ------------------------------------
@@ -167,6 +188,12 @@ log "provisioning complete; writing login banner."
 CRED_LINE="  Admin pw:  generated — see /root/kg-credentials.txt (or set in the UI)"
 [ -z "${ADMIN_PW}" ] && CRED_LINE="  Admin pw:  set it on first sign-in"
 
+# When Cockpit is fronted by Traefik, point at the trusted-cert URL too.
+COCKPIT_LINE=""
+if [ "${KG_COCKPIT_PROXY:-true}" = "true" ] && [ -n "${KG_EXTERNAL_URL:-}" ] && [ "${KG_TLS_MODE:-}" = "letsencrypt" ]; then
+    COCKPIT_LINE="             also at ${KG_EXTERNAL_URL%/}/cockpit/ (trusted cert, via Traefik)"
+fi
+
 cat > /etc/motd <<EOF
 
   Kappa Graph appliance — ready.
@@ -174,6 +201,7 @@ cat > /etc/motd <<EOF
   Web UI:    http://${IP}:3000/
   Host mgmt: https://${IP}:9090/   (Cockpit — network, storage, logs, updates)
              log in as '${HOST_LOGIN_USER}' (OS account — see /root/kg-credentials.txt)
+${COCKPIT_LINE}
 ${CRED_LINE}
 
   NEXT STEPS (in the web UI):

--- a/appliance/files/provision.env.example
+++ b/appliance/files/provision.env.example
@@ -76,3 +76,9 @@
 # is set, a random one is generated and recorded in /root/kg-credentials.txt.
 #KG_HOST_LOGIN_USER=kgadmin
 #KG_HOST_LOGIN_PASSWORD=
+
+# Cockpit behind Traefik at https://<host>/cockpit/ — shares the trusted cert so
+# you don't hit Cockpit's self-signed cert on :9090 (which HSTS on the main host
+# won't let a browser click through). Default ON when KG_EXTERNAL_URL is set and
+# KG_TLS_MODE=letsencrypt. Set false to keep Cockpit only on :9090.
+#KG_COCKPIT_PROXY=true

--- a/docker/docker-compose.traefik-cockpit.yml
+++ b/docker/docker-compose.traefik-cockpit.yml
@@ -1,0 +1,56 @@
+# ============================================================================
+# Knowledge Graph System — Cockpit host console behind Traefik (ADR-105)
+# ============================================================================
+# Routes the appliance's Cockpit host console through the same Traefik front
+# door at https://<host>/cockpit/, so it shares the trusted Let's Encrypt cert
+# instead of Cockpit's self-signed cert on :9090 (which a browser won't trust,
+# and which HSTS on the main hostname refuses to let you click through).
+#
+# Cockpit runs on the VM HOST, not in a container, so Traefik's docker provider
+# can't see it directly. This tiny socat sidecar bridges the gap: Traefik routes
+# /cockpit to the sidecar, which TCP-forwards to the host's :9090 via Docker's
+# host-gateway. No change to Traefik's command or the existing web/api routes.
+#
+# Requires Cockpit configured for the sub-path (UrlRoot=/cockpit + Origins): the
+# appliance's kg-cockpit-proxy.sh writes /etc/cockpit/cockpit.conf from the
+# external URL. Assumes the letsencrypt cert resolver `le` (the router-fronted
+# TLS path); selected by COCKPIT_PROXY=true (operator overlay selection).
+#
+# Cockpit does NOT self-redirect its UrlRoot prefix — a bare /cockpit (no slash)
+# drops the connection (Traefik then reports 502). The redirectregex middleware
+# 301s /cockpit -> /cockpit/ before it reaches the backend. (compose escapes $
+# as $$, so $$1 reaches Traefik as the $1 backreference.)
+# ============================================================================
+
+networks:
+  kg-router:
+    name: knowledge-graph-router
+
+services:
+  cockpit-proxy:
+    # socat L4 forwarder. Pinned by digest (alpine/socat:latest at build time)
+    # for a reproducible, supply-chain-stable sidecar.
+    image: alpine/socat@sha256:2b6b49e9000105672bf70648f8642801791374a24f549d30bed3c3115c13d24c
+    container_name: ${CONTAINER_PREFIX:-knowledge-graph}-cockpit-proxy
+    restart: unless-stopped
+    command: TCP-LISTEN:9090,fork,reuseaddr TCP:host.docker.internal:9090
+    extra_hosts:
+      # Reach Cockpit on the VM host (cockpit.socket listens on *:9090).
+      - "host.docker.internal:host-gateway"
+    networks:
+      - kg-router
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=knowledge-graph-router
+      # Higher priority than the web catch-all (PathPrefix(`/`), priority 1).
+      - "traefik.http.routers.kgcockpit.rule=PathPrefix(`/cockpit`)"
+      - traefik.http.routers.kgcockpit.entrypoints=websecure
+      - traefik.http.routers.kgcockpit.priority=20
+      - traefik.http.routers.kgcockpit.tls=true
+      - traefik.http.routers.kgcockpit.tls.certresolver=le
+      - "traefik.http.routers.kgcockpit.tls.domains[0].main=${TLS_DOMAIN}"
+      - traefik.http.routers.kgcockpit.middlewares=kgcockpit-slash
+      - "traefik.http.middlewares.kgcockpit-slash.redirectregex.regex=^(https?://[^/]+)/cockpit$$"
+      - "traefik.http.middlewares.kgcockpit-slash.redirectregex.replacement=$${1}/cockpit/"
+      - traefik.http.middlewares.kgcockpit-slash.redirectregex.permanent=true
+      - traefik.http.services.kgcockpit.loadbalancer.server.port=9090

--- a/docs/self-host/appliance-libvirt.md
+++ b/docs/self-host/appliance-libvirt.md
@@ -185,6 +185,28 @@ ssh -L 5901:localhost:5900 <user>@<libvirt-host>   # keep open
 remote-viewer vnc://localhost:5901                  # or gvncviewer localhost:5901
 ```
 
+### Cockpit behind Traefik (`/cockpit`)
+
+Cockpit's own cert on `:9090` is self-signed, and HSTS on the main hostname stops
+a browser from clicking through it. So the appliance fronts Cockpit through the
+same Traefik door at **`https://<host>/cockpit/`**, sharing the trusted cert. It's
+on by default (`KG_COCKPIT_PROXY`, when `KG_EXTERNAL_URL` + `KG_TLS_MODE=letsencrypt`
+are set); `=false` opts out and leaves Cockpit only on `:9090`.
+
+How it fits together (Cockpit runs on the *host*, which Traefik's docker provider
+can't see directly):
+- `kg-cockpit-proxy.sh` writes `/etc/cockpit/cockpit.conf` (`UrlRoot=/cockpit`,
+  `Origins` from `KG_EXTERNAL_URL`, `AllowUnencrypted`) so Cockpit serves the
+  sub-path and accepts the proxied origin's login WebSocket.
+- `docker-compose.traefik-cockpit.yml` adds a tiny `socat` sidecar that Traefik
+  routes `/cockpit` to; it TCP-forwards to the host's `:9090` via the Docker
+  host-gateway. A `redirectregex` middleware 301s the bare `/cockpit` → `/cockpit/`
+  (Cockpit drops the slashless prefix, which would otherwise surface as a 502).
+
+Log in with the OS account (`kgadmin` by default — see the host-login section
+above). Reset the Cockpit config later with
+`sudo KG_EXTERNAL_URL=https://<host> /opt/kg/appliance/files/kg-cockpit-proxy.sh`.
+
 ## 4. The certificate
 
 With `KG_TLS_MODE=letsencrypt` + `KG_ACME_CHALLENGE=dns-01`, Traefik obtains and

--- a/operator/lib/common.sh
+++ b/operator/lib/common.sh
@@ -183,6 +183,12 @@ get_compose_cmd() {
         esac
     fi
 
+    # Cockpit host console behind Traefik at /cockpit (ADR-105) when enabled.
+    if [ "${COCKPIT_PROXY:-false}" = "true" ] && [ "$ROUTER_MODE" = "traefik" ] \
+            && [ -f "$DOCKER_DIR/docker-compose.traefik-cockpit.yml" ]; then
+        cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-cockpit.yml"
+    fi
+
     # Add dev overlay if in development mode
     if [ "$DEV_MODE" = "true" ]; then
         if [ -f "$DOCKER_DIR/docker-compose.dev.yml" ]; then

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -46,6 +46,7 @@ TLS_MODE="none"
 LE_EMAIL=""
 ACME_CHALLENGE="tls-alpn-01"
 ACME_DNS_PROVIDER="porkbun"
+COCKPIT_PROXY=false
 SKIP_AI_CONFIG=false
 SKIP_CLI=false
 SHOW_HELP=false
@@ -128,6 +129,10 @@ ${BOLD}Web Configuration:${NC}
                           PORKBUN_SECRET_API_KEY in the environment (e.g. via the
                           appliance provision.env); they are written to .env and
                           read by Traefik/lego — never passed on the command line.
+  --cockpit-proxy         Route the Cockpit host console through Traefik at
+                          /cockpit (shares the trusted cert). Requires --router=
+                          traefik + --tls=letsencrypt + Cockpit configured for the
+                          sub-path (the appliance's kg-cockpit-proxy.sh does this).
 
 ${BOLD}AI Configuration:${NC}
   --ai-provider PROVIDER  AI extraction provider (openai, anthropic, openrouter)
@@ -324,6 +329,10 @@ parse_args() {
             --dns-provider)
                 ACME_DNS_PROVIDER="$2"
                 shift 2
+                ;;
+            --cockpit-proxy)
+                COCKPIT_PROXY=true
+                shift
                 ;;
             *)
                 echo -e "${RED}Unknown option: $1${NC}"
@@ -692,6 +701,7 @@ IMAGE_SOURCE=$IMAGE_SOURCE
 ROUTER_MODE=$ROUTER_MODE
 TLS_MODE=$TLS_MODE
 ACME_CHALLENGE=$ACME_CHALLENGE
+COCKPIT_PROXY=$COCKPIT_PROXY
 ACME_DNS_PROVIDER=$ACME_DNS_PROVIDER
 EXTERNAL_URL=$EXTERNAL_URL
 INITIALIZED_AT=$(date -Iseconds)

--- a/operator/lib/start-platform.sh
+++ b/operator/lib/start-platform.sh
@@ -171,6 +171,12 @@ start_application() {
             esac
         fi
 
+        # Cockpit host console behind Traefik at /cockpit (ADR-105) when enabled.
+        if [ "${COCKPIT_PROXY:-false}" = "true" ] && [ "$ROUTER_MODE" = "traefik" ] \
+                && [ -f docker-compose.traefik-cockpit.yml ]; then
+            compose_cmd="$compose_cmd -f docker-compose.traefik-cockpit.yml"
+        fi
+
         compose_cmd="$compose_cmd --env-file $ENV_FILE"
 
         # Use --no-recreate to avoid recreating already-running containers
@@ -179,6 +185,8 @@ start_application() {
         # Bring up the in-VM router when enabled (ADR-105) — named explicitly so
         # first-boot leaves the unified ingress serving, not just api/web.
         [ "$ROUTER_MODE" = "traefik" ] && $compose_cmd up -d --no-recreate traefik
+        # Bring up the Cockpit proxy sidecar when enabled (ADR-105).
+        [ "${COCKPIT_PROXY:-false}" = "true" ] && [ "$ROUTER_MODE" = "traefik" ] && $compose_cmd up -d --no-recreate cockpit-proxy
 
         # Wait for API health
         echo -e "${BLUE}→ Waiting for API...${NC}"


### PR DESCRIPTION
Productionizes the `/cockpit` proxy validated live on cube (task follow-up to the host-login work).

## Why
Cockpit's self-signed cert on `:9090` won't pass a browser, and HSTS on the main host blocks the click-through. Front Cockpit through the same Traefik door at `https://<host>/cockpit/` so it shares the trusted Let's Encrypt cert.

## How (Cockpit runs on the host, not a container)
- **`docker-compose.traefik-cockpit.yml`** — a digest-pinned `socat` sidecar Traefik routes `/cockpit` to; it TCP-forwards to the host's `:9090` via the docker host-gateway. A `redirectregex` middleware 301s bare `/cockpit` → `/cockpit/` (Cockpit drops the slashless prefix → Traefik 502 otherwise). **No change to Traefik's command or the existing web/api routes.**
- **`appliance/files/kg-cockpit-proxy.sh`** — reusable, idempotent: writes `/etc/cockpit/cockpit.conf` (`UrlRoot=/cockpit`, `Origins` from `KG_EXTERNAL_URL`, `AllowUnencrypted`) and restarts Cockpit.
- **Operator**: `--cockpit-proxy` flag (persisted `COCKPIT_PROXY`); both compose selectors include the overlay when `COCKPIT_PROXY=true` + traefik.
- **First-boot**: enabled by default when `KG_EXTERNAL_URL` + `KG_TLS_MODE=letsencrypt`; `KG_COCKPIT_PROXY=false` opts out. Banner shows the `/cockpit` URL.

## Also fixes
A latent first-boot bug: `provision.env` values are *sourced* (not exported), so `kg-host-login.sh` / `kg-cockpit-proxy.sh` weren't actually receiving `KG_HOST_LOGIN_*` / `KG_EXTERNAL_URL` — now passed explicitly.

## Verified on cube
`https://kg.broccoli.house/cockpit/` → 200 trusted cert; `/cockpit` → 301 → `/cockpit/`; existing routes unaffected. (Live box currently runs the interim `docker run` sidecar; the next image build picks up this compose-managed form.)