### PR TITLE
feat(appliance): configurable /cockpit access control + auth hardening

### DIFF
--- a/appliance/files/kg-console.sh
+++ b/appliance/files/kg-console.sh
@@ -40,6 +40,7 @@ banner() {
     5) Appliance / credentials info
     6) Platform config shell (operator container)
     7) Login shell (host)
+    c) Cockpit /cockpit access control
     8) Reboot
     9) Power off
   ════════════════════════════════════════════════════════════════
@@ -68,6 +69,24 @@ action() {
         # surface for the graph itself, distinct from a host shell.
         6) echo "  Entering operator container (Ctrl-D returns to this menu)..."; (cd "${KG_DIR}" && ./operator.sh shell) || true ;;
         7) echo "  Launching host login (Ctrl-D returns to this menu)..."; /bin/login || true ;;
+        c|C)
+            echo
+            (cd "${KG_DIR}" && ./operator.sh cockpit-access) 2>&1 | sed 's/^/  /'
+            echo
+            echo "  Restrict who can reach the /cockpit host console (before its login):"
+            echo "    1) Open  — no restriction (default)"
+            echo "    2) Private/LAN only (RFC-1918 ranges)"
+            echo "    3) Custom CIDRs"
+            read -rp "  Choose [1-3], Enter to cancel: " sub
+            case "${sub}" in
+                1) (cd "${KG_DIR}" && ./operator.sh cockpit-access open)    2>&1 | sed 's/^/  /' ;;
+                2) (cd "${KG_DIR}" && ./operator.sh cockpit-access private) 2>&1 | sed 's/^/  /' ;;
+                3) read -rp "  CIDRs (comma-separated, e.g. 192.168.1.0/24): " cidrs
+                   [ -n "${cidrs}" ] && (cd "${KG_DIR}" && ./operator.sh cockpit-access "${cidrs}") 2>&1 | sed 's/^/  /' \
+                       || echo "  (cancelled)" ;;
+                *) echo "  (cancelled)" ;;
+            esac
+            pause ;;
         8) read -rp "  Reboot the appliance? [y/N] " a; [ "${a,,}" = "y" ] && systemctl reboot ;;
         9) read -rp "  Power off the appliance? [y/N] " a; [ "${a,,}" = "y" ] && systemctl poweroff ;;
         *) ;;
@@ -88,6 +107,6 @@ while true; do
     # Exit cleanly on stdin EOF (console detach, or a login subshell closing
     # stdin) so getty respawns us — without the guard the loop busy-spins at
     # 100% CPU and Restart=always never fires because the process stays alive (H3).
-    read -rp "  Select an option [1-9]: " choice || { sleep 1; exit 0; }
+    read -rp "  Select an option [1-9, c]: " choice || { sleep 1; exit 0; }
     action "${choice}"
 done

--- a/appliance/files/kg-firstboot.sh
+++ b/appliance/files/kg-firstboot.sh
@@ -131,6 +131,9 @@ if [ "${KG_COCKPIT_PROXY:-true}" = "true" ] && [ -n "${KG_EXTERNAL_URL:-}" ] \
     log "configuring Cockpit behind Traefik at /cockpit..."
     if KG_EXTERNAL_URL="${KG_EXTERNAL_URL}" "${KG_DIR}/appliance/files/kg-cockpit-proxy.sh"; then
         INIT_ARGS+=( --cockpit-proxy )
+        # Optional declarative source-IP allowlist — exported so headless-init
+        # persists it to .env (it reads from env, never argv). Unset => open.
+        [ -n "${KG_COCKPIT_ALLOW_CIDRS:-}" ] && export KG_COCKPIT_ALLOW_CIDRS
     else
         log "WARNING: cockpit-proxy config failed; Cockpit stays on :9090."
     fi

--- a/appliance/files/provision.env.example
+++ b/appliance/files/provision.env.example
@@ -82,3 +82,11 @@
 # won't let a browser click through). Default ON when KG_EXTERNAL_URL is set and
 # KG_TLS_MODE=letsencrypt. Set false to keep Cockpit only on :9090.
 #KG_COCKPIT_PROXY=true
+#
+# Source-IP allowlist in front of Cockpit's PAM login (defense in depth for a
+# root-capable surface). Default OPEN (any IP that can reach the box). Lock it to
+# your LAN/VPN/admin range. Change later from the console TUI or
+# `operator.sh cockpit-access <open|private|CIDR[,CIDR...]>`.
+#   open (default) = 0.0.0.0/0,::/0
+#   private        = 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+#KG_COCKPIT_ALLOW_CIDRS=192.168.1.0/24

