### PR TITLE
feat(appliance): show egress MAC on the console banner

### DIFF
--- a/appliance/files/kg-console.sh
+++ b/appliance/files/kg-console.sh
@@ -20,10 +20,24 @@ primary_ip() {
         | awk '{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}'
 }
 
+# Egress interface name + its MAC. Surfaced on the banner so an operator can set a
+# DHCP reservation (pin the appliance to a stable IP) straight from the console —
+# without SSH or hunting through `ip link`. The reservation is also the
+# prerequisite for a public DNS A-record / TLS hostname (ADR-105).
+egress_iface() {
+    ip route get 1.1.1.1 2>/dev/null \
+        | awk '{for (i=1;i<=NF;i++) if ($i=="dev") {print $(i+1); exit}}'
+}
+egress_mac() {
+    local ifc; ifc="$(egress_iface)"
+    [ -n "${ifc}" ] && cat "/sys/class/net/${ifc}/address" 2>/dev/null
+}
+
 pause() { echo; read -rp "  Press Enter to return to the menu... " _; }
 
 banner() {
     local ip; ip="$(primary_ip)"; ip="${ip:-(no network)}"
+    local ifc mac; ifc="$(egress_iface)"; mac="$(egress_mac)"
     clear 2>/dev/null || true
     cat <<EOF
   ════════════════════════════════════════════════════════════════
@@ -32,6 +46,7 @@ banner() {
     Web UI:     http://${ip}:3000/
     Host mgmt:  https://${ip}:9090/   (Cockpit)
     Hostname:   $(hostname)
+    MAC addr:   ${mac:-(unknown)}  on ${ifc:-?}  — pin a DHCP reservation here
   ────────────────────────────────────────────────────────────────
     1) Platform status
     2) Recent API logs


### PR DESCRIPTION
## What
Add the egress interface's MAC address to the console-TUI banner, next to Web UI / Host mgmt / Hostname.

## Why
To pin the appliance to a stable LAN IP you set a **DHCP reservation**, which needs the NIC's MAC. Surfacing it on the console (no SSH, no `ip link` hunting) makes that a self-service step — and the reservation is the prerequisite for a public DNS A-record + TLS hostname (ADR-105). Came straight out of dogfooding the zero-config appliance boot: the first thing you want after it grabs a DHCP lease is its MAC, to pin it.

## How
`egress_iface()` / `egress_mac()` helpers (mirroring `primary_ip()` — `ip route get 1.1.1.1`, then `/sys/class/net/<if>/address`); one banner line. Degrades to `(unknown)` if offline.