### PR TITLE
chore(cli): bump version to 0.14.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaronsb/kg-cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Knowledge Graph CLI and MCP server - interact with knowledge graph systems",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump `@aaronsb/kg-cli` to `0.14.1` so the `kg search query --min-similarity` fix (merged in #537) can be published to npm (0.14.0 is already on the registry).

## Test plan
- Version-only change; CI TypeScript build check confirms the package still builds.

https://claude.ai/code/session_01A1PdjoZKXTFczm71hzYwcw