--- a/docker/docker-compose.traefik-cockpit.yml
+++ b/docker/docker-compose.traefik-cockpit.yml
@@ -49,7 +49,14 @@ services:
       - traefik.http.routers.kgcockpit.tls=true
       - traefik.http.routers.kgcockpit.tls.certresolver=le
       - "traefik.http.routers.kgcockpit.tls.domains[0].main=${TLS_DOMAIN}"
-      - traefik.http.routers.kgcockpit.middlewares=kgcockpit-slash
+      # Chain: IP allowlist (gate) -> trailing-slash redirect -> Cockpit.
+      - traefik.http.routers.kgcockpit.middlewares=kgcockpit-allow,kgcockpit-slash
+      # Source-IP allowlist in FRONT of Cockpit's PAM login (defense in depth for a
+      # root-capable surface). Default 0.0.0.0/0,::/0 = open (no restriction; works
+      # as-is); set KG_COCKPIT_ALLOW_CIDRS (via `operator.sh cockpit-access` or the
+      # console TUI) to lock it to a LAN/VPN/admin range. Traefik sees the real
+      # client IP (Docker DNAT preserves the source), so this matches the caller.
+      - "traefik.http.middlewares.kgcockpit-allow.ipallowlist.sourcerange=${KG_COCKPIT_ALLOW_CIDRS:-0.0.0.0/0,::/0}"
       - "traefik.http.middlewares.kgcockpit-slash.redirectregex.regex=^(https?://[^/]+)/cockpit$$"
       - "traefik.http.middlewares.kgcockpit-slash.redirectregex.replacement=$${1}/cockpit/"
       - traefik.http.middlewares.kgcockpit-slash.redirectregex.permanent=true

--- a/docs/self-host/appliance-libvirt.md
+++ b/docs/self-host/appliance-libvirt.md
@@ -219,6 +219,25 @@ Log in with the OS account (`kgadmin` by default — see the host-login section
 above). Reset the Cockpit config later with
 `sudo KG_EXTERNAL_URL=https://<host> /opt/kg/appliance/files/kg-cockpit-proxy.sh`.
 
