### PR TITLE
feat: configurable search similarity threshold (ADR-508 Phase 1)

### DIFF
--- a/api/app/lib/search_config.py
+++ b/api/app/lib/search_config.py
@@ -1,0 +1,70 @@
+"""
+Search configuration helpers (ADR-508).
+
+Single source of truth for the runtime-configurable default similarity threshold
+that every search entry point (concept search, source search, program/MCP
+dispatch) inherits when a caller omits ``min_similarity``. Reads from
+``kg_api.platform_config`` with a short in-process TTL cache, invalidated on write.
+"""
+
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Config key seeded by migration 079.
+SEARCH_THRESHOLD_KEY = "search_default_similarity_threshold"
+
+# Fallback when the key is unset/unreadable. MUST match the migration 079 seed.
+DEFAULT_SEARCH_THRESHOLD = 0.6
+
+# The default changes rarely; cache it briefly to keep it off the per-search hot
+# path. Writes (admin PUT) call invalidate_default_cache() for immediate effect.
+_CACHE_TTL_SECONDS = 5.0
+_cache: dict = {"value": None, "expires": 0.0}
+
+
+def invalidate_default_cache() -> None:
+    """Drop the cached default so the next read reflects a just-written value."""
+    _cache["value"] = None
+    _cache["expires"] = 0.0
+
+
+def get_configured_default(client) -> float:
+    """Return the configured default threshold (cached), or the fallback.
+
+    ``client`` is an AGEClient (uses ``client.pool``). Never raises — logs and
+    falls back to ``DEFAULT_SEARCH_THRESHOLD`` on any error.
+    """
+    now = time.monotonic()
+    if _cache["value"] is not None and now < _cache["expires"]:
+        return _cache["value"]
+
+    value = DEFAULT_SEARCH_THRESHOLD
+    try:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT kg_api.get_platform_config(%s)", (SEARCH_THRESHOLD_KEY,))
+                row = cur.fetchone()
+            if row and row[0] is not None and str(row[0]).strip() != "":
+                value = float(row[0])
+        finally:
+            client.pool.putconn(conn)
+    except Exception:
+        logger.warning(
+            "Could not read %s; using %.2f", SEARCH_THRESHOLD_KEY,
+            DEFAULT_SEARCH_THRESHOLD, exc_info=True,
+        )
+
+    _cache["value"] = value
+    _cache["expires"] = now + _CACHE_TTL_SECONDS
+    return value
+
+
+def resolve_search_threshold(client, requested: Optional[float]) -> float:
+    """Return ``requested`` if given, else the configured server default (ADR-508)."""
+    if requested is not None:
+        return requested
+    return get_configured_default(client)

--- a/api/app/models/queries.py
+++ b/api/app/models/queries.py
@@ -353,9 +353,9 @@ class SourceSearchRequest(BaseModel):
     """
     query: str = Field(..., description="Search query text", min_length=1)
     limit: int = Field(10, description="Maximum number of sources to return", ge=1, le=100)
-    min_similarity: float = Field(
-        DEFAULT_SOURCE_SEARCH_SIMILARITY,
-        description="Minimum similarity score (0.0-1.0, default 0.7=70%)",
+    min_similarity: Optional[float] = Field(
+        None,
+        description="Minimum similarity score (0.0-1.0). Omit to inherit the server-configured default (ADR-508).",
         ge=0.0,
         le=1.0
     )

--- a/api/app/models/queries.py
+++ b/api/app/models/queries.py
@@ -26,7 +26,7 @@ class SearchRequest(BaseModel):
     """
     query: str = Field(..., description="Search query text (2-3 word phrases work best)", min_length=1)
     limit: int = Field(10, description="Maximum number of results to return", ge=1, le=100)
-    min_similarity: float = Field(0.7, description="Minimum similarity score (0.0-1.0, default 70%)", ge=0.0, le=1.0)
+    min_similarity: Optional[float] = Field(None, description="Minimum similarity score (0.0-1.0). Omit to inherit the server-configured default (ADR-508: search_default_similarity_threshold).", ge=0.0, le=1.0)
     offset: int = Field(0, description="Number of results to skip for pagination (default: 0)", ge=0)
     ontology: Optional[str] = Field(None, description="Filter results to concepts from this ontology only")
     include_evidence: bool = Field(False, description="Include sample evidence instances (quotes from source text) for each concept")

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -44,7 +44,7 @@ from ..lib.backup_integrity import check_backup_integrity, check_backup_data
 from ..lib.backup_oracle import validate_backup_object
 from ..lib.age_client import AGEClient
 from ..lib.encrypted_keys import EncryptedKeyStore
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from ..constants import API_KEY_PROVIDERS, LOCAL_PROVIDERS, EXTRACTION_PROVIDERS
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -1149,3 +1149,63 @@ async def regenerate_concept_embeddings(
 # - --only-incompatible flag for model migrations
 # - Worker-based architecture for safety
 # ====================================================================
+
+
+# ====================================================================
+# Search configuration (ADR-508): runtime-tunable default similarity threshold
+# ====================================================================
+
+SEARCH_THRESHOLD_KEY = "search_default_similarity_threshold"
+SEARCH_THRESHOLD_FALLBACK = 0.6
+
+
+class SearchThresholdUpdate(BaseModel):
+    """Body for setting the default search similarity threshold (ADR-508)."""
+    threshold: float = Field(..., ge=0.0, le=1.0, description="Default min cosine similarity for /query/search (0.0-1.0)")
+
+
+@router.get("/config/search-threshold")
+async def get_search_threshold(
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("search_config", "read")),
+):
+    """Read the configured default search similarity threshold (ADR-508)."""
+    age_client = AGEClient()
+    conn = age_client.pool.getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT kg_api.get_platform_config(%s)", (SEARCH_THRESHOLD_KEY,))
+            row = cur.fetchone()
+        value = row[0] if row and row[0] not in (None, "") else None
+        return {
+            "key": SEARCH_THRESHOLD_KEY,
+            "threshold": float(value) if value is not None else None,
+            "fallback": SEARCH_THRESHOLD_FALLBACK,
+        }
+    finally:
+        age_client.pool.putconn(conn)
+
+
+@router.put("/config/search-threshold")
+async def set_search_threshold(
+    body: SearchThresholdUpdate,
+    current_user: CurrentUser,
+    _: None = Depends(require_permission("search_config", "write")),
+):
+    """Set the default search similarity threshold (ADR-508)."""
+    age_client = AGEClient()
+    conn = age_client.pool.getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT kg_api.set_platform_config(%s, %s, %s)",
+                (SEARCH_THRESHOLD_KEY, str(body.threshold), current_user.username),
+            )
+        conn.commit()
+        logger.info(
+            "Search default similarity threshold set to %s by %s",
+            body.threshold, current_user.username,
+        )
+        return {"key": SEARCH_THRESHOLD_KEY, "threshold": body.threshold}
+    finally:
+        age_client.pool.putconn(conn)

