### PR TITLE
fix(fuse): make cli.py parse under Python 3.11

### DIFF
--- a/fuse/kg_fuse/cli.py
+++ b/fuse/kg_fuse/cli.py
@@ -574,7 +574,7 @@ def cmd_mount(args: Namespace) -> None:
 
         # daemon mode — print systemd hint if available
         if has_systemd():
-            print(f"{_dim('Info: systemd user services available. Set daemon_mode to \"systemd\" in fuse.json or run kg-fuse init.')}")
+            print(_dim('Info: systemd user services available. Set daemon_mode to "systemd" in fuse.json or run kg-fuse init.'))
 
     if mountpoint:
         mountpoint = os.path.realpath(mountpoint)


### PR DESCRIPTION
## Why
After #543 unblocked the CLI build in the docs deploy, the workflow reached the next latent failure: `generate-fuse-docs.py` (runs on Python 3.11) `ast.parse()`s `fuse/kg_fuse/cli.py`, which has an f-string with a backslash **and** the delimiter quote inside the `{…}` expression — both forbidden before 3.12 (PEP 701). Since fuse declares `requires-python = ">=3.11"`, this is a real latent bug: `kg-fuse` won't import on 3.11 at all.

## Fix
The `f"{_dim(...)}"` wrapper only interpolated a single call, so drop it → `_dim('…')`. The `"systemd"` quotes then sit in a plain single-quoted string, no escaping needed. Message text unchanged.

## Verification
`uv run --python 3.11` compile-checked **all 32 fuse modules** → clean (was: SyntaxError at cli.py:577).

Second of the two fast CI fixes before the schema-diagram docs work (follows #543).

https://claude.ai/code/session_017Her5fGimBvtzYD4q9tNnf