+**Gating who can reach it.** Cockpit is root-capable, so a source-IP allowlist
+sits in front of its PAM login (defense in depth). It defaults to **open** (works
+as-is); lock it to a LAN/VPN/admin range from the **console TUI** ("Cockpit
+`/cockpit` access control") or:
+
+```bash
+./operator.sh cockpit-access            # show current
+./operator.sh cockpit-access private    # RFC-1918 only (refuses public IPs)
+./operator.sh cockpit-access 192.168.1.0/24,100.64.0.0/10   # custom (subnet + VPN)
+./operator.sh cockpit-access open       # back to no restriction
+```
+
+Or declaratively at first boot via `KG_COCKPIT_ALLOW_CIDRS` in `provision.env`.
+A future option is mTLS (a client cert) for a cryptographic gate.
+
+> **Rotate the host login.** `kgadmin`'s generated password is stored in cleartext
+> at `/root/kg-credentials.txt` and now also gates `/cockpit`. After first login,
+> change it (`passwd kgadmin`) and shred the file.
+
 ![Cockpit login at /cockpit — OS account (kgadmin)](../media/appliance/cockpit-login.png)
 <!-- TODO(screenshot): replace placeholder — Cockpit login page at
      https://<host>/cockpit/ (note the trusted-cert padlock). -->

--- a/operator.sh
+++ b/operator.sh
@@ -125,6 +125,11 @@ get_compose_cmd() {
         esac
     fi
 
+    # Cockpit host console behind Traefik at /cockpit (ADR-105) when enabled.
+    [ "${COCKPIT_PROXY:-false}" = "true" ] && [ "$ROUTER_MODE" = "traefik" ] \
+        && [ -f "$DOCKER_DIR/docker-compose.traefik-cockpit.yml" ] \
+        && cmd="$cmd -f $DOCKER_DIR/docker-compose.traefik-cockpit.yml"
+
     # Dev mode overlay (adds hot reload, source mounts)
     [ "$DEV_MODE" = "true" ] && [ -f "$DOCKER_DIR/docker-compose.dev.yml" ] && cmd="$cmd -f $DOCKER_DIR/docker-compose.dev.yml"
 
@@ -763,6 +768,47 @@ cmd_restart() {
     fi
 }
 
+# Configure the source-IP allowlist in front of the /cockpit host console.
+# This is defense in depth ahead of Cockpit's own PAM login (a root-capable
+# surface). Default is open (no restriction); lock it to a LAN/VPN/admin range.
+cmd_cockpit_access() {
+    check_env
+    load_config
+
+    if [ "${COCKPIT_PROXY:-false}" != "true" ]; then
+        echo -e "${YELLOW}⚠ Cockpit proxy not enabled (COCKPIT_PROXY != true).${NC}"
+        echo "  Enable it first: provision.env KG_COCKPIT_PROXY=true, or init --cockpit-proxy."
+        exit 1
+    fi
+
+    local arg="${1:-status}" cidrs
+    case "$arg" in
+        status|"")
+            local cur
+            cur="$(grep -E '^KG_COCKPIT_ALLOW_CIDRS=' "$ENV_FILE" 2>/dev/null | cut -d= -f2-)"
+            echo -e "${BLUE}/cockpit allow CIDRs:${NC} ${cur:-0.0.0.0/0,::/0 (open — no restriction)}"
+            echo "Usage: $0 cockpit-access <open|private|CIDR[,CIDR...]>"
+            return 0 ;;
+        open)                 cidrs="0.0.0.0/0,::/0" ;;
+        private|rfc1918|lan)  cidrs="127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" ;;
+        *)                    cidrs="$arg" ;;   # custom comma-separated CIDR list
+    esac
+
+    # Upsert KG_COCKPIT_ALLOW_CIDRS in .env; compose substitutes it into the
+    # cockpit router's ipallowlist label when the sidecar is (re)created.
+    if grep -qE '^KG_COCKPIT_ALLOW_CIDRS=' "$ENV_FILE" 2>/dev/null; then
+        sed -i "s|^KG_COCKPIT_ALLOW_CIDRS=.*|KG_COCKPIT_ALLOW_CIDRS=$cidrs|" "$ENV_FILE"
+    else
+        echo "KG_COCKPIT_ALLOW_CIDRS=$cidrs" >> "$ENV_FILE"
+    fi
+
+    echo -e "${BLUE}→ Applying /cockpit allowlist: ${BOLD}$cidrs${NC}"
+    cd "$DOCKER_DIR"
+    run_compose up -d --force-recreate cockpit-proxy
+    echo -e "${GREEN}✓ /cockpit access updated${NC}"
+    [ "$cidrs" = "0.0.0.0/0,::/0" ] && echo -e "  ${YELLOW}(open — any source IP that can reach the box)${NC}"
+}
+
 cmd_update() {
     check_env
     load_config
@@ -883,6 +929,10 @@ ${BOLD}Database:${NC}
 ${BOLD}Infrastructure:${NC}
   garage             Manage Garage storage (status, init, repair)
 
+${BOLD}Security:${NC}
+  cockpit-access <x> /cockpit source-IP allowlist: open | private | CIDR[,CIDR...]
+                     (no arg shows current; default open)
+
 ${BOLD}Maintenance:${NC}
   self-update        Update operator.sh and operator container
 
@@ -938,6 +988,9 @@ case "${1:-help}" in
         check_operator
         docker exec "$OPERATOR_CONTAINER" /workspace/operator/lib/recert.sh "$@"
         ;;
+
+    # Cockpit /cockpit source-IP allowlist (defense in depth before PAM login)
+    cockpit-access) shift; cmd_cockpit_access "$@" ;;
 
     # Self-update: update operator.sh and operator container
     self-update)