--- a/api/app/routes/admin.py
+++ b/api/app/routes/admin.py
@@ -1155,8 +1155,11 @@ async def regenerate_concept_embeddings(
 # Search configuration (ADR-508): runtime-tunable default similarity threshold
 # ====================================================================
 
-SEARCH_THRESHOLD_KEY = "search_default_similarity_threshold"
-SEARCH_THRESHOLD_FALLBACK = 0.6
+from ..lib.search_config import (
+    SEARCH_THRESHOLD_KEY,
+    DEFAULT_SEARCH_THRESHOLD as SEARCH_THRESHOLD_FALLBACK,
+    invalidate_default_cache,
+)
 
 
 class SearchThresholdUpdate(BaseModel):
@@ -1202,6 +1205,7 @@ async def set_search_threshold(
                 (SEARCH_THRESHOLD_KEY, str(body.threshold), current_user.username),
             )
         conn.commit()
+        invalidate_default_cache()  # ADR-508: reflect the new value immediately
         logger.info(
             "Search default similarity threshold set to %s by %s",
             body.threshold, current_user.username,

--- a/api/app/routes/queries.py
+++ b/api/app/routes/queries.py
@@ -255,6 +255,40 @@ def get_age_client() -> AGEClient:
     return AGEClient()
 
 
+# ADR-508: fallback when the config key is missing/unreadable. Kept in sync with the
+# seed in migration 079.
+DEFAULT_SEARCH_THRESHOLD = 0.6
+
+
+def resolve_search_threshold(client: AGEClient, requested: Optional[float]) -> float:
+    """Resolve the effective search threshold (ADR-508).
+
+    Returns the caller's ``requested`` value when provided, otherwise the
+    server-configured ``search_default_similarity_threshold`` from platform_config,
+    falling back to ``DEFAULT_SEARCH_THRESHOLD`` if the key is unset or unreadable.
+    """
+    if requested is not None:
+        return requested
+    try:
+        conn = client.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT kg_api.get_platform_config('search_default_similarity_threshold')"
+                )
+                row = cur.fetchone()
+            if row and row[0] is not None and str(row[0]).strip() != "":
+                return float(row[0])
+        finally:
+            client.pool.putconn(conn)
+    except Exception:
+        logger.warning(
+            "Could not read search_default_similarity_threshold; using %.2f",
+            DEFAULT_SEARCH_THRESHOLD, exc_info=True
+        )
+    return DEFAULT_SEARCH_THRESHOLD
+
+
 def resolve_epistemic_filters_to_rel_types(
     age_client: AGEClient,
     include_epistemic_status: Optional[List[str]] = None,
@@ -580,6 +614,10 @@ async def search_concepts(
 
         # Vector similarity search using AGE client
         client = get_age_client()
+        # ADR-508: when the caller omits min_similarity, inherit the server-configured
+        # default. Resolve once and write back so every downstream use (search, hint
+        # computation, threshold_used) sees the effective value.
+        request.min_similarity = resolve_search_threshold(client, request.min_similarity)
         try:
             # Use AGEClient's vector_search method with threshold from request
             # Fetch limit + offset to handle pagination

--- a/api/app/routes/queries.py
+++ b/api/app/routes/queries.py
@@ -75,6 +75,7 @@ def _dedupe_evidence(evidence_list: List[ConceptInstance]) -> List[ConceptInstan
             result.append(e)
     return result
 from api.app.lib.age_client import AGEClient
+from api.app.lib.search_config import resolve_search_threshold  # ADR-508
 from api.app.lib.ai_providers import get_provider
 
 
@@ -253,40 +254,6 @@ router = APIRouter(prefix="/query", tags=["queries"])
 def get_age_client() -> AGEClient:
     """Get AGE client instance"""
     return AGEClient()
-
-
-# ADR-508: fallback when the config key is missing/unreadable. Kept in sync with the
-# seed in migration 079.
-DEFAULT_SEARCH_THRESHOLD = 0.6
-
-
-def resolve_search_threshold(client: AGEClient, requested: Optional[float]) -> float:
-    """Resolve the effective search threshold (ADR-508).
-
-    Returns the caller's ``requested`` value when provided, otherwise the
-    server-configured ``search_default_similarity_threshold`` from platform_config,
-    falling back to ``DEFAULT_SEARCH_THRESHOLD`` if the key is unset or unreadable.
-    """
-    if requested is not None:
-        return requested
-    try:
-        conn = client.pool.getconn()
-        try:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT kg_api.get_platform_config('search_default_similarity_threshold')"
-                )
-                row = cur.fetchone()
-            if row and row[0] is not None and str(row[0]).strip() != "":
-                return float(row[0])
-        finally:
-            client.pool.putconn(conn)
-    except Exception:
-        logger.warning(
-            "Could not read search_default_similarity_threshold; using %.2f",
-            DEFAULT_SEARCH_THRESHOLD, exc_info=True
-        )
-    return DEFAULT_SEARCH_THRESHOLD
 
 
 def resolve_epistemic_filters_to_rel_types(
@@ -943,6 +910,13 @@ async def search_sources(
         }
     """
     try:
+        # ADR-508: inherit the server-configured default when min_similarity is omitted.
+        _cfg_client = get_age_client()
+        try:
+            request.min_similarity = resolve_search_threshold(_cfg_client, request.min_similarity)
+        finally:
+            _cfg_client.close()
+
         # 1. Generate embedding for query
         query_embedding = _generate_source_search_embedding(request.query)
 

--- a/api/app/services/program_dispatch.py
+++ b/api/app/services/program_dispatch.py
@@ -11,6 +11,7 @@ ApiOp: Calls internal service functions directly (no HTTP), maps to WorkingGraph
 import logging
 from typing import Any, Dict, List, Optional
 
+from api.app.lib.search_config import resolve_search_threshold  # ADR-508
 from api.app.models.program import (
     CypherOp,
     ApiOp,
@@ -197,15 +198,17 @@ def _dispatch_search_concepts(ctx: DispatchContext, params: Dict[str, Any]) -> W
     else:
         embedding = embedding_result
 
+    # ADR-508: inherit the server-configured default when the program omits min_similarity.
+    threshold = resolve_search_threshold(ctx.client, params.get('min_similarity'))
     matches = ctx.client.vector_search(
         embedding,
-        threshold=params.get('min_similarity', 0.7),
+        threshold=threshold,
         top_k=params.get('limit', 10),
     )
 
     nodes = []
     for m in matches:
-        if m.get('similarity', 0) < params.get('min_similarity', 0.7):
+        if m.get('similarity', 0) < threshold:
             continue
         nodes.append(RawNode(
             concept_id=m['concept_id'],
@@ -231,7 +234,7 @@ def _dispatch_search_sources(ctx: DispatchContext, params: Dict[str, Any]) -> Wo
     query_embedding = np.array(embedding)
     source_matches = _search_source_embeddings_by_similarity(
         query_embedding=query_embedding,
-        min_similarity=params.get('min_similarity', 0.7),
+        min_similarity=resolve_search_threshold(ctx.client, params.get('min_similarity')),  # ADR-508
         limit=params.get('limit', 10),
     )
 

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -1381,6 +1381,18 @@ export class KnowledgeGraphClient {
     return response.data;
   }
 
+  /** Get the server-configured default search similarity threshold (ADR-508). */
+  async getSearchThreshold(): Promise<{ key: string; threshold: number | null; fallback: number }> {
+    const response = await this.client.get('/admin/config/search-threshold');
+    return response.data;
+  }
+
+  /** Set the server-configured default search similarity threshold (ADR-508). */
+  async setSearchThreshold(threshold: number): Promise<{ key: string; threshold: number }> {
+    const response = await this.client.put('/admin/config/search-threshold', { threshold });
+    return response.data;
+  }
+
   /**
    * Manually trigger job scheduler cleanup (ADR-300)
    */

--- a/cli/src/cli/admin/index.ts
+++ b/cli/src/cli/admin/index.ts
@@ -15,6 +15,7 @@ import { createStatusCommand } from './status';
 import { createBackupCommand, createListBackupsCommand, createRestoreCommand, createVerifyBackupCommand } from './backup';
 import { createSchedulerCommand } from './scheduler';
 import { createWorkersCommand } from './workers';
+import { createSearchThresholdCommand } from './search-config';
 
 // Create command instances
 const statusCommand = createStatusCommand();
@@ -39,7 +40,8 @@ export const adminCommand = setCommandHelp(
   .addCommand(restoreCommand)
   .addCommand(verifyBackupCommand)
   .addCommand(schedulerCommand)
-  .addCommand(workersCommand);
+  .addCommand(workersCommand)
+  .addCommand(createSearchThresholdCommand());
 
 // ADR-403: Register user management commands
 registerAuthAdminCommand(adminCommand);

--- a/cli/src/cli/admin/search-config.ts
+++ b/cli/src/cli/admin/search-config.ts
@@ -1,0 +1,42 @@
+/**
+ * Admin Search Config Command (ADR-508)
+ * Get or set the server-side default similarity threshold that clients inherit
+ * when they don't pass --min-similarity.
+ */
+
+import { Command } from 'commander';
+import { createClientFromEnv } from '../../api/client';
+import * as colors from '../colors';
+
+export function createSearchThresholdCommand(): Command {
+  return new Command('search-threshold')
+    .description('Get or set the default search similarity threshold clients inherit (ADR-508)')
+    .argument('[value]', 'New threshold 0.0-1.0; omit to show the current value')
+    .action(async (value?: string) => {
+      try {
+        const client = createClientFromEnv();
+
+        if (value === undefined) {
+          const cfg = await client.getSearchThreshold();
+          const shown = cfg.threshold ?? cfg.fallback;
+          console.log(
+            `${colors.ui.key('Default search threshold:')} ${colors.ui.value(String(shown))}` +
+            (cfg.threshold === null ? colors.status.dim(`  (unset — using fallback ${cfg.fallback})`) : '')
+          );
+          return;
+        }
+
+        const t = parseFloat(value);
+        if (Number.isNaN(t) || t < 0 || t > 1) {
+          console.error(colors.status.error(`✗ Threshold must be a number in [0.0, 1.0], got "${value}"`));
+          process.exit(1);
+        }
+        const res = await client.setSearchThreshold(t);
+        console.log(colors.status.success(`✓ Default search threshold set to ${res.threshold}`));
+      } catch (error: any) {
+        console.error(colors.status.error('✗ Failed'));
+        console.error(colors.status.error(error.response?.data?.detail || error.message));
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/cli/search.ts
+++ b/cli/src/cli/search.ts
@@ -148,7 +148,7 @@ const queryCommand = setCommandHelp(
       // and bare `kg search query` show help instead of erroring on a missing arg.
       .argument('[query]', 'Natural language search query (2-3 words work best)')
       .option('-l, --limit <number>', 'Maximum number of results to return', '10')
-      .option('--min-similarity <number>', 'Minimum similarity score (0.0-1.0, default 0.7=70%, lower to 0.5 for broader matches)', '0.7')
+      .option('--min-similarity <number>', 'Minimum similarity score (0.0-1.0). Omit to inherit the server default (set via `kg admin search-threshold`).')
       .option('--no-evidence', 'Hide evidence quotes (shown by default)')
       .option('--no-images', 'Hide inline image display (shown by default if chafa installed)')
       .option('--no-grounding', 'Disable grounding strength calculation (ADR-808 probabilistic truth convergence) for faster results')

--- a/cli/src/cli/search.ts
+++ b/cli/src/cli/search.ts
@@ -174,11 +174,14 @@ const queryCommand = setCommandHelp(
           const shouldShowImages = options.images !== undefined ? options.images : config.getSearchShowImages();
           const includeGrounding = options.grounding !== false; // Default: true
           const includeDiversity = options.diversity !== false; // Default: true
+          // ADR-508: omit when not passed so the server default is inherited (avoid
+          // sending NaN and relying on JSON.stringify coercing it to null).
+          const minSimilarity = options.minSimilarity !== undefined ? parseFloat(options.minSimilarity) : undefined;
 
           const result = await client.searchConcepts({
             query,
             limit: parseInt(options.limit),
-            min_similarity: parseFloat(options.minSimilarity),
+            min_similarity: minSimilarity,
             include_evidence: includeEvidence,
             include_grounding: includeGrounding,
             include_diversity: includeDiversity,
@@ -299,7 +302,7 @@ const queryCommand = setCommandHelp(
                 parameters: {
                   query,
                   limit: parseInt(options.limit),
-                  min_similarity: parseFloat(options.minSimilarity),
+                  min_similarity: minSimilarity,
                   include_evidence: includeEvidence,
                   include_grounding: includeGrounding,
                   include_diversity: includeDiversity,

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -108,6 +108,7 @@ _Pathfinding, projections, diversity, search_
 | [ADR-506](./query-search/ADR-506-pathfinding-optimization.md) | Pathfinding Optimization for Apache AGE | Proposed |
 | [ADR-506.1](./query-search/ADR-506.1-pathfinding-baseline.md) | Pathfinding Performance Baseline | Accepted |
 | [ADR-507](./query-search/ADR-507-document-search.md) | Document-Level Search | Proposed |
+| [ADR-508](./query-search/ADR-508-configurable-search-similarity-threshold.md) | Configurable Search Similarity Threshold | Draft |
 
 ## Vocabulary
 _Relationships, grounding, categorization_

--- a/docs/architecture/query-search/ADR-508-configurable-search-similarity-threshold.md
+++ b/docs/architecture/query-search/ADR-508-configurable-search-similarity-threshold.md
@@ -1,0 +1,115 @@
+---
+status: Draft
+date: 2026-07-01
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-804
+  - ADR-715.1
+---
+
+# ADR-508: Configurable Search Similarity Threshold
+
+## Context
+
+Semantic search returns noisy results: nonsense queries match real concepts.
+Empirically, `kg search query "asdfgh qwerty zxcvb"` (random characters) returns
+concepts, and every query — relevant or not — tops out around the same score.
+
+### Root cause (measured)
+
+The active embedding profile is **`nomic-ai/nomic-embed-text-v1.5`** (768-dim,
+local provider; `kg_api.embedding_profile`, ADR-804). Measuring cosine similarity
+directly against the live model:
+
+| Query kind | cosine (max) |
+|---|---|
+| Gibberish vs domain concepts | ~0.47–0.51 |
+| Relevant query ("application security") vs domain concepts | ~0.60–0.65 |
+
+The scoring path is correct — proper cosine over L2-normalized vectors
+(`api/app/lib/age_client/query.py`), no rescaling. The high floor is **inherent to
+this embedding model**: nomic v1.5 has a compressed cosine distribution where even
+out-of-distribution text sits at ~0.5.
+
+The defect is therefore **calibration, not computation**: the clients disagree on
+the threshold and one of them sits *below the model's noise floor*.
+
+| Client | default `min_similarity` | effect on nomic v1.5 |
+|---|---|---|
+| API model (`models/queries.py`) | 0.7 | too high — relevant queries return 0 |
+| CLI (`kg search`) | 0.7 | same |
+| FUSE (`kg-fuse`, ADR-715.1) | 0.5 | too low — **below the ~0.5 gibberish floor**, so noise passes |
+
+The "right" threshold (~0.55–0.60 for this model) is **model- and corpus-dependent**.
+Hardcoding it in three clients is what produced the split-brain behavior. It belongs
+in configuration.
+
+### Related finding (deferred, not this ADR's fix)
+
+The nomic task prefixes (`search_query:` / `search_document:`) are configured in the
+profile but **never applied**: `_embed_sentence_transformers`
+(`api/app/lib/embedding_model_manager.py`) gates on the configured strings, then
+applies them via sentence-transformers `prompt_name` — but the model's named prompts
+are empty strings, so `prompt_name="query"` is a no-op (verified: prefixed and
+unprefixed embeddings are identical). Applying the prefixes correctly requires
+re-embedding the corpus (query and document spaces must match). Measured on
+real-domain text, correct prefixes were **neutral-to-slightly-worse** for separation,
+so fixing this does **not** address the noise problem and is out of scope here. See
+Phase 2 / a future embedding-correctness ADR.
+
+## Decision
+
+Introduce a single server-side, runtime-configurable default similarity threshold,
+stored in the existing `kg_api.platform_config` key-value table (migration `031`),
+and have clients **inherit** it rather than hardcode their own.
+
+1. **Storage.** Seed `search_default_similarity_threshold` (default **`0.6`**, chosen
+   from the measurements above) via a new migration, using the existing
+   `set_platform_config` / `get_platform_config` helpers. Plaintext (non-secret),
+   consistent with other `platform_config` entries.
+
+2. **API.** `SearchRequest.min_similarity` becomes `Optional[float]` (default `None`).
+   When a request omits it, `/query/search` reads the configured default from
+   `platform_config` (falling back to `0.6` if unset). An admin-gated endpoint
+   (`require_permission(...)`, per the `admin.py` convention) exposes GET/PUT of the
+   value.
+
+3. **Clients inherit.** CLI (`kg search`) and FUSE both change their default from a
+   hardcoded number to "unset", so an omitted flag inherits the server default. This
+   supersedes the FUSE `0.5` constant (ADR-715.1) and the CLI/API `0.7`. Explicit
+   `--min-similarity` / `.meta/threshold` still override per query.
+
+4. **Surfaces.** The value is settable via `operator/configure.py platform-config`
+   (already supports it), the new admin API, `kg config`, and a web settings surface.
+
+Phased delivery: **Phase 1** = schema + API + CLI + FUSE + web (this ADR). **Phase 2**
+= the prefix-application fix + corpus re-embed, gated on a real before/after
+separation eval (separate ADR).
+
+## Consequences
+
+### Positive
+
+- One place to tune search precision per deployment; ends the split-brain 0.5/0.7 defaults.
+- Operators can raise/lower the floor to match their embedding model and corpus without a redeploy.
+- FUSE `mkdir` auto-adjust (ADR-715.1) becomes meaningfully useful: with the default at 0.6, zero-result cases occur and queries auto-tune down to where real matches live.
+- No new tables or mechanisms — reuses `platform_config`, `configure.py`, RBAC admin endpoints.
+
+### Negative
+
+- `min_similarity` becoming optional touches the API model and every client default; care needed so scripts passing explicit values are unaffected.
+- A per-deployment default can be mis-set (too high → empty results; too low → noise). Mitigated by the FUSE auto-adjust hint and a sane seed.
+
+### Neutral
+
+- Does not change the embedding model or scoring math. The nomic floor remains; the threshold is calibrated around it.
+- The prefix no-op bug remains until Phase 2.
+
+## Alternatives Considered
+
+- **Hardcode a higher default (~0.6) in each client.** Rejected: perpetuates split-brain defaults and can't be tuned per deployment/model.
+- **Fix the nomic prefixes + re-embed as the primary fix.** Rejected as the primary lever: measured separation was neutral-to-worse; it's a correctness improvement, not the noise fix. Deferred to Phase 2, evidence-gated.
+- **Switch to a wider-range embedding model** (e.g. the inactive `text-embedding-3-small` profile). Viable but orthogonal and heavier (external provider, re-embed); the config surface makes the threshold tunable regardless of model, and model choice stays a separate `embedding_profile` decision (ADR-804).
+- **Per-ontology thresholds.** Deferred: start with one global default; the key-value store can grow scoped keys later if needed.

--- a/docs/architecture/query-search/ADR-508-configurable-search-similarity-threshold.md
+++ b/docs/architecture/query-search/ADR-508-configurable-search-similarity-threshold.md
@@ -82,7 +82,20 @@ and have clients **inherit** it rather than hardcode their own.
    `--min-similarity` / `.meta/threshold` still override per query.
 
 4. **Surfaces.** The value is settable via `operator/configure.py platform-config`
-   (already supports it), the new admin API, `kg config`, and a web settings surface.
+   (already supports it), the new admin API, `kg admin search-threshold`, and a web
+   settings surface.
+
+5. **Floor the FUSE auto-adjust (supersedes part of ADR-715.1).** ADR-715.1's `mkdir`
+   auto-adjust lowered a zero-result query's threshold to "show files". Once the
+   default is calibrated (and clients inherit it), that auto-lowering works *against*
+   noise filtering: a gibberish query that returns 0 at the default would be dropped
+   below it and resurface noise. Auto-adjust is therefore **floored at the server
+   default** — it must never lower below it. Because a freshly created FUSE query
+   inherits exactly that default, there is nothing above it to surface at creation, so
+   the `mkdir` probe now no-ops for inherited queries (the common case) — effectively
+   retiring the auto-lower behavior while the calibrated default does the job. The
+   machinery is retained for a possible future path that creates queries with an
+   explicit, over-tight threshold.
 
 Phased delivery: **Phase 1** = schema + API + CLI + FUSE + web (this ADR). **Phase 2**
 = the prefix-application fix + corpus re-embed, gated on a real before/after
@@ -94,7 +107,7 @@ separation eval (separate ADR).
 
 - One place to tune search precision per deployment; ends the split-brain 0.5/0.7 defaults.
 - Operators can raise/lower the floor to match their embedding model and corpus without a redeploy.
-- FUSE `mkdir` auto-adjust (ADR-715.1) becomes meaningfully useful: with the default at 0.6, zero-result cases occur and queries auto-tune down to where real matches live.
+- Noise filtering is consistent across surfaces: CLI/API and FUSE all apply the same calibrated default, and FUSE no longer auto-lowers below it (the floor), so gibberish no longer resurfaces on the FUSE surface.
 - No new tables or mechanisms — reuses `platform_config`, `configure.py`, RBAC admin endpoints.
 
 ### Negative

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -891,7 +891,7 @@ kg query [query]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-l, --limit <number>` | Maximum number of results to return | `"10"` |
-| `--min-similarity <number>` | Minimum similarity score (0.0-1.0, default 0.7=70%, lower to 0.5 for broader matches) | `"0.7"` |
+| `--min-similarity <number>` | Minimum similarity score (0.0-1.0). Omit to inherit the server default (set via `kg admin search-threshold`). | - |
 | `--no-evidence` | Hide evidence quotes (shown by default) | - |
 | `--no-images` | Hide inline image display (shown by default if chafa installed) | - |
 | `--no-grounding` | Disable grounding strength calculation (ADR-808 probabilistic truth convergence) for faster results | - |
@@ -2260,6 +2260,7 @@ kg admin [options]
 - `verify-backup` - Validate a backup file without restoring it (runs the server-side oracle)
 - `scheduler` - Job scheduler management (ADR-300 job queue) - monitor worker status, cleanup stale jobs
 - `workers` - Worker lane management (ADR-100) - monitor slot utilization, queue depth, active jobs
+- `search-threshold` - Get or set the default search similarity threshold clients inherit (ADR-508)
 - `user` - User management commands (admin only)
 - `rbac` - Manage roles, permissions, and access control (ADR-404)
 - `embedding` - Manage embedding profiles (text + image model configuration)
@@ -2429,6 +2430,19 @@ kg set <lane>
 | `--stale-timeout <min>` | Stale job timeout in minutes (5–1440) | - |
 | `--enable` | Enable the lane | - |
 | `--disable` | Disable the lane | - |
+
+### search-threshold
+
+Get or set the default search similarity threshold clients inherit (ADR-508)
+
+**Usage:**
+```bash
+kg search-threshold [value]
+```
+
+**Arguments:**
+
+- `<value>` - New threshold 0.0-1.0; omit to show the current value
 
 ### user
 

--- a/fuse/kg_fuse/filesystem/directory.py
+++ b/fuse/kg_fuse/filesystem/directory.py
@@ -556,9 +556,12 @@ class DirectoryMixin:
                 """Search for a single term, optionally across multiple ontologies."""
                 body = {
                     "query": term,
-                    "min_similarity": threshold,
                     "limit": fetch_limit or limit * 2,  # Fetch more for intersection/filtering
                 }
+                # ADR-508: omit min_similarity when the query inherits the server
+                # default (threshold is None); a concrete value overrides it.
+                if threshold is not None:
+                    body["min_similarity"] = threshold
 
                 if ontology is not None:
                     # Scoped query - search single ontology

--- a/fuse/kg_fuse/filesystem/write.py
+++ b/fuse/kg_fuse/filesystem/write.py
@@ -123,10 +123,15 @@ class WriteMixin:
                         break
 
             elif entry.meta_key == "threshold":
-                # Extract the float (skip comment lines)
+                # Extract the float, or the 'inherit' sentinel (skip comment lines)
                 for line in content.split("\n"):
                     line = line.strip()
                     if line and not line.startswith("#"):
+                        if line.lower() in ("inherit", "default", "server", "none"):
+                            # ADR-508: revert an explicit override to the server default
+                            self.query_store.clear_threshold(entry.ontology, entry.query_path)
+                            self._invalidate_query_cache(entry.ontology, entry.query_path)
+                            break
                         try:
                             threshold = float(line)
                             self.query_store.update_threshold(entry.ontology, entry.query_path, threshold)
@@ -175,7 +180,11 @@ class WriteMixin:
             elif entry.meta_key == "union":
                 self.query_store.clear_union(entry.ontology, entry.query_path)
                 self._invalidate_query_cache(entry.ontology, entry.query_path)
-            # limit and threshold don't have clear - they just keep their value
+            elif entry.meta_key == "threshold":
+                # ADR-508: truncating threshold reverts it to the inherited server default
+                self.query_store.clear_threshold(entry.ontology, entry.query_path)
+                self._invalidate_query_cache(entry.ontology, entry.query_path)
+            # limit doesn't have clear - it just keeps its value
 
         return await self.getattr(inode, ctx)
 

--- a/fuse/kg_fuse/filesystem/write.py
+++ b/fuse/kg_fuse/filesystem/write.py
@@ -543,7 +543,10 @@ class WriteMixin:
             return
         default_threshold = query.threshold  # capture before apply_creation_threshold mutates it
 
-        body = {"query": query_text, "min_similarity": query.threshold, "limit": query.limit}
+        body = {"query": query_text, "limit": query.limit}
+        # ADR-508: probe at the query's threshold, or the server default when it inherits (None).
+        if query.threshold is not None:
+            body["min_similarity"] = query.threshold
         if ontology is not None:
             body["ontology"] = ontology
 
@@ -565,9 +568,10 @@ class WriteMixin:
             return  # Genuinely no near-misses to reveal.
 
         if self.query_store.apply_creation_threshold(ontology, query_path, suggested):
+            from_label = "server default" if default_threshold is None else default_threshold
             log.info(
                 f"auto-adjusted new query {ontology}/{query_path}: "
-                f"{default_threshold} -> {suggested} (0 results at default)"
+                f"{from_label} -> {suggested} (0 results at default)"
             )
             self._invalidate_query_cache(ontology, query_path)
 

--- a/fuse/kg_fuse/filesystem/write.py
+++ b/fuse/kg_fuse/filesystem/write.py
@@ -541,6 +541,14 @@ class WriteMixin:
         query = self.query_store.get_query(ontology, query_path)
         if not query or query.auto_adjusted:
             return
+        # ADR-508 floor: a new query inherits the calibrated server default (the noise
+        # floor). Auto-adjust must never lower below it, and a freshly created query
+        # starts AT the default, so there is nothing above it to surface — skip the
+        # probe entirely. (Machinery retained for a possible future path that creates
+        # a query with an explicit, over-tight threshold; that case would floor at the
+        # server default rather than at the API's near-miss suggestion.)
+        if query.threshold is None:
+            return
         default_threshold = query.threshold  # capture before apply_creation_threshold mutates it
 
         body = {"query": query_text, "limit": query.limit}

--- a/fuse/kg_fuse/formatters.py
+++ b/fuse/kg_fuse/formatters.py
@@ -303,7 +303,13 @@ def render_meta_file(meta_key: str, query: Optional[Query], ontology: Optional[s
         return f"# Maximum number of concepts to return. Default is 50.\n{query.limit}\n"
 
     elif meta_key == "threshold":
-        return f"# Minimum similarity score (0.0-1.0). Default is 0.5 (auto-lowered on creation if no results).\n{query.threshold}\n"
+        # None => inherit the server-configured default (ADR-508). Writing a number here overrides it.
+        value = "inherit" if query.threshold is None else query.threshold
+        return (
+            "# Minimum similarity score (0.0-1.0), or 'inherit' to use the server default.\n"
+            "# Write a number to override; auto-lowered on creation if it returns nothing.\n"
+            f"{value}\n"
+        )
 
     elif meta_key == "exclude":
         content = "# Terms to exclude from results (one per line, semantic NOT).\n"
@@ -321,7 +327,10 @@ def render_meta_file(meta_key: str, query: Optional[Query], ontology: Optional[s
         # Read-only debug view of the full query
         lines = ["# Full query state (read-only)", ""]
         lines.append(f'query_text = "{query.query_text}"')
-        lines.append(f"threshold = {query.threshold}")
+        if query.threshold is None:
+            lines.append('threshold = "inherit"  # server default (ADR-508)')
+        else:
+            lines.append(f"threshold = {query.threshold}")
         lines.append(f"limit = {query.limit}")
         exclude_str = ", ".join(f'"{e}"' for e in query.exclude)
         lines.append(f"exclude = [{exclude_str}]")

--- a/fuse/kg_fuse/query_store.py
+++ b/fuse/kg_fuse/query_store.py
@@ -23,7 +23,7 @@ except ImportError:
 class Query:
     """A user-created query directory definition with .meta control plane settings."""
     query_text: str
-    threshold: float = 0.5  # Default similarity threshold (matches add_query / ADR-715.1)
+    threshold: Optional[float] = None  # None = inherit the server default (ADR-508); a float overrides it
     limit: int = 50  # Default max results
     exclude: list[str] = None  # Terms to exclude (NOT)
     union: list[str] = None  # Terms to add (OR)
@@ -113,7 +113,14 @@ class QueryStore:
             return
 
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        data = {"queries": {k: v.to_dict() for k, v in self.queries.items()}}
+        # TOML has no null type: drop None-valued keys (e.g. an inherited threshold,
+        # ADR-508). They round-trip back to the dataclass default (None) on load.
+        data = {
+            "queries": {
+                k: {kk: vv for kk, vv in v.to_dict().items() if vv is not None}
+                for k, v in self.queries.items()
+            }
+        }
         with open(self.path, "wb") as f:
             tomli_w.dump(data, f)
 
@@ -126,7 +133,9 @@ class QueryStore:
             # TOML table with dotted key
             lines.append(f'[queries."{key}"]')
             lines.append(f'query_text = "{query.query_text}"')
-            lines.append(f"threshold = {query.threshold}")
+            # Omit an inherited (None) threshold — it reloads as the default (ADR-508).
+            if query.threshold is not None:
+                lines.append(f"threshold = {query.threshold}")
             lines.append(f"limit = {query.limit}")
             # Format lists as TOML arrays
             exclude_str = ", ".join(f'"{e}"' for e in query.exclude)
@@ -162,7 +171,7 @@ class QueryStore:
 
         query = Query(
             query_text=query_text,
-            threshold=0.5,  # Lower default for broader matches
+            threshold=None,  # inherit the server default (ADR-508) until auto-adjust or a user write sets one
             created_at=datetime.now().isoformat(),
         )
         self.queries[key] = query

--- a/fuse/kg_fuse/query_store.py
+++ b/fuse/kg_fuse/query_store.py
@@ -266,6 +266,19 @@ class QueryStore:
             return True
         return False
 
+    def clear_threshold(self, ontology: Optional[str], path: str) -> bool:
+        """Reset a query's threshold to None so it inherits the server default (ADR-508).
+
+        The inverse of update_threshold — lets a user revert an explicit override by
+        writing 'inherit' to .meta/threshold (or truncating it).
+        """
+        query = self.get_query(ontology, path)
+        if query:
+            query.threshold = None
+            self._save()
+            return True
+        return False
+
     def apply_creation_threshold(self, ontology: Optional[str], path: str, threshold: float) -> bool:
         """Adopt the creation-time auto-adjusted threshold, exactly once.
 

--- a/fuse/pyproject.toml
+++ b/fuse/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kg-fuse"
-version = "0.13.0"
+version = "0.14.0"
 description = "FUSE filesystem for Knowledge Graph - mount your knowledge graph as a filesystem"
 readme = "README.md"
 license = "MIT"

--- a/fuse/tests/test_query_store.py
+++ b/fuse/tests/test_query_store.py
@@ -205,6 +205,16 @@ class TestQueryStore:
         """Adjusting a nonexistent query returns False."""
         assert store.apply_creation_threshold("ont", "missing", 0.5) is False
 
+    def test_clear_threshold_reverts_to_inherit(self, store):
+        """clear_threshold resets an explicit override back to None (inherit, ADR-508)."""
+        store.add_query("ont", "test")
+        store.update_threshold("ont", "test", 0.8)
+        assert store.get_query("ont", "test").threshold == 0.8
+
+        assert store.clear_threshold("ont", "test") is True
+        assert store.get_query("ont", "test").threshold is None
+        assert store.clear_threshold("ont", "missing") is False
+
     def test_load_tolerates_unknown_fields(self, tmp_path):
         """A toml written by a newer kg-fuse (extra keys) must still load, not wipe.
 

--- a/fuse/tests/test_query_store.py
+++ b/fuse/tests/test_query_store.py
@@ -14,7 +14,7 @@ class TestQuery:
         """Query should initialize with correct defaults."""
         q = Query(query_text="test")
         assert q.query_text == "test"
-        assert q.threshold == 0.5
+        assert q.threshold is None  # ADR-508: inherit the server default until set
         assert q.limit == 50
         assert q.exclude == []
         assert q.union == []

--- a/schema/migrations/079_search_default_threshold.sql
+++ b/schema/migrations/079_search_default_threshold.sql
@@ -1,0 +1,28 @@
+-- Migration: 079_search_default_threshold
+-- Description: Configurable default similarity threshold for concept search (ADR-508)
+-- Date: 2026-07-01
+--
+-- Root cause (ADR-508): the active embedding model (nomic-embed-text-v1.5) has a
+-- compressed cosine distribution — irrelevant/gibberish queries score ~0.47-0.51,
+-- relevant matches ~0.60-0.65. The "right" threshold is model- and corpus-dependent,
+-- so it belongs in configuration rather than hardcoded across three clients (API,
+-- CLI, FUSE) whose split defaults (0.7 / 0.7 / 0.5) produced the noise problem.
+--
+-- Clients omit min_similarity to inherit this server-side default; /query/search
+-- reads it via kg_api.get_platform_config('search_default_similarity_threshold').
+
+BEGIN;
+
+-- Seed the default. 0.6 sits below relevant matches (~0.62) and above the nomic
+-- gibberish floor (~0.51). Tunable at runtime via the admin API / kg config /
+-- operator configure.py without a redeploy.
+INSERT INTO kg_api.platform_config (key, value, description) VALUES
+    ('search_default_similarity_threshold', '0.6',
+     'Default min cosine similarity for /query/search when a client omits min_similarity (0.0-1.0). ADR-508.')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (79, 'search_default_threshold')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/schema/migrations/080_search_config_permission.sql
+++ b/schema/migrations/080_search_config_permission.sql
@@ -1,0 +1,39 @@
+-- Migration: 080_search_config_permission
+-- Description: RBAC grants for reading/writing search config (ADR-508)
+-- Date: 2026-07-01
+--
+-- The admin API endpoints that read and set the configurable default similarity
+-- threshold (ADR-508) gate on ('search_config', 'read'|'write'). Grant those to the
+-- admin and platform_admin roles, matching the per-config-resource permission
+-- convention used by extraction_config / embedding_config / vocabulary_config.
+
+BEGIN;
+
+-- Register the resource (role_permissions.resource_type FKs to kg_auth.resources).
+INSERT INTO kg_auth.resources (resource_type, description, available_actions, supports_scoping, registered_by)
+VALUES ('search_config', 'Configurable semantic search settings (default similarity threshold, ADR-508)',
+        ARRAY['read', 'write'], FALSE, 'system')
+ON CONFLICT (resource_type) DO NOTHING;
+
+DO $$
+BEGIN
+    -- search_config:read + search_config:write for admin and platform_admin
+    INSERT INTO kg_auth.role_permissions (role_name, resource_type, action, scope_type, granted)
+    SELECT r.role_name, 'search_config', a.action, 'global', TRUE
+    FROM (VALUES ('admin'), ('platform_admin')) AS r(role_name)
+    CROSS JOIN (VALUES ('read'), ('write')) AS a(action)
+    WHERE NOT EXISTS (
+        SELECT 1 FROM kg_auth.role_permissions rp
+        WHERE rp.role_name = r.role_name
+          AND rp.resource_type = 'search_config'
+          AND rp.action = a.action
+    );
+
+    RAISE NOTICE 'Migration 080: granted search_config read/write to admin and platform_admin';
+END $$;
+
+INSERT INTO public.schema_migrations (version, name)
+VALUES (80, 'search_config_permission')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/tests/api/test_search_threshold_config.py
+++ b/tests/api/test_search_threshold_config.py
@@ -1,0 +1,93 @@
+"""
+Tests for the configurable default search similarity threshold (ADR-508).
+
+Covers:
+- admin GET/PUT of /admin/config/search-threshold (round-trips via platform_config)
+- RBAC: setting requires search_config:write (admin), denied for read_only
+- /query/search inherits the configured default when min_similarity is omitted,
+  and an explicit min_similarity still overrides it
+"""
+
+import pytest
+
+THRESHOLD_URL = "/admin/config/search-threshold"
+
+
+def _restore_default(api_client, headers, value=0.6):
+    api_client.put(THRESHOLD_URL, json={"threshold": value}, headers=headers)
+
+
+@pytest.mark.api
+def test_get_search_threshold_admin(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """Admin can read the configured default threshold."""
+    resp = api_client.get(THRESHOLD_URL, headers=auth_headers_admin)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["key"] == "search_default_similarity_threshold"
+    assert "threshold" in body and "fallback" in body
+
+
+@pytest.mark.api
+def test_set_search_threshold_roundtrips(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """PUT updates the value; a subsequent GET reflects it."""
+    try:
+        resp = api_client.put(THRESHOLD_URL, json={"threshold": 0.55}, headers=auth_headers_admin)
+        assert resp.status_code == 200
+        assert resp.json()["threshold"] == 0.55
+
+        got = api_client.get(THRESHOLD_URL, headers=auth_headers_admin).json()
+        assert got["threshold"] == 0.55
+    finally:
+        _restore_default(api_client, auth_headers_admin)
+
+
+@pytest.mark.api
+def test_set_search_threshold_validates_range(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """Out-of-range thresholds are rejected by the request model (422)."""
+    resp = api_client.put(THRESHOLD_URL, json={"threshold": 1.5}, headers=auth_headers_admin)
+    assert resp.status_code == 422
+
+
+@pytest.mark.api
+@pytest.mark.security
+def test_set_search_threshold_denied_for_readonly(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_readonly
+):
+    """Setting the threshold requires search_config:write; read_only is denied."""
+    resp = api_client.put(THRESHOLD_URL, json={"threshold": 0.55}, headers=auth_headers_readonly)
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.api
+def test_search_inherits_configured_default(
+    api_client, mock_oauth_validation, ensure_test_users_in_db, auth_headers_admin
+):
+    """A search with no min_similarity uses the configured default; explicit overrides it."""
+    try:
+        api_client.put(THRESHOLD_URL, json={"threshold": 0.72}, headers=auth_headers_admin)
+
+        inherited = api_client.post(
+            "/query/search",
+            json={"query": "application security", "limit": 3,
+                  "include_grounding": False, "include_diversity": False},
+            headers=auth_headers_admin,
+        )
+        assert inherited.status_code == 200
+        assert inherited.json()["threshold_used"] == 0.72
+
+        explicit = api_client.post(
+            "/query/search",
+            json={"query": "application security", "limit": 3, "min_similarity": 0.4,
+                  "include_grounding": False, "include_diversity": False},
+            headers=auth_headers_admin,
+        )
+        assert explicit.status_code == 200
+        assert explicit.json()["threshold_used"] == 0.4
+    finally:
+        _restore_default(api_client, auth_headers_admin)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1427,6 +1427,22 @@ class APIClient {
   }
 
   /**
+   * Get the server-configured default search similarity threshold (ADR-508)
+   */
+  async getSearchThreshold(): Promise<{ key: string; threshold: number | null; fallback: number }> {
+    const response = await this.client.get('/admin/config/search-threshold');
+    return response.data;
+  }
+
+  /**
+   * Set the server-configured default search similarity threshold (ADR-508)
+   */
+  async setSearchThreshold(threshold: number): Promise<{ key: string; threshold: number }> {
+    const response = await this.client.put('/admin/config/search-threshold', { threshold });
+    return response.data;
+  }
+
+  /**
    * List API keys with validation status (admin)
    */
   async listApiKeys(): Promise<Array<{

--- a/web/src/components/admin/SystemTab.tsx
+++ b/web/src/components/admin/SystemTab.tsx
@@ -53,6 +53,12 @@ const DEFAULT_TEMPERATURE = '0.1';
 export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const { hasPermission } = useAuthStore();
   const canManageWorkers = hasPermission('workers', 'manage');
+  const canSetSearchThreshold = hasPermission('search_config', 'write');
+
+  // ADR-508: server-configured default search similarity threshold
+  const [searchThreshold, setSearchThreshold] = useState<{ threshold: number | null; fallback: number } | null>(null);
+  const [searchThresholdInput, setSearchThresholdInput] = useState<string>('');
+  const [savingThreshold, setSavingThreshold] = useState(false);
 
   // Data states
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null);
@@ -113,7 +119,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
   const loadData = async () => {
     setLoading(true);
     try {
-      const [status, stats, counters, scheduler, workers, embeddings, extraction, keys, apiInfo, dbEpoch, modelCatalog, supportedProviders] = await Promise.all([
+      const [status, stats, counters, scheduler, workers, embeddings, extraction, keys, apiInfo, dbEpoch, modelCatalog, supportedProviders, searchCfg] = await Promise.all([
         apiClient.getSystemStatus().catch(() => null),
         apiClient.getDatabaseStats().catch(() => null),
         apiClient.getDatabaseCounters().catch(() => null),
@@ -126,6 +132,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
         apiClient.getDatabaseEpoch().catch(() => 0),
         apiClient.getModelCatalog().then(r => r.models).catch(() => []),
         apiClient.getProviders().then(r => r.providers).catch(() => []),
+        apiClient.getSearchThreshold().catch(() => null),
       ]);
       setSystemStatus(status);
       setDbStats(stats);
@@ -139,6 +146,10 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
       setApiKeys(keys);
       setCatalog(modelCatalog);
       setProviders(supportedProviders);
+      if (searchCfg) {
+        setSearchThreshold(searchCfg);
+        setSearchThresholdInput(String(searchCfg.threshold ?? searchCfg.fallback));
+      }
 
       // Hydrate each provider card's draft from its saved DB row so the
       // card shows what is actually persisted (two-way source of truth, #8).
@@ -396,8 +407,60 @@ export const SystemTab: React.FC<SystemTabProps> = ({ onError }) => {
     );
   }
 
+  const handleSaveSearchThreshold = async () => {
+    const v = parseFloat(searchThresholdInput);
+    if (Number.isNaN(v) || v < 0 || v > 1) {
+      onError('Search threshold must be a number between 0.0 and 1.0');
+      return;
+    }
+    setSavingThreshold(true);
+    try {
+      const res = await apiClient.setSearchThreshold(v);
+      setSearchThreshold({ threshold: res.threshold, fallback: searchThreshold?.fallback ?? 0.6 });
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to save search threshold');
+    } finally {
+      setSavingThreshold(false);
+    }
+  };
+
   return (
     <>
+      {canSetSearchThreshold && (
+        <Section
+          title="Search Similarity Threshold"
+          icon={<Activity className="w-5 h-5" />}
+        >
+          <p className="text-sm text-muted-foreground mb-3">
+            Default minimum cosine similarity for concept search (ADR-508). Clients that don't
+            pass an explicit value inherit this. Higher = fewer, more precise matches; lower =
+            broader, noisier. Current active model's useful range is roughly 0.55–0.65.
+          </p>
+          <div className="flex items-center gap-3">
+            <input
+              type="number"
+              min={0}
+              max={1}
+              step={0.01}
+              value={searchThresholdInput}
+              onChange={(e) => setSearchThresholdInput(e.target.value)}
+              className="w-28 px-3 py-2 rounded-md border border-border bg-background text-foreground"
+            />
+            <button
+              onClick={handleSaveSearchThreshold}
+              disabled={savingThreshold}
+              className="px-4 py-2 rounded-md bg-primary text-primary-foreground disabled:opacity-50"
+            >
+              {savingThreshold ? 'Saving…' : 'Save'}
+            </button>
+            {searchThreshold && (
+              <span className="text-sm text-muted-foreground">
+                Active: {searchThreshold.threshold ?? `${searchThreshold.fallback} (fallback)`}
+              </span>
+            )}
+          </div>
+        </Section>
+      )}
       <Section
         title="System Config"
         icon={<Server className="w-5 h-5" />}


### PR DESCRIPTION
Fixes the root cause behind "search feels broken / gibberish matches concepts": the active embedding model (`nomic-embed-text-v1.5`) has a compressed cosine distribution (gibberish ~0.47–0.51, relevant ~0.60–0.65), and clients hardcoded split, miscalibrated thresholds (FUSE `0.5` sat *below* the noise floor; CLI/API `0.7` above real matches). See **ADR-508**.

## What changed (schema → API → CLI → FUSE → web)

- **schema `079`**: seed `platform_config.search_default_similarity_threshold = 0.6`.
- **schema `080`**: register `search_config` resource + grant admin/platform_admin `read`/`write`.
- **API**: `SearchRequest.min_similarity` → `Optional`; `/query/search` resolves the server default from `platform_config` when omitted (`resolve_search_threshold`). New admin `GET/PUT /admin/config/search-threshold` gated on `search_config`.
- **CLI**: `kg search` drops its hardcoded `0.7` and inherits the server default; new `kg admin search-threshold [value]`.
- **FUSE**: query threshold defaults to `None` = inherit; `_execute_search`/probe omit `min_similarity` when inheriting; TOML round-trips the `None`. Supersedes the FUSE `0.5` constant.
- **FUSE auto-adjust floored (supersedes part of ADR-715.1)**: the `mkdir` auto-adjust no longer lowers below the server default, so gibberish stops resurfacing on the FUSE surface.
- **web**: admin System tab gains a `search_config:write`-gated control to read/set the default.

## Verification

- **API** (live curl + `tests/api/test_search_threshold_config.py`, 5 pass): omitted `min_similarity` → `threshold_used=0.6`; explicit honored; PUT `0.55` → subsequent omitted search uses `0.55`; read_only denied; range-validated.
- **CLI**: `kg admin search-threshold` get/set; omitted search inherits; explicit overrides.
- **FUSE** (live mount, driver `0.14.0`): real term inherits (4 results, `auto_adjusted=false`); floored auto-adjust keeps a zero-at-default gibberish query from lowering below the default; 34 unit tests pass.
- **web**: `tsc -b` clean; Vite recompiled `SystemTab` with no errors; served modules contain the new endpoint + UI. (Visual click-through pending the web admin login.)

## Notes

- `0.6` isn't a perfectly clean cutoff for nomic (thin margin); the whole point is it's now tunable per deployment. Phase 2 (evidence-gated) would revisit the nomic prefix no-op + re-embed.
- Publishing (CLI/FUSE) is separate and needs interactive auth — handled post-merge.

https://claude.ai/code/session_01A1PdjoZKXTFczm71hzYwcw