--- a/operator/lib/headless-init.sh
+++ b/operator/lib/headless-init.sh
@@ -654,6 +654,18 @@ main() {
         sed -i "s|^TLS_DOMAIN=.*|TLS_DOMAIN=$TLS_DOMAIN|" "$PROJECT_ROOT/.env"
     fi
 
+    # Cockpit /cockpit source-IP allowlist (optional; read from the environment so
+    # it never appears in argv). The overlay defaults to open when this is unset,
+    # so only write it when an operator declared a restriction.
+    if [ -n "${KG_COCKPIT_ALLOW_CIDRS:-}" ]; then
+        if ! grep -q '^KG_COCKPIT_ALLOW_CIDRS=' "$PROJECT_ROOT/.env" 2>/dev/null; then
+            echo "# Cockpit /cockpit source-IP allowlist (operator.sh cockpit-access)" >> "$PROJECT_ROOT/.env"
+            echo "KG_COCKPIT_ALLOW_CIDRS=$KG_COCKPIT_ALLOW_CIDRS" >> "$PROJECT_ROOT/.env"
+        else
+            sed -i "s|^KG_COCKPIT_ALLOW_CIDRS=.*|KG_COCKPIT_ALLOW_CIDRS=$KG_COCKPIT_ALLOW_CIDRS|" "$PROJECT_ROOT/.env"
+        fi
+    fi
+
     # Add LE_EMAIL to .env when set (consumed by the letsencrypt overlay's ACME resolver)
     if [ -n "$LE_EMAIL" ]; then
         if ! grep -q '^LE_EMAIL=' "$PROJECT_ROOT/.env" 2>/dev/null; then
@@ -746,11 +758,20 @@ EOF
     # init registered http://.)
     local POSTGRES_CONTAINER=$(get_container_name postgres)
     local REDIRECT_URI="${EXTERNAL_URL}/callback"
+    # Include the localhost dev callback ONLY for local/dev deployments. On a
+    # public/router-fronted box, a registered http://localhost redirect on a public
+    # OAuth client is an unnecessary standing target (security review H3) — drop it
+    # so only the derived external redirect is accepted.
+    local REDIRECT_ARRAY="ARRAY['${REDIRECT_URI}']"
+    case "$EXTERNAL_URL" in
+        *://localhost*|*://127.0.0.1*)
+            REDIRECT_ARRAY="ARRAY['${REDIRECT_URI}', 'http://localhost:3000/callback']" ;;
+    esac
     echo -e "${BLUE}  Registering OAuth client (kg-web)...${NC}"
     docker exec "$POSTGRES_CONTAINER" psql -U ${POSTGRES_USER:-admin} -d ${POSTGRES_DB:-knowledge_graph} -c \
         "INSERT INTO kg_auth.oauth_clients (client_id, client_name, client_type, redirect_uris, grant_types, scopes)
          VALUES ('kg-web', 'Knowledge Graph Web', 'public',
-                 ARRAY['${REDIRECT_URI}', 'http://localhost:3000/callback'],
+                 ${REDIRECT_ARRAY},
                  ARRAY['authorization_code', 'refresh_token'],
                  ARRAY['*'])
          ON CONFLICT (client_id) DO UPDATE SET


### PR DESCRIPTION
Follow-up to the `/cockpit` feature + the security review. Adds **defense in depth in front of Cockpit's PAM login** (root-capable surface), configurable from the **operator and the framebuffer console**, per the agreed direction: CIDR allowlist, **default open** (nothing breaks), mTLS later.

## What's new
- **`docker-compose.traefik-cockpit.yml`** — `ipAllowList` middleware on the `/cockpit` router, `sourcerange=${KG_COCKPIT_ALLOW_CIDRS:-0.0.0.0/0,::/0}` (open default), chained before the slash-redirect. Traefik sees the real client IP (Docker DNAT preserves source).
- **`operator.sh cockpit-access <open|private|CIDR[,...]>`** — upserts the CIDRs in `.env` + force-recreates the sidecar. Also **fixes a #528 gap**: `operator.sh`'s own `get_compose_cmd` now includes the cockpit overlay (the other two selectors already did).
- **Console TUI** — new item *"Cockpit `/cockpit` access control"* with **Open / Private (RFC-1918) / Custom** presets.
- **`headless-init.sh`** — persists `KG_COCKPIT_ALLOW_CIDRS` to `.env` when declared (read from env, never argv); first-boot exports it. Documented in `provision.env.example`.

## Security-review fixes folded in
- **H3** — drop `http://localhost:3000/callback` from the registered `kg-web` `redirect_uris` on **non-localhost** deployments (keep it only for local/dev). Removes an unnecessary standing redirect target on public boxes. (Validation is already exact-match + PKCE-enforced, so this is hardening, not a hole.)
- **H2 doc** — runbook now tells you to rotate `kgadmin` and shred `/root/kg-credentials.txt`.

## Not included (by your call)
- localhost-bind of `:9090` (you opted to leave it as-is).
- mTLS — noted as a future option.

## Live box
The running cube appliance stays on the interim `docker run` sidecar (open) and is functionally identical; the configurable gate + operator/TUI command land when it's rebuilt from this code. I can wire it onto the live box too if you want to exercise the gate there now.

doclint + link-check clean locally.