### PR TITLE
feat(docs): interactive DBML ER diagram for the database schema

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,10 @@ jobs:
           # docs:cli/docs:mcp import from cli/dist, so the CLI must be built first.
           (cd cli && npm install && npm run build && npm run docs:cli && npm run docs:mcp)
           python3 fuse/scripts/generate-fuse-docs.py
+          # Schema: markdown + DBML from the DDL, then the interactive ER diagram
+          # (render reads schema.dbml, so it must run after the Python generator).
           python3 schema/scripts/generate-schema-docs.py
+          (cd schema/scripts && npm install && node render-schema-diagram.mjs)
 
       - name: Build and deploy
         run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
           # Schema: markdown + DBML from the DDL, then the interactive ER diagram
           # (render reads schema.dbml, so it must run after the Python generator).
           python3 schema/scripts/generate-schema-docs.py
-          (cd schema/scripts && npm install && node render-schema-diagram.mjs)
+          (cd schema/scripts && npm ci && node render-schema-diagram.mjs)
 
       - name: Build and deploy
         run: mkdocs gh-deploy --force

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ docs-fuse: ## Generate FUSE driver API reference (markdown)
 
 docs-schema: ## Generate database schema reference (markdown + DBML + interactive ERD)
 	@python3 schema/scripts/generate-schema-docs.py
-	@[ -d schema/scripts/node_modules ] || npm --prefix schema/scripts install --silent --no-audit --no-fund
+	@npm --prefix schema/scripts ci --silent --no-audit --no-fund
 	@node schema/scripts/render-schema-diagram.mjs
 
 docs-site: ## Build documentation site (MkDocs)

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,10 @@ docs-mcp: ## Generate MCP server tool reference
 docs-fuse: ## Generate FUSE driver API reference (markdown)
 	@python3 fuse/scripts/generate-fuse-docs.py
 
-docs-schema: ## Generate database schema reference (markdown)
+docs-schema: ## Generate database schema reference (markdown + DBML + interactive ERD)
 	@python3 schema/scripts/generate-schema-docs.py
+	@[ -d schema/scripts/node_modules ] || npm --prefix schema/scripts install --silent --no-audit --no-fund
+	@node schema/scripts/render-schema-diagram.mjs
 
 docs-site: ## Build documentation site (MkDocs)
 	@./site/scripts/docs build

--- a/docs/reference/schema-erd.html
+++ b/docs/reference/schema-erd.html
@@ -1,0 +1,4157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Knowledge Graph — Schema ER Diagram</title>
+<style>
+  /* --erd-cell / --erd-ink recolor the two theme-sensitive fills baked into
+     the Graphviz SVG (light beige cells, navy ink for text/borders/edges).
+     Schema header fills and their white text work in both modes, so they stay
+     fixed. The attribute-selector rules further down apply these vars. */
+  :root {
+    --bg: #ffffff; --fg: #1a2233; --panel: #f4f5f7; --border: #d0d5dd;
+    --muted: #667085; --accent: #7c3aed; --dim: 0.12;
+    --erd-cell: #e7e2dd; --erd-ink: #29235c;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #0f1419; --fg: #e6e9ee; --panel: #1a222c; --border: #2c3745;
+            --muted: #93a0b4; --dim: 0.08;
+            --erd-cell: #212a36; --erd-ink: #cfd8e6; }
+  }
+  html.dark {
+    --bg: #0f1419; --fg: #e6e9ee; --panel: #1a222c; --border: #2c3745;
+    --muted: #93a0b4; --dim: 0.08;
+    --erd-cell: #212a36; --erd-ink: #cfd8e6;
+  }
+  html.light {
+    --bg: #ffffff; --fg: #1a2233; --panel: #f4f5f7; --border: #d0d5dd;
+    --muted: #667085; --dim: 0.12;
+    --erd-cell: #e7e2dd; --erd-ink: #29235c;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
+    font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  #stage { position: fixed; inset: 0; overflow: hidden; cursor: grab; }
+  #stage.grabbing { cursor: grabbing; }
+  #erd { width: 100%; height: 100%; display: block; touch-action: none; }
+  #erd .node, #erd .edge { transition: opacity 0.15s ease; }
+  /* Recolor the two theme-sensitive baked colors to the active theme. A CSS
+     fill/stroke property overrides the SVG presentation attribute, and the
+     attribute selector targets exactly those elements. Schema header fills
+     (#7c3aed etc.) and white header text are intentionally left alone. */
+  #erd [fill="#e7e2dd"] { fill: var(--erd-cell); }
+  #erd [fill="#29235c"] { fill: var(--erd-ink); }
+  #erd [stroke="#29235c"] { stroke: var(--erd-ink); }
+  #erd.focusing .node.dim, #erd.focusing .edge.dim { opacity: var(--dim); }
+  #erd .node.hit > * { outline: none; }
+  .toolbar {
+    position: fixed; top: 12px; left: 12px; right: 12px; display: flex;
+    gap: 8px; align-items: center; flex-wrap: wrap; z-index: 10;
+    pointer-events: none;
+  }
+  .toolbar > * { pointer-events: auto; }
+  .group {
+    display: flex; gap: 4px; align-items: center; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 10px; padding: 4px 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+  }
+  button {
+    font: inherit; color: var(--fg); background: transparent; border: 0;
+    border-radius: 7px; padding: 6px 10px; cursor: pointer; white-space: nowrap;
+  }
+  button:hover { background: var(--border); }
+  input[type=search] {
+    font: inherit; color: var(--fg); background: var(--bg);
+    border: 1px solid var(--border); border-radius: 7px; padding: 6px 10px;
+    width: 190px; outline: none;
+  }
+  input[type=search]:focus { border-color: var(--accent); }
+  .legend { gap: 12px; }
+  .chip { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .chip i { width: 12px; height: 12px; border-radius: 3px; display: inline-block; }
+  .hint {
+    position: fixed; bottom: 10px; left: 12px; color: var(--muted);
+    font-size: 12px; z-index: 10; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 8px; padding: 4px 9px;
+  }
+  #count { color: var(--muted); font-size: 12px; padding: 0 4px; }
+  #matches {
+    position: absolute; top: 40px; left: 0; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
+    min-width: 220px; max-height: 260px; overflow-y: auto; display: none;
+  }
+  #matches div { padding: 6px 10px; cursor: pointer; }
+  #matches div:hover, #matches div.active { background: var(--border); }
+  .searchwrap { position: relative; }
+</style>
+</head>
+<body>
+<div id="stage">
+<svg id="erd" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0.00 0.00 10996.36 17107.29" preserveAspectRatio="xMidYMid meet">
+<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 17103.29)">
+<title>dbml</title>
+<!-- public.graph_metrics -->
+<g id="public.graph_metrics" class="node">
+<title>public.graph_metrics</title>
+<g id="a_public.graph_metrics"><a xlink:title="public.graph_metrics&#10;Change counters for triggering periodic epistemic status measurement">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.24" cy="-14410.9" rx="509.23" ry="299.63"/>
+<polygon fill="#475569" stroke="transparent" points="7758.24,-14560.9 7758.24,-14620.9 8474.24,-14620.9 8474.24,-14560.9 7758.24,-14560.9"/>
+<polygon fill="none" stroke="#29235c" points="7758.24,-14560.9 7758.24,-14620.9 8474.24,-14620.9 8474.24,-14560.9 7758.24,-14560.9"/>
+<text text-anchor="start" x="7906.42" y="-14582.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;public.graph_metrics &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7758.24,-14500.9 7758.24,-14560.9 8474.24,-14560.9 8474.24,-14500.9 7758.24,-14500.9"/>
+<polygon fill="none" stroke="#29235c" points="7758.24,-14500.9 7758.24,-14560.9 8474.24,-14560.9 8474.24,-14500.9 7758.24,-14500.9"/>
+<text text-anchor="start" x="7769.24" y="-14522.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">metric_name</text>
+<text text-anchor="start" x="7954.13" y="-14522.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8104.11" y="-14522.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="8424.15" y="-14522.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8433.04" y="-14522.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7758.24,-14440.9 7758.24,-14500.9 8474.24,-14500.9 8474.24,-14440.9 7758.24,-14440.9"/>
+<polygon fill="none" stroke="#29235c" points="7758.24,-14440.9 7758.24,-14500.9 8474.24,-14500.9 8474.24,-14440.9 7758.24,-14440.9"/>
+<text text-anchor="start" x="7769.24" y="-14461.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">counter &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8347.69" y="-14462.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<text text-anchor="start" x="8424.15" y="-14462.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8433.04" y="-14462.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7758.24,-14380.9 7758.24,-14440.9 8474.24,-14440.9 8474.24,-14380.9 7758.24,-14380.9"/>
+<polygon fill="none" stroke="#29235c" points="7758.24,-14380.9 7758.24,-14440.9 8474.24,-14440.9 8474.24,-14380.9 7758.24,-14380.9"/>
+<text text-anchor="start" x="7769.24" y="-14401.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_measured_counter &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8347.69" y="-14402.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<text text-anchor="start" x="8424.15" y="-14402.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8433.04" y="-14402.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7758.24,-14320.9 7758.24,-14380.9 8474.24,-14380.9 8474.24,-14320.9 7758.24,-14320.9"/>
+<polygon fill="none" stroke="#29235c" points="7758.24,-14320.9 7758.24,-14380.9 8474.24,-14380.9 8474.24,-14320.9 7758.24,-14320.9"/>
+<text text-anchor="start" x="7768.81" y="-14341.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_measured_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8058.04" y="-14342.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7758.24,-14260.9 7758.24,-14320.9 8474.24,-14320.9 8474.24,-14260.9 7758.24,-14260.9"/>
+<polygon fill="none" stroke="#29235c" points="7758.24,-14260.9 7758.24,-14320.9 8474.24,-14320.9 8474.24,-14260.9 7758.24,-14260.9"/>
+<text text-anchor="start" x="7769.24" y="-14281.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8057.85" y="-14282.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7758.24,-14200.9 7758.24,-14260.9 8474.24,-14260.9 8474.24,-14200.9 7758.24,-14200.9"/>
+<polygon fill="none" stroke="#29235c" points="7758.24,-14200.9 7758.24,-14260.9 8474.24,-14260.9 8474.24,-14200.9 7758.24,-14200.9"/>
+<text text-anchor="start" x="7769.24" y="-14221.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">notes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8411.66" y="-14222.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7757.24,-14199.9 7757.24,-14621.9 8475.24,-14621.9 8475.24,-14199.9 7757.24,-14199.9"/>
+</a>
+</g>
+</g>
+<!-- public.schema_migrations -->
+<g id="public.schema_migrations" class="node">
+<title>public.schema_migrations</title>
+<g id="a_public.schema_migrations"><a xlink:title="public.schema_migrations&#10;Tracks applied schema migrations for safe schema evolution &#45; ADR&#45;040">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6172.61" cy="-16841.9" rx="461.98" ry="172.57"/>
+<polygon fill="#475569" stroke="transparent" points="5848.61,-16901.9 5848.61,-16961.9 6497.61,-16961.9 6497.61,-16901.9 5848.61,-16901.9"/>
+<polygon fill="none" stroke="#29235c" points="5848.61,-16901.9 5848.61,-16961.9 6497.61,-16961.9 6497.61,-16901.9 5848.61,-16901.9"/>
+<text text-anchor="start" x="5925.95" y="-16923.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;public.schema_migrations &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5848.61,-16841.9 5848.61,-16901.9 6497.61,-16901.9 6497.61,-16841.9 5848.61,-16841.9"/>
+<polygon fill="none" stroke="#29235c" points="5848.61,-16841.9 5848.61,-16901.9 6497.61,-16901.9 6497.61,-16841.9 5848.61,-16841.9"/>
+<text text-anchor="start" x="5859.61" y="-16863.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">version</text>
+<text text-anchor="start" x="5962.73" y="-16863.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6349.72" y="-16863.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6447.52" y="-16863.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6456.42" y="-16863.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5848.61,-16781.9 5848.61,-16841.9 6497.61,-16841.9 6497.61,-16781.9 5848.61,-16781.9"/>
+<polygon fill="none" stroke="#29235c" points="5848.61,-16781.9 5848.61,-16841.9 6497.61,-16841.9 6497.61,-16781.9 5848.61,-16781.9"/>
+<text text-anchor="start" x="5859.61" y="-16802.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6395.95" y="-16803.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="6447.52" y="-16803.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6456.42" y="-16803.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5848.61,-16721.9 5848.61,-16781.9 6497.61,-16781.9 6497.61,-16721.9 5848.61,-16721.9"/>
+<polygon fill="none" stroke="#29235c" points="5848.61,-16721.9 5848.61,-16781.9 6497.61,-16781.9 6497.61,-16721.9 5848.61,-16721.9"/>
+<text text-anchor="start" x="5859.52" y="-16742.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">applied_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6042.37" y="-16743.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<text text-anchor="start" x="6447.77" y="-16743.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6456.66" y="-16743.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5847.11,-16720.9 5847.11,-16962.9 6498.11,-16962.9 6498.11,-16720.9 5847.11,-16720.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.aggressiveness_profiles -->
+<g id="kg_api.aggressiveness_profiles" class="node">
+<title>kg_api.aggressiveness_profiles</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.71" cy="-13506.9" rx="442.8" ry="427.19"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7805.71,-13746.9 7805.71,-13806.9 8427.71,-13806.9 8427.71,-13746.9 7805.71,-13746.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13746.9 7805.71,-13806.9 8427.71,-13806.9 8427.71,-13746.9 7805.71,-13746.9"/>
+<text text-anchor="start" x="7831.29" y="-13768.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.aggressiveness_profiles &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13686.9 7805.71,-13746.9 8427.71,-13746.9 8427.71,-13686.9 7805.71,-13686.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13686.9 7805.71,-13746.9 8427.71,-13746.9 8427.71,-13686.9 7805.71,-13686.9"/>
+<text text-anchor="start" x="7816.71" y="-13708.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">profile_name</text>
+<text text-anchor="start" x="8001.63" y="-13708.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8075.37" y="-13708.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="8377.62" y="-13708.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8386.51" y="-13708.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13626.9 7805.71,-13686.9 8427.71,-13686.9 8427.71,-13626.9 7805.71,-13626.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13626.9 7805.71,-13686.9 8427.71,-13686.9 8427.71,-13626.9 7805.71,-13626.9"/>
+<text text-anchor="start" x="7816.71" y="-13647.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">control_x1 &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8144.67" y="-13648.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<text text-anchor="start" x="8377.62" y="-13648.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8386.51" y="-13648.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13566.9 7805.71,-13626.9 8427.71,-13626.9 8427.71,-13566.9 7805.71,-13566.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13566.9 7805.71,-13626.9 8427.71,-13626.9 8427.71,-13566.9 7805.71,-13566.9"/>
+<text text-anchor="start" x="7816.71" y="-13587.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">control_y1 &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8144.67" y="-13588.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<text text-anchor="start" x="8377.62" y="-13588.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8386.51" y="-13588.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13506.9 7805.71,-13566.9 8427.71,-13566.9 8427.71,-13506.9 7805.71,-13506.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13506.9 7805.71,-13566.9 8427.71,-13566.9 8427.71,-13506.9 7805.71,-13506.9"/>
+<text text-anchor="start" x="7816.71" y="-13527.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">control_x2 &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8144.67" y="-13528.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<text text-anchor="start" x="8377.62" y="-13528.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8386.51" y="-13528.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13446.9 7805.71,-13506.9 8427.71,-13506.9 8427.71,-13446.9 7805.71,-13446.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13446.9 7805.71,-13506.9 8427.71,-13506.9 8427.71,-13446.9 7805.71,-13446.9"/>
+<text text-anchor="start" x="7816.71" y="-13467.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">control_y2 &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8144.67" y="-13468.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<text text-anchor="start" x="8377.62" y="-13468.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8386.51" y="-13468.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13386.9 7805.71,-13446.9 8427.71,-13446.9 8427.71,-13386.9 7805.71,-13386.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13386.9 7805.71,-13446.9 8427.71,-13446.9 8427.71,-13386.9 7805.71,-13386.9"/>
+<text text-anchor="start" x="7816.71" y="-13407.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8365.13" y="-13408.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13326.9 7805.71,-13386.9 8427.71,-13386.9 8427.71,-13326.9 7805.71,-13326.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13326.9 7805.71,-13386.9 8427.71,-13386.9 8427.71,-13326.9 7805.71,-13326.9"/>
+<text text-anchor="start" x="7816.71" y="-13347.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_builtin &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8302.87" y="-13348.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13266.9 7805.71,-13326.9 8427.71,-13326.9 8427.71,-13266.9 7805.71,-13266.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13266.9 7805.71,-13326.9 8427.71,-13326.9 8427.71,-13266.9 7805.71,-13266.9"/>
+<text text-anchor="start" x="7816.71" y="-13287.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8011.31" y="-13288.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7805.71,-13206.9 7805.71,-13266.9 8427.71,-13266.9 8427.71,-13206.9 7805.71,-13206.9"/>
+<polygon fill="none" stroke="#29235c" points="7805.71,-13206.9 7805.71,-13266.9 8427.71,-13266.9 8427.71,-13206.9 7805.71,-13206.9"/>
+<text text-anchor="start" x="7816.37" y="-13227.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8011.51" y="-13228.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7804.71,-13205.9 7804.71,-13807.9 8428.71,-13807.9 8428.71,-13205.9 7804.71,-13205.9"/>
+</g>
+<!-- kg_api.ai_extraction_config -->
+<g id="kg_api.ai_extraction_config" class="node">
+<title>kg_api.ai_extraction_config</title>
+<g id="a_kg_api.ai_extraction_config"><a xlink:title="kg_api.ai_extraction_config&#10;AI extraction provider configuration for runtime&#45;switchable models &#45; ADR&#45;041">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9978.56" cy="-9137.9" rx="427.6" ry="808.86"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9678.56,-9647.9 9678.56,-9707.9 10279.56,-9707.9 10279.56,-9647.9 9678.56,-9647.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9647.9 9678.56,-9707.9 10279.56,-9707.9 10279.56,-9647.9 9678.56,-9647.9"/>
+<text text-anchor="start" x="9722.97" y="-9669.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.ai_extraction_config &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9587.9 9678.56,-9647.9 10279.56,-9647.9 10279.56,-9587.9 9678.56,-9587.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9587.9 9678.56,-9647.9 10279.56,-9647.9 10279.56,-9587.9 9678.56,-9587.9"/>
+<text text-anchor="start" x="9689.56" y="-9609.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="9714.45" y="-9609.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10131.66" y="-9609.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10229.46" y="-9609.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10238.36" y="-9609.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9527.9 9678.56,-9587.9 10279.56,-9587.9 10279.56,-9527.9 9678.56,-9527.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9527.9 9678.56,-9587.9 10279.56,-9587.9 10279.56,-9527.9 9678.56,-9527.9"/>
+<text text-anchor="start" x="9689.56" y="-9548.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9927.22" y="-9549.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="10229.46" y="-9549.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10238.36" y="-9549.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9467.9 9678.56,-9527.9 10279.56,-9527.9 10279.56,-9467.9 9678.56,-9467.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9467.9 9678.56,-9527.9 10279.56,-9527.9 10279.56,-9467.9 9678.56,-9467.9"/>
+<text text-anchor="start" x="9689.31" y="-9488.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">model_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9909.49" y="-9489.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="10229.53" y="-9489.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10238.42" y="-9489.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9407.9 9678.56,-9467.9 10279.56,-9467.9 10279.56,-9407.9 9678.56,-9407.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9407.9 9678.56,-9467.9 10279.56,-9467.9 10279.56,-9407.9 9678.56,-9407.9"/>
+<text text-anchor="start" x="9689.56" y="-9428.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">supports_vision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10154.72" y="-9429.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9347.9 9678.56,-9407.9 10279.56,-9407.9 10279.56,-9347.9 9678.56,-9347.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9347.9 9678.56,-9407.9 10279.56,-9407.9 10279.56,-9347.9 9678.56,-9347.9"/>
+<text text-anchor="start" x="9689.56" y="-9368.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">supports_json_mode &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10154.72" y="-9369.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9287.9 9678.56,-9347.9 10279.56,-9347.9 10279.56,-9287.9 9678.56,-9287.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9287.9 9678.56,-9347.9 10279.56,-9347.9 10279.56,-9287.9 9678.56,-9287.9"/>
+<text text-anchor="start" x="9689.56" y="-9308.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_tokens &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10170.75" y="-9309.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9227.9 9678.56,-9287.9 10279.56,-9287.9 10279.56,-9227.9 9678.56,-9227.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9227.9 9678.56,-9287.9 10279.56,-9287.9 10279.56,-9227.9 9678.56,-9227.9"/>
+<text text-anchor="start" x="9689.56" y="-9248.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9907.63" y="-9249.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9167.9 9678.56,-9227.9 10279.56,-9227.9 10279.56,-9167.9 9678.56,-9167.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9167.9 9678.56,-9227.9 10279.56,-9227.9 10279.56,-9167.9 9678.56,-9167.9"/>
+<text text-anchor="start" x="9689.56" y="-9188.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9907.63" y="-9189.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9107.9 9678.56,-9167.9 10279.56,-9167.9 10279.56,-9107.9 9678.56,-9107.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9107.9 9678.56,-9167.9 10279.56,-9167.9 10279.56,-9107.9 9678.56,-9107.9"/>
+<text text-anchor="start" x="9689.56" y="-9128.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9948.52" y="-9129.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-9047.9 9678.56,-9107.9 10279.56,-9107.9 10279.56,-9047.9 9678.56,-9047.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-9047.9 9678.56,-9107.9 10279.56,-9107.9 10279.56,-9047.9 9678.56,-9047.9"/>
+<text text-anchor="start" x="9689.56" y="-9068.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10154.72" y="-9069.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8987.9 9678.56,-9047.9 10279.56,-9047.9 10279.56,-8987.9 9678.56,-8987.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8987.9 9678.56,-9047.9 10279.56,-9047.9 10279.56,-8987.9 9678.56,-8987.9"/>
+<text text-anchor="start" x="9689.56" y="-9008.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">base_url &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9948.52" y="-9009.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8927.9 9678.56,-8987.9 10279.56,-8987.9 10279.56,-8927.9 9678.56,-8927.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8927.9 9678.56,-8987.9 10279.56,-8987.9 10279.56,-8927.9 9678.56,-8927.9"/>
+<text text-anchor="start" x="9689.56" y="-8948.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">temperature &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10035.61" y="-8949.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8867.9 9678.56,-8927.9 10279.56,-8927.9 10279.56,-8867.9 9678.56,-8867.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8867.9 9678.56,-8927.9 10279.56,-8927.9 10279.56,-8867.9 9678.56,-8867.9"/>
+<text text-anchor="start" x="9689.56" y="-8888.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">top_p &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10035.61" y="-8889.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8807.9 9678.56,-8867.9 10279.56,-8867.9 10279.56,-8807.9 9678.56,-8807.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8807.9 9678.56,-8867.9 10279.56,-8867.9 10279.56,-8807.9 9678.56,-8807.9"/>
+<text text-anchor="start" x="9689.56" y="-8828.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">gpu_layers &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10170.75" y="-8829.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8747.9 9678.56,-8807.9 10279.56,-8807.9 10279.56,-8747.9 9678.56,-8747.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8747.9 9678.56,-8807.9 10279.56,-8807.9 10279.56,-8747.9 9678.56,-8747.9"/>
+<text text-anchor="start" x="9689.56" y="-8768.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">num_threads &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10170.75" y="-8769.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8687.9 9678.56,-8747.9 10279.56,-8747.9 10279.56,-8687.9 9678.56,-8687.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8687.9 9678.56,-8747.9 10279.56,-8747.9 10279.56,-8687.9 9678.56,-8687.9"/>
+<text text-anchor="start" x="9689.56" y="-8708.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">thinking_mode &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9966.31" y="-8709.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8627.9 9678.56,-8687.9 10279.56,-8687.9 10279.56,-8627.9 9678.56,-8627.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8627.9 9678.56,-8687.9 10279.56,-8687.9 10279.56,-8627.9 9678.56,-8627.9"/>
+<text text-anchor="start" x="9689.56" y="-8648.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_concurrent_requests &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10170.75" y="-8649.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9678.56,-8567.9 9678.56,-8627.9 10279.56,-8627.9 10279.56,-8567.9 9678.56,-8567.9"/>
+<polygon fill="none" stroke="#29235c" points="9678.56,-8567.9 9678.56,-8627.9 10279.56,-8627.9 10279.56,-8567.9 9678.56,-8567.9"/>
+<text text-anchor="start" x="9689.56" y="-8588.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_retries &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10170.75" y="-8589.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9677.06,-8566.9 9677.06,-9708.9 10280.06,-9708.9 10280.06,-8566.9 9677.06,-8566.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.ai_vision_config -->
+<g id="kg_api.ai_vision_config" class="node">
+<title>kg_api.ai_vision_config</title>
+<g id="a_kg_api.ai_vision_config"><a xlink:title="kg_api.ai_vision_config&#10;Active vision (image&#45;&gt;prose) provider selection — ADR&#45;802 / #378. Selection&#45;only; connectivity reused from per&#45;provider config.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2535.56" cy="-14410.9" rx="427.6" ry="427.19"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2235.56,-14650.9 2235.56,-14710.9 2836.56,-14710.9 2836.56,-14650.9 2235.56,-14650.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14650.9 2235.56,-14710.9 2836.56,-14710.9 2836.56,-14650.9 2235.56,-14650.9"/>
+<text text-anchor="start" x="2308.43" y="-14672.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.ai_vision_config &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14590.9 2235.56,-14650.9 2836.56,-14650.9 2836.56,-14590.9 2235.56,-14590.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14590.9 2235.56,-14650.9 2836.56,-14650.9 2836.56,-14590.9 2235.56,-14590.9"/>
+<text text-anchor="start" x="2246.56" y="-14612.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2271.45" y="-14612.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2688.66" y="-14612.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2786.46" y="-14612.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2795.36" y="-14612.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14530.9 2235.56,-14590.9 2836.56,-14590.9 2836.56,-14530.9 2235.56,-14530.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14530.9 2235.56,-14590.9 2836.56,-14590.9 2836.56,-14530.9 2235.56,-14530.9"/>
+<text text-anchor="start" x="2246.56" y="-14551.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2484.22" y="-14552.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2786.46" y="-14552.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2795.36" y="-14552.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14470.9 2235.56,-14530.9 2836.56,-14530.9 2836.56,-14470.9 2235.56,-14470.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14470.9 2235.56,-14530.9 2836.56,-14530.9 2836.56,-14470.9 2235.56,-14470.9"/>
+<text text-anchor="start" x="2246.31" y="-14491.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">model_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2466.49" y="-14492.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="2786.53" y="-14492.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2795.42" y="-14492.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14410.9 2235.56,-14470.9 2836.56,-14470.9 2836.56,-14410.9 2235.56,-14410.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14410.9 2235.56,-14470.9 2836.56,-14470.9 2836.56,-14410.9 2235.56,-14410.9"/>
+<text text-anchor="start" x="2246.56" y="-14431.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_tokens &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2727.75" y="-14432.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14350.9 2235.56,-14410.9 2836.56,-14410.9 2836.56,-14350.9 2235.56,-14350.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14350.9 2235.56,-14410.9 2836.56,-14410.9 2836.56,-14350.9 2235.56,-14350.9"/>
+<text text-anchor="start" x="2246.56" y="-14371.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">temperature &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2592.61" y="-14372.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14290.9 2235.56,-14350.9 2836.56,-14350.9 2836.56,-14290.9 2235.56,-14290.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14290.9 2235.56,-14350.9 2836.56,-14350.9 2836.56,-14290.9 2235.56,-14290.9"/>
+<text text-anchor="start" x="2246.56" y="-14311.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2464.63" y="-14312.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14230.9 2235.56,-14290.9 2836.56,-14290.9 2836.56,-14230.9 2235.56,-14230.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14230.9 2235.56,-14290.9 2836.56,-14290.9 2836.56,-14230.9 2235.56,-14230.9"/>
+<text text-anchor="start" x="2246.56" y="-14251.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2464.63" y="-14252.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14170.9 2235.56,-14230.9 2836.56,-14230.9 2836.56,-14170.9 2235.56,-14170.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14170.9 2235.56,-14230.9 2836.56,-14230.9 2836.56,-14170.9 2235.56,-14170.9"/>
+<text text-anchor="start" x="2246.56" y="-14191.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2505.52" y="-14192.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2235.56,-14110.9 2235.56,-14170.9 2836.56,-14170.9 2836.56,-14110.9 2235.56,-14110.9"/>
+<polygon fill="none" stroke="#29235c" points="2235.56,-14110.9 2235.56,-14170.9 2836.56,-14170.9 2836.56,-14110.9 2235.56,-14110.9"/>
+<text text-anchor="start" x="2246.56" y="-14131.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2711.72" y="-14132.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2234.06,-14109.9 2234.06,-14711.9 2837.06,-14711.9 2837.06,-14109.9 2234.06,-14109.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.annealing_options -->
+<g id="kg_api.annealing_options" class="node">
+<title>kg_api.annealing_options</title>
+<g id="a_kg_api.annealing_options"><a xlink:title="kg_api.annealing_options&#10;Tunable parameters for ontology annealing cycles (ADR&#45;200 Phase 3b). Code defaults apply when a key is absent; database values override.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9978.53" cy="-16841.9" rx="410.66" ry="214.92"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9690.53,-16931.9 9690.53,-16991.9 10267.53,-16991.9 10267.53,-16931.9 9690.53,-16931.9"/>
+<polygon fill="none" stroke="#29235c" points="9690.53,-16931.9 9690.53,-16991.9 10267.53,-16991.9 10267.53,-16931.9 9690.53,-16931.9"/>
+<text text-anchor="start" x="9735.37" y="-16953.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.annealing_options &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9690.53,-16871.9 9690.53,-16931.9 10267.53,-16931.9 10267.53,-16871.9 9690.53,-16871.9"/>
+<polygon fill="none" stroke="#29235c" points="9690.53,-16871.9 9690.53,-16931.9 10267.53,-16931.9 10267.53,-16871.9 9690.53,-16871.9"/>
+<text text-anchor="start" x="9701.53" y="-16893.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">key</text>
+<text text-anchor="start" x="9751.32" y="-16893.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9897.4" y="-16893.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="10217.44" y="-16893.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10226.33" y="-16893.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9690.53,-16811.9 9690.53,-16871.9 10267.53,-16871.9 10267.53,-16811.9 9690.53,-16811.9"/>
+<polygon fill="none" stroke="#29235c" points="9690.53,-16811.9 9690.53,-16871.9 10267.53,-16871.9 10267.53,-16811.9 9690.53,-16811.9"/>
+<text text-anchor="start" x="9701.53" y="-16832.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">value &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10165.86" y="-16833.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="10217.44" y="-16833.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10226.33" y="-16833.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9690.53,-16751.9 9690.53,-16811.9 10267.53,-16811.9 10267.53,-16751.9 9690.53,-16751.9"/>
+<polygon fill="none" stroke="#29235c" points="9690.53,-16751.9 9690.53,-16811.9 10267.53,-16811.9 10267.53,-16751.9 9690.53,-16751.9"/>
+<text text-anchor="start" x="9701.53" y="-16772.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10204.95" y="-16773.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9690.53,-16691.9 9690.53,-16751.9 10267.53,-16751.9 10267.53,-16691.9 9690.53,-16691.9"/>
+<polygon fill="none" stroke="#29235c" points="9690.53,-16691.9 9690.53,-16751.9 10267.53,-16751.9 10267.53,-16691.9 9690.53,-16691.9"/>
+<text text-anchor="start" x="9701.19" y="-16712.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9896.07" y="-16713.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9689.03,-16690.9 9689.03,-16992.9 10268.03,-16992.9 10268.03,-16690.9 9689.03,-16690.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.annealing_pressure_history -->
+<g id="kg_api.annealing_pressure_history" class="node">
+<title>kg_api.annealing_pressure_history</title>
+<g id="a_kg_api.annealing_pressure_history"><a xlink:title="kg_api.annealing_pressure_history&#10;One row per annealing cycle: ecological snapshot + Bezier pressure read&#45;out (#249, ADR&#45;206 §Phase 3). Drives the web admin ”pressure” panel and the future trend chart.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9978.05" cy="-12346.9" rx="518.12" ry="427.19"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9614.05,-12586.9 9614.05,-12646.9 10343.05,-12646.9 10343.05,-12586.9 9614.05,-12586.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12586.9 9614.05,-12646.9 10343.05,-12646.9 10343.05,-12586.9 9614.05,-12586.9"/>
+<text text-anchor="start" x="9668.23" y="-12608.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.annealing_pressure_history &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12526.9 9614.05,-12586.9 10343.05,-12586.9 10343.05,-12526.9 9614.05,-12526.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12526.9 9614.05,-12586.9 10343.05,-12586.9 10343.05,-12526.9 9614.05,-12526.9"/>
+<text text-anchor="start" x="9625.05" y="-12548.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="9649.94" y="-12548.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10195.15" y="-12548.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10292.96" y="-12548.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12548.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12466.9 9614.05,-12526.9 10343.05,-12526.9 10343.05,-12466.9 9614.05,-12466.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12466.9 9614.05,-12526.9 10343.05,-12526.9 10343.05,-12466.9 9614.05,-12466.9"/>
+<text text-anchor="start" x="9625.05" y="-12487.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">epoch &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10195.15" y="-12488.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10292.96" y="-12488.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12488.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12406.9 9614.05,-12466.9 10343.05,-12466.9 10343.05,-12406.9 9614.05,-12406.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12406.9 9614.05,-12466.9 10343.05,-12466.9 10343.05,-12406.9 9614.05,-12406.9"/>
+<text text-anchor="start" x="9625.05" y="-12427.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">total_ontologies &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10195.15" y="-12428.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10292.96" y="-12428.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12428.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12346.9 9614.05,-12406.9 10343.05,-12406.9 10343.05,-12346.9 9614.05,-12346.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12346.9 9614.05,-12406.9 10343.05,-12406.9 10343.05,-12346.9 9614.05,-12346.9"/>
+<text text-anchor="start" x="9625.05" y="-12367.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">total_concepts &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10195.15" y="-12368.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10292.96" y="-12368.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12368.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12286.9 9614.05,-12346.9 10343.05,-12346.9 10343.05,-12286.9 9614.05,-12286.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12286.9 9614.05,-12346.9 10343.05,-12346.9 10343.05,-12286.9 9614.05,-12286.9"/>
+<text text-anchor="start" x="9624.68" y="-12307.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">avg_concepts_per_ontology &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10060.03" y="-12308.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<text text-anchor="start" x="10292.97" y="-12308.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.87" y="-12308.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12226.9 9614.05,-12286.9 10343.05,-12286.9 10343.05,-12226.9 9614.05,-12226.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12226.9 9614.05,-12286.9 10343.05,-12286.9 10343.05,-12226.9 9614.05,-12226.9"/>
+<text text-anchor="start" x="9625.05" y="-12247.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">pressure_score &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10060.01" y="-12248.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<text text-anchor="start" x="10292.96" y="-12248.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12248.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12166.9 9614.05,-12226.9 10343.05,-12226.9 10343.05,-12166.9 9614.05,-12166.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12166.9 9614.05,-12226.9 10343.05,-12226.9 10343.05,-12166.9 9614.05,-12166.9"/>
+<text text-anchor="start" x="9625.05" y="-12187.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">pressure_zone &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9990.71" y="-12188.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="10292.96" y="-12188.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12188.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12106.9 9614.05,-12166.9 10343.05,-12166.9 10343.05,-12106.9 9614.05,-12106.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12106.9 9614.05,-12166.9 10343.05,-12166.9 10343.05,-12106.9 9614.05,-12106.9"/>
+<text text-anchor="start" x="9625.05" y="-12127.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">pressure_recommendation &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10216.49" y="-12128.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<text text-anchor="start" x="10292.96" y="-12128.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12128.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9614.05,-12046.9 9614.05,-12106.9 10343.05,-12106.9 10343.05,-12046.9 9614.05,-12046.9"/>
+<polygon fill="none" stroke="#29235c" points="9614.05,-12046.9 9614.05,-12106.9 10343.05,-12106.9 10343.05,-12046.9 9614.05,-12046.9"/>
+<text text-anchor="start" x="9625.05" y="-12067.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">recorded_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9932.03" y="-12068.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10292.96" y="-12068.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10301.85" y="-12068.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9612.55,-12045.9 9612.55,-12647.9 10343.55,-12647.9 10343.55,-12045.9 9612.55,-12045.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.annealing_proposals -->
+<g id="kg_api.annealing_proposals" class="node">
+<title>kg_api.annealing_proposals</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6172.03" cy="-9137.9" rx="460.15" ry="978.77"/>
+<polygon fill="#7c3aed" stroke="transparent" points="5849.03,-9767.9 5849.03,-9827.9 6496.03,-9827.9 6496.03,-9767.9 5849.03,-9767.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9767.9 5849.03,-9827.9 6496.03,-9827.9 6496.03,-9767.9 5849.03,-9767.9"/>
+<text text-anchor="start" x="5911.1" y="-9789.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.annealing_proposals &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9707.9 5849.03,-9767.9 6496.03,-9767.9 6496.03,-9707.9 5849.03,-9707.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9707.9 5849.03,-9767.9 6496.03,-9767.9 6496.03,-9707.9 5849.03,-9707.9"/>
+<text text-anchor="start" x="5860.03" y="-9729.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="5884.92" y="-9729.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6348.14" y="-9729.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6445.94" y="-9729.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-9729.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9647.9 5849.03,-9707.9 6496.03,-9707.9 6496.03,-9647.9 5849.03,-9647.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9647.9 5849.03,-9707.9 6496.03,-9707.9 6496.03,-9647.9 5849.03,-9647.9"/>
+<text text-anchor="start" x="5860.03" y="-9668.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">proposal_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6143.69" y="-9669.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="6445.94" y="-9669.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-9669.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9587.9 5849.03,-9647.9 6496.03,-9647.9 6496.03,-9587.9 5849.03,-9587.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9587.9 5849.03,-9647.9 6496.03,-9647.9 6496.03,-9587.9 5849.03,-9587.9"/>
+<text text-anchor="start" x="5860.03" y="-9608.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">ontology_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6125.9" y="-9609.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="6445.94" y="-9609.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-9609.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9527.9 5849.03,-9587.9 6496.03,-9587.9 6496.03,-9527.9 5849.03,-9527.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9527.9 5849.03,-9587.9 6496.03,-9587.9 6496.03,-9527.9 5849.03,-9527.9"/>
+<text text-anchor="start" x="5859.58" y="-9548.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">anchor_concept_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6165.01" y="-9549.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9467.9 5849.03,-9527.9 6496.03,-9527.9 6496.03,-9467.9 5849.03,-9467.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9467.9 5849.03,-9527.9 6496.03,-9527.9 6496.03,-9467.9 5849.03,-9467.9"/>
+<text text-anchor="start" x="5860.03" y="-9488.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">target_ontology &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6164.99" y="-9489.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9407.9 5849.03,-9467.9 6496.03,-9467.9 6496.03,-9407.9 5849.03,-9407.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9407.9 5849.03,-9467.9 6496.03,-9467.9 6496.03,-9407.9 5849.03,-9407.9"/>
+<text text-anchor="start" x="5860.03" y="-9428.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reasoning &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6394.36" y="-9429.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="6445.94" y="-9429.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-9429.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9347.9 5849.03,-9407.9 6496.03,-9407.9 6496.03,-9347.9 5849.03,-9347.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9347.9 5849.03,-9407.9 6496.03,-9407.9 6496.03,-9347.9 5849.03,-9347.9"/>
+<text text-anchor="start" x="5860.03" y="-9368.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">mass_score &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6287.69" y="-9369.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(10,4)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9287.9 5849.03,-9347.9 6496.03,-9347.9 6496.03,-9287.9 5849.03,-9287.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9287.9 5849.03,-9347.9 6496.03,-9347.9 6496.03,-9287.9 5849.03,-9287.9"/>
+<text text-anchor="start" x="5860.03" y="-9308.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">coherence_score &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6287.69" y="-9309.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(10,4)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9227.9 5849.03,-9287.9 6496.03,-9287.9 6496.03,-9227.9 5849.03,-9227.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9227.9 5849.03,-9287.9 6496.03,-9287.9 6496.03,-9227.9 5849.03,-9227.9"/>
+<text text-anchor="start" x="5860.03" y="-9248.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">protection_score &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6287.69" y="-9249.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(10,4)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9167.9 5849.03,-9227.9 6496.03,-9227.9 6496.03,-9167.9 5849.03,-9167.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9167.9 5849.03,-9227.9 6496.03,-9227.9 6496.03,-9167.9 5849.03,-9167.9"/>
+<text text-anchor="start" x="5860.03" y="-9188.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6143.69" y="-9189.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="6445.94" y="-9189.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-9189.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9107.9 5849.03,-9167.9 6496.03,-9167.9 6496.03,-9107.9 5849.03,-9107.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9107.9 5849.03,-9167.9 6496.03,-9167.9 6496.03,-9107.9 5849.03,-9107.9"/>
+<text text-anchor="start" x="5860.03" y="-9128.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6085.02" y="-9129.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="6445.94" y="-9129.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-9129.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-9047.9 5849.03,-9107.9 6496.03,-9107.9 6496.03,-9047.9 5849.03,-9047.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-9047.9 5849.03,-9107.9 6496.03,-9107.9 6496.03,-9047.9 5849.03,-9047.9"/>
+<text text-anchor="start" x="5860.03" y="-9068.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at_epoch &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6348.14" y="-9069.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6445.94" y="-9069.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-9069.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8987.9 5849.03,-9047.9 6496.03,-9047.9 6496.03,-8987.9 5849.03,-8987.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8987.9 5849.03,-9047.9 6496.03,-9047.9 6496.03,-8987.9 5849.03,-8987.9"/>
+<text text-anchor="start" x="5860.03" y="-9008.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reviewed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6124.11" y="-9009.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8927.9 5849.03,-8987.9 6496.03,-8987.9 6496.03,-8927.9 5849.03,-8927.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8927.9 5849.03,-8987.9 6496.03,-8987.9 6496.03,-8927.9 5849.03,-8927.9"/>
+<text text-anchor="start" x="5860.03" y="-8948.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reviewed_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6164.99" y="-8949.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8867.9 5849.03,-8927.9 6496.03,-8927.9 6496.03,-8867.9 5849.03,-8867.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8867.9 5849.03,-8927.9 6496.03,-8927.9 6496.03,-8867.9 5849.03,-8867.9"/>
+<text text-anchor="start" x="5860.03" y="-8888.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reviewer_notes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6433.45" y="-8889.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8807.9 5849.03,-8867.9 6496.03,-8867.9 6496.03,-8807.9 5849.03,-8807.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8807.9 5849.03,-8867.9 6496.03,-8867.9 6496.03,-8807.9 5849.03,-8807.9"/>
+<text text-anchor="start" x="5860.03" y="-8828.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6124.11" y="-8829.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8747.9 5849.03,-8807.9 6496.03,-8807.9 6496.03,-8747.9 5849.03,-8747.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8747.9 5849.03,-8807.9 6496.03,-8807.9 6496.03,-8747.9 5849.03,-8747.9"/>
+<text text-anchor="start" x="5860.03" y="-8768.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">executed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6124.11" y="-8769.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8687.9 5849.03,-8747.9 6496.03,-8747.9 6496.03,-8687.9 5849.03,-8687.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8687.9 5849.03,-8747.9 6496.03,-8747.9 6496.03,-8687.9 5849.03,-8687.9"/>
+<text text-anchor="start" x="5860.03" y="-8708.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">execution_result &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6408.56" y="-8709.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8627.9 5849.03,-8687.9 6496.03,-8687.9 6496.03,-8627.9 5849.03,-8627.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8627.9 5849.03,-8687.9 6496.03,-8687.9 6496.03,-8627.9 5849.03,-8627.9"/>
+<text text-anchor="start" x="5860.03" y="-8648.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">suggested_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6164.99" y="-8649.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8567.9 5849.03,-8627.9 6496.03,-8627.9 6496.03,-8567.9 5849.03,-8567.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8567.9 5849.03,-8627.9 6496.03,-8627.9 6496.03,-8567.9 5849.03,-8567.9"/>
+<text text-anchor="start" x="5860.03" y="-8588.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">suggested_description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6433.45" y="-8589.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8507.9 5849.03,-8567.9 6496.03,-8567.9 6496.03,-8507.9 5849.03,-8507.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8507.9 5849.03,-8567.9 6496.03,-8567.9 6496.03,-8507.9 5849.03,-8507.9"/>
+<text text-anchor="start" x="5860.03" y="-8528.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">proposal_kind &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6143.69" y="-8529.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="6445.94" y="-8529.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.83" y="-8529.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5849.03,-8447.9 5849.03,-8507.9 6496.03,-8507.9 6496.03,-8447.9 5849.03,-8447.9"/>
+<polygon fill="none" stroke="#29235c" points="5849.03,-8447.9 5849.03,-8507.9 6496.03,-8507.9 6496.03,-8447.9 5849.03,-8447.9"/>
+<text text-anchor="start" x="5860.03" y="-8468.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">params &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6408.56" y="-8469.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5847.53,-8446.9 5847.53,-9828.9 6496.53,-9828.9 6496.53,-8446.9 5847.53,-8446.9"/>
+</g>
+<!-- kg_api.artifacts -->
+<g id="kg_api.artifacts" class="node">
+<title>kg_api.artifacts</title>
+<g id="a_kg_api.artifacts"><a xlink:title="kg_api.artifacts&#10;Computed artifact metadata with Garage blob pointers (ADR&#45;083)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="1485.5" cy="-1732.9" rx="433" ry="681.8"/>
+<polygon fill="#7c3aed" stroke="transparent" points="1181.5,-2152.9 1181.5,-2212.9 1789.5,-2212.9 1789.5,-2152.9 1181.5,-2152.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-2152.9 1181.5,-2212.9 1789.5,-2212.9 1789.5,-2152.9 1181.5,-2152.9"/>
+<text text-anchor="start" x="1315.67" y="-2174.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.artifacts &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-2092.9 1181.5,-2152.9 1789.5,-2152.9 1789.5,-2092.9 1181.5,-2092.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-2092.9 1181.5,-2152.9 1789.5,-2152.9 1789.5,-2092.9 1181.5,-2092.9"/>
+<text text-anchor="start" x="1192.5" y="-2114.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="1217.39" y="-2114.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1641.61" y="-2114.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="1739.41" y="-2114.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1748.3" y="-2114.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-2032.9 1181.5,-2092.9 1789.5,-2092.9 1789.5,-2032.9 1181.5,-2032.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-2032.9 1181.5,-2092.9 1789.5,-2092.9 1789.5,-2032.9 1181.5,-2032.9"/>
+<text text-anchor="start" x="1192.5" y="-2053.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">artifact_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1437.16" y="-2054.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="1739.41" y="-2054.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1748.3" y="-2054.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1972.9 1181.5,-2032.9 1789.5,-2032.9 1789.5,-1972.9 1181.5,-1972.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1972.9 1181.5,-2032.9 1789.5,-2032.9 1789.5,-1972.9 1181.5,-1972.9"/>
+<text text-anchor="start" x="1192.5" y="-1993.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">representation &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1437.16" y="-1994.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="1739.41" y="-1994.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1748.3" y="-1994.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1912.9 1181.5,-1972.9 1789.5,-1972.9 1789.5,-1912.9 1181.5,-1912.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1912.9 1181.5,-1972.9 1789.5,-1972.9 1789.5,-1912.9 1181.5,-1912.9"/>
+<text text-anchor="start" x="1192.5" y="-1933.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1458.46" y="-1934.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1852.9 1181.5,-1912.9 1789.5,-1912.9 1789.5,-1852.9 1181.5,-1852.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1852.9 1181.5,-1912.9 1789.5,-1912.9 1789.5,-1852.9 1181.5,-1852.9"/>
+<text text-anchor="start" x="1192.5" y="-1873.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">owner_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1680.7" y="-1874.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1792.9 1181.5,-1852.9 1789.5,-1852.9 1789.5,-1792.9 1181.5,-1792.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1792.9 1181.5,-1852.9 1789.5,-1852.9 1789.5,-1792.9 1181.5,-1792.9"/>
+<text text-anchor="start" x="1192.5" y="-1813.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">graph_epoch &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1662.95" y="-1814.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<text text-anchor="start" x="1739.41" y="-1814.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1748.3" y="-1814.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1732.9 1181.5,-1792.9 1789.5,-1792.9 1789.5,-1732.9 1181.5,-1732.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1732.9 1181.5,-1792.9 1789.5,-1792.9 1789.5,-1732.9 1181.5,-1732.9"/>
+<text text-anchor="start" x="1192.13" y="-1753.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1378.49" y="-1754.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="1739.41" y="-1754.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1748.31" y="-1754.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1672.9 1181.5,-1732.9 1789.5,-1732.9 1789.5,-1672.9 1181.5,-1672.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1672.9 1181.5,-1732.9 1789.5,-1732.9 1789.5,-1672.9 1181.5,-1672.9"/>
+<text text-anchor="start" x="1192.5" y="-1693.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1417.58" y="-1694.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1612.9 1181.5,-1672.9 1789.5,-1672.9 1789.5,-1612.9 1181.5,-1612.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1612.9 1181.5,-1672.9 1789.5,-1672.9 1789.5,-1612.9 1181.5,-1612.9"/>
+<text text-anchor="start" x="1192.5" y="-1633.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">parameters &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1662.94" y="-1634.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<text text-anchor="start" x="1739.41" y="-1634.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1748.3" y="-1634.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1552.9 1181.5,-1612.9 1789.5,-1612.9 1789.5,-1552.9 1181.5,-1552.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1552.9 1181.5,-1612.9 1789.5,-1612.9 1789.5,-1552.9 1181.5,-1552.9"/>
+<text text-anchor="start" x="1192.5" y="-1573.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1702.03" y="-1574.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1492.9 1181.5,-1552.9 1789.5,-1552.9 1789.5,-1492.9 1181.5,-1492.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1492.9 1181.5,-1552.9 1789.5,-1552.9 1789.5,-1492.9 1181.5,-1492.9"/>
+<text text-anchor="start" x="1192.5" y="-1513.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">inline_result &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1702.03" y="-1514.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1432.9 1181.5,-1492.9 1789.5,-1492.9 1789.5,-1432.9 1181.5,-1432.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1432.9 1181.5,-1492.9 1789.5,-1492.9 1789.5,-1432.9 1181.5,-1432.9"/>
+<text text-anchor="start" x="1192.5" y="-1453.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">garage_key &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1458.46" y="-1454.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1372.9 1181.5,-1432.9 1789.5,-1432.9 1789.5,-1372.9 1181.5,-1372.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1372.9 1181.5,-1432.9 1789.5,-1432.9 1789.5,-1372.9 1181.5,-1372.9"/>
+<text text-anchor="start" x="1192.5" y="-1393.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">query_definition_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1680.7" y="-1394.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1312.9 1181.5,-1372.9 1789.5,-1372.9 1789.5,-1312.9 1181.5,-1312.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1312.9 1181.5,-1372.9 1789.5,-1372.9 1789.5,-1312.9 1181.5,-1312.9"/>
+<text text-anchor="start" x="1192.5" y="-1333.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">ontology &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1458.46" y="-1334.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1181.5,-1252.9 1181.5,-1312.9 1789.5,-1312.9 1789.5,-1252.9 1181.5,-1252.9"/>
+<polygon fill="none" stroke="#29235c" points="1181.5,-1252.9 1181.5,-1312.9 1789.5,-1312.9 1789.5,-1252.9 1181.5,-1252.9"/>
+<text text-anchor="start" x="1192.5" y="-1273.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">concept_ids &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1709.14" y="-1274.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="1180.5,-1251.9 1180.5,-2213.9 1790.5,-2213.9 1790.5,-1251.9 1180.5,-1251.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.query_definitions -->
+<g id="kg_api.query_definitions" class="node">
+<title>kg_api.query_definitions</title>
+<g id="a_kg_api.query_definitions"><a xlink:title="kg_api.query_definitions&#10;Saved query recipes that can be re&#45;executed (ADR&#45;083)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2548.15" cy="-1852.9" rx="439.23" ry="384.83"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2240.15,-2062.9 2240.15,-2122.9 2857.15,-2122.9 2857.15,-2062.9 2240.15,-2062.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-2062.9 2240.15,-2122.9 2857.15,-2122.9 2857.15,-2062.9 2240.15,-2062.9"/>
+<text text-anchor="start" x="2313.9" y="-2084.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.query_definitions &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-2002.9 2240.15,-2062.9 2857.15,-2062.9 2857.15,-2002.9 2240.15,-2002.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-2002.9 2240.15,-2062.9 2857.15,-2062.9 2857.15,-2002.9 2240.15,-2002.9"/>
+<text text-anchor="start" x="2251.15" y="-2024.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2276.04" y="-2024.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2709.25" y="-2024.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2807.05" y="-2024.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2815.95" y="-2024.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-1942.9 2240.15,-2002.9 2857.15,-2002.9 2857.15,-1942.9 2240.15,-1942.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-1942.9 2240.15,-2002.9 2857.15,-2002.9 2857.15,-1942.9 2240.15,-1942.9"/>
+<text text-anchor="start" x="2251.15" y="-1963.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2487.02" y="-1964.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="2807.05" y="-1964.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2815.95" y="-1964.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-1882.9 2240.15,-1942.9 2857.15,-1942.9 2857.15,-1882.9 2240.15,-1882.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-1882.9 2240.15,-1942.9 2857.15,-1942.9 2857.15,-1882.9 2240.15,-1882.9"/>
+<text text-anchor="start" x="2251.15" y="-1903.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">definition_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2504.81" y="-1904.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2807.05" y="-1904.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2815.95" y="-1904.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-1822.9 2240.15,-1882.9 2857.15,-1882.9 2857.15,-1822.9 2240.15,-1822.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-1822.9 2240.15,-1882.9 2857.15,-1882.9 2857.15,-1822.9 2240.15,-1822.9"/>
+<text text-anchor="start" x="2251.15" y="-1843.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">definition &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2730.59" y="-1844.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<text text-anchor="start" x="2807.05" y="-1844.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2815.95" y="-1844.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-1762.9 2240.15,-1822.9 2857.15,-1822.9 2857.15,-1762.9 2240.15,-1762.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-1762.9 2240.15,-1822.9 2857.15,-1822.9 2857.15,-1762.9 2240.15,-1762.9"/>
+<text text-anchor="start" x="2251.15" y="-1783.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">owner_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2748.34" y="-1784.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-1702.9 2240.15,-1762.9 2857.15,-1762.9 2857.15,-1702.9 2240.15,-1702.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-1702.9 2240.15,-1762.9 2857.15,-1762.9 2857.15,-1702.9 2240.15,-1702.9"/>
+<text text-anchor="start" x="2251.15" y="-1723.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2446.13" y="-1724.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2807.05" y="-1724.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2815.95" y="-1724.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-1642.9 2240.15,-1702.9 2857.15,-1702.9 2857.15,-1642.9 2240.15,-1642.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-1642.9 2240.15,-1702.9 2857.15,-1702.9 2857.15,-1642.9 2240.15,-1642.9"/>
+<text text-anchor="start" x="2250.81" y="-1663.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2446.14" y="-1664.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2807.06" y="-1664.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2815.95" y="-1664.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2240.15,-1582.9 2240.15,-1642.9 2857.15,-1642.9 2857.15,-1582.9 2240.15,-1582.9"/>
+<polygon fill="none" stroke="#29235c" points="2240.15,-1582.9 2240.15,-1642.9 2857.15,-1642.9 2857.15,-1582.9 2240.15,-1582.9"/>
+<text text-anchor="start" x="2251.15" y="-1603.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2769.68" y="-1604.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2238.65,-1581.9 2238.65,-2123.9 2857.65,-2123.9 2857.65,-1581.9 2238.65,-1581.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.artifacts&#45;&gt;kg_api.query_definitions -->
+<!-- kg_api.artifacts&#45;&gt;kg_api.query_definitions -->
+<g id="edge2" class="edge">
+<title>kg_api.artifacts:e&#45;&gt;kg_api.query_definitions:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1790.5,-1402.9C2130.72,-1402.9 1900.24,-2020.05 2228.75,-2032.7"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2229.08,-2036.21 2239.15,-2032.9 2229.21,-2029.21 2229.08,-2036.21"/>
+</g>
+<!-- kg_auth.users -->
+<g id="kg_auth.users" class="node">
+<title>kg_auth.users</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="3577.56" cy="-5056.9" rx="455.25" ry="342.48"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="3257.56,-5236.9 3257.56,-5296.9 3897.56,-5296.9 3897.56,-5236.9 3257.56,-5236.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-5236.9 3257.56,-5296.9 3897.56,-5296.9 3897.56,-5236.9 3257.56,-5236.9"/>
+<text text-anchor="start" x="3414.83" y="-5258.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.users &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3257.56,-5176.9 3257.56,-5236.9 3897.56,-5236.9 3897.56,-5176.9 3257.56,-5176.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-5176.9 3257.56,-5236.9 3897.56,-5236.9 3897.56,-5176.9 3257.56,-5176.9"/>
+<text text-anchor="start" x="3268.56" y="-5198.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="3293.45" y="-5198.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3749.67" y="-5198.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="3847.47" y="-5198.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3856.36" y="-5198.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3257.56,-5116.9 3257.56,-5176.9 3897.56,-5176.9 3897.56,-5116.9 3257.56,-5116.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-5116.9 3257.56,-5176.9 3897.56,-5176.9 3897.56,-5116.9 3257.56,-5116.9"/>
+<text text-anchor="start" x="3268.56" y="-5137.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">username &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3527.43" y="-5138.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="3847.47" y="-5138.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3856.36" y="-5138.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3257.56,-5056.9 3257.56,-5116.9 3897.56,-5116.9 3897.56,-5056.9 3257.56,-5056.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-5056.9 3257.56,-5116.9 3897.56,-5116.9 3897.56,-5056.9 3257.56,-5056.9"/>
+<text text-anchor="start" x="3268.24" y="-5077.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">password_hash &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3527.49" y="-5078.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="3847.53" y="-5078.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3856.43" y="-5078.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3257.56,-4996.9 3257.56,-5056.9 3897.56,-5056.9 3897.56,-4996.9 3257.56,-4996.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-4996.9 3257.56,-5056.9 3897.56,-5056.9 3897.56,-4996.9 3257.56,-4996.9"/>
+<text text-anchor="start" x="3268.56" y="-5017.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">primary_role &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3545.22" y="-5018.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="3847.47" y="-5018.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3856.36" y="-5018.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3257.56,-4936.9 3257.56,-4996.9 3897.56,-4996.9 3897.56,-4936.9 3257.56,-4936.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-4936.9 3257.56,-4996.9 3897.56,-4996.9 3897.56,-4936.9 3257.56,-4936.9"/>
+<text text-anchor="start" x="3268.56" y="-4957.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3486.55" y="-4958.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="3847.47" y="-4958.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3856.36" y="-4958.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3257.56,-4876.9 3257.56,-4936.9 3897.56,-4936.9 3897.56,-4876.9 3257.56,-4876.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-4876.9 3257.56,-4936.9 3897.56,-4936.9 3897.56,-4876.9 3257.56,-4876.9"/>
+<text text-anchor="start" x="3268.56" y="-4897.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_login &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3525.64" y="-4898.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3257.56,-4816.9 3257.56,-4876.9 3897.56,-4876.9 3897.56,-4816.9 3257.56,-4816.9"/>
+<polygon fill="none" stroke="#29235c" points="3257.56,-4816.9 3257.56,-4876.9 3897.56,-4876.9 3897.56,-4816.9 3257.56,-4816.9"/>
+<text text-anchor="start" x="3268.56" y="-4837.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">disabled &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3772.73" y="-4838.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="3256.56,-4815.9 3256.56,-5297.9 3898.56,-5297.9 3898.56,-4815.9 3256.56,-4815.9"/>
+</g>
+<!-- kg_api.artifacts&#45;&gt;kg_auth.users -->
+<!-- kg_api.artifacts&#45;&gt;kg_auth.users -->
+<g id="edge4" class="edge">
+<title>kg_api.artifacts:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1790.5,-1882.9C2009.29,-1882.9 1843.08,-1564.33 2031.96,-1453.9 2428.06,-1222.31 2731.69,-1137.86 3064.33,-1453.9 3364.53,-1739.11 2847.72,-5149.59 3246.36,-5206.19"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.34,-5209.69 3256.56,-5206.9 3246.83,-5202.71 3246.34,-5209.69"/>
+</g>
+<!-- kg_api.catalog_edge -->
+<g id="kg_api.catalog_edge" class="node">
+<title>kg_api.catalog_edge</title>
+<g id="a_kg_api.catalog_edge"><a xlink:title="kg_api.catalog_edge&#10;ADR&#45;501: parent&#45;&gt;child membership edges projecting canonical :SCOPED_BY (ontology&lt;&#45;document) and :HAS_SOURCE/:APPEARS (document&lt;&#45;concept). A concept may have many parent documents (DAG).">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2536.01" cy="-16841.9" rx="402.19" ry="257.27"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2254.01,-16961.9 2254.01,-17021.9 2819.01,-17021.9 2819.01,-16961.9 2254.01,-16961.9"/>
+<polygon fill="none" stroke="#29235c" points="2254.01,-16961.9 2254.01,-17021.9 2819.01,-17021.9 2819.01,-16961.9 2254.01,-16961.9"/>
+<text text-anchor="start" x="2326.64" y="-16983.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.catalog_edge &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2254.01,-16901.9 2254.01,-16961.9 2819.01,-16961.9 2819.01,-16901.9 2254.01,-16901.9"/>
+<polygon fill="none" stroke="#29235c" points="2254.01,-16901.9 2254.01,-16961.9 2819.01,-16961.9 2819.01,-16901.9 2254.01,-16901.9"/>
+<text text-anchor="start" x="2264.64" y="-16923.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">parent_kind</text>
+<text text-anchor="start" x="2431.81" y="-16923.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2466.84" y="-16923.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(16)</text>
+<text text-anchor="start" x="2769.09" y="-16923.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2777.98" y="-16923.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2254.01,-16841.9 2254.01,-16901.9 2819.01,-16901.9 2819.01,-16841.9 2254.01,-16841.9"/>
+<polygon fill="none" stroke="#29235c" points="2254.01,-16841.9 2254.01,-16901.9 2819.01,-16901.9 2819.01,-16841.9 2254.01,-16841.9"/>
+<text text-anchor="start" x="2265.01" y="-16863.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">parent_id</text>
+<text text-anchor="start" x="2398.39" y="-16863.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2717.35" y="-16863.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2768.92" y="-16863.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2777.81" y="-16863.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2254.01,-16781.9 2254.01,-16841.9 2819.01,-16841.9 2819.01,-16781.9 2254.01,-16781.9"/>
+<polygon fill="none" stroke="#29235c" points="2254.01,-16781.9 2254.01,-16841.9 2819.01,-16841.9 2819.01,-16781.9 2254.01,-16781.9"/>
+<text text-anchor="start" x="2265.01" y="-16803.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">child_kind</text>
+<text text-anchor="start" x="2407.26" y="-16803.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2466.67" y="-16803.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(16)</text>
+<text text-anchor="start" x="2768.92" y="-16803.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2777.81" y="-16803.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2254.01,-16721.9 2254.01,-16781.9 2819.01,-16781.9 2819.01,-16721.9 2254.01,-16721.9"/>
+<polygon fill="none" stroke="#29235c" points="2254.01,-16721.9 2254.01,-16781.9 2819.01,-16781.9 2819.01,-16721.9 2254.01,-16721.9"/>
+<text text-anchor="start" x="2265.01" y="-16743.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">child_id</text>
+<text text-anchor="start" x="2373.47" y="-16743.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2717.35" y="-16743.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2768.92" y="-16743.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2777.81" y="-16743.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2254.01,-16661.9 2254.01,-16721.9 2819.01,-16721.9 2819.01,-16661.9 2254.01,-16661.9"/>
+<polygon fill="none" stroke="#29235c" points="2254.01,-16661.9 2254.01,-16721.9 2819.01,-16721.9 2819.01,-16661.9 2254.01,-16661.9"/>
+<text text-anchor="start" x="2265.01" y="-16682.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">graph_epoch &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2692.46" y="-16683.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<text text-anchor="start" x="2768.92" y="-16683.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2777.81" y="-16683.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2252.51,-16660.9 2252.51,-17022.9 2819.51,-17022.9 2819.51,-16660.9 2252.51,-16660.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.catalog_node -->
+<g id="kg_api.catalog_node" class="node">
+<title>kg_api.catalog_node</title>
+<g id="a_kg_api.catalog_node"><a xlink:title="kg_api.catalog_node&#10;ADR&#45;501: materialized identity/metadata for catalog nodes (ontology/document/concept). Source of truth is the AGE graph; rebuilt on graph epoch advance.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9978.36" cy="-13506.9" rx="436.98" ry="427.19"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9671.36,-13746.9 9671.36,-13806.9 10285.36,-13806.9 10285.36,-13746.9 9671.36,-13746.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13746.9 9671.36,-13806.9 10285.36,-13806.9 10285.36,-13746.9 9671.36,-13746.9"/>
+<text text-anchor="start" x="9768.49" y="-13768.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.catalog_node &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13686.9 9671.36,-13746.9 10285.36,-13746.9 10285.36,-13686.9 9671.36,-13686.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13686.9 9671.36,-13746.9 10285.36,-13746.9 10285.36,-13686.9 9671.36,-13686.9"/>
+<text text-anchor="start" x="9682.36" y="-13708.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">kind</text>
+<text text-anchor="start" x="9741.04" y="-13708.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9933.02" y="-13708.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(16)</text>
+<text text-anchor="start" x="10235.27" y="-13708.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13708.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13626.9 9671.36,-13686.9 10285.36,-13686.9 10285.36,-13626.9 9671.36,-13626.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13626.9 9671.36,-13686.9 10285.36,-13686.9 10285.36,-13626.9 9671.36,-13626.9"/>
+<text text-anchor="start" x="9682.36" y="-13648.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">node_id</text>
+<text text-anchor="start" x="9796.2" y="-13648.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10183.7" y="-13648.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="10235.27" y="-13648.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13648.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13566.9 9671.36,-13626.9 10285.36,-13626.9 10285.36,-13566.9 9671.36,-13566.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13566.9 9671.36,-13626.9 10285.36,-13626.9 10285.36,-13566.9 9671.36,-13566.9"/>
+<text text-anchor="start" x="9682.36" y="-13587.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10183.7" y="-13588.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="10235.27" y="-13588.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13588.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13506.9 9671.36,-13566.9 10285.36,-13566.9 10285.36,-13506.9 9671.36,-13506.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13506.9 9671.36,-13566.9 10285.36,-13566.9 10285.36,-13506.9 9671.36,-13506.9"/>
+<text text-anchor="start" x="9682.36" y="-13527.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">name_lower &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10183.7" y="-13528.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="10235.27" y="-13528.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13528.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13446.9 9671.36,-13506.9 10285.36,-13506.9 10285.36,-13446.9 9671.36,-13446.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13446.9 9671.36,-13506.9 10285.36,-13506.9 10285.36,-13446.9 9671.36,-13446.9"/>
+<text text-anchor="start" x="9682.36" y="-13467.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">child_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10137.47" y="-13468.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10235.27" y="-13468.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13468.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13386.9 9671.36,-13446.9 10285.36,-13446.9 10285.36,-13386.9 9671.36,-13386.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13386.9 9671.36,-13446.9 10285.36,-13446.9 10285.36,-13386.9 9671.36,-13386.9"/>
+<text text-anchor="start" x="9682.36" y="-13407.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">content_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9972.11" y="-13408.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(32)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13326.9 9671.36,-13386.9 10285.36,-13386.9 10285.36,-13326.9 9671.36,-13326.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13326.9 9671.36,-13386.9 10285.36,-13386.9 10285.36,-13326.9 9671.36,-13326.9"/>
+<text text-anchor="start" x="9682.36" y="-13347.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">properties &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10158.81" y="-13348.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<text text-anchor="start" x="10235.27" y="-13348.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13348.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13266.9 9671.36,-13326.9 10285.36,-13326.9 10285.36,-13266.9 9671.36,-13266.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13266.9 9671.36,-13326.9 10285.36,-13326.9 10285.36,-13266.9 9671.36,-13266.9"/>
+<text text-anchor="start" x="9682.36" y="-13287.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">graph_epoch &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10158.81" y="-13288.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<text text-anchor="start" x="10235.27" y="-13288.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13288.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9671.36,-13206.9 9671.36,-13266.9 10285.36,-13266.9 10285.36,-13206.9 9671.36,-13206.9"/>
+<polygon fill="none" stroke="#29235c" points="9671.36,-13206.9 9671.36,-13266.9 10285.36,-13266.9 10285.36,-13206.9 9671.36,-13206.9"/>
+<text text-anchor="start" x="9682.32" y="-13227.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">indexed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9874.36" y="-13228.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10235.28" y="-13228.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10244.17" y="-13228.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9670.36,-13205.9 9670.36,-13807.9 10286.36,-13807.9 10286.36,-13205.9 9670.36,-13205.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.concept_access_stats -->
+<g id="kg_api.concept_access_stats" class="node">
+<title>kg_api.concept_access_stats</title>
+<g id="a_kg_api.concept_access_stats"><a xlink:title="kg_api.concept_access_stats&#10;Node&#45;level access patterns for caching &#45; ADR&#45;025">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2536.12" cy="-15753.9" rx="441.47" ry="299.63"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2226.12,-15903.9 2226.12,-15963.9 2846.12,-15963.9 2846.12,-15903.9 2226.12,-15903.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.12,-15903.9 2226.12,-15963.9 2846.12,-15963.9 2846.12,-15903.9 2226.12,-15903.9"/>
+<text text-anchor="start" x="2264.91" y="-15925.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.concept_access_stats &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.12,-15843.9 2226.12,-15903.9 2846.12,-15903.9 2846.12,-15843.9 2226.12,-15843.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.12,-15843.9 2226.12,-15903.9 2846.12,-15903.9 2846.12,-15843.9 2226.12,-15843.9"/>
+<text text-anchor="start" x="2237.12" y="-15865.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">concept_id</text>
+<text text-anchor="start" x="2391.85" y="-15865.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2475.99" y="-15865.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2796.03" y="-15865.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2804.92" y="-15865.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.12,-15783.9 2226.12,-15843.9 2846.12,-15843.9 2846.12,-15783.9 2226.12,-15783.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.12,-15783.9 2226.12,-15843.9 2846.12,-15843.9 2846.12,-15783.9 2226.12,-15783.9"/>
+<text text-anchor="start" x="2237.12" y="-15804.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">access_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2737.32" y="-15805.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.12,-15723.9 2226.12,-15783.9 2846.12,-15783.9 2846.12,-15723.9 2226.12,-15723.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.12,-15723.9 2226.12,-15783.9 2846.12,-15783.9 2846.12,-15723.9 2226.12,-15723.9"/>
+<text text-anchor="start" x="2236.97" y="-15744.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_accessed &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2474.66" y="-15745.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.12,-15663.9 2226.12,-15723.9 2846.12,-15723.9 2846.12,-15663.9 2226.12,-15663.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.12,-15663.9 2226.12,-15723.9 2846.12,-15723.9 2846.12,-15663.9 2226.12,-15663.9"/>
+<text text-anchor="start" x="2237.12" y="-15684.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">avg_query_time_ms &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2637.78" y="-15685.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(10,2)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.12,-15603.9 2226.12,-15663.9 2846.12,-15663.9 2846.12,-15603.9 2226.12,-15603.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.12,-15603.9 2226.12,-15663.9 2846.12,-15663.9 2846.12,-15603.9 2226.12,-15603.9"/>
+<text text-anchor="start" x="2237.12" y="-15624.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">queries_as_start &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2737.32" y="-15625.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.12,-15543.9 2226.12,-15603.9 2846.12,-15603.9 2846.12,-15543.9 2226.12,-15543.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.12,-15543.9 2226.12,-15603.9 2846.12,-15603.9 2846.12,-15543.9 2226.12,-15543.9"/>
+<text text-anchor="start" x="2237.12" y="-15564.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">queries_as_result &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2737.32" y="-15565.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2225.12,-15542.9 2225.12,-15964.9 2847.12,-15964.9 2847.12,-15542.9 2225.12,-15542.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.concept_version_metadata -->
+<g id="kg_api.concept_version_metadata" class="node">
+<title>kg_api.concept_version_metadata</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2068.56" cy="-9407.9" rx="450.35" ry="172.57"/>
+<polygon fill="#7c3aed" stroke="transparent" points="1752.56,-9467.9 1752.56,-9527.9 2385.56,-9527.9 2385.56,-9467.9 1752.56,-9467.9"/>
+<polygon fill="none" stroke="#29235c" points="1752.56,-9467.9 1752.56,-9527.9 2385.56,-9527.9 2385.56,-9467.9 1752.56,-9467.9"/>
+<text text-anchor="start" x="1763.17" y="-9489.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.concept_version_metadata &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1752.56,-9407.9 1752.56,-9467.9 2385.56,-9467.9 2385.56,-9407.9 1752.56,-9407.9"/>
+<polygon fill="none" stroke="#29235c" points="1752.56,-9407.9 1752.56,-9467.9 2385.56,-9467.9 2385.56,-9407.9 1752.56,-9407.9"/>
+<text text-anchor="start" x="1763.56" y="-9429.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">concept_id</text>
+<text text-anchor="start" x="1918.29" y="-9429.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2015.43" y="-9429.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2335.47" y="-9429.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2344.36" y="-9429.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1752.56,-9347.9 1752.56,-9407.9 2385.56,-9407.9 2385.56,-9347.9 1752.56,-9347.9"/>
+<polygon fill="none" stroke="#29235c" points="1752.56,-9347.9 1752.56,-9407.9 2385.56,-9407.9 2385.56,-9347.9 1752.56,-9347.9"/>
+<text text-anchor="start" x="1763.56" y="-9368.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_in_version &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2276.76" y="-9369.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1752.56,-9287.9 1752.56,-9347.9 2385.56,-9347.9 2385.56,-9287.9 1752.56,-9287.9"/>
+<polygon fill="none" stroke="#29235c" points="1752.56,-9287.9 1752.56,-9347.9 2385.56,-9347.9 2385.56,-9287.9 1752.56,-9287.9"/>
+<text text-anchor="start" x="1763.56" y="-9308.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_modified_version &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2276.76" y="-9309.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="1751.06,-9286.9 1751.06,-9528.9 2386.06,-9528.9 2386.06,-9286.9 1751.06,-9286.9"/>
+</g>
+<!-- kg_api.ontology_versions -->
+<g id="kg_api.ontology_versions" class="node">
+<title>kg_api.ontology_versions</title>
+<g id="a_kg_api.ontology_versions"><a xlink:title="kg_api.ontology_versions&#10;Formal ontology versioning with immutable snapshots &#45; ADR&#45;026">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="3008.17" cy="-9137.9" rx="446.37" ry="554.24"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2695.17,-9467.9 2695.17,-9527.9 3322.17,-9527.9 3322.17,-9467.9 2695.17,-9467.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9467.9 2695.17,-9527.9 3322.17,-9527.9 3322.17,-9467.9 2695.17,-9467.9"/>
+<text text-anchor="start" x="2765.92" y="-9489.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.ontology_versions &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-9407.9 2695.17,-9467.9 3322.17,-9467.9 3322.17,-9407.9 2695.17,-9407.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9407.9 2695.17,-9467.9 3322.17,-9467.9 3322.17,-9407.9 2695.17,-9407.9"/>
+<text text-anchor="start" x="2706.17" y="-9429.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">version_id</text>
+<text text-anchor="start" x="2851.97" y="-9429.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3174.28" y="-9429.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="3272.08" y="-9429.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3280.97" y="-9429.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-9347.9 2695.17,-9407.9 3322.17,-9407.9 3322.17,-9347.9 2695.17,-9347.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9347.9 2695.17,-9407.9 3322.17,-9407.9 3322.17,-9347.9 2695.17,-9347.9"/>
+<text text-anchor="start" x="2705.7" y="-9368.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">version_number &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2970" y="-9369.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="3272.25" y="-9369.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3281.14" y="-9369.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-9287.9 2695.17,-9347.9 3322.17,-9347.9 3322.17,-9287.9 2695.17,-9287.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9287.9 2695.17,-9347.9 3322.17,-9347.9 3322.17,-9287.9 2695.17,-9287.9"/>
+<text text-anchor="start" x="2706.17" y="-9308.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2911.16" y="-9309.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="3272.08" y="-9309.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3280.97" y="-9309.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-9227.9 2695.17,-9287.9 3322.17,-9287.9 3322.17,-9227.9 2695.17,-9227.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9227.9 2695.17,-9287.9 3322.17,-9287.9 3322.17,-9227.9 2695.17,-9227.9"/>
+<text text-anchor="start" x="2706.17" y="-9248.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2991.13" y="-9249.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-9167.9 2695.17,-9227.9 3322.17,-9227.9 3322.17,-9167.9 2695.17,-9167.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9167.9 2695.17,-9227.9 3322.17,-9227.9 3322.17,-9167.9 2695.17,-9167.9"/>
+<text text-anchor="start" x="2706.17" y="-9188.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">change_summary &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3259.6" y="-9189.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-9107.9 2695.17,-9167.9 3322.17,-9167.9 3322.17,-9107.9 2695.17,-9107.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9107.9 2695.17,-9167.9 3322.17,-9167.9 3322.17,-9107.9 2695.17,-9107.9"/>
+<text text-anchor="start" x="2706.17" y="-9128.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3197.34" y="-9129.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-9047.9 2695.17,-9107.9 3322.17,-9107.9 3322.17,-9047.9 2695.17,-9047.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-9047.9 2695.17,-9107.9 3322.17,-9107.9 3322.17,-9047.9 2695.17,-9047.9"/>
+<text text-anchor="start" x="2706.17" y="-9068.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">vocabulary_snapshot &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3195.61" y="-9069.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<text text-anchor="start" x="3272.08" y="-9069.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3280.97" y="-9069.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-8987.9 2695.17,-9047.9 3322.17,-9047.9 3322.17,-8987.9 2695.17,-8987.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-8987.9 2695.17,-9047.9 3322.17,-9047.9 3322.17,-8987.9 2695.17,-8987.9"/>
+<text text-anchor="start" x="2706.17" y="-9008.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">types_added &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3241.81" y="-9009.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-8927.9 2695.17,-8987.9 3322.17,-8987.9 3322.17,-8927.9 2695.17,-8927.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-8927.9 2695.17,-8987.9 3322.17,-8987.9 3322.17,-8927.9 2695.17,-8927.9"/>
+<text text-anchor="start" x="2706.17" y="-8948.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">types_aliased &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3234.7" y="-8949.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-8867.9 2695.17,-8927.9 3322.17,-8927.9 3322.17,-8867.9 2695.17,-8867.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-8867.9 2695.17,-8927.9 3322.17,-8927.9 3322.17,-8867.9 2695.17,-8867.9"/>
+<text text-anchor="start" x="2706.17" y="-8888.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">types_deprecated &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3241.81" y="-8889.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-8807.9 2695.17,-8867.9 3322.17,-8867.9 3322.17,-8807.9 2695.17,-8807.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-8807.9 2695.17,-8867.9 3322.17,-8867.9 3322.17,-8807.9 2695.17,-8807.9"/>
+<text text-anchor="start" x="2706.17" y="-8828.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">backward_compatible &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3197.34" y="-8829.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2695.17,-8747.9 2695.17,-8807.9 3322.17,-8807.9 3322.17,-8747.9 2695.17,-8747.9"/>
+<polygon fill="none" stroke="#29235c" points="2695.17,-8747.9 2695.17,-8807.9 3322.17,-8807.9 3322.17,-8747.9 2695.17,-8747.9"/>
+<text text-anchor="start" x="2706.17" y="-8768.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">migration_required &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3197.34" y="-8769.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2693.67,-8746.9 2693.67,-9528.9 3322.67,-9528.9 3322.67,-8746.9 2693.67,-8746.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.concept_version_metadata&#45;&gt;kg_api.ontology_versions -->
+<!-- kg_api.concept_version_metadata&#45;&gt;kg_api.ontology_versions -->
+<g id="edge6" class="edge">
+<title>kg_api.concept_version_metadata:e&#45;&gt;kg_api.ontology_versions:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2386.56,-9377.9C2522.45,-9377.9 2553.4,-9435.01 2684.16,-9437.79"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2684.13,-9441.29 2694.17,-9437.9 2684.21,-9434.29 2684.13,-9441.29"/>
+</g>
+<!-- kg_api.concept_version_metadata&#45;&gt;kg_api.ontology_versions -->
+<!-- kg_api.concept_version_metadata&#45;&gt;kg_api.ontology_versions -->
+<g id="edge8" class="edge">
+<title>kg_api.concept_version_metadata:e&#45;&gt;kg_api.ontology_versions:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2386.56,-9317.9C2529.87,-9317.9 2546.69,-9432.34 2684.07,-9437.71"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2684.11,-9441.21 2694.17,-9437.9 2684.24,-9434.21 2684.11,-9441.21"/>
+</g>
+<!-- kg_api.edge_usage_stats -->
+<g id="kg_api.edge_usage_stats" class="node">
+<title>kg_api.edge_usage_stats</title>
+<g id="a_kg_api.edge_usage_stats"><a xlink:title="kg_api.edge_usage_stats&#10;Performance tracking for graph traversals &#45; ADR&#45;025">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2536.25" cy="-15145.9" rx="468.21" ry="299.63"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2207.25,-15295.9 2207.25,-15355.9 2865.25,-15355.9 2865.25,-15295.9 2207.25,-15295.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-15295.9 2207.25,-15355.9 2865.25,-15355.9 2865.25,-15295.9 2207.25,-15295.9"/>
+<text text-anchor="start" x="2291.7" y="-15317.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.edge_usage_stats &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-15235.9 2207.25,-15295.9 2865.25,-15295.9 2865.25,-15235.9 2207.25,-15235.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-15235.9 2207.25,-15295.9 2865.25,-15295.9 2865.25,-15235.9 2207.25,-15235.9"/>
+<text text-anchor="start" x="2218.25" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">from_concept_id</text>
+<text text-anchor="start" x="2454.75" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2495.12" y="-15257.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2815.16" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2824.05" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-15175.9 2207.25,-15235.9 2865.25,-15235.9 2865.25,-15175.9 2207.25,-15175.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-15175.9 2207.25,-15235.9 2865.25,-15235.9 2865.25,-15175.9 2207.25,-15175.9"/>
+<text text-anchor="start" x="2218.25" y="-15197.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">to_concept_id</text>
+<text text-anchor="start" x="2417.45" y="-15197.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2495.12" y="-15197.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2815.16" y="-15197.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2824.05" y="-15197.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-15115.9 2207.25,-15175.9 2865.25,-15175.9 2865.25,-15115.9 2207.25,-15115.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-15115.9 2207.25,-15175.9 2865.25,-15175.9 2865.25,-15115.9 2207.25,-15115.9"/>
+<text text-anchor="start" x="2218.05" y="-15137.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">relationship_type</text>
+<text text-anchor="start" x="2459.89" y="-15137.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2495.19" y="-15137.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2815.22" y="-15137.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2824.12" y="-15137.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-15055.9 2207.25,-15115.9 2865.25,-15115.9 2865.25,-15055.9 2207.25,-15055.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-15055.9 2207.25,-15115.9 2865.25,-15115.9 2865.25,-15055.9 2207.25,-15055.9"/>
+<text text-anchor="start" x="2218.25" y="-15076.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">traversal_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2756.45" y="-15077.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-14995.9 2207.25,-15055.9 2865.25,-15055.9 2865.25,-14995.9 2207.25,-14995.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-14995.9 2207.25,-15055.9 2865.25,-15055.9 2865.25,-14995.9 2207.25,-14995.9"/>
+<text text-anchor="start" x="2218.25" y="-15016.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_traversed &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2493.33" y="-15017.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-14935.9 2207.25,-14995.9 2865.25,-14995.9 2865.25,-14935.9 2207.25,-14935.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-14935.9 2207.25,-14995.9 2865.25,-14995.9 2865.25,-14935.9 2207.25,-14935.9"/>
+<text text-anchor="start" x="2218.25" y="-14956.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">avg_query_time_ms &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2656.91" y="-14957.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(10,2)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2206.25,-14934.9 2206.25,-15356.9 2866.25,-15356.9 2866.25,-14934.9 2206.25,-14934.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.embedding_config_legacy -->
+<g id="kg_api.embedding_config_legacy" class="node">
+<title>kg_api.embedding_config_legacy</title>
+<g id="a_kg_api.embedding_config_legacy"><a xlink:title="kg_api.embedding_config_legacy&#10;Resource&#45;aware embedding configuration for local and remote models &#45; ADR&#45;039. Includes preset for nomic&#45;embed&#45;text&#45;v1.5.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2536.41" cy="-10890.9" rx="441.88" ry="766.51"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2226.41,-11370.9 2226.41,-11430.9 2847.41,-11430.9 2847.41,-11370.9 2226.41,-11370.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-11370.9 2226.41,-11430.9 2847.41,-11430.9 2847.41,-11370.9 2226.41,-11370.9"/>
+<text text-anchor="start" x="2237.25" y="-11392.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.embedding_config_legacy &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-11310.9 2226.41,-11370.9 2847.41,-11370.9 2847.41,-11310.9 2226.41,-11310.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-11310.9 2226.41,-11370.9 2847.41,-11370.9 2847.41,-11310.9 2226.41,-11310.9"/>
+<text text-anchor="start" x="2237.41" y="-11332.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2262.3" y="-11332.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2699.52" y="-11332.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2797.32" y="-11332.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2806.22" y="-11332.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-11250.9 2226.41,-11310.9 2847.41,-11310.9 2847.41,-11250.9 2226.41,-11250.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-11250.9 2226.41,-11310.9 2847.41,-11310.9 2847.41,-11250.9 2226.41,-11250.9"/>
+<text text-anchor="start" x="2237.41" y="-11271.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2495.07" y="-11272.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2797.32" y="-11272.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2806.22" y="-11272.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-11190.9 2226.41,-11250.9 2847.41,-11250.9 2847.41,-11190.9 2226.41,-11190.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-11190.9 2226.41,-11250.9 2847.41,-11250.9 2847.41,-11190.9 2226.41,-11190.9"/>
+<text text-anchor="start" x="2237.41" y="-11211.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">model_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2477.28" y="-11212.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="2797.32" y="-11212.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2806.22" y="-11212.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-11130.9 2226.41,-11190.9 2847.41,-11190.9 2847.41,-11130.9 2226.41,-11130.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-11130.9 2226.41,-11190.9 2847.41,-11190.9 2847.41,-11130.9 2226.41,-11130.9"/>
+<text text-anchor="start" x="2237.41" y="-11151.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_dimensions &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2699.52" y="-11152.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2797.32" y="-11152.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2806.22" y="-11152.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-11070.9 2226.41,-11130.9 2847.41,-11130.9 2847.41,-11070.9 2226.41,-11070.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-11070.9 2226.41,-11130.9 2847.41,-11130.9 2847.41,-11070.9 2226.41,-11070.9"/>
+<text text-anchor="start" x="2237.41" y="-11091.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">precision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2495.07" y="-11092.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="2797.32" y="-11092.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2806.22" y="-11092.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-11010.9 2226.41,-11070.9 2847.41,-11070.9 2847.41,-11010.9 2226.41,-11010.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-11010.9 2226.41,-11070.9 2847.41,-11070.9 2847.41,-11010.9 2226.41,-11010.9"/>
+<text text-anchor="start" x="2237.41" y="-11031.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_memory_mb &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2738.61" y="-11032.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10950.9 2226.41,-11010.9 2847.41,-11010.9 2847.41,-10950.9 2226.41,-10950.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10950.9 2226.41,-11010.9 2847.41,-11010.9 2847.41,-10950.9 2226.41,-10950.9"/>
+<text text-anchor="start" x="2237.41" y="-10971.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">num_threads &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2738.61" y="-10972.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10890.9 2226.41,-10950.9 2847.41,-10950.9 2847.41,-10890.9 2226.41,-10890.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10890.9 2226.41,-10950.9 2847.41,-10950.9 2847.41,-10890.9 2226.41,-10890.9"/>
+<text text-anchor="start" x="2237.41" y="-10911.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">device &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2534.16" y="-10912.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10830.9 2226.41,-10890.9 2847.41,-10890.9 2847.41,-10830.9 2226.41,-10830.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10830.9 2226.41,-10890.9 2847.41,-10890.9 2847.41,-10830.9 2226.41,-10830.9"/>
+<text text-anchor="start" x="2237.41" y="-10851.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">batch_size &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2738.61" y="-10852.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10770.9 2226.41,-10830.9 2847.41,-10830.9 2847.41,-10770.9 2226.41,-10770.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10770.9 2226.41,-10830.9 2847.41,-10830.9 2847.41,-10770.9 2226.41,-10770.9"/>
+<text text-anchor="start" x="2237.41" y="-10791.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_seq_length &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2738.61" y="-10792.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10710.9 2226.41,-10770.9 2847.41,-10770.9 2847.41,-10710.9 2226.41,-10710.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10710.9 2226.41,-10770.9 2847.41,-10770.9 2847.41,-10710.9 2226.41,-10710.9"/>
+<text text-anchor="start" x="2237.41" y="-10731.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">normalize_embeddings &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.58" y="-10732.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10650.9 2226.41,-10710.9 2847.41,-10710.9 2847.41,-10650.9 2226.41,-10650.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10650.9 2226.41,-10710.9 2847.41,-10710.9 2847.41,-10650.9 2226.41,-10650.9"/>
+<text text-anchor="start" x="2237.41" y="-10671.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2475.49" y="-10672.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10590.9 2226.41,-10650.9 2847.41,-10650.9 2847.41,-10590.9 2226.41,-10590.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10590.9 2226.41,-10650.9 2847.41,-10650.9 2847.41,-10590.9 2226.41,-10590.9"/>
+<text text-anchor="start" x="2237.41" y="-10611.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2475.49" y="-10612.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10530.9 2226.41,-10590.9 2847.41,-10590.9 2847.41,-10530.9 2226.41,-10530.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10530.9 2226.41,-10590.9 2847.41,-10590.9 2847.41,-10530.9 2226.41,-10530.9"/>
+<text text-anchor="start" x="2237.41" y="-10551.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2516.38" y="-10552.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10470.9 2226.41,-10530.9 2847.41,-10530.9 2847.41,-10470.9 2226.41,-10470.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10470.9 2226.41,-10530.9 2847.41,-10530.9 2847.41,-10470.9 2226.41,-10470.9"/>
+<text text-anchor="start" x="2237.41" y="-10491.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.58" y="-10492.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10410.9 2226.41,-10470.9 2847.41,-10470.9 2847.41,-10410.9 2226.41,-10410.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10410.9 2226.41,-10470.9 2847.41,-10470.9 2847.41,-10410.9 2226.41,-10410.9"/>
+<text text-anchor="start" x="2237.41" y="-10431.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">delete_protected &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.58" y="-10432.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.41,-10350.9 2226.41,-10410.9 2847.41,-10410.9 2847.41,-10350.9 2226.41,-10350.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.41,-10350.9 2226.41,-10410.9 2847.41,-10410.9 2847.41,-10350.9 2226.41,-10350.9"/>
+<text text-anchor="start" x="2237.41" y="-10371.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">change_protected &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.58" y="-10372.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2224.91,-10349.9 2224.91,-11431.9 2847.91,-11431.9 2847.91,-10349.9 2224.91,-10349.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.embedding_generation_jobs -->
+<g id="kg_api.embedding_generation_jobs" class="node">
+<title>kg_api.embedding_generation_jobs</title>
+<g id="a_kg_api.embedding_generation_jobs"><a xlink:title="kg_api.embedding_generation_jobs&#10;ADR&#45;045: Tracks embedding generation jobs for audit trail and progress monitoring">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="10523.79" cy="-4075.9" rx="464.64" ry="681.8"/>
+<polygon fill="#7c3aed" stroke="transparent" points="10197.79,-4495.9 10197.79,-4555.9 10850.79,-4555.9 10850.79,-4495.9 10197.79,-4495.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4495.9 10197.79,-4555.9 10850.79,-4555.9 10850.79,-4495.9 10197.79,-4495.9"/>
+<text text-anchor="start" x="10208.61" y="-4517.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.embedding_generation_jobs &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4435.9 10197.79,-4495.9 10850.79,-4495.9 10850.79,-4435.9 10197.79,-4435.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4435.9 10197.79,-4495.9 10850.79,-4495.9 10850.79,-4435.9 10197.79,-4435.9"/>
+<text text-anchor="start" x="10208.79" y="-4457.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">job_id</text>
+<text text-anchor="start" x="10294.14" y="-4457.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10740.23" y="-4457.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">uuid</text>
+<text text-anchor="start" x="10800.7" y="-4457.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10809.59" y="-4457.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4375.9 10197.79,-4435.9 10850.79,-4435.9 10850.79,-4375.9 10197.79,-4375.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4375.9 10197.79,-4435.9 10850.79,-4435.9 10850.79,-4375.9 10197.79,-4375.9"/>
+<text text-anchor="start" x="10208.79" y="-4396.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">job_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10498.45" y="-4397.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="10800.7" y="-4397.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10809.59" y="-4397.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4315.9 10197.79,-4375.9 10850.79,-4375.9 10850.79,-4315.9 10197.79,-4315.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4315.9 10197.79,-4375.9 10850.79,-4375.9 10850.79,-4315.9 10197.79,-4315.9"/>
+<text text-anchor="start" x="10208.79" y="-4336.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">target_types &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10501.96" y="-4337.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4255.9 10197.79,-4315.9 10850.79,-4315.9 10850.79,-4255.9 10197.79,-4255.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4255.9 10197.79,-4315.9 10850.79,-4315.9 10850.79,-4255.9 10197.79,-4255.9"/>
+<text text-anchor="start" x="10208.79" y="-4276.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">target_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10741.98" y="-4277.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4195.9 10197.79,-4255.9 10850.79,-4255.9 10850.79,-4195.9 10197.79,-4195.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4195.9 10197.79,-4255.9 10850.79,-4255.9 10850.79,-4195.9 10197.79,-4195.9"/>
+<text text-anchor="start" x="10208.79" y="-4216.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10498.45" y="-4217.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="10800.7" y="-4217.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10809.59" y="-4217.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4135.9 10197.79,-4195.9 10850.79,-4195.9 10850.79,-4135.9 10197.79,-4135.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4135.9 10197.79,-4195.9 10850.79,-4195.9 10850.79,-4135.9 10197.79,-4135.9"/>
+<text text-anchor="start" x="10208.79" y="-4156.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">processed_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10741.98" y="-4157.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4075.9 10197.79,-4135.9 10850.79,-4135.9 10850.79,-4075.9 10197.79,-4075.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4075.9 10197.79,-4135.9 10850.79,-4135.9 10850.79,-4075.9 10197.79,-4075.9"/>
+<text text-anchor="start" x="10208.79" y="-4096.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">failed_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10741.98" y="-4097.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-4015.9 10197.79,-4075.9 10850.79,-4075.9 10850.79,-4015.9 10197.79,-4015.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-4015.9 10197.79,-4075.9 10850.79,-4075.9 10850.79,-4015.9 10197.79,-4015.9"/>
+<text text-anchor="start" x="10208.79" y="-4036.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_model &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10519.75" y="-4037.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-3955.9 10197.79,-4015.9 10850.79,-4015.9 10850.79,-3955.9 10197.79,-3955.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-3955.9 10197.79,-4015.9 10850.79,-4015.9 10850.79,-3955.9 10197.79,-3955.9"/>
+<text text-anchor="start" x="10208.79" y="-3976.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10537.54" y="-3977.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-3895.9 10197.79,-3955.9 10850.79,-3955.9 10850.79,-3895.9 10197.79,-3895.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-3895.9 10197.79,-3955.9 10850.79,-3955.9 10850.79,-3895.9 10197.79,-3895.9"/>
+<text text-anchor="start" x="10208.79" y="-3916.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10478.86" y="-3917.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-3835.9 10197.79,-3895.9 10850.79,-3895.9 10850.79,-3835.9 10197.79,-3835.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-3835.9 10197.79,-3895.9 10850.79,-3895.9 10850.79,-3835.9 10197.79,-3835.9"/>
+<text text-anchor="start" x="10208.79" y="-3856.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">started_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10478.86" y="-3857.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-3775.9 10197.79,-3835.9 10850.79,-3835.9 10850.79,-3775.9 10197.79,-3775.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-3775.9 10197.79,-3835.9 10850.79,-3835.9 10850.79,-3775.9 10197.79,-3775.9"/>
+<text text-anchor="start" x="10208.79" y="-3796.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">completed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10478.86" y="-3797.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-3715.9 10197.79,-3775.9 10850.79,-3775.9 10850.79,-3715.9 10197.79,-3715.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-3715.9 10197.79,-3775.9 10850.79,-3775.9 10850.79,-3715.9 10197.79,-3715.9"/>
+<text text-anchor="start" x="10208.79" y="-3736.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">duration_ms &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10741.98" y="-3737.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-3655.9 10197.79,-3715.9 10850.79,-3715.9 10850.79,-3655.9 10197.79,-3655.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-3655.9 10197.79,-3715.9 10850.79,-3715.9 10850.79,-3655.9 10197.79,-3655.9"/>
+<text text-anchor="start" x="10208.79" y="-3676.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">result_summary &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10763.32" y="-3677.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="10197.79,-3595.9 10197.79,-3655.9 10850.79,-3655.9 10850.79,-3595.9 10197.79,-3595.9"/>
+<polygon fill="none" stroke="#29235c" points="10197.79,-3595.9 10197.79,-3655.9 10850.79,-3655.9 10850.79,-3595.9 10197.79,-3595.9"/>
+<text text-anchor="start" x="10208.79" y="-3616.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">error_message &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10788.21" y="-3617.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="10196.29,-3594.9 10196.29,-4556.9 10851.29,-4556.9 10851.29,-3594.9 10196.29,-3594.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.embedding_profile -->
+<g id="kg_api.embedding_profile" class="node">
+<title>kg_api.embedding_profile</title>
+<g id="a_kg_api.embedding_profile"><a xlink:title="kg_api.embedding_profile&#10;Unified embedding profile with text + image model slots. Replaces embedding_config.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.57" cy="-4075.9" rx="485.56" ry="1445.15"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7775.57,-5035.9 7775.57,-5095.9 8458.57,-5095.9 8458.57,-5035.9 7775.57,-5035.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-5035.9 7775.57,-5095.9 8458.57,-5095.9 8458.57,-5035.9 7775.57,-5035.9"/>
+<text text-anchor="start" x="7871.66" y="-5057.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.embedding_profile &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4975.9 7775.57,-5035.9 8458.57,-5035.9 8458.57,-4975.9 7775.57,-4975.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4975.9 7775.57,-5035.9 8458.57,-5035.9 8458.57,-4975.9 7775.57,-4975.9"/>
+<text text-anchor="start" x="7786.57" y="-4997.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="7811.46" y="-4997.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8310.68" y="-4997.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="8408.48" y="-4997.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8417.37" y="-4997.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4915.9 7775.57,-4975.9 8458.57,-4975.9 8458.57,-4915.9 7775.57,-4915.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4915.9 7775.57,-4975.9 8458.57,-4975.9 8458.57,-4915.9 7775.57,-4915.9"/>
+<text text-anchor="start" x="7786.57" y="-4936.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8088.44" y="-4937.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="8408.48" y="-4937.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8417.37" y="-4937.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4855.9 7775.57,-4915.9 8458.57,-4915.9 8458.57,-4855.9 7775.57,-4855.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4855.9 7775.57,-4915.9 8458.57,-4915.9 8458.57,-4855.9 7775.57,-4855.9"/>
+<text text-anchor="start" x="7786.57" y="-4876.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">vector_space &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8088.44" y="-4877.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="8408.48" y="-4877.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8417.37" y="-4877.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4795.9 7775.57,-4855.9 8458.57,-4855.9 8458.57,-4795.9 7775.57,-4795.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4795.9 7775.57,-4855.9 8458.57,-4855.9 8458.57,-4795.9 7775.57,-4795.9"/>
+<text text-anchor="start" x="7786.57" y="-4816.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">multimodal &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8333.74" y="-4817.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4735.9 7775.57,-4795.9 8458.57,-4795.9 8458.57,-4735.9 7775.57,-4735.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4735.9 7775.57,-4795.9 8458.57,-4795.9 8458.57,-4735.9 7775.57,-4735.9"/>
+<text text-anchor="start" x="7786.57" y="-4756.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8106.23" y="-4757.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="8408.48" y="-4757.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8417.37" y="-4757.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4675.9 7775.57,-4735.9 8458.57,-4735.9 8458.57,-4675.9 7775.57,-4675.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4675.9 7775.57,-4735.9 8458.57,-4735.9 8458.57,-4675.9 7775.57,-4675.9"/>
+<text text-anchor="start" x="7786.57" y="-4696.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_model_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8088.44" y="-4697.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="8408.48" y="-4697.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8417.37" y="-4697.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4615.9 7775.57,-4675.9 8458.57,-4675.9 8458.57,-4615.9 7775.57,-4615.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4615.9 7775.57,-4675.9 8458.57,-4675.9 8458.57,-4615.9 7775.57,-4615.9"/>
+<text text-anchor="start" x="7786.57" y="-4636.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_loader &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8106.23" y="-4637.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="8408.48" y="-4637.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8417.37" y="-4637.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4555.9 7775.57,-4615.9 8458.57,-4615.9 8458.57,-4555.9 7775.57,-4555.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4555.9 7775.57,-4615.9 8458.57,-4615.9 8458.57,-4555.9 7775.57,-4555.9"/>
+<text text-anchor="start" x="7786.57" y="-4576.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_revision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8127.53" y="-4577.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4495.9 7775.57,-4555.9 8458.57,-4555.9 8458.57,-4495.9 7775.57,-4495.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4495.9 7775.57,-4555.9 8458.57,-4555.9 8458.57,-4495.9 7775.57,-4495.9"/>
+<text text-anchor="start" x="7786.57" y="-4516.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_dimensions &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8310.68" y="-4517.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="8408.48" y="-4517.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8417.37" y="-4517.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4435.9 7775.57,-4495.9 8458.57,-4495.9 8458.57,-4435.9 7775.57,-4435.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4435.9 7775.57,-4495.9 8458.57,-4495.9 8458.57,-4435.9 7775.57,-4435.9"/>
+<text text-anchor="start" x="7786.57" y="-4456.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_precision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8145.32" y="-4457.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4375.9 7775.57,-4435.9 8458.57,-4435.9 8458.57,-4375.9 7775.57,-4375.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4375.9 7775.57,-4435.9 8458.57,-4435.9 8458.57,-4375.9 7775.57,-4375.9"/>
+<text text-anchor="start" x="7786.57" y="-4396.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_trust_remote_code &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8333.74" y="-4397.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4315.9 7775.57,-4375.9 8458.57,-4375.9 8458.57,-4315.9 7775.57,-4315.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4315.9 7775.57,-4375.9 8458.57,-4375.9 8458.57,-4315.9 7775.57,-4315.9"/>
+<text text-anchor="start" x="7786.57" y="-4336.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8145.32" y="-4337.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4255.9 7775.57,-4315.9 8458.57,-4315.9 8458.57,-4255.9 7775.57,-4255.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4255.9 7775.57,-4315.9 8458.57,-4315.9 8458.57,-4255.9 7775.57,-4255.9"/>
+<text text-anchor="start" x="7786.57" y="-4276.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_model_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8127.53" y="-4277.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4195.9 7775.57,-4255.9 8458.57,-4255.9 8458.57,-4195.9 7775.57,-4195.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4195.9 7775.57,-4255.9 8458.57,-4255.9 8458.57,-4195.9 7775.57,-4195.9"/>
+<text text-anchor="start" x="7786.57" y="-4216.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_loader &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8145.32" y="-4217.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4135.9 7775.57,-4195.9 8458.57,-4195.9 8458.57,-4135.9 7775.57,-4135.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4135.9 7775.57,-4195.9 8458.57,-4195.9 8458.57,-4135.9 7775.57,-4135.9"/>
+<text text-anchor="start" x="7786.57" y="-4156.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_revision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8127.53" y="-4157.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4075.9 7775.57,-4135.9 8458.57,-4135.9 8458.57,-4075.9 7775.57,-4075.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4075.9 7775.57,-4135.9 8458.57,-4135.9 8458.57,-4075.9 7775.57,-4075.9"/>
+<text text-anchor="start" x="7786.57" y="-4096.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_dimensions &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8349.77" y="-4097.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-4015.9 7775.57,-4075.9 8458.57,-4075.9 8458.57,-4015.9 7775.57,-4015.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-4015.9 7775.57,-4075.9 8458.57,-4075.9 8458.57,-4015.9 7775.57,-4015.9"/>
+<text text-anchor="start" x="7786.57" y="-4036.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_precision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8145.32" y="-4037.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3955.9 7775.57,-4015.9 8458.57,-4015.9 8458.57,-3955.9 7775.57,-3955.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3955.9 7775.57,-4015.9 8458.57,-4015.9 8458.57,-3955.9 7775.57,-3955.9"/>
+<text text-anchor="start" x="7786.57" y="-3976.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_trust_remote_code &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8333.74" y="-3977.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3895.9 7775.57,-3955.9 8458.57,-3955.9 8458.57,-3895.9 7775.57,-3895.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3895.9 7775.57,-3955.9 8458.57,-3955.9 8458.57,-3895.9 7775.57,-3895.9"/>
+<text text-anchor="start" x="7786.57" y="-3916.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">device &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8145.32" y="-3917.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3835.9 7775.57,-3895.9 8458.57,-3895.9 8458.57,-3835.9 7775.57,-3835.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3835.9 7775.57,-3895.9 8458.57,-3895.9 8458.57,-3835.9 7775.57,-3835.9"/>
+<text text-anchor="start" x="7786.57" y="-3856.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_memory_mb &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8349.77" y="-3857.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3775.9 7775.57,-3835.9 8458.57,-3835.9 8458.57,-3775.9 7775.57,-3775.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3775.9 7775.57,-3835.9 8458.57,-3835.9 8458.57,-3775.9 7775.57,-3775.9"/>
+<text text-anchor="start" x="7786.57" y="-3796.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">num_threads &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8349.77" y="-3797.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3715.9 7775.57,-3775.9 8458.57,-3775.9 8458.57,-3715.9 7775.57,-3715.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3715.9 7775.57,-3775.9 8458.57,-3775.9 8458.57,-3715.9 7775.57,-3715.9"/>
+<text text-anchor="start" x="7786.57" y="-3736.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">batch_size &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8349.77" y="-3737.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3655.9 7775.57,-3715.9 8458.57,-3715.9 8458.57,-3655.9 7775.57,-3655.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3655.9 7775.57,-3715.9 8458.57,-3715.9 8458.57,-3655.9 7775.57,-3655.9"/>
+<text text-anchor="start" x="7786.57" y="-3676.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_seq_length &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8349.77" y="-3677.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3595.9 7775.57,-3655.9 8458.57,-3655.9 8458.57,-3595.9 7775.57,-3595.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3595.9 7775.57,-3655.9 8458.57,-3655.9 8458.57,-3595.9 7775.57,-3595.9"/>
+<text text-anchor="start" x="7786.57" y="-3616.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">normalize_embeddings &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8333.74" y="-3617.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3535.9 7775.57,-3595.9 8458.57,-3595.9 8458.57,-3535.9 7775.57,-3535.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3535.9 7775.57,-3595.9 8458.57,-3595.9 8458.57,-3535.9 7775.57,-3535.9"/>
+<text text-anchor="start" x="7786.57" y="-3556.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8333.74" y="-3557.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3475.9 7775.57,-3535.9 8458.57,-3535.9 8458.57,-3475.9 7775.57,-3475.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3475.9 7775.57,-3535.9 8458.57,-3535.9 8458.57,-3475.9 7775.57,-3475.9"/>
+<text text-anchor="start" x="7786.57" y="-3496.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">delete_protected &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8333.74" y="-3497.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3415.9 7775.57,-3475.9 8458.57,-3475.9 8458.57,-3415.9 7775.57,-3415.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3415.9 7775.57,-3475.9 8458.57,-3475.9 8458.57,-3415.9 7775.57,-3415.9"/>
+<text text-anchor="start" x="7786.57" y="-3436.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">change_protected &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8333.74" y="-3437.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3355.9 7775.57,-3415.9 8458.57,-3415.9 8458.57,-3355.9 7775.57,-3355.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3355.9 7775.57,-3415.9 8458.57,-3415.9 8458.57,-3355.9 7775.57,-3355.9"/>
+<text text-anchor="start" x="7786.57" y="-3376.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8086.65" y="-3377.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3295.9 7775.57,-3355.9 8458.57,-3355.9 8458.57,-3295.9 7775.57,-3295.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3295.9 7775.57,-3355.9 8458.57,-3355.9 8458.57,-3295.9 7775.57,-3295.9"/>
+<text text-anchor="start" x="7786.57" y="-3316.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8086.65" y="-3317.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3235.9 7775.57,-3295.9 8458.57,-3295.9 8458.57,-3235.9 7775.57,-3235.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3235.9 7775.57,-3295.9 8458.57,-3295.9 8458.57,-3235.9 7775.57,-3235.9"/>
+<text text-anchor="start" x="7786.57" y="-3256.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8127.53" y="-3257.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3175.9 7775.57,-3235.9 8458.57,-3235.9 8458.57,-3175.9 7775.57,-3175.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3175.9 7775.57,-3235.9 8458.57,-3235.9 8458.57,-3175.9 7775.57,-3175.9"/>
+<text text-anchor="start" x="7786.57" y="-3196.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_query_prefix &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8127.53" y="-3197.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3115.9 7775.57,-3175.9 8458.57,-3175.9 8458.57,-3115.9 7775.57,-3115.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3115.9 7775.57,-3175.9 8458.57,-3175.9 8458.57,-3115.9 7775.57,-3115.9"/>
+<text text-anchor="start" x="7786.35" y="-3136.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">text_document_prefix &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8127.55" y="-3137.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7775.57,-3055.9 7775.57,-3115.9 8458.57,-3115.9 8458.57,-3055.9 7775.57,-3055.9"/>
+<polygon fill="none" stroke="#29235c" points="7775.57,-3055.9 7775.57,-3115.9 8458.57,-3115.9 8458.57,-3055.9 7775.57,-3055.9"/>
+<text text-anchor="start" x="7786.57" y="-3076.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">image_vector_space &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8127.53" y="-3077.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7774.07,-3054.9 7774.07,-5096.9 8459.07,-5096.9 8459.07,-3054.9 7774.07,-3054.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.graph_epoch_kinds -->
+<g id="kg_api.graph_epoch_kinds" class="node">
+<title>kg_api.graph_epoch_kinds</title>
+<g id="a_kg_api.graph_epoch_kinds"><a xlink:title="kg_api.graph_epoch_kinds&#10;ADR&#45;203: Discriminator for graph_epochs.kind. semantic_wallclock distinguishes events whose occurred_at is semantically primary (ingestion, edit) from those where it is forensic&#45;only (reasoning, annealing).">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8583.17" cy="-11010.9" rx="376.36" ry="172.57"/>
+<polygon fill="#7c3aed" stroke="transparent" points="8319.17,-11070.9 8319.17,-11130.9 8847.17,-11130.9 8847.17,-11070.9 8319.17,-11070.9"/>
+<polygon fill="none" stroke="#29235c" points="8319.17,-11070.9 8319.17,-11130.9 8847.17,-11130.9 8847.17,-11070.9 8319.17,-11070.9"/>
+<text text-anchor="start" x="8329.74" y="-11092.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.graph_epoch_kinds &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="8319.17,-11010.9 8319.17,-11070.9 8847.17,-11070.9 8847.17,-11010.9 8319.17,-11010.9"/>
+<polygon fill="none" stroke="#29235c" points="8319.17,-11010.9 8319.17,-11070.9 8847.17,-11070.9 8847.17,-11010.9 8319.17,-11010.9"/>
+<text text-anchor="start" x="8330.17" y="-11032.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">kind</text>
+<text text-anchor="start" x="8388.85" y="-11032.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8745.51" y="-11032.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="8797.08" y="-11032.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8805.98" y="-11032.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="8319.17,-10950.9 8319.17,-11010.9 8847.17,-11010.9 8847.17,-10950.9 8319.17,-10950.9"/>
+<polygon fill="none" stroke="#29235c" points="8319.17,-10950.9 8319.17,-11010.9 8847.17,-11010.9 8847.17,-10950.9 8319.17,-10950.9"/>
+<text text-anchor="start" x="8330.17" y="-10971.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">semantic_wallclock &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8683.25" y="-10972.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<text text-anchor="start" x="8797.08" y="-10972.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8805.98" y="-10972.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="8319.17,-10890.9 8319.17,-10950.9 8847.17,-10950.9 8847.17,-10890.9 8319.17,-10890.9"/>
+<polygon fill="none" stroke="#29235c" points="8319.17,-10890.9 8319.17,-10950.9 8847.17,-10950.9 8847.17,-10890.9 8319.17,-10890.9"/>
+<text text-anchor="start" x="8330.17" y="-10911.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8784.6" y="-10912.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="8318.17,-10889.9 8318.17,-11131.9 8848.17,-11131.9 8848.17,-10889.9 8318.17,-10889.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.graph_epochs -->
+<g id="kg_api.graph_epochs" class="node">
+<title>kg_api.graph_epochs</title>
+<g id="a_kg_api.graph_epochs"><a xlink:title="kg_api.graph_epochs&#10;ADR&#45;203: Monotonic event log of graph mutations. Distinct from graph_change_counter (ADR&#45;079) which is a composite cache&#45;invalidation checksum.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="7718.52" cy="-10890.9" rx="445.45" ry="342.48"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7405.52,-11070.9 7405.52,-11130.9 8031.52,-11130.9 8031.52,-11070.9 7405.52,-11070.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-11070.9 7405.52,-11130.9 8031.52,-11130.9 8031.52,-11070.9 7405.52,-11070.9"/>
+<text text-anchor="start" x="7503.32" y="-11092.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.graph_epochs &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7405.52,-11010.9 7405.52,-11070.9 8031.52,-11070.9 8031.52,-11010.9 7405.52,-11010.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-11010.9 7405.52,-11070.9 8031.52,-11070.9 8031.52,-11010.9 7405.52,-11010.9"/>
+<text text-anchor="start" x="7416.52" y="-11032.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">event_id</text>
+<text text-anchor="start" x="7537.45" y="-11032.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7904.96" y="-11032.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<text text-anchor="start" x="7981.43" y="-11032.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="7990.32" y="-11032.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7405.52,-10950.9 7405.52,-11010.9 8031.52,-11010.9 8031.52,-10950.9 7405.52,-10950.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-10950.9 7405.52,-11010.9 8031.52,-11010.9 8031.52,-10950.9 7405.52,-10950.9"/>
+<text text-anchor="start" x="7416.27" y="-10971.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">occurred_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7620.51" y="-10972.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="7981.43" y="-10972.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="7990.32" y="-10972.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7405.52,-10890.9 7405.52,-10950.9 8031.52,-10950.9 8031.52,-10890.9 7405.52,-10890.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-10890.9 7405.52,-10950.9 8031.52,-10950.9 8031.52,-10890.9 7405.52,-10890.9"/>
+<text text-anchor="start" x="7416.52" y="-10911.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">kind &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7929.85" y="-10912.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="7981.43" y="-10912.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="7990.32" y="-10912.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7405.52,-10830.9 7405.52,-10890.9 8031.52,-10890.9 8031.52,-10830.9 7405.52,-10830.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-10830.9 7405.52,-10890.9 8031.52,-10890.9 8031.52,-10830.9 7405.52,-10830.9"/>
+<text text-anchor="start" x="7416.52" y="-10851.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">actor &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7968.94" y="-10852.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7405.52,-10770.9 7405.52,-10830.9 8031.52,-10830.9 8031.52,-10770.9 7405.52,-10770.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-10770.9 7405.52,-10830.9 8031.52,-10830.9 8031.52,-10770.9 7405.52,-10770.9"/>
+<text text-anchor="start" x="7416.52" y="-10791.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">counter_after &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7944.06" y="-10792.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7405.52,-10710.9 7405.52,-10770.9 8031.52,-10770.9 8031.52,-10710.9 7405.52,-10710.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-10710.9 7405.52,-10770.9 8031.52,-10770.9 8031.52,-10710.9 7405.52,-10710.9"/>
+<text text-anchor="start" x="7416.52" y="-10731.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7904.96" y="-10732.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<text text-anchor="start" x="7981.43" y="-10732.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="7990.32" y="-10732.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7405.52,-10650.9 7405.52,-10710.9 8031.52,-10710.9 8031.52,-10650.9 7405.52,-10650.9"/>
+<polygon fill="none" stroke="#29235c" points="7405.52,-10650.9 7405.52,-10710.9 8031.52,-10710.9 8031.52,-10650.9 7405.52,-10650.9"/>
+<text text-anchor="start" x="7416.52" y="-10671.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7929.85" y="-10672.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="7981.43" y="-10672.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="7990.32" y="-10672.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7404.52,-10649.9 7404.52,-11131.9 8032.52,-11131.9 8032.52,-10649.9 7404.52,-10649.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.graph_epochs&#45;&gt;kg_api.graph_epoch_kinds -->
+<!-- kg_api.graph_epochs&#45;&gt;kg_api.graph_epoch_kinds -->
+<g id="edge10" class="edge">
+<title>kg_api.graph_epochs:e&#45;&gt;kg_api.graph_epoch_kinds:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M8032.52,-10920.9C8166.73,-10920.9 8179.87,-11034.88 8307.93,-11040.67"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="8308.1,-11044.18 8318.17,-11040.9 8308.26,-11037.18 8308.1,-11044.18"/>
+</g>
+<!-- kg_api.jobs -->
+<g id="kg_api.jobs" class="node">
+<title>kg_api.jobs</title>
+<g id="a_kg_api.jobs"><a xlink:title="kg_api.jobs&#10;Unified job queue for all background tasks (ingestion, backup, vocab, scheduled)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="469.52" cy="-1402.9" rx="465.05" ry="1402.8"/>
+<polygon fill="#7c3aed" stroke="transparent" points="142.52,-2332.9 142.52,-2392.9 796.52,-2392.9 796.52,-2332.9 142.52,-2332.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-2332.9 142.52,-2392.9 796.52,-2392.9 796.52,-2332.9 142.52,-2332.9"/>
+<text text-anchor="start" x="326.36" y="-2354.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.jobs &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-2272.9 142.52,-2332.9 796.52,-2332.9 796.52,-2272.9 142.52,-2272.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-2272.9 142.52,-2332.9 796.52,-2332.9 796.52,-2272.9 142.52,-2272.9"/>
+<text text-anchor="start" x="153.52" y="-2294.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">job_id</text>
+<text text-anchor="start" x="238.88" y="-2294.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="694.85" y="-2294.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="746.43" y="-2294.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-2294.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-2212.9 142.52,-2272.9 796.52,-2272.9 796.52,-2212.9 142.52,-2212.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-2212.9 142.52,-2272.9 796.52,-2272.9 796.52,-2212.9 142.52,-2212.9"/>
+<text text-anchor="start" x="153.52" y="-2233.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">job_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="694.85" y="-2234.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="746.43" y="-2234.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-2234.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-2152.9 142.52,-2212.9 796.52,-2212.9 796.52,-2152.9 142.52,-2152.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-2152.9 142.52,-2212.9 796.52,-2212.9 796.52,-2152.9 142.52,-2152.9"/>
+<text text-anchor="start" x="153.52" y="-2173.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">content_hash &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-2174.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-2092.9 142.52,-2152.9 796.52,-2152.9 796.52,-2092.9 142.52,-2092.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-2092.9 142.52,-2152.9 796.52,-2152.9 796.52,-2092.9 142.52,-2092.9"/>
+<text text-anchor="start" x="153.52" y="-2113.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">ontology &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-2114.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-2032.9 142.52,-2092.9 796.52,-2092.9 796.52,-2032.9 142.52,-2032.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-2032.9 142.52,-2092.9 796.52,-2092.9 796.52,-2032.9 142.52,-2032.9"/>
+<text text-anchor="start" x="153.52" y="-2053.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="694.85" y="-2054.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="746.43" y="-2054.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-2054.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1972.9 142.52,-2032.9 796.52,-2032.9 796.52,-1972.9 142.52,-1972.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1972.9 142.52,-2032.9 796.52,-2032.9 796.52,-1972.9 142.52,-1972.9"/>
+<text text-anchor="start" x="153.52" y="-1993.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">progress &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-1994.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1912.9 142.52,-1972.9 796.52,-1972.9 796.52,-1912.9 142.52,-1912.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1912.9 142.52,-1972.9 796.52,-1972.9 796.52,-1912.9 142.52,-1912.9"/>
+<text text-anchor="start" x="153.52" y="-1933.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">result &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-1934.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1852.9 142.52,-1912.9 796.52,-1912.9 796.52,-1852.9 142.52,-1852.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1852.9 142.52,-1912.9 796.52,-1912.9 796.52,-1852.9 142.52,-1852.9"/>
+<text text-anchor="start" x="153.52" y="-1873.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">error &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-1874.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1792.9 142.52,-1852.9 796.52,-1852.9 796.52,-1792.9 142.52,-1792.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1792.9 142.52,-1852.9 796.52,-1852.9 796.52,-1792.9 142.52,-1792.9"/>
+<text text-anchor="start" x="153.52" y="-1813.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="341.04" y="-1814.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<text text-anchor="start" x="746.43" y="-1814.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-1814.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1732.9 142.52,-1792.9 796.52,-1792.9 796.52,-1732.9 142.52,-1732.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1732.9 142.52,-1792.9 796.52,-1792.9 796.52,-1732.9 142.52,-1732.9"/>
+<text text-anchor="start" x="153.52" y="-1753.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">started_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="380.13" y="-1754.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1672.9 142.52,-1732.9 796.52,-1732.9 796.52,-1672.9 142.52,-1672.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1672.9 142.52,-1732.9 796.52,-1732.9 796.52,-1672.9 142.52,-1672.9"/>
+<text text-anchor="start" x="153.2" y="-1693.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">completed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="380.32" y="-1694.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1612.9 142.52,-1672.9 796.52,-1672.9 796.52,-1612.9 142.52,-1612.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1612.9 142.52,-1672.9 796.52,-1672.9 796.52,-1612.9 142.52,-1612.9"/>
+<text text-anchor="start" x="153.52" y="-1633.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">job_data &#160;&#160;&#160;</text>
+<text text-anchor="start" x="669.96" y="-1634.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<text text-anchor="start" x="746.43" y="-1634.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-1634.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1552.9 142.52,-1612.9 796.52,-1612.9 796.52,-1552.9 142.52,-1552.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1552.9 142.52,-1612.9 796.52,-1612.9 796.52,-1552.9 142.52,-1552.9"/>
+<text text-anchor="start" x="153.52" y="-1573.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">analysis &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-1574.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1492.9 142.52,-1552.9 796.52,-1552.9 796.52,-1492.9 142.52,-1492.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1492.9 142.52,-1552.9 796.52,-1552.9 796.52,-1492.9 142.52,-1492.9"/>
+<text text-anchor="start" x="153.52" y="-1513.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">approved_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="380.13" y="-1514.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1432.9 142.52,-1492.9 796.52,-1492.9 796.52,-1432.9 142.52,-1432.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1432.9 142.52,-1492.9 796.52,-1492.9 796.52,-1432.9 142.52,-1432.9"/>
+<text text-anchor="start" x="153.52" y="-1453.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">approved_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-1454.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1372.9 142.52,-1432.9 796.52,-1432.9 796.52,-1372.9 142.52,-1372.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1372.9 142.52,-1432.9 796.52,-1432.9 796.52,-1372.9 142.52,-1372.9"/>
+<text text-anchor="start" x="153.52" y="-1393.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="380.13" y="-1394.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1312.9 142.52,-1372.9 796.52,-1372.9 796.52,-1312.9 142.52,-1312.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1312.9 142.52,-1372.9 796.52,-1372.9 796.52,-1312.9 142.52,-1312.9"/>
+<text text-anchor="start" x="153.52" y="-1333.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">processing_mode &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-1334.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1252.9 142.52,-1312.9 796.52,-1312.9 796.52,-1252.9 142.52,-1252.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1252.9 142.52,-1312.9 796.52,-1312.9 796.52,-1252.9 142.52,-1252.9"/>
+<text text-anchor="start" x="153.52" y="-1273.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">job_source &#160;&#160;&#160;</text>
+<text text-anchor="start" x="483.27" y="-1274.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1192.9 142.52,-1252.9 796.52,-1252.9 796.52,-1192.9 142.52,-1192.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1192.9 142.52,-1252.9 796.52,-1252.9 796.52,-1192.9 142.52,-1192.9"/>
+<text text-anchor="start" x="153.52" y="-1213.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="465.48" y="-1214.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1132.9 142.52,-1192.9 796.52,-1192.9 796.52,-1132.9 142.52,-1132.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1132.9 142.52,-1192.9 796.52,-1192.9 796.52,-1132.9 142.52,-1132.9"/>
+<text text-anchor="start" x="153.52" y="-1153.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_system_job &#160;&#160;&#160;</text>
+<text text-anchor="start" x="671.69" y="-1154.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1072.9 142.52,-1132.9 796.52,-1132.9 796.52,-1072.9 142.52,-1072.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1072.9 142.52,-1132.9 796.52,-1132.9 796.52,-1072.9 142.52,-1072.9"/>
+<text text-anchor="start" x="153.52" y="-1093.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="648.63" y="-1094.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="746.43" y="-1094.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-1094.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-1012.9 142.52,-1072.9 796.52,-1072.9 796.52,-1012.9 142.52,-1012.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-1012.9 142.52,-1072.9 796.52,-1072.9 796.52,-1012.9 142.52,-1012.9"/>
+<text text-anchor="start" x="153.52" y="-1033.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">source_filename &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-1034.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-952.9 142.52,-1012.9 796.52,-1012.9 796.52,-952.9 142.52,-952.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-952.9 142.52,-1012.9 796.52,-1012.9 796.52,-952.9 142.52,-952.9"/>
+<text text-anchor="start" x="153.52" y="-973.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">source_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-974.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-892.9 142.52,-952.9 796.52,-952.9 796.52,-892.9 142.52,-892.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-892.9 142.52,-952.9 796.52,-952.9 796.52,-892.9 142.52,-892.9"/>
+<text text-anchor="start" x="153.52" y="-913.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">source_path &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-914.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-832.9 142.52,-892.9 796.52,-892.9 796.52,-832.9 142.52,-832.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-832.9 142.52,-892.9 796.52,-892.9 796.52,-832.9 142.52,-832.9"/>
+<text text-anchor="start" x="153.52" y="-853.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">source_hostname &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-854.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-772.9 142.52,-832.9 796.52,-832.9 796.52,-772.9 142.52,-772.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-772.9 142.52,-832.9 796.52,-832.9 796.52,-772.9 142.52,-772.9"/>
+<text text-anchor="start" x="153.52" y="-793.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">artifact_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="687.72" y="-794.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-712.9 142.52,-772.9 796.52,-772.9 796.52,-712.9 142.52,-712.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-712.9 142.52,-772.9 796.52,-772.9 796.52,-712.9 142.52,-712.9"/>
+<text text-anchor="start" x="153.52" y="-733.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">priority &#160;&#160;&#160;</text>
+<text text-anchor="start" x="648.63" y="-734.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="746.43" y="-734.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-734.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-652.9 142.52,-712.9 796.52,-712.9 796.52,-652.9 142.52,-652.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-652.9 142.52,-712.9 796.52,-712.9 796.52,-652.9 142.52,-652.9"/>
+<text text-anchor="start" x="153.52" y="-673.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">claimed_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="733.94" y="-674.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-592.9 142.52,-652.9 796.52,-652.9 796.52,-592.9 142.52,-592.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-592.9 142.52,-652.9 796.52,-652.9 796.52,-592.9 142.52,-592.9"/>
+<text text-anchor="start" x="153.52" y="-613.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">claimed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="424.6" y="-614.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-532.9 142.52,-592.9 796.52,-592.9 796.52,-532.9 142.52,-532.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-532.9 142.52,-592.9 796.52,-592.9 796.52,-532.9 142.52,-532.9"/>
+<text text-anchor="start" x="153.52" y="-553.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">cancelled &#160;&#160;&#160;</text>
+<text text-anchor="start" x="632.59" y="-554.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<text text-anchor="start" x="746.43" y="-554.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-554.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-472.9 142.52,-532.9 796.52,-532.9 796.52,-472.9 142.52,-472.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-472.9 142.52,-532.9 796.52,-532.9 796.52,-472.9 142.52,-472.9"/>
+<text text-anchor="start" x="153.52" y="-493.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">retries &#160;&#160;&#160;</text>
+<text text-anchor="start" x="648.63" y="-494.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="746.43" y="-494.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-494.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="142.52,-412.9 142.52,-472.9 796.52,-472.9 796.52,-412.9 142.52,-412.9"/>
+<polygon fill="none" stroke="#29235c" points="142.52,-412.9 142.52,-472.9 796.52,-472.9 796.52,-412.9 142.52,-412.9"/>
+<text text-anchor="start" x="153.52" y="-433.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_retries &#160;&#160;&#160;</text>
+<text text-anchor="start" x="648.63" y="-434.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="746.43" y="-434.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="755.32" y="-434.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="141.52,-411.9 141.52,-2393.9 797.52,-2393.9 797.52,-411.9 141.52,-411.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.jobs&#45;&gt;kg_api.artifacts -->
+<!-- kg_api.jobs&#45;&gt;kg_api.artifacts -->
+<g id="edge12" class="edge">
+<title>kg_api.jobs:e&#45;&gt;kg_api.artifacts:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M797.52,-802.9C1099.52,-802.9 880.12,-2093.42 1170.41,-2122.4"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="1170.34,-2125.9 1180.5,-2122.9 1170.68,-2118.91 1170.34,-2125.9"/>
+</g>
+<!-- kg_api.jobs&#45;&gt;kg_auth.users -->
+<!-- kg_api.jobs&#45;&gt;kg_auth.users -->
+<g id="edge14" class="edge">
+<title>kg_api.jobs:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M797.52,-1102.9C884.62,-1102.9 896.22,-1051.79 982.04,-1036.9 1898.25,-877.97 2454.06,-539.28 3064.33,-1240.9 3351.61,-1571.18 2823.74,-5150.33 3246.4,-5206.24"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.35,-5209.74 3256.56,-5206.9 3246.81,-5202.76 3246.35,-5209.74"/>
+</g>
+<!-- kg_api.ontology_tombstones -->
+<g id="kg_api.ontology_tombstones" class="node">
+<title>kg_api.ontology_tombstones</title>
+<g id="a_kg_api.ontology_tombstones"><a xlink:title="kg_api.ontology_tombstones&#10;Positive operator&#45;intent signal that an ontology was deliberately removed and must not be silently recreated by a subsequent ingest (#402 Defect B2). Operator&#45;initiated delete writes a row; annealing dissolution does not.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9977.88" cy="-16318.9" rx="445.45" ry="214.92"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9664.88,-16408.9 9664.88,-16468.9 10290.88,-16468.9 10290.88,-16408.9 9664.88,-16408.9"/>
+<polygon fill="none" stroke="#29235c" points="9664.88,-16408.9 9664.88,-16468.9 10290.88,-16468.9 10290.88,-16408.9 9664.88,-16408.9"/>
+<text text-anchor="start" x="9712" y="-16430.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.ontology_tombstones &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9664.88,-16348.9 9664.88,-16408.9 10290.88,-16408.9 10290.88,-16348.9 9664.88,-16348.9"/>
+<polygon fill="none" stroke="#29235c" points="9664.88,-16348.9 9664.88,-16408.9 10290.88,-16408.9 10290.88,-16348.9 9664.88,-16348.9"/>
+<text text-anchor="start" x="9675.88" y="-16370.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">name</text>
+<text text-anchor="start" x="9755.9" y="-16370.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9920.75" y="-16370.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="10240.79" y="-16370.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10249.68" y="-16370.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9664.88,-16288.9 9664.88,-16348.9 10290.88,-16348.9 10290.88,-16288.9 9664.88,-16288.9"/>
+<polygon fill="none" stroke="#29235c" points="9664.88,-16288.9 9664.88,-16348.9 10290.88,-16348.9 10290.88,-16288.9 9664.88,-16288.9"/>
+<text text-anchor="start" x="9675.63" y="-16309.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">removed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9879.87" y="-16310.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10240.79" y="-16310.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10249.69" y="-16310.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9664.88,-16228.9 9664.88,-16288.9 10290.88,-16288.9 10290.88,-16228.9 9664.88,-16228.9"/>
+<polygon fill="none" stroke="#29235c" points="9664.88,-16228.9 9664.88,-16288.9 10290.88,-16288.9 10290.88,-16228.9 9664.88,-16228.9"/>
+<text text-anchor="start" x="9675.88" y="-16249.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">removed_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9959.84" y="-16250.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9664.88,-16168.9 9664.88,-16228.9 10290.88,-16228.9 10290.88,-16168.9 9664.88,-16168.9"/>
+<polygon fill="none" stroke="#29235c" points="9664.88,-16168.9 9664.88,-16228.9 10290.88,-16228.9 10290.88,-16168.9 9664.88,-16168.9"/>
+<text text-anchor="start" x="9675.88" y="-16189.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reason &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10228.3" y="-16190.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9663.88,-16167.9 9663.88,-16469.9 10291.88,-16469.9 10291.88,-16167.9 9663.88,-16167.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.platform_config -->
+<g id="kg_api.platform_config" class="node">
+<title>kg_api.platform_config</title>
+<g id="a_kg_api.platform_config"><a xlink:title="kg_api.platform_config&#10;Platform lifecycle configuration for operator control plane (ADR&#45;061)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.53" cy="-16318.9" rx="410.66" ry="257.27"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7828.53,-16438.9 7828.53,-16498.9 8405.53,-16498.9 8405.53,-16438.9 7828.53,-16438.9"/>
+<polygon fill="none" stroke="#29235c" points="7828.53,-16438.9 7828.53,-16498.9 8405.53,-16498.9 8405.53,-16438.9 7828.53,-16438.9"/>
+<text text-anchor="start" x="7893.85" y="-16460.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.platform_config &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7828.53,-16378.9 7828.53,-16438.9 8405.53,-16438.9 8405.53,-16378.9 7828.53,-16378.9"/>
+<polygon fill="none" stroke="#29235c" points="7828.53,-16378.9 7828.53,-16438.9 8405.53,-16438.9 8405.53,-16378.9 7828.53,-16378.9"/>
+<text text-anchor="start" x="7839.53" y="-16400.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">key</text>
+<text text-anchor="start" x="7889.32" y="-16400.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8035.4" y="-16400.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="8355.44" y="-16400.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8364.33" y="-16400.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7828.53,-16318.9 7828.53,-16378.9 8405.53,-16378.9 8405.53,-16318.9 7828.53,-16318.9"/>
+<polygon fill="none" stroke="#29235c" points="7828.53,-16318.9 7828.53,-16378.9 8405.53,-16378.9 8405.53,-16318.9 7828.53,-16318.9"/>
+<text text-anchor="start" x="7839.53" y="-16339.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">value &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8303.86" y="-16340.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="8355.44" y="-16340.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8364.33" y="-16340.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7828.53,-16258.9 7828.53,-16318.9 8405.53,-16318.9 8405.53,-16258.9 7828.53,-16258.9"/>
+<polygon fill="none" stroke="#29235c" points="7828.53,-16258.9 7828.53,-16318.9 8405.53,-16318.9 8405.53,-16258.9 7828.53,-16258.9"/>
+<text text-anchor="start" x="7839.53" y="-16279.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8342.95" y="-16280.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7828.53,-16198.9 7828.53,-16258.9 8405.53,-16258.9 8405.53,-16198.9 7828.53,-16198.9"/>
+<polygon fill="none" stroke="#29235c" points="7828.53,-16198.9 7828.53,-16258.9 8405.53,-16258.9 8405.53,-16198.9 7828.53,-16198.9"/>
+<text text-anchor="start" x="7839.19" y="-16219.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8034.07" y="-16220.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7828.53,-16138.9 7828.53,-16198.9 8405.53,-16198.9 8405.53,-16138.9 7828.53,-16138.9"/>
+<polygon fill="none" stroke="#29235c" points="7828.53,-16138.9 7828.53,-16198.9 8405.53,-16198.9 8405.53,-16138.9 7828.53,-16138.9"/>
+<text text-anchor="start" x="7839.53" y="-16159.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8074.49" y="-16160.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7827.03,-16137.9 7827.03,-16499.9 8406.03,-16499.9 8406.03,-16137.9 7827.03,-16137.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.provider_model_catalog -->
+<g id="kg_api.provider_model_catalog" class="node">
+<title>kg_api.provider_model_catalog</title>
+<g id="a_kg_api.provider_model_catalog"><a xlink:title="kg_api.provider_model_catalog&#10;Cached model catalog per AI provider with curation and pricing (ADR&#45;800)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.15" cy="-9137.9" rx="458.41" ry="978.77"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7794.15,-9767.9 7794.15,-9827.9 8438.15,-9827.9 8438.15,-9767.9 7794.15,-9767.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9767.9 7794.15,-9827.9 8438.15,-9827.9 8438.15,-9767.9 7794.15,-9767.9"/>
+<text text-anchor="start" x="7831.62" y="-9789.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.provider_model_catalog &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9707.9 7794.15,-9767.9 8438.15,-9767.9 8438.15,-9707.9 7794.15,-9707.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9707.9 7794.15,-9767.9 8438.15,-9767.9 8438.15,-9707.9 7794.15,-9707.9"/>
+<text text-anchor="start" x="7805.15" y="-9729.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="7830.04" y="-9729.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8290.26" y="-9729.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="8388.06" y="-9729.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8396.95" y="-9729.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9647.9 7794.15,-9707.9 8438.15,-9707.9 8438.15,-9647.9 7794.15,-9647.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9647.9 7794.15,-9707.9 8438.15,-9707.9 8438.15,-9647.9 7794.15,-9647.9"/>
+<text text-anchor="start" x="7805.15" y="-9668.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8085.81" y="-9669.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="8388.06" y="-9669.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8396.95" y="-9669.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9587.9 7794.15,-9647.9 8438.15,-9647.9 8438.15,-9587.9 7794.15,-9587.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9587.9 7794.15,-9647.9 8438.15,-9647.9 8438.15,-9587.9 7794.15,-9587.9"/>
+<text text-anchor="start" x="7805.15" y="-9608.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">model_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8068.02" y="-9609.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(300)</text>
+<text text-anchor="start" x="8388.06" y="-9609.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8396.95" y="-9609.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9527.9 7794.15,-9587.9 8438.15,-9587.9 8438.15,-9527.9 7794.15,-9527.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9527.9 7794.15,-9587.9 8438.15,-9587.9 8438.15,-9527.9 7794.15,-9527.9"/>
+<text text-anchor="start" x="7805.15" y="-9548.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">display_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8107.11" y="-9549.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(300)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9467.9 7794.15,-9527.9 8438.15,-9527.9 8438.15,-9467.9 7794.15,-9467.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9467.9 7794.15,-9527.9 8438.15,-9527.9 8438.15,-9467.9 7794.15,-9467.9"/>
+<text text-anchor="start" x="7805.15" y="-9488.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">category &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8085.81" y="-9489.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="8388.06" y="-9489.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8396.95" y="-9489.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9407.9 7794.15,-9467.9 8438.15,-9467.9 8438.15,-9407.9 7794.15,-9407.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9407.9 7794.15,-9467.9 8438.15,-9467.9 8438.15,-9407.9 7794.15,-9407.9"/>
+<text text-anchor="start" x="7805.15" y="-9428.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">context_length &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8329.35" y="-9429.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9347.9 7794.15,-9407.9 8438.15,-9407.9 8438.15,-9347.9 7794.15,-9347.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9347.9 7794.15,-9407.9 8438.15,-9407.9 8438.15,-9347.9 7794.15,-9347.9"/>
+<text text-anchor="start" x="7805.15" y="-9368.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_completion_tokens &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8329.35" y="-9369.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9287.9 7794.15,-9347.9 8438.15,-9347.9 8438.15,-9287.9 7794.15,-9287.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9287.9 7794.15,-9347.9 8438.15,-9347.9 8438.15,-9287.9 7794.15,-9287.9"/>
+<text text-anchor="start" x="7805.15" y="-9308.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">supports_vision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.32" y="-9309.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9227.9 7794.15,-9287.9 8438.15,-9287.9 8438.15,-9227.9 7794.15,-9227.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9227.9 7794.15,-9287.9 8438.15,-9287.9 8438.15,-9227.9 7794.15,-9227.9"/>
+<text text-anchor="start" x="7805.15" y="-9248.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">supports_json_mode &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.32" y="-9249.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9167.9 7794.15,-9227.9 8438.15,-9227.9 8438.15,-9167.9 7794.15,-9167.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9167.9 7794.15,-9227.9 8438.15,-9227.9 8438.15,-9167.9 7794.15,-9167.9"/>
+<text text-anchor="start" x="7805.15" y="-9188.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">supports_tool_use &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.32" y="-9189.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9107.9 7794.15,-9167.9 8438.15,-9167.9 8438.15,-9107.9 7794.15,-9107.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9107.9 7794.15,-9167.9 8438.15,-9167.9 8438.15,-9107.9 7794.15,-9107.9"/>
+<text text-anchor="start" x="7805.15" y="-9128.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">supports_streaming &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.32" y="-9129.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-9047.9 7794.15,-9107.9 8438.15,-9107.9 8438.15,-9047.9 7794.15,-9047.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-9047.9 7794.15,-9107.9 8438.15,-9107.9 8438.15,-9047.9 7794.15,-9047.9"/>
+<text text-anchor="start" x="7805.15" y="-9068.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">price_prompt_per_m &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.38" y="-9069.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8987.9 7794.15,-9047.9 8438.15,-9047.9 8438.15,-8987.9 7794.15,-8987.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8987.9 7794.15,-9047.9 8438.15,-9047.9 8438.15,-8987.9 7794.15,-8987.9"/>
+<text text-anchor="start" x="7805.15" y="-9008.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">price_completion_per_m &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.38" y="-9009.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8927.9 7794.15,-8987.9 8438.15,-8987.9 8438.15,-8927.9 7794.15,-8927.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8927.9 7794.15,-8987.9 8438.15,-8987.9 8438.15,-8927.9 7794.15,-8927.9"/>
+<text text-anchor="start" x="7805.15" y="-8948.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">price_cache_read_per_m &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.38" y="-8949.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8867.9 7794.15,-8927.9 8438.15,-8927.9 8438.15,-8867.9 7794.15,-8867.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8867.9 7794.15,-8927.9 8438.15,-8927.9 8438.15,-8867.9 7794.15,-8867.9"/>
+<text text-anchor="start" x="7805.15" y="-8888.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">enabled &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.32" y="-8889.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8807.9 7794.15,-8867.9 8438.15,-8867.9 8438.15,-8807.9 7794.15,-8807.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8807.9 7794.15,-8867.9 8438.15,-8867.9 8438.15,-8807.9 7794.15,-8807.9"/>
+<text text-anchor="start" x="7805.15" y="-8828.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_default &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8313.32" y="-8829.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8747.9 7794.15,-8807.9 8438.15,-8807.9 8438.15,-8747.9 7794.15,-8747.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8747.9 7794.15,-8807.9 8438.15,-8807.9 8438.15,-8747.9 7794.15,-8747.9"/>
+<text text-anchor="start" x="7805.15" y="-8768.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">sort_order &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8329.35" y="-8769.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8687.9 7794.15,-8747.9 8438.15,-8747.9 8438.15,-8687.9 7794.15,-8687.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8687.9 7794.15,-8747.9 8438.15,-8747.9 8438.15,-8687.9 7794.15,-8687.9"/>
+<text text-anchor="start" x="7805.01" y="-8708.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">upstream_provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8107.13" y="-8709.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8627.9 7794.15,-8687.9 8438.15,-8687.9 8438.15,-8627.9 7794.15,-8627.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8627.9 7794.15,-8687.9 8438.15,-8687.9 8438.15,-8627.9 7794.15,-8627.9"/>
+<text text-anchor="start" x="7805.15" y="-8648.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">raw_metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8350.68" y="-8649.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8567.9 7794.15,-8627.9 8438.15,-8627.9 8438.15,-8567.9 7794.15,-8567.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8567.9 7794.15,-8627.9 8438.15,-8627.9 8438.15,-8567.9 7794.15,-8567.9"/>
+<text text-anchor="start" x="7805.15" y="-8588.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">fetched_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8066.23" y="-8589.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8507.9 7794.15,-8567.9 8438.15,-8567.9 8438.15,-8507.9 7794.15,-8507.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8507.9 7794.15,-8567.9 8438.15,-8567.9 8438.15,-8507.9 7794.15,-8507.9"/>
+<text text-anchor="start" x="7805.15" y="-8528.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8066.23" y="-8529.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7794.15,-8447.9 7794.15,-8507.9 8438.15,-8507.9 8438.15,-8447.9 7794.15,-8447.9"/>
+<polygon fill="none" stroke="#29235c" points="7794.15,-8447.9 7794.15,-8507.9 8438.15,-8507.9 8438.15,-8447.9 7794.15,-8447.9"/>
+<text text-anchor="start" x="7805.15" y="-8468.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8066.23" y="-8469.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7793.15,-8446.9 7793.15,-9828.9 8439.15,-9828.9 8439.15,-8446.9 7793.15,-8446.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.pruning_recommendations -->
+<g id="kg_api.pruning_recommendations" class="node">
+<title>kg_api.pruning_recommendations</title>
+<g id="a_kg_api.pruning_recommendations"><a xlink:title="kg_api.pruning_recommendations&#10;Pending vocabulary management actions &#45; ADR&#45;032">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6172.25" cy="-10890.9" rx="468.21" ry="724.15"/>
+<polygon fill="#7c3aed" stroke="transparent" points="5843.25,-11340.9 5843.25,-11400.9 6501.25,-11400.9 6501.25,-11340.9 5843.25,-11340.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-11340.9 5843.25,-11400.9 6501.25,-11400.9 6501.25,-11340.9 5843.25,-11340.9"/>
+<text text-anchor="start" x="5869.05" y="-11362.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.pruning_recommendations &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-11280.9 5843.25,-11340.9 6501.25,-11340.9 6501.25,-11280.9 5843.25,-11280.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-11280.9 5843.25,-11340.9 6501.25,-11340.9 6501.25,-11280.9 5843.25,-11280.9"/>
+<text text-anchor="start" x="5854.25" y="-11302.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="5879.14" y="-11302.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6353.36" y="-11302.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6451.16" y="-11302.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.05" y="-11302.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-11220.9 5843.25,-11280.9 6501.25,-11280.9 6501.25,-11220.9 5843.25,-11220.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-11220.9 5843.25,-11280.9 6501.25,-11280.9 6501.25,-11220.9 5843.25,-11220.9"/>
+<text text-anchor="start" x="5854.05" y="-11241.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">relationship_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6131.19" y="-11242.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="6451.22" y="-11242.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.12" y="-11242.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-11160.9 5843.25,-11220.9 6501.25,-11220.9 6501.25,-11160.9 5843.25,-11160.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-11160.9 5843.25,-11220.9 6501.25,-11220.9 6501.25,-11160.9 5843.25,-11160.9"/>
+<text text-anchor="start" x="5854.25" y="-11181.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">target_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6170.21" y="-11182.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-11100.9 5843.25,-11160.9 6501.25,-11160.9 6501.25,-11100.9 5843.25,-11100.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-11100.9 5843.25,-11160.9 6501.25,-11160.9 6501.25,-11100.9 5843.25,-11100.9"/>
+<text text-anchor="start" x="5854.25" y="-11121.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">action_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6148.91" y="-11122.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="6451.16" y="-11122.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.05" y="-11122.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-11040.9 5843.25,-11100.9 6501.25,-11100.9 6501.25,-11040.9 5843.25,-11040.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-11040.9 5843.25,-11100.9 6501.25,-11100.9 6501.25,-11040.9 5843.25,-11040.9"/>
+<text text-anchor="start" x="5854.25" y="-11061.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">review_level &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6148.91" y="-11062.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="6451.16" y="-11062.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.05" y="-11062.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10980.9 5843.25,-11040.9 6501.25,-11040.9 6501.25,-10980.9 5843.25,-10980.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10980.9 5843.25,-11040.9 6501.25,-11040.9 6501.25,-10980.9 5843.25,-10980.9"/>
+<text text-anchor="start" x="5854.25" y="-11001.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reasoning &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6399.59" y="-11002.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="6451.16" y="-11002.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.05" y="-11002.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10920.9 5843.25,-10980.9 6501.25,-10980.9 6501.25,-10920.9 5843.25,-10920.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10920.9 5843.25,-10980.9 6501.25,-10980.9 6501.25,-10920.9 5843.25,-10920.9"/>
+<text text-anchor="start" x="5854.25" y="-10941.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">similarity &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6310.7" y="-10942.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(4,3)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10860.9 5843.25,-10920.9 6501.25,-10920.9 6501.25,-10860.9 5843.25,-10860.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10860.9 5843.25,-10920.9 6501.25,-10920.9 6501.25,-10860.9 5843.25,-10860.9"/>
+<text text-anchor="start" x="5854.25" y="-10881.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">value_score &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6292.91" y="-10882.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(10,2)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10800.9 5843.25,-10860.9 6501.25,-10860.9 6501.25,-10800.9 5843.25,-10800.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10800.9 5843.25,-10860.9 6501.25,-10860.9 6501.25,-10800.9 5843.25,-10800.9"/>
+<text text-anchor="start" x="5854.25" y="-10821.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6413.78" y="-10822.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10740.9 5843.25,-10800.9 6501.25,-10800.9 6501.25,-10740.9 5843.25,-10740.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10740.9 5843.25,-10800.9 6501.25,-10800.9 6501.25,-10740.9 5843.25,-10740.9"/>
+<text text-anchor="start" x="5854.25" y="-10761.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6148.91" y="-10762.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="6451.16" y="-10762.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.05" y="-10762.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10680.9 5843.25,-10740.9 6501.25,-10740.9 6501.25,-10680.9 5843.25,-10680.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10680.9 5843.25,-10740.9 6501.25,-10740.9 6501.25,-10680.9 5843.25,-10680.9"/>
+<text text-anchor="start" x="5854.25" y="-10701.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6090.24" y="-10702.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="6451.16" y="-10702.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.05" y="-10702.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10620.9 5843.25,-10680.9 6501.25,-10680.9 6501.25,-10620.9 5843.25,-10620.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10620.9 5843.25,-10680.9 6501.25,-10680.9 6501.25,-10620.9 5843.25,-10620.9"/>
+<text text-anchor="start" x="5854.25" y="-10641.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reviewed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6129.33" y="-10642.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10560.9 5843.25,-10620.9 6501.25,-10620.9 6501.25,-10560.9 5843.25,-10560.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10560.9 5843.25,-10620.9 6501.25,-10620.9 6501.25,-10560.9 5843.25,-10560.9"/>
+<text text-anchor="start" x="5854.25" y="-10581.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reviewed_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6170.21" y="-10582.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10500.9 5843.25,-10560.9 6501.25,-10560.9 6501.25,-10500.9 5843.25,-10500.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10500.9 5843.25,-10560.9 6501.25,-10560.9 6501.25,-10500.9 5843.25,-10500.9"/>
+<text text-anchor="start" x="5854.25" y="-10521.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reviewer_notes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6438.68" y="-10522.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10440.9 5843.25,-10500.9 6501.25,-10500.9 6501.25,-10440.9 5843.25,-10440.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10440.9 5843.25,-10500.9 6501.25,-10500.9 6501.25,-10440.9 5843.25,-10440.9"/>
+<text text-anchor="start" x="5854.25" y="-10461.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">executed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6129.33" y="-10462.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.25,-10380.9 5843.25,-10440.9 6501.25,-10440.9 6501.25,-10380.9 5843.25,-10380.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.25,-10380.9 5843.25,-10440.9 6501.25,-10440.9 6501.25,-10380.9 5843.25,-10380.9"/>
+<text text-anchor="start" x="5854.25" y="-10401.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6129.33" y="-10402.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5842.25,-10379.9 5842.25,-11401.9 6502.25,-11401.9 6502.25,-10379.9 5842.25,-10379.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.query_definitions&#45;&gt;kg_auth.users -->
+<!-- kg_api.query_definitions&#45;&gt;kg_auth.users -->
+<g id="edge16" class="edge">
+<title>kg_api.query_definitions:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2858.15,-1792.9C3085.03,-1792.9 3010.3,-2039.54 3064.33,-2259.9 3141.64,-2575.18 2932.98,-5150.7 3246.17,-5206"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.29,-5209.52 3256.56,-5206.9 3246.9,-5202.55 3246.29,-5209.52"/>
+</g>
+<!-- kg_api.rate_limits -->
+<g id="kg_api.rate_limits" class="node">
+<title>kg_api.rate_limits</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6172.15" cy="-16318.9" rx="458.41" ry="214.92"/>
+<polygon fill="#7c3aed" stroke="transparent" points="5850.15,-16408.9 5850.15,-16468.9 6494.15,-16468.9 6494.15,-16408.9 5850.15,-16408.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.15,-16408.9 5850.15,-16468.9 6494.15,-16468.9 6494.15,-16408.9 5850.15,-16408.9"/>
+<text text-anchor="start" x="5985.45" y="-16430.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.rate_limits &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.15,-16348.9 5850.15,-16408.9 6494.15,-16408.9 6494.15,-16348.9 5850.15,-16348.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.15,-16348.9 5850.15,-16408.9 6494.15,-16408.9 6494.15,-16348.9 5850.15,-16348.9"/>
+<text text-anchor="start" x="5861.15" y="-16370.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">client_id</text>
+<text text-anchor="start" x="5978.5" y="-16370.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6124.02" y="-16370.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="6444.06" y="-16370.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6452.95" y="-16370.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.15,-16288.9 5850.15,-16348.9 6494.15,-16348.9 6494.15,-16288.9 5850.15,-16288.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.15,-16288.9 5850.15,-16348.9 6494.15,-16348.9 6494.15,-16288.9 5850.15,-16288.9"/>
+<text text-anchor="start" x="5861.15" y="-16310.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">endpoint</text>
+<text text-anchor="start" x="5983.88" y="-16310.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6124.02" y="-16310.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="6444.06" y="-16310.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6452.95" y="-16310.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.15,-16228.9 5850.15,-16288.9 6494.15,-16288.9 6494.15,-16228.9 5850.15,-16228.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.15,-16228.9 5850.15,-16288.9 6494.15,-16288.9 6494.15,-16228.9 5850.15,-16228.9"/>
+<text text-anchor="start" x="5861.02" y="-16250.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">window_start</text>
+<text text-anchor="start" x="6047.71" y="-16250.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6083.14" y="-16250.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="6444.07" y="-16250.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6452.96" y="-16250.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.15,-16168.9 5850.15,-16228.9 6494.15,-16228.9 6494.15,-16168.9 5850.15,-16168.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.15,-16168.9 5850.15,-16228.9 6494.15,-16228.9 6494.15,-16168.9 5850.15,-16168.9"/>
+<text text-anchor="start" x="5861.15" y="-16189.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">request_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6346.26" y="-16190.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6444.06" y="-16190.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6452.95" y="-16190.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5849.15,-16167.9 5849.15,-16469.9 6495.15,-16469.9 6495.15,-16167.9 5849.15,-16167.9"/>
+</g>
+<!-- kg_api.relationship_vocabulary -->
+<g id="kg_api.relationship_vocabulary" class="node">
+<title>kg_api.relationship_vocabulary</title>
+<g id="a_kg_api.relationship_vocabulary"><a xlink:title="kg_api.relationship_vocabulary&#10;Canonical relationship types with embeddings &#45; ADR&#45;025, ADR&#45;032">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6704.62" cy="-4075.9" rx="560.97" ry="1063.48"/>
+<polygon fill="#7c3aed" stroke="transparent" points="6310.62,-4765.9 6310.62,-4825.9 7099.62,-4825.9 7099.62,-4765.9 6310.62,-4765.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4765.9 6310.62,-4825.9 7099.62,-4825.9 7099.62,-4765.9 6310.62,-4765.9"/>
+<text text-anchor="start" x="6423.26" y="-4787.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.relationship_vocabulary &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4705.9 6310.62,-4765.9 7099.62,-4765.9 7099.62,-4705.9 6310.62,-4705.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4705.9 6310.62,-4765.9 7099.62,-4765.9 7099.62,-4705.9 6310.62,-4705.9"/>
+<text text-anchor="start" x="6321.62" y="-4727.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">relationship_type</text>
+<text text-anchor="start" x="6563.46" y="-4727.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6729.49" y="-4727.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="7049.53" y="-4727.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="7058.42" y="-4727.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4645.9 6310.62,-4705.9 7099.62,-4705.9 7099.62,-4645.9 6310.62,-4645.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4645.9 6310.62,-4705.9 7099.62,-4705.9 7099.62,-4645.9 6310.62,-4645.9"/>
+<text text-anchor="start" x="6321.62" y="-4666.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7037.05" y="-4667.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4585.9 6310.62,-4645.9 7099.62,-4645.9 7099.62,-4585.9 6310.62,-4585.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4585.9 6310.62,-4645.9 7099.62,-4645.9 7099.62,-4585.9 6310.62,-4585.9"/>
+<text text-anchor="start" x="6321.62" y="-4606.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">category &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6786.37" y="-4607.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4525.9 6310.62,-4585.9 7099.62,-4585.9 7099.62,-4525.9 6310.62,-4525.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4525.9 6310.62,-4585.9 7099.62,-4585.9 7099.62,-4525.9 6310.62,-4525.9"/>
+<text text-anchor="start" x="6321.62" y="-4546.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">added_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6768.58" y="-4547.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4465.9 6310.62,-4525.9 7099.62,-4525.9 7099.62,-4465.9 6310.62,-4465.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4465.9 6310.62,-4525.9 7099.62,-4525.9 7099.62,-4465.9 6310.62,-4465.9"/>
+<text text-anchor="start" x="6321.62" y="-4486.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">added_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6688.61" y="-4487.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="7049.53" y="-4487.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="7058.42" y="-4487.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4405.9 6310.62,-4465.9 7099.62,-4465.9 7099.62,-4405.9 6310.62,-4405.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4405.9 6310.62,-4465.9 7099.62,-4465.9 7099.62,-4405.9 6310.62,-4405.9"/>
+<text text-anchor="start" x="6321.62" y="-4426.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">usage_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6990.82" y="-4427.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4345.9 6310.62,-4405.9 7099.62,-4405.9 7099.62,-4345.9 6310.62,-4345.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4345.9 6310.62,-4405.9 7099.62,-4405.9 7099.62,-4345.9 6310.62,-4345.9"/>
+<text text-anchor="start" x="6321.62" y="-4366.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6974.79" y="-4367.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4285.9 6310.62,-4345.9 7099.62,-4345.9 7099.62,-4285.9 6310.62,-4285.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4285.9 6310.62,-4345.9 7099.62,-4345.9 7099.62,-4285.9 6310.62,-4285.9"/>
+<text text-anchor="start" x="6321.62" y="-4306.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_builtin &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6974.79" y="-4307.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4225.9 6310.62,-4285.9 7099.62,-4285.9 7099.62,-4225.9 6310.62,-4225.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4225.9 6310.62,-4285.9 7099.62,-4285.9 7099.62,-4225.9 6310.62,-4225.9"/>
+<text text-anchor="start" x="6321.62" y="-4246.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">synonyms &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6750.8" y="-4247.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4165.9 6310.62,-4225.9 7099.62,-4225.9 7099.62,-4165.9 6310.62,-4165.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4165.9 6310.62,-4225.9 7099.62,-4225.9 7099.62,-4165.9 6310.62,-4165.9"/>
+<text text-anchor="start" x="6321.62" y="-4186.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">deprecation_reason &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7037.05" y="-4187.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4105.9 6310.62,-4165.9 7099.62,-4165.9 7099.62,-4105.9 6310.62,-4105.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4105.9 6310.62,-4165.9 7099.62,-4165.9 7099.62,-4105.9 6310.62,-4105.9"/>
+<text text-anchor="start" x="6321.62" y="-4126.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7012.15" y="-4127.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-4045.9 6310.62,-4105.9 7099.62,-4105.9 7099.62,-4045.9 6310.62,-4045.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-4045.9 6310.62,-4105.9 7099.62,-4105.9 7099.62,-4045.9 6310.62,-4045.9"/>
+<text text-anchor="start" x="6321.62" y="-4066.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_model &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6768.58" y="-4067.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3985.9 6310.62,-4045.9 7099.62,-4045.9 7099.62,-3985.9 6310.62,-3985.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3985.9 6310.62,-4045.9 7099.62,-4045.9 7099.62,-3985.9 6310.62,-3985.9"/>
+<text text-anchor="start" x="6321.62" y="-4006.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_generated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6727.7" y="-4007.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3925.9 6310.62,-3985.9 7099.62,-3985.9 7099.62,-3925.9 6310.62,-3925.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3925.9 6310.62,-3985.9 7099.62,-3985.9 7099.62,-3925.9 6310.62,-3925.9"/>
+<text text-anchor="start" x="6321.62" y="-3946.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">grounding_contribution &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6855.67" y="-3947.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3865.9 6310.62,-3925.9 7099.62,-3925.9 7099.62,-3865.9 6310.62,-3865.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3865.9 6310.62,-3925.9 7099.62,-3925.9 7099.62,-3865.9 6310.62,-3865.9"/>
+<text text-anchor="start" x="6321.5" y="-3886.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_grounding_calculated &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6728.16" y="-3887.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3805.9 6310.62,-3865.9 7099.62,-3865.9 7099.62,-3805.9 6310.62,-3805.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3805.9 6310.62,-3865.9 7099.62,-3865.9 7099.62,-3805.9 6310.62,-3805.9"/>
+<text text-anchor="start" x="6321.62" y="-3826.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">avg_confidence &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6855.67" y="-3827.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3745.9 6310.62,-3805.9 7099.62,-3805.9 7099.62,-3745.9 6310.62,-3745.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3745.9 6310.62,-3805.9 7099.62,-3805.9 7099.62,-3745.9 6310.62,-3745.9"/>
+<text text-anchor="start" x="6321.62" y="-3766.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">semantic_diversity &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6855.67" y="-3767.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3685.9 6310.62,-3745.9 7099.62,-3745.9 7099.62,-3685.9 6310.62,-3685.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3685.9 6310.62,-3745.9 7099.62,-3745.9 7099.62,-3685.9 6310.62,-3685.9"/>
+<text text-anchor="start" x="6321.62" y="-3706.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_quality_score &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6855.67" y="-3707.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3625.9 6310.62,-3685.9 7099.62,-3685.9 7099.62,-3625.9 6310.62,-3625.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3625.9 6310.62,-3685.9 7099.62,-3685.9 7099.62,-3625.9 6310.62,-3625.9"/>
+<text text-anchor="start" x="6321.62" y="-3646.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_validation_status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6786.37" y="-3647.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3565.9 6310.62,-3625.9 7099.62,-3625.9 7099.62,-3565.9 6310.62,-3565.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3565.9 6310.62,-3625.9 7099.62,-3625.9 7099.62,-3565.9 6310.62,-3565.9"/>
+<text text-anchor="start" x="6321.62" y="-3586.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">category_source &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6786.37" y="-3587.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3505.9 6310.62,-3565.9 7099.62,-3565.9 7099.62,-3505.9 6310.62,-3505.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3505.9 6310.62,-3565.9 7099.62,-3565.9 7099.62,-3505.9 6310.62,-3505.9"/>
+<text text-anchor="start" x="6321.62" y="-3526.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">category_confidence &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6855.67" y="-3527.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3445.9 6310.62,-3505.9 7099.62,-3505.9 7099.62,-3445.9 6310.62,-3445.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3445.9 6310.62,-3505.9 7099.62,-3505.9 7099.62,-3445.9 6310.62,-3445.9"/>
+<text text-anchor="start" x="6321.62" y="-3466.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">category_scores &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7012.15" y="-3467.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3385.9 6310.62,-3445.9 7099.62,-3445.9 7099.62,-3385.9 6310.62,-3385.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3385.9 6310.62,-3445.9 7099.62,-3445.9 7099.62,-3385.9 6310.62,-3385.9"/>
+<text text-anchor="start" x="6321.62" y="-3406.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">category_ambiguous &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6974.79" y="-3407.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="6310.62,-3325.9 6310.62,-3385.9 7099.62,-3385.9 7099.62,-3325.9 6310.62,-3325.9"/>
+<polygon fill="none" stroke="#29235c" points="6310.62,-3325.9 6310.62,-3385.9 7099.62,-3385.9 7099.62,-3325.9 6310.62,-3325.9"/>
+<text text-anchor="start" x="6321.62" y="-3346.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">direction_semantics &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6786.37" y="-3347.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="6309.12,-3324.9 6309.12,-4826.9 7100.12,-4826.9 7100.12,-3324.9 6309.12,-3324.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.scheduled_jobs -->
+<g id="kg_api.scheduled_jobs" class="node">
+<title>kg_api.scheduled_jobs</title>
+<g id="a_kg_api.scheduled_jobs"><a xlink:title="kg_api.scheduled_jobs&#10;Scheduled background jobs: &#45; category_refresh: Re&#45;integrate LLM&#45;generated vocabulary categories (every 6 hours) &#45; vocab_consolidation: Auto&#45;consolidate vocabulary based on hysteresis thresholds (every 12 hours)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6172.44" cy="-12346.9" rx="458.82" ry="596.6"/>
+<polygon fill="#7c3aed" stroke="transparent" points="5850.44,-12706.9 5850.44,-12766.9 6495.44,-12766.9 6495.44,-12706.9 5850.44,-12706.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12706.9 5850.44,-12766.9 6495.44,-12766.9 6495.44,-12706.9 5850.44,-12706.9"/>
+<text text-anchor="start" x="5947.97" y="-12728.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.scheduled_jobs &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12646.9 5850.44,-12706.9 6495.44,-12706.9 6495.44,-12646.9 5850.44,-12646.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12646.9 5850.44,-12706.9 6495.44,-12706.9 6495.44,-12646.9 5850.44,-12646.9"/>
+<text text-anchor="start" x="5861.44" y="-12668.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="5886.33" y="-12668.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6347.55" y="-12668.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6445.35" y="-12668.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.24" y="-12668.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12586.9 5850.44,-12646.9 6495.44,-12646.9 6495.44,-12586.9 5850.44,-12586.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12586.9 5850.44,-12646.9 6495.44,-12646.9 6495.44,-12586.9 5850.44,-12586.9"/>
+<text text-anchor="start" x="5861.44" y="-12607.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6125.31" y="-12608.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="6445.35" y="-12608.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.24" y="-12608.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12526.9 5850.44,-12586.9 6495.44,-12586.9 6495.44,-12526.9 5850.44,-12526.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12526.9 5850.44,-12586.9 6495.44,-12586.9 6495.44,-12526.9 5850.44,-12526.9"/>
+<text text-anchor="start" x="5861.44" y="-12547.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">launcher_class &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6125.31" y="-12548.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="6445.35" y="-12548.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.24" y="-12548.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12466.9 5850.44,-12526.9 6495.44,-12526.9 6495.44,-12466.9 5850.44,-12466.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12466.9 5850.44,-12526.9 6495.44,-12526.9 6495.44,-12466.9 5850.44,-12466.9"/>
+<text text-anchor="start" x="5861.44" y="-12487.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">schedule_cron &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6125.31" y="-12488.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="6445.35" y="-12488.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6454.24" y="-12488.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12406.9 5850.44,-12466.9 6495.44,-12466.9 6495.44,-12406.9 5850.44,-12406.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12406.9 5850.44,-12466.9 6495.44,-12466.9 6495.44,-12406.9 5850.44,-12406.9"/>
+<text text-anchor="start" x="5861.44" y="-12427.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">enabled &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6370.61" y="-12428.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12346.9 5850.44,-12406.9 6495.44,-12406.9 6495.44,-12346.9 5850.44,-12346.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12346.9 5850.44,-12406.9 6495.44,-12406.9 6495.44,-12346.9 5850.44,-12346.9"/>
+<text text-anchor="start" x="5861.44" y="-12367.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_retries &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6386.64" y="-12368.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12286.9 5850.44,-12346.9 6495.44,-12346.9 6495.44,-12286.9 5850.44,-12286.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12286.9 5850.44,-12346.9 6495.44,-12346.9 6495.44,-12286.9 5850.44,-12286.9"/>
+<text text-anchor="start" x="5861.44" y="-12307.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">retry_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6386.64" y="-12308.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12226.9 5850.44,-12286.9 6495.44,-12286.9 6495.44,-12226.9 5850.44,-12226.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12226.9 5850.44,-12286.9 6495.44,-12286.9 6495.44,-12226.9 5850.44,-12226.9"/>
+<text text-anchor="start" x="5861.44" y="-12247.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_run &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6079.05" y="-12248.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12166.9 5850.44,-12226.9 6495.44,-12226.9 6495.44,-12166.9 5850.44,-12166.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12166.9 5850.44,-12226.9 6495.44,-12226.9 6495.44,-12166.9 5850.44,-12166.9"/>
+<text text-anchor="start" x="5861.08" y="-12187.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_success &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6079.25" y="-12188.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12106.9 5850.44,-12166.9 6495.44,-12166.9 6495.44,-12106.9 5850.44,-12106.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12106.9 5850.44,-12166.9 6495.44,-12166.9 6495.44,-12106.9 5850.44,-12106.9"/>
+<text text-anchor="start" x="5861.44" y="-12127.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_failure &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6079.05" y="-12128.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-12046.9 5850.44,-12106.9 6495.44,-12106.9 6495.44,-12046.9 5850.44,-12046.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-12046.9 5850.44,-12106.9 6495.44,-12106.9 6495.44,-12046.9 5850.44,-12046.9"/>
+<text text-anchor="start" x="5861.44" y="-12067.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">next_run &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6079.05" y="-12068.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-11986.9 5850.44,-12046.9 6495.44,-12046.9 6495.44,-11986.9 5850.44,-11986.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-11986.9 5850.44,-12046.9 6495.44,-12046.9 6495.44,-11986.9 5850.44,-11986.9"/>
+<text text-anchor="start" x="5861.44" y="-12007.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6079.05" y="-12008.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5850.44,-11926.9 5850.44,-11986.9 6495.44,-11986.9 6495.44,-11926.9 5850.44,-11926.9"/>
+<polygon fill="none" stroke="#29235c" points="5850.44,-11926.9 5850.44,-11986.9 6495.44,-11986.9 6495.44,-11926.9 5850.44,-11926.9"/>
+<text text-anchor="start" x="5861.44" y="-11947.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6079.05" y="-11948.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5848.94,-11925.9 5848.94,-12767.9 6495.94,-12767.9 6495.94,-11925.9 5848.94,-11925.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.schema_migrations -->
+<g id="kg_api.schema_migrations" class="node">
+<title>kg_api.schema_migrations</title>
+<g id="a_kg_api.schema_migrations"><a xlink:title="kg_api.schema_migrations&#10;Tracks applied database migrations for backup/restore compatibility. Schema version is included in backups to ensure restore compatibility when database schema evolves. See ADR&#45;015 for details.">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.61" cy="-16841.9" rx="461.98" ry="172.57"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7792.61,-16901.9 7792.61,-16961.9 8441.61,-16961.9 8441.61,-16901.9 7792.61,-16901.9"/>
+<polygon fill="none" stroke="#29235c" points="7792.61,-16901.9 7792.61,-16961.9 8441.61,-16961.9 8441.61,-16901.9 7792.61,-16901.9"/>
+<text text-anchor="start" x="7864.61" y="-16923.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.schema_migrations &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7792.61,-16841.9 7792.61,-16901.9 8441.61,-16901.9 8441.61,-16841.9 7792.61,-16841.9"/>
+<polygon fill="none" stroke="#29235c" points="7792.61,-16841.9 7792.61,-16901.9 8441.61,-16901.9 8441.61,-16841.9 7792.61,-16841.9"/>
+<text text-anchor="start" x="7803.61" y="-16863.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">version</text>
+<text text-anchor="start" x="7906.73" y="-16863.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8293.72" y="-16863.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="8391.52" y="-16863.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8400.42" y="-16863.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7792.61,-16781.9 7792.61,-16841.9 8441.61,-16841.9 8441.61,-16781.9 7792.61,-16781.9"/>
+<polygon fill="none" stroke="#29235c" points="7792.61,-16781.9 7792.61,-16841.9 8441.61,-16841.9 8441.61,-16781.9 7792.61,-16781.9"/>
+<text text-anchor="start" x="7803.61" y="-16802.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8339.95" y="-16803.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="8391.52" y="-16803.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8400.42" y="-16803.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7792.61,-16721.9 7792.61,-16781.9 8441.61,-16781.9 8441.61,-16721.9 7792.61,-16721.9"/>
+<polygon fill="none" stroke="#29235c" points="7792.61,-16721.9 7792.61,-16781.9 8441.61,-16781.9 8441.61,-16721.9 7792.61,-16721.9"/>
+<text text-anchor="start" x="7803.52" y="-16742.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">applied_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="7986.37" y="-16743.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp without time zone</text>
+<text text-anchor="start" x="8391.77" y="-16743.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8400.66" y="-16743.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7791.11,-16720.9 7791.11,-16962.9 8442.11,-16962.9 8442.11,-16720.9 7791.11,-16720.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.sessions -->
+<g id="kg_api.sessions" class="node">
+<title>kg_api.sessions</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9977.71" cy="-15145.9" rx="442.8" ry="299.63"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9666.71,-15295.9 9666.71,-15355.9 10288.71,-15355.9 10288.71,-15295.9 9666.71,-15295.9"/>
+<polygon fill="none" stroke="#29235c" points="9666.71,-15295.9 9666.71,-15355.9 10288.71,-15355.9 10288.71,-15295.9 9666.71,-15295.9"/>
+<text text-anchor="start" x="9801.65" y="-15317.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.sessions &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9666.71,-15235.9 9666.71,-15295.9 10288.71,-15295.9 10288.71,-15235.9 9666.71,-15235.9"/>
+<polygon fill="none" stroke="#29235c" points="9666.71,-15235.9 9666.71,-15295.9 10288.71,-15295.9 10288.71,-15235.9 9666.71,-15235.9"/>
+<text text-anchor="start" x="9677.71" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">session_id</text>
+<text text-anchor="start" x="9828.85" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9918.58" y="-15257.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="10238.62" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10247.51" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9666.71,-15175.9 9666.71,-15235.9 10288.71,-15235.9 10288.71,-15175.9 9666.71,-15175.9"/>
+<polygon fill="none" stroke="#29235c" points="9666.71,-15175.9 9666.71,-15235.9 10288.71,-15235.9 10288.71,-15175.9 9666.71,-15175.9"/>
+<text text-anchor="start" x="9677.71" y="-15196.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10179.91" y="-15197.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9666.71,-15115.9 9666.71,-15175.9 10288.71,-15175.9 10288.71,-15115.9 9666.71,-15115.9"/>
+<polygon fill="none" stroke="#29235c" points="9666.71,-15115.9 9666.71,-15175.9 10288.71,-15175.9 10288.71,-15115.9 9666.71,-15115.9"/>
+<text text-anchor="start" x="9677.71" y="-15136.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9877.69" y="-15137.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10238.62" y="-15137.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10247.51" y="-15137.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9666.71,-15055.9 9666.71,-15115.9 10288.71,-15115.9 10288.71,-15055.9 9666.71,-15055.9"/>
+<polygon fill="none" stroke="#29235c" points="9666.71,-15055.9 9666.71,-15115.9 10288.71,-15115.9 10288.71,-15055.9 9666.71,-15055.9"/>
+<text text-anchor="start" x="9677.71" y="-15076.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9877.69" y="-15077.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10238.62" y="-15077.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10247.51" y="-15077.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9666.71,-14995.9 9666.71,-15055.9 10288.71,-15055.9 10288.71,-14995.9 9666.71,-14995.9"/>
+<polygon fill="none" stroke="#29235c" points="9666.71,-14995.9 9666.71,-15055.9 10288.71,-15055.9 10288.71,-14995.9 9666.71,-14995.9"/>
+<text text-anchor="start" x="9677.25" y="-15016.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_activity &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9877.7" y="-15017.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10238.62" y="-15017.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10247.51" y="-15017.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9666.71,-14935.9 9666.71,-14995.9 10288.71,-14995.9 10288.71,-14935.9 9666.71,-14935.9"/>
+<polygon fill="none" stroke="#29235c" points="9666.71,-14935.9 9666.71,-14995.9 10288.71,-14995.9 10288.71,-14935.9 9666.71,-14935.9"/>
+<text text-anchor="start" x="9677.71" y="-14956.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10201.24" y="-14957.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9665.71,-14934.9 9665.71,-15356.9 10289.71,-15356.9 10289.71,-14934.9 9665.71,-14934.9"/>
+</g>
+<!-- kg_api.skipped_relationships -->
+<g id="kg_api.skipped_relationships" class="node">
+<title>kg_api.skipped_relationships</title>
+<g id="a_kg_api.skipped_relationships"><a xlink:title="kg_api.skipped_relationships&#10;Capture layer for unmatched relationship types &#45; ADR&#45;025">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2536.25" cy="-13506.9" rx="468.21" ry="469.54"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2207.25,-13776.9 2207.25,-13836.9 2865.25,-13836.9 2865.25,-13776.9 2207.25,-13776.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13776.9 2207.25,-13836.9 2865.25,-13836.9 2865.25,-13776.9 2207.25,-13776.9"/>
+<text text-anchor="start" x="2268.61" y="-13798.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.skipped_relationships &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13716.9 2207.25,-13776.9 2865.25,-13776.9 2865.25,-13716.9 2207.25,-13716.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13716.9 2207.25,-13776.9 2865.25,-13776.9 2865.25,-13716.9 2207.25,-13716.9"/>
+<text text-anchor="start" x="2218.25" y="-13738.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2243.14" y="-13738.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2717.36" y="-13738.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2815.16" y="-13738.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2824.05" y="-13738.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13656.9 2207.25,-13716.9 2865.25,-13716.9 2865.25,-13656.9 2207.25,-13656.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13656.9 2207.25,-13716.9 2865.25,-13716.9 2865.25,-13656.9 2207.25,-13656.9"/>
+<text text-anchor="start" x="2218.05" y="-13677.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">relationship_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2495.19" y="-13678.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2815.22" y="-13678.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2824.12" y="-13678.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13596.9 2207.25,-13656.9 2865.25,-13656.9 2865.25,-13596.9 2207.25,-13596.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13596.9 2207.25,-13656.9 2865.25,-13656.9 2865.25,-13596.9 2207.25,-13596.9"/>
+<text text-anchor="start" x="2218.25" y="-13617.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">from_concept_label &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2534.21" y="-13618.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(500)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13536.9 2207.25,-13596.9 2865.25,-13596.9 2865.25,-13536.9 2207.25,-13536.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13536.9 2207.25,-13596.9 2865.25,-13596.9 2865.25,-13536.9 2207.25,-13536.9"/>
+<text text-anchor="start" x="2218.25" y="-13557.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">to_concept_label &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2534.21" y="-13558.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(500)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13476.9 2207.25,-13536.9 2865.25,-13536.9 2865.25,-13476.9 2207.25,-13476.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13476.9 2207.25,-13536.9 2865.25,-13536.9 2865.25,-13476.9 2207.25,-13476.9"/>
+<text text-anchor="start" x="2218.25" y="-13497.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">job_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2552" y="-13498.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13416.9 2207.25,-13476.9 2865.25,-13476.9 2865.25,-13416.9 2207.25,-13416.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13416.9 2207.25,-13476.9 2865.25,-13476.9 2865.25,-13416.9 2207.25,-13416.9"/>
+<text text-anchor="start" x="2218.25" y="-13437.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">ontology &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2534.21" y="-13438.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13356.9 2207.25,-13416.9 2865.25,-13416.9 2865.25,-13356.9 2207.25,-13356.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13356.9 2207.25,-13416.9 2865.25,-13416.9 2865.25,-13356.9 2207.25,-13356.9"/>
+<text text-anchor="start" x="2218.25" y="-13377.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">first_seen &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2454.24" y="-13378.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2815.16" y="-13378.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2824.05" y="-13378.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13296.9 2207.25,-13356.9 2865.25,-13356.9 2865.25,-13296.9 2207.25,-13296.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13296.9 2207.25,-13356.9 2865.25,-13356.9 2865.25,-13296.9 2207.25,-13296.9"/>
+<text text-anchor="start" x="2218.25" y="-13317.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_seen &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2454.24" y="-13318.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2815.16" y="-13318.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2824.05" y="-13318.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13236.9 2207.25,-13296.9 2865.25,-13296.9 2865.25,-13236.9 2207.25,-13236.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13236.9 2207.25,-13296.9 2865.25,-13296.9 2865.25,-13236.9 2207.25,-13236.9"/>
+<text text-anchor="start" x="2218.25" y="-13257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">occurrence_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2756.45" y="-13258.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2207.25,-13176.9 2207.25,-13236.9 2865.25,-13236.9 2865.25,-13176.9 2207.25,-13176.9"/>
+<polygon fill="none" stroke="#29235c" points="2207.25,-13176.9 2207.25,-13236.9 2865.25,-13236.9 2865.25,-13176.9 2207.25,-13176.9"/>
+<text text-anchor="start" x="2218.25" y="-13197.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">sample_context &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2777.78" y="-13198.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2206.25,-13175.9 2206.25,-13837.9 2866.25,-13837.9 2866.25,-13175.9 2206.25,-13175.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.source_embeddings -->
+<g id="kg_api.source_embeddings" class="node">
+<title>kg_api.source_embeddings</title>
+<g id="a_kg_api.source_embeddings"><a xlink:title="kg_api.source_embeddings&#10;ADR&#45;068: Embeddings for source text chunks with offset tracking and hash verification">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2535.53" cy="-12346.9" rx="410.66" ry="681.8"/>
+<polygon fill="#7c3aed" stroke="transparent" points="2247.53,-12766.9 2247.53,-12826.9 2824.53,-12826.9 2824.53,-12766.9 2247.53,-12766.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12766.9 2247.53,-12826.9 2824.53,-12826.9 2824.53,-12766.9 2247.53,-12766.9"/>
+<text text-anchor="start" x="2278.16" y="-12788.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.source_embeddings &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12706.9 2247.53,-12766.9 2824.53,-12766.9 2824.53,-12706.9 2247.53,-12706.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12706.9 2247.53,-12766.9 2824.53,-12766.9 2824.53,-12706.9 2247.53,-12706.9"/>
+<text text-anchor="start" x="2258.53" y="-12728.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">embedding_id</text>
+<text text-anchor="start" x="2459.48" y="-12728.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2676.63" y="-12728.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2774.44" y="-12728.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12728.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12646.9 2247.53,-12706.9 2824.53,-12706.9 2824.53,-12646.9 2247.53,-12646.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12646.9 2247.53,-12706.9 2824.53,-12706.9 2824.53,-12646.9 2247.53,-12646.9"/>
+<text text-anchor="start" x="2258.53" y="-12667.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">source_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.86" y="-12668.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2774.44" y="-12668.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12668.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12586.9 2247.53,-12646.9 2824.53,-12646.9 2824.53,-12586.9 2247.53,-12586.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12586.9 2247.53,-12646.9 2824.53,-12646.9 2824.53,-12586.9 2247.53,-12586.9"/>
+<text text-anchor="start" x="2258.53" y="-12607.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">chunk_index &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2676.63" y="-12608.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2774.44" y="-12608.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12608.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12526.9 2247.53,-12586.9 2824.53,-12586.9 2824.53,-12526.9 2247.53,-12526.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12526.9 2247.53,-12586.9 2824.53,-12586.9 2824.53,-12526.9 2247.53,-12526.9"/>
+<text text-anchor="start" x="2258.53" y="-12547.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">chunk_strategy &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.86" y="-12548.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2774.44" y="-12548.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12548.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12466.9 2247.53,-12526.9 2824.53,-12526.9 2824.53,-12466.9 2247.53,-12466.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12466.9 2247.53,-12526.9 2824.53,-12526.9 2824.53,-12466.9 2247.53,-12466.9"/>
+<text text-anchor="start" x="2258.53" y="-12487.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">start_offset &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2676.63" y="-12488.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2774.44" y="-12488.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12488.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12406.9 2247.53,-12466.9 2824.53,-12466.9 2824.53,-12406.9 2247.53,-12406.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12406.9 2247.53,-12466.9 2824.53,-12466.9 2824.53,-12406.9 2247.53,-12406.9"/>
+<text text-anchor="start" x="2258.53" y="-12427.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">end_offset &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2676.63" y="-12428.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2774.44" y="-12428.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12428.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12346.9 2247.53,-12406.9 2824.53,-12406.9 2824.53,-12346.9 2247.53,-12346.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12346.9 2247.53,-12406.9 2824.53,-12406.9 2824.53,-12346.9 2247.53,-12346.9"/>
+<text text-anchor="start" x="2258.53" y="-12367.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">chunk_text &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.86" y="-12368.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2774.44" y="-12368.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12368.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12286.9 2247.53,-12346.9 2824.53,-12346.9 2824.53,-12286.9 2247.53,-12286.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12286.9 2247.53,-12346.9 2824.53,-12346.9 2824.53,-12286.9 2247.53,-12286.9"/>
+<text text-anchor="start" x="2258.53" y="-12307.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">chunk_hash &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.86" y="-12308.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2774.44" y="-12308.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12308.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12226.9 2247.53,-12286.9 2824.53,-12286.9 2824.53,-12226.9 2247.53,-12226.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12226.9 2247.53,-12286.9 2824.53,-12286.9 2824.53,-12226.9 2247.53,-12226.9"/>
+<text text-anchor="start" x="2258.53" y="-12247.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">source_hash &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.86" y="-12248.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2774.44" y="-12248.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12248.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12166.9 2247.53,-12226.9 2824.53,-12226.9 2824.53,-12166.9 2247.53,-12166.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12166.9 2247.53,-12226.9 2824.53,-12226.9 2824.53,-12166.9 2247.53,-12166.9"/>
+<text text-anchor="start" x="2258.53" y="-12187.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2696.18" y="-12188.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bytea</text>
+<text text-anchor="start" x="2774.44" y="-12188.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12188.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12106.9 2247.53,-12166.9 2824.53,-12166.9 2824.53,-12106.9 2247.53,-12106.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12106.9 2247.53,-12166.9 2824.53,-12166.9 2824.53,-12106.9 2247.53,-12106.9"/>
+<text text-anchor="start" x="2258.53" y="-12127.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_model &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2722.86" y="-12128.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="2774.44" y="-12128.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12128.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-12046.9 2247.53,-12106.9 2824.53,-12106.9 2824.53,-12046.9 2247.53,-12046.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-12046.9 2247.53,-12106.9 2824.53,-12106.9 2824.53,-12046.9 2247.53,-12046.9"/>
+<text text-anchor="start" x="2258.53" y="-12067.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_dimension &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2676.63" y="-12068.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2774.44" y="-12068.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2783.33" y="-12068.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-11986.9 2247.53,-12046.9 2824.53,-12046.9 2824.53,-11986.9 2247.53,-11986.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-11986.9 2247.53,-12046.9 2824.53,-12046.9 2824.53,-11986.9 2247.53,-11986.9"/>
+<text text-anchor="start" x="2258.53" y="-12007.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">embedding_provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2761.95" y="-12008.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-11926.9 2247.53,-11986.9 2824.53,-11986.9 2824.53,-11926.9 2247.53,-11926.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-11926.9 2247.53,-11986.9 2824.53,-11986.9 2824.53,-11926.9 2247.53,-11926.9"/>
+<text text-anchor="start" x="2258.53" y="-11947.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2452.6" y="-11948.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2247.53,-11866.9 2247.53,-11926.9 2824.53,-11926.9 2824.53,-11866.9 2247.53,-11866.9"/>
+<polygon fill="none" stroke="#29235c" points="2247.53,-11866.9 2247.53,-11926.9 2824.53,-11926.9 2824.53,-11866.9 2247.53,-11866.9"/>
+<text text-anchor="start" x="2258.19" y="-11887.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2453.07" y="-11888.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2246.03,-11865.9 2246.03,-12827.9 2825.03,-12827.9 2825.03,-11865.9 2246.03,-11865.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.synonym_clusters -->
+<g id="kg_api.synonym_clusters" class="node">
+<title>kg_api.synonym_clusters</title>
+<g id="a_kg_api.synonym_clusters"><a xlink:title="kg_api.synonym_clusters&#10;ADR&#45;046: Tracks groups of synonymous edge types discovered through embedding&#45;based semantic similarity (threshold &gt; 0.85)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="5590.35" cy="-4465.9" rx="510.56" ry="511.89"/>
+<polygon fill="#7c3aed" stroke="transparent" points="5231.35,-4765.9 5231.35,-4825.9 5949.35,-4825.9 5949.35,-4765.9 5231.35,-4765.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4765.9 5231.35,-4825.9 5949.35,-4825.9 5949.35,-4765.9 5231.35,-4765.9"/>
+<text text-anchor="start" x="5348.51" y="-4787.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.synonym_clusters &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4705.9 5231.35,-4765.9 5949.35,-4765.9 5949.35,-4705.9 5231.35,-4705.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4705.9 5231.35,-4765.9 5949.35,-4765.9 5949.35,-4705.9 5231.35,-4705.9"/>
+<text text-anchor="start" x="5242.35" y="-4727.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">cluster_id</text>
+<text text-anchor="start" x="5379.26" y="-4727.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5838.79" y="-4727.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">uuid</text>
+<text text-anchor="start" x="5899.26" y="-4727.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="5908.15" y="-4727.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4645.9 5231.35,-4705.9 5949.35,-4705.9 5949.35,-4645.9 5231.35,-4645.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4645.9 5231.35,-4705.9 5949.35,-4705.9 5949.35,-4645.9 5231.35,-4645.9"/>
+<text text-anchor="start" x="5242.35" y="-4666.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">representative_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5618.31" y="-4667.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4585.9 5231.35,-4645.9 5949.35,-4645.9 5949.35,-4585.9 5231.35,-4585.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4585.9 5231.35,-4645.9 5949.35,-4645.9 5949.35,-4585.9 5231.35,-4585.9"/>
+<text text-anchor="start" x="5242.35" y="-4606.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">member_types &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5600.53" y="-4607.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4525.9 5231.35,-4585.9 5949.35,-4585.9 5949.35,-4525.9 5231.35,-4525.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4525.9 5231.35,-4585.9 5949.35,-4585.9 5949.35,-4525.9 5231.35,-4525.9"/>
+<text text-anchor="start" x="5242.35" y="-4546.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">avg_similarity &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5705.41" y="-4547.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">double precision</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4465.9 5231.35,-4525.9 5949.35,-4525.9 5949.35,-4465.9 5231.35,-4465.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4465.9 5231.35,-4525.9 5949.35,-4525.9 5949.35,-4465.9 5231.35,-4465.9"/>
+<text text-anchor="start" x="5242.35" y="-4486.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">cluster_size &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5840.55" y="-4487.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4405.9 5231.35,-4465.9 5949.35,-4465.9 5949.35,-4405.9 5231.35,-4405.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4405.9 5231.35,-4465.9 5949.35,-4465.9 5949.35,-4405.9 5231.35,-4405.9"/>
+<text text-anchor="start" x="5242.35" y="-4426.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">total_usage_count &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5840.55" y="-4427.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4345.9 5231.35,-4405.9 5949.35,-4405.9 5949.35,-4345.9 5231.35,-4345.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4345.9 5231.35,-4405.9 5949.35,-4405.9 5949.35,-4345.9 5231.35,-4345.9"/>
+<text text-anchor="start" x="5242.35" y="-4366.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">detected_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5577.43" y="-4367.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4285.9 5231.35,-4345.9 5949.35,-4345.9 5949.35,-4285.9 5231.35,-4285.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4285.9 5231.35,-4345.9 5949.35,-4345.9 5949.35,-4285.9 5231.35,-4285.9"/>
+<text text-anchor="start" x="5242.35" y="-4306.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">detection_method &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5636.1" y="-4307.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4225.9 5231.35,-4285.9 5949.35,-4285.9 5949.35,-4225.9 5231.35,-4225.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4225.9 5231.35,-4285.9 5949.35,-4285.9 5949.35,-4225.9 5231.35,-4225.9"/>
+<text text-anchor="start" x="5242.35" y="-4246.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5824.52" y="-4247.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4165.9 5231.35,-4225.9 5949.35,-4225.9 5949.35,-4165.9 5231.35,-4165.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4165.9 5231.35,-4225.9 5949.35,-4225.9 5949.35,-4165.9 5231.35,-4165.9"/>
+<text text-anchor="start" x="5242.35" y="-4186.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">merge_recommended &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5824.52" y="-4187.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5231.35,-4105.9 5231.35,-4165.9 5949.35,-4165.9 5949.35,-4105.9 5231.35,-4105.9"/>
+<polygon fill="none" stroke="#29235c" points="5231.35,-4105.9 5231.35,-4165.9 5949.35,-4165.9 5949.35,-4105.9 5231.35,-4105.9"/>
+<text text-anchor="start" x="5242.31" y="-4126.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">merge_completed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="5577.89" y="-4127.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5230.35,-4104.9 5230.35,-4826.9 5950.35,-4826.9 5950.35,-4104.9 5230.35,-4104.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.synonym_clusters&#45;&gt;kg_api.relationship_vocabulary -->
+<!-- kg_api.synonym_clusters&#45;&gt;kg_api.relationship_vocabulary -->
+<g id="edge18" class="edge">
+<title>kg_api.synonym_clusters:e&#45;&gt;kg_api.relationship_vocabulary:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M5950.35,-4675.9C6108.76,-4675.9 6146.15,-4733.35 6299.36,-4735.82"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="6299.59,-4739.32 6309.62,-4735.9 6299.65,-4732.32 6299.59,-4739.32"/>
+</g>
+<!-- kg_api.system_api_keys -->
+<g id="kg_api.system_api_keys" class="node">
+<title>kg_api.system_api_keys</title>
+<g id="a_kg_api.system_api_keys"><a xlink:title="kg_api.system_api_keys&#10;Encrypted system API keys for LLM providers (ADR&#45;031, ADR&#45;041)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6171.96" cy="-15145.9" rx="467.3" ry="299.63"/>
+<polygon fill="#7c3aed" stroke="transparent" points="5843.96,-15295.9 5843.96,-15355.9 6500.96,-15355.9 6500.96,-15295.9 5843.96,-15295.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.96,-15295.9 5843.96,-15355.9 6500.96,-15355.9 6500.96,-15295.9 5843.96,-15295.9"/>
+<text text-anchor="start" x="5935.94" y="-15317.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.system_api_keys &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.96,-15235.9 5843.96,-15295.9 6500.96,-15295.9 6500.96,-15235.9 5843.96,-15235.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.96,-15235.9 5843.96,-15295.9 6500.96,-15295.9 6500.96,-15235.9 5843.96,-15235.9"/>
+<text text-anchor="start" x="5854.96" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">provider</text>
+<text text-anchor="start" x="5970.52" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6148.62" y="-15257.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="6450.87" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6459.76" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.96,-15175.9 5843.96,-15235.9 6500.96,-15235.9 6500.96,-15175.9 5843.96,-15175.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.96,-15175.9 5843.96,-15235.9 6500.96,-15235.9 6500.96,-15175.9 5843.96,-15175.9"/>
+<text text-anchor="start" x="5854.96" y="-15196.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">encrypted_key &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6372.61" y="-15197.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bytea</text>
+<text text-anchor="start" x="6450.87" y="-15197.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6459.76" y="-15197.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.96,-15115.9 5843.96,-15175.9 6500.96,-15175.9 6500.96,-15115.9 5843.96,-15115.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.96,-15115.9 5843.96,-15175.9 6500.96,-15175.9 6500.96,-15115.9 5843.96,-15115.9"/>
+<text text-anchor="start" x="5854.96" y="-15136.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6129.04" y="-15137.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.96,-15055.9 5843.96,-15115.9 6500.96,-15115.9 6500.96,-15055.9 5843.96,-15055.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.96,-15055.9 5843.96,-15115.9 6500.96,-15115.9 6500.96,-15055.9 5843.96,-15055.9"/>
+<text text-anchor="start" x="5854.96" y="-15076.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">validation_status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6187.71" y="-15077.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.96,-14995.9 5843.96,-15055.9 6500.96,-15055.9 6500.96,-14995.9 5843.96,-14995.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.96,-14995.9 5843.96,-15055.9 6500.96,-15055.9 6500.96,-14995.9 5843.96,-14995.9"/>
+<text text-anchor="start" x="5854.63" y="-15016.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_validated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6129.5" y="-15017.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5843.96,-14935.9 5843.96,-14995.9 6500.96,-14995.9 6500.96,-14935.9 5843.96,-14935.9"/>
+<polygon fill="none" stroke="#29235c" points="5843.96,-14935.9 5843.96,-14995.9 6500.96,-14995.9 6500.96,-14935.9 5843.96,-14935.9"/>
+<text text-anchor="start" x="5854.96" y="-14956.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">validation_error &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6438.38" y="-14957.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5842.46,-14934.9 5842.46,-15356.9 6501.46,-15356.9 6501.46,-14934.9 5842.46,-14934.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.system_initialization_status -->
+<g id="kg_api.system_initialization_status" class="node">
+<title>kg_api.system_initialization_status</title>
+<g id="a_kg_api.system_initialization_status"><a xlink:title="kg_api.system_initialization_status&#10;ADR&#45;045: Tracks completion of system initialization tasks like cold start embedding generation">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9491.54" cy="-4315.9" rx="524.85" ry="342.48"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9122.54,-4495.9 9122.54,-4555.9 9860.54,-4555.9 9860.54,-4495.9 9122.54,-4495.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4495.9 9122.54,-4555.9 9860.54,-4555.9 9860.54,-4495.9 9122.54,-4495.9"/>
+<text text-anchor="start" x="9183.92" y="-4517.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.system_initialization_status &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9122.54,-4435.9 9122.54,-4495.9 9860.54,-4495.9 9860.54,-4435.9 9122.54,-4435.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4435.9 9122.54,-4495.9 9860.54,-4495.9 9860.54,-4435.9 9122.54,-4435.9"/>
+<text text-anchor="start" x="9133.54" y="-4457.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">component</text>
+<text text-anchor="start" x="9291.82" y="-4457.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9508.2" y="-4457.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="9810.45" y="-4457.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="9819.35" y="-4457.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9122.54,-4375.9 9122.54,-4435.9 9860.54,-4435.9 9860.54,-4375.9 9122.54,-4375.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4375.9 9122.54,-4435.9 9860.54,-4435.9 9860.54,-4375.9 9122.54,-4375.9"/>
+<text text-anchor="start" x="9133.54" y="-4396.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">initialized &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9735.71" y="-4397.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9122.54,-4315.9 9122.54,-4375.9 9860.54,-4375.9 9860.54,-4315.9 9122.54,-4315.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4315.9 9122.54,-4375.9 9860.54,-4375.9 9860.54,-4315.9 9122.54,-4315.9"/>
+<text text-anchor="start" x="9133.54" y="-4336.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">initialized_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9488.62" y="-4337.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9122.54,-4255.9 9122.54,-4315.9 9860.54,-4315.9 9860.54,-4255.9 9122.54,-4255.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4255.9 9122.54,-4315.9 9860.54,-4315.9 9860.54,-4255.9 9122.54,-4255.9"/>
+<text text-anchor="start" x="9133.54" y="-4276.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">initialization_job_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9789.08" y="-4277.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">uuid</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9122.54,-4195.9 9122.54,-4255.9 9860.54,-4255.9 9860.54,-4195.9 9122.54,-4195.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4195.9 9122.54,-4255.9 9860.54,-4255.9 9860.54,-4195.9 9122.54,-4195.9"/>
+<text text-anchor="start" x="9133.54" y="-4216.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">version &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9547.29" y="-4217.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9122.54,-4135.9 9122.54,-4195.9 9860.54,-4195.9 9860.54,-4135.9 9122.54,-4135.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4135.9 9122.54,-4195.9 9860.54,-4195.9 9860.54,-4135.9 9122.54,-4135.9"/>
+<text text-anchor="start" x="9133.54" y="-4156.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9773.08" y="-4157.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9122.54,-4075.9 9122.54,-4135.9 9860.54,-4135.9 9860.54,-4075.9 9122.54,-4075.9"/>
+<polygon fill="none" stroke="#29235c" points="9122.54,-4075.9 9122.54,-4135.9 9860.54,-4135.9 9860.54,-4075.9 9122.54,-4075.9"/>
+<text text-anchor="start" x="9133.49" y="-4096.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_processed_vocab_change_counter &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9734.27" y="-4097.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">bigint</text>
+<text text-anchor="start" x="9810.73" y="-4097.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="9819.62" y="-4097.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9121.54,-4074.9 9121.54,-4556.9 9861.54,-4556.9 9861.54,-4074.9 9121.54,-4074.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.system_initialization_status&#45;&gt;kg_api.embedding_generation_jobs -->
+<!-- kg_api.system_initialization_status&#45;&gt;kg_api.embedding_generation_jobs -->
+<g id="edge20" class="edge">
+<title>kg_api.system_initialization_status:e&#45;&gt;kg_api.embedding_generation_jobs:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M9861.54,-4285.9C10027.19,-4285.9 10027.72,-4458.59 10186.6,-4465.68"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="10186.71,-4469.18 10196.79,-4465.9 10186.87,-4462.18 10186.71,-4469.18"/>
+</g>
+<!-- kg_api.vocabulary_audit -->
+<g id="kg_api.vocabulary_audit" class="node">
+<title>kg_api.vocabulary_audit</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.03" cy="-15145.9" rx="460.15" ry="299.63"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7793.03,-15295.9 7793.03,-15355.9 8440.03,-15355.9 8440.03,-15295.9 7793.03,-15295.9"/>
+<polygon fill="none" stroke="#29235c" points="7793.03,-15295.9 7793.03,-15355.9 8440.03,-15355.9 8440.03,-15295.9 7793.03,-15295.9"/>
+<text text-anchor="start" x="7881.78" y="-15317.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.vocabulary_audit &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7793.03,-15235.9 7793.03,-15295.9 8440.03,-15295.9 8440.03,-15235.9 7793.03,-15235.9"/>
+<polygon fill="none" stroke="#29235c" points="7793.03,-15235.9 7793.03,-15295.9 8440.03,-15295.9 8440.03,-15235.9 7793.03,-15235.9"/>
+<text text-anchor="start" x="7804.03" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="7828.92" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8292.14" y="-15257.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="8389.94" y="-15257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8398.83" y="-15257.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7793.03,-15175.9 7793.03,-15235.9 8440.03,-15235.9 8440.03,-15175.9 7793.03,-15175.9"/>
+<polygon fill="none" stroke="#29235c" points="7793.03,-15175.9 7793.03,-15235.9 8440.03,-15235.9 8440.03,-15175.9 7793.03,-15175.9"/>
+<text text-anchor="start" x="7804.03" y="-15196.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">relationship_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8108.99" y="-15197.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7793.03,-15115.9 7793.03,-15175.9 8440.03,-15175.9 8440.03,-15115.9 7793.03,-15115.9"/>
+<polygon fill="none" stroke="#29235c" points="7793.03,-15115.9 7793.03,-15175.9 8440.03,-15175.9 8440.03,-15115.9 7793.03,-15115.9"/>
+<text text-anchor="start" x="7804.03" y="-15136.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">action &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8087.69" y="-15137.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="8389.94" y="-15137.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8398.83" y="-15137.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7793.03,-15055.9 7793.03,-15115.9 8440.03,-15115.9 8440.03,-15055.9 7793.03,-15055.9"/>
+<polygon fill="none" stroke="#29235c" points="7793.03,-15055.9 7793.03,-15115.9 8440.03,-15115.9 8440.03,-15055.9 7793.03,-15055.9"/>
+<text text-anchor="start" x="7804.03" y="-15076.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">performed_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8108.99" y="-15077.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7793.03,-14995.9 7793.03,-15055.9 8440.03,-15055.9 8440.03,-14995.9 7793.03,-14995.9"/>
+<polygon fill="none" stroke="#29235c" points="7793.03,-14995.9 7793.03,-15055.9 8440.03,-15055.9 8440.03,-14995.9 7793.03,-14995.9"/>
+<text text-anchor="start" x="7803.61" y="-15016.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">performed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8029.02" y="-15017.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="8389.94" y="-15017.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8398.84" y="-15017.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7793.03,-14935.9 7793.03,-14995.9 8440.03,-14995.9 8440.03,-14935.9 7793.03,-14935.9"/>
+<polygon fill="none" stroke="#29235c" points="7793.03,-14935.9 7793.03,-14995.9 8440.03,-14995.9 8440.03,-14935.9 7793.03,-14935.9"/>
+<text text-anchor="start" x="7804.03" y="-14956.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">details &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8352.56" y="-14957.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7791.53,-14934.9 7791.53,-15356.9 8440.53,-15356.9 8440.53,-14934.9 7791.53,-14934.9"/>
+</g>
+<!-- kg_api.vocabulary_config -->
+<g id="kg_api.vocabulary_config" class="node">
+<title>kg_api.vocabulary_config</title>
+<g id="a_kg_api.vocabulary_config"><a xlink:title="kg_api.vocabulary_config&#10;System configuration for automatic vocabulary management (ADR&#45;032)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.24" cy="-15753.9" rx="439.23" ry="257.27"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7808.24,-15873.9 7808.24,-15933.9 8425.24,-15933.9 8425.24,-15873.9 7808.24,-15873.9"/>
+<polygon fill="none" stroke="#29235c" points="7808.24,-15873.9 7808.24,-15933.9 8425.24,-15933.9 8425.24,-15873.9 7808.24,-15873.9"/>
+<text text-anchor="start" x="7874" y="-15895.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.vocabulary_config &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7808.24,-15813.9 7808.24,-15873.9 8425.24,-15873.9 8425.24,-15813.9 7808.24,-15813.9"/>
+<polygon fill="none" stroke="#29235c" points="7808.24,-15813.9 7808.24,-15873.9 8425.24,-15873.9 8425.24,-15813.9 7808.24,-15813.9"/>
+<text text-anchor="start" x="7819.24" y="-15835.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">key</text>
+<text text-anchor="start" x="7869.03" y="-15835.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8055.11" y="-15835.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="8375.15" y="-15835.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8384.04" y="-15835.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7808.24,-15753.9 7808.24,-15813.9 8425.24,-15813.9 8425.24,-15753.9 7808.24,-15753.9"/>
+<polygon fill="none" stroke="#29235c" points="7808.24,-15753.9 7808.24,-15813.9 8425.24,-15813.9 8425.24,-15753.9 7808.24,-15753.9"/>
+<text text-anchor="start" x="7819.24" y="-15774.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">value &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8323.58" y="-15775.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="8375.15" y="-15775.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8384.04" y="-15775.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7808.24,-15693.9 7808.24,-15753.9 8425.24,-15753.9 8425.24,-15693.9 7808.24,-15693.9"/>
+<polygon fill="none" stroke="#29235c" points="7808.24,-15693.9 7808.24,-15753.9 8425.24,-15753.9 8425.24,-15693.9 7808.24,-15693.9"/>
+<text text-anchor="start" x="7819.24" y="-15714.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8362.67" y="-15715.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7808.24,-15633.9 7808.24,-15693.9 8425.24,-15693.9 8425.24,-15633.9 7808.24,-15633.9"/>
+<polygon fill="none" stroke="#29235c" points="7808.24,-15633.9 7808.24,-15693.9 8425.24,-15693.9 8425.24,-15633.9 7808.24,-15633.9"/>
+<text text-anchor="start" x="7818.91" y="-15654.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8014.24" y="-15655.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="8375.16" y="-15655.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8384.05" y="-15655.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7808.24,-15573.9 7808.24,-15633.9 8425.24,-15633.9 8425.24,-15573.9 7808.24,-15573.9"/>
+<polygon fill="none" stroke="#29235c" points="7808.24,-15573.9 7808.24,-15633.9 8425.24,-15633.9 8425.24,-15573.9 7808.24,-15573.9"/>
+<text text-anchor="start" x="7819.24" y="-15594.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8094.2" y="-15595.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7806.74,-15572.9 7806.74,-15934.9 8425.74,-15934.9 8425.74,-15572.9 7806.74,-15572.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.vocabulary_history -->
+<g id="kg_api.vocabulary_history" class="node">
+<title>kg_api.vocabulary_history</title>
+<g id="a_kg_api.vocabulary_history"><a xlink:title="kg_api.vocabulary_history&#10;Detailed vocabulary change tracking with context (ADR&#45;032)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="8116.25" cy="-12346.9" rx="468.21" ry="554.24"/>
+<polygon fill="#7c3aed" stroke="transparent" points="7787.25,-12676.9 7787.25,-12736.9 8445.25,-12736.9 8445.25,-12676.9 7787.25,-12676.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12676.9 7787.25,-12736.9 8445.25,-12736.9 8445.25,-12676.9 7787.25,-12676.9"/>
+<text text-anchor="start" x="7869.07" y="-12698.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.vocabulary_history &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12616.9 7787.25,-12676.9 8445.25,-12676.9 8445.25,-12616.9 7787.25,-12616.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12616.9 7787.25,-12676.9 8445.25,-12676.9 8445.25,-12616.9 7787.25,-12616.9"/>
+<text text-anchor="start" x="7798.25" y="-12638.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="7823.14" y="-12638.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8297.36" y="-12638.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="8395.16" y="-12638.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8404.05" y="-12638.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12556.9 7787.25,-12616.9 8445.25,-12616.9 8445.25,-12556.9 7787.25,-12556.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12556.9 7787.25,-12616.9 8445.25,-12616.9 8445.25,-12556.9 7787.25,-12556.9"/>
+<text text-anchor="start" x="7798.05" y="-12577.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">relationship_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8075.19" y="-12578.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="8395.22" y="-12578.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8404.12" y="-12578.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12496.9 7787.25,-12556.9 8445.25,-12556.9 8445.25,-12496.9 7787.25,-12496.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12496.9 7787.25,-12556.9 8445.25,-12556.9 8445.25,-12496.9 7787.25,-12496.9"/>
+<text text-anchor="start" x="7798.25" y="-12517.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">action &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8092.91" y="-12518.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="8395.16" y="-12518.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8404.05" y="-12518.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12436.9 7787.25,-12496.9 8445.25,-12496.9 8445.25,-12436.9 7787.25,-12436.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12436.9 7787.25,-12496.9 8445.25,-12496.9 8445.25,-12436.9 7787.25,-12436.9"/>
+<text text-anchor="start" x="7798.25" y="-12457.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">performed_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8075.12" y="-12458.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="8395.16" y="-12458.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8404.05" y="-12458.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12376.9 7787.25,-12436.9 8445.25,-12436.9 8445.25,-12376.9 7787.25,-12376.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12376.9 7787.25,-12436.9 8445.25,-12436.9 8445.25,-12376.9 7787.25,-12376.9"/>
+<text text-anchor="start" x="7798.25" y="-12397.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">performed_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8034.24" y="-12398.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="8395.16" y="-12398.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="8404.05" y="-12398.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12316.9 7787.25,-12376.9 8445.25,-12376.9 8445.25,-12316.9 7787.25,-12316.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12316.9 7787.25,-12376.9 8445.25,-12376.9 8445.25,-12316.9 7787.25,-12316.9"/>
+<text text-anchor="start" x="7798.25" y="-12337.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">target_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8114.21" y="-12338.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12256.9 7787.25,-12316.9 8445.25,-12316.9 8445.25,-12256.9 7787.25,-12256.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12256.9 7787.25,-12316.9 8445.25,-12316.9 8445.25,-12256.9 7787.25,-12256.9"/>
+<text text-anchor="start" x="7798.25" y="-12277.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reason &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8382.68" y="-12278.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12196.9 7787.25,-12256.9 8445.25,-12256.9 8445.25,-12196.9 7787.25,-12196.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12196.9 7787.25,-12256.9 8445.25,-12256.9 8445.25,-12196.9 7787.25,-12196.9"/>
+<text text-anchor="start" x="7798.25" y="-12217.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8357.78" y="-12218.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12136.9 7787.25,-12196.9 8445.25,-12196.9 8445.25,-12136.9 7787.25,-12136.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12136.9 7787.25,-12196.9 8445.25,-12196.9 8445.25,-12136.9 7787.25,-12136.9"/>
+<text text-anchor="start" x="7798.25" y="-12157.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">aggressiveness &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8254.7" y="-12158.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(4,3)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12076.9 7787.25,-12136.9 8445.25,-12136.9 8445.25,-12076.9 7787.25,-12076.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12076.9 7787.25,-12136.9 8445.25,-12136.9 8445.25,-12076.9 7787.25,-12076.9"/>
+<text text-anchor="start" x="7798.25" y="-12097.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">zone &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8132" y="-12098.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-12016.9 7787.25,-12076.9 8445.25,-12076.9 8445.25,-12016.9 7787.25,-12016.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-12016.9 7787.25,-12076.9 8445.25,-12076.9 8445.25,-12016.9 7787.25,-12016.9"/>
+<text text-anchor="start" x="7798.25" y="-12037.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">vocab_size_before &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8336.45" y="-12038.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="7787.25,-11956.9 7787.25,-12016.9 8445.25,-12016.9 8445.25,-11956.9 7787.25,-11956.9"/>
+<polygon fill="none" stroke="#29235c" points="7787.25,-11956.9 7787.25,-12016.9 8445.25,-12016.9 8445.25,-11956.9 7787.25,-11956.9"/>
+<text text-anchor="start" x="7798.25" y="-11977.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">vocab_size_after &#160;&#160;&#160;</text>
+<text text-anchor="start" x="8336.45" y="-11978.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="7786.25,-11955.9 7786.25,-12737.9 8446.25,-12737.9 8446.25,-11955.9 7786.25,-11955.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.vocabulary_suggestions -->
+<g id="kg_api.vocabulary_suggestions" class="node">
+<title>kg_api.vocabulary_suggestions</title>
+<g id="a_kg_api.vocabulary_suggestions"><a xlink:title="kg_api.vocabulary_suggestions&#10;LLM&#45;assisted vocabulary curation suggestions &#45; ADR&#45;026">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9977.95" cy="-10890.9" rx="537.3" ry="596.6"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9599.95,-11250.9 9599.95,-11310.9 10355.95,-11310.9 10355.95,-11250.9 9599.95,-11250.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-11250.9 9599.95,-11310.9 10355.95,-11310.9 10355.95,-11250.9 9599.95,-11250.9"/>
+<text text-anchor="start" x="9692.52" y="-11272.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.vocabulary_suggestions &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-11190.9 9599.95,-11250.9 10355.95,-11250.9 10355.95,-11190.9 9599.95,-11190.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-11190.9 9599.95,-11250.9 10355.95,-11250.9 10355.95,-11190.9 9599.95,-11190.9"/>
+<text text-anchor="start" x="9610.95" y="-11212.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="9635.84" y="-11212.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10208.06" y="-11212.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10305.86" y="-11212.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10314.76" y="-11212.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-11130.9 9599.95,-11190.9 10355.95,-11190.9 10355.95,-11130.9 9599.95,-11130.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-11130.9 9599.95,-11190.9 10355.95,-11190.9 10355.95,-11130.9 9599.95,-11130.9"/>
+<text text-anchor="start" x="9610.95" y="-11151.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">relationship_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9985.82" y="-11152.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="10305.86" y="-11152.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10314.76" y="-11152.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-11070.9 9599.95,-11130.9 10355.95,-11130.9 10355.95,-11070.9 9599.95,-11070.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-11070.9 9599.95,-11130.9 10355.95,-11130.9 10355.95,-11070.9 9599.95,-11070.9"/>
+<text text-anchor="start" x="9610.95" y="-11091.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">suggestion_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10003.61" y="-11092.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="10305.86" y="-11092.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10314.76" y="-11092.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-11010.9 9599.95,-11070.9 10355.95,-11070.9 10355.95,-11010.9 9599.95,-11010.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-11010.9 9599.95,-11070.9 10355.95,-11070.9 10355.95,-11010.9 9599.95,-11010.9"/>
+<text text-anchor="start" x="9610.95" y="-11031.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">confidence &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10126.31" y="-11032.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(3,2)</text>
+<text text-anchor="start" x="10305.86" y="-11032.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10314.76" y="-11032.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10950.9 9599.95,-11010.9 10355.95,-11010.9 10355.95,-10950.9 9599.95,-10950.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10950.9 9599.95,-11010.9 10355.95,-11010.9 10355.95,-10950.9 9599.95,-10950.9"/>
+<text text-anchor="start" x="9610.76" y="-10971.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">suggested_canonical_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10024.94" y="-10972.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10890.9 9599.95,-10950.9 10355.95,-10950.9 10355.95,-10890.9 9599.95,-10890.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10890.9 9599.95,-10950.9 10355.95,-10950.9 10355.95,-10890.9 9599.95,-10890.9"/>
+<text text-anchor="start" x="9610.95" y="-10911.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">suggested_category &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10042.7" y="-10912.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10830.9 9599.95,-10890.9 10355.95,-10890.9 10355.95,-10830.9 9599.95,-10830.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10830.9 9599.95,-10890.9 10355.95,-10890.9 10355.95,-10830.9 9599.95,-10830.9"/>
+<text text-anchor="start" x="9610.95" y="-10851.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">suggested_description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10293.38" y="-10852.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10770.9 9599.95,-10830.9 10355.95,-10830.9 10355.95,-10770.9 9599.95,-10770.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10770.9 9599.95,-10830.9 10355.95,-10830.9 10355.95,-10770.9 9599.95,-10770.9"/>
+<text text-anchor="start" x="9610.95" y="-10791.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">similar_types &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10268.49" y="-10792.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10710.9 9599.95,-10770.9 10355.95,-10770.9 10355.95,-10710.9 9599.95,-10710.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10710.9 9599.95,-10770.9 10355.95,-10770.9 10355.95,-10710.9 9599.95,-10710.9"/>
+<text text-anchor="start" x="9610.95" y="-10731.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reasoning &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10293.38" y="-10732.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10650.9 9599.95,-10710.9 10355.95,-10710.9 10355.95,-10650.9 9599.95,-10650.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10650.9 9599.95,-10710.9 10355.95,-10710.9 10355.95,-10650.9 9599.95,-10650.9"/>
+<text text-anchor="start" x="9610.95" y="-10671.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9944.94" y="-10672.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10305.86" y="-10672.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10314.76" y="-10672.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10590.9 9599.95,-10650.9 10355.95,-10650.9 10355.95,-10590.9 9599.95,-10590.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10590.9 9599.95,-10650.9 10355.95,-10650.9 10355.95,-10590.9 9599.95,-10590.9"/>
+<text text-anchor="start" x="9610.95" y="-10611.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">reviewed &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10231.12" y="-10612.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10530.9 9599.95,-10590.9 10355.95,-10590.9 10355.95,-10530.9 9599.95,-10530.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10530.9 9599.95,-10590.9 10355.95,-10590.9 10355.95,-10530.9 9599.95,-10530.9"/>
+<text text-anchor="start" x="9610.95" y="-10551.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">curator_decision &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10042.7" y="-10552.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9599.95,-10470.9 9599.95,-10530.9 10355.95,-10530.9 10355.95,-10470.9 9599.95,-10470.9"/>
+<polygon fill="none" stroke="#29235c" points="9599.95,-10470.9 9599.95,-10530.9 10355.95,-10530.9 10355.95,-10470.9 9599.95,-10470.9"/>
+<text text-anchor="start" x="9610.95" y="-10491.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">curator_notes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10293.38" y="-10492.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9598.95,-10469.9 9598.95,-11311.9 10356.95,-11311.9 10356.95,-10469.9 9598.95,-10469.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.worker_lanes -->
+<g id="kg_api.worker_lanes" class="node">
+<title>kg_api.worker_lanes</title>
+<g id="a_kg_api.worker_lanes"><a xlink:title="kg_api.worker_lanes&#10;Worker lane configuration for database&#45;driven job dispatch (ADR&#45;100)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9978.24" cy="-14410.9" rx="439.23" ry="342.48"/>
+<polygon fill="#7c3aed" stroke="transparent" points="9670.24,-14590.9 9670.24,-14650.9 10287.24,-14650.9 10287.24,-14590.9 9670.24,-14590.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14590.9 9670.24,-14650.9 10287.24,-14650.9 10287.24,-14590.9 9670.24,-14590.9"/>
+<text text-anchor="start" x="9769.8" y="-14612.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.worker_lanes &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9670.24,-14530.9 9670.24,-14590.9 10287.24,-14590.9 10287.24,-14530.9 9670.24,-14530.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14530.9 9670.24,-14590.9 10287.24,-14590.9 10287.24,-14530.9 9670.24,-14530.9"/>
+<text text-anchor="start" x="9681.24" y="-14552.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">name</text>
+<text text-anchor="start" x="9761.26" y="-14552.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10185.58" y="-14552.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="10237.15" y="-14552.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10246.04" y="-14552.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9670.24,-14470.9 9670.24,-14530.9 10287.24,-14530.9 10287.24,-14470.9 9670.24,-14470.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14470.9 9670.24,-14530.9 10287.24,-14530.9 10287.24,-14470.9 9670.24,-14470.9"/>
+<text text-anchor="start" x="9681.24" y="-14491.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">job_types &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10167.79" y="-14492.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<text text-anchor="start" x="10237.15" y="-14492.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10246.04" y="-14492.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9670.24,-14410.9 9670.24,-14470.9 10287.24,-14470.9 10287.24,-14410.9 9670.24,-14410.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14410.9 9670.24,-14470.9 10287.24,-14470.9 10287.24,-14410.9 9670.24,-14410.9"/>
+<text text-anchor="start" x="9681.24" y="-14431.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">max_slots &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10139.35" y="-14432.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10237.15" y="-14432.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10246.04" y="-14432.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9670.24,-14350.9 9670.24,-14410.9 10287.24,-14410.9 10287.24,-14350.9 9670.24,-14350.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14350.9 9670.24,-14410.9 10287.24,-14410.9 10287.24,-14350.9 9670.24,-14350.9"/>
+<text text-anchor="start" x="9681.24" y="-14371.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">poll_interval_ms &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10139.35" y="-14372.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10237.15" y="-14372.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10246.04" y="-14372.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9670.24,-14290.9 9670.24,-14350.9 10287.24,-14350.9 10287.24,-14290.9 9670.24,-14290.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14290.9 9670.24,-14350.9 10287.24,-14350.9 10287.24,-14290.9 9670.24,-14290.9"/>
+<text text-anchor="start" x="9681.24" y="-14311.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">stale_timeout_minutes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10139.35" y="-14312.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10237.15" y="-14312.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10246.04" y="-14312.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9670.24,-14230.9 9670.24,-14290.9 10287.24,-14290.9 10287.24,-14230.9 9670.24,-14230.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14230.9 9670.24,-14290.9 10287.24,-14290.9 10287.24,-14230.9 9670.24,-14230.9"/>
+<text text-anchor="start" x="9681.24" y="-14251.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">enabled &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10123.32" y="-14252.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<text text-anchor="start" x="10237.15" y="-14252.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10246.04" y="-14252.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9670.24,-14170.9 9670.24,-14230.9 10287.24,-14230.9 10287.24,-14170.9 9670.24,-14170.9"/>
+<polygon fill="none" stroke="#29235c" points="9670.24,-14170.9 9670.24,-14230.9 10287.24,-14230.9 10287.24,-14170.9 9670.24,-14170.9"/>
+<text text-anchor="start" x="9680.91" y="-14191.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">updated_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9876.24" y="-14192.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10237.16" y="-14192.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10246.05" y="-14192.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9668.74,-14169.9 9668.74,-14651.9 10287.74,-14651.9 10287.74,-14169.9 9668.74,-14169.9"/>
+</a>
+</g>
+</g>
+<!-- kg_api.worker_status -->
+<g id="kg_api.worker_status" class="node">
+<title>kg_api.worker_status</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6171.84" cy="-15753.9" rx="469.54" ry="257.27"/>
+<polygon fill="#7c3aed" stroke="transparent" points="5841.84,-15873.9 5841.84,-15933.9 6501.84,-15933.9 6501.84,-15873.9 5841.84,-15873.9"/>
+<polygon fill="none" stroke="#29235c" points="5841.84,-15873.9 5841.84,-15933.9 6501.84,-15933.9 6501.84,-15873.9 5841.84,-15873.9"/>
+<text text-anchor="start" x="5958.44" y="-15895.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_api.worker_status &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5841.84,-15813.9 5841.84,-15873.9 6501.84,-15873.9 6501.84,-15813.9 5841.84,-15813.9"/>
+<polygon fill="none" stroke="#29235c" points="5841.84,-15813.9 5841.84,-15873.9 6501.84,-15873.9 6501.84,-15813.9 5841.84,-15813.9"/>
+<text text-anchor="start" x="5852.84" y="-15835.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">worker_id</text>
+<text text-anchor="start" x="5991.5" y="-15835.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6131.71" y="-15835.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="6451.75" y="-15835.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.64" y="-15835.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5841.84,-15753.9 5841.84,-15813.9 6501.84,-15813.9 6501.84,-15753.9 5841.84,-15753.9"/>
+<polygon fill="none" stroke="#29235c" points="5841.84,-15753.9 5841.84,-15813.9 6501.84,-15813.9 6501.84,-15753.9 5841.84,-15753.9"/>
+<text text-anchor="start" x="5852.68" y="-15774.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_heartbeat &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6090.83" y="-15775.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="6451.75" y="-15775.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.64" y="-15775.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5841.84,-15693.9 5841.84,-15753.9 6501.84,-15753.9 6501.84,-15693.9 5841.84,-15693.9"/>
+<polygon fill="none" stroke="#29235c" points="5841.84,-15693.9 5841.84,-15753.9 6501.84,-15753.9 6501.84,-15693.9 5841.84,-15693.9"/>
+<text text-anchor="start" x="5852.84" y="-15714.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">current_job_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6188.59" y="-15715.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5841.84,-15633.9 5841.84,-15693.9 6501.84,-15693.9 6501.84,-15633.9 5841.84,-15633.9"/>
+<polygon fill="none" stroke="#29235c" points="5841.84,-15633.9 5841.84,-15693.9 6501.84,-15693.9 6501.84,-15633.9 5841.84,-15633.9"/>
+<text text-anchor="start" x="5852.84" y="-15654.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6149.5" y="-15655.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="6451.75" y="-15655.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6460.64" y="-15655.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5841.84,-15573.9 5841.84,-15633.9 6501.84,-15633.9 6501.84,-15573.9 5841.84,-15573.9"/>
+<polygon fill="none" stroke="#29235c" points="5841.84,-15573.9 5841.84,-15633.9 6501.84,-15633.9 6501.84,-15573.9 5841.84,-15573.9"/>
+<text text-anchor="start" x="5852.84" y="-15594.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6414.37" y="-15595.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5840.84,-15572.9 5840.84,-15934.9 6502.84,-15934.9 6502.84,-15572.9 5840.84,-15572.9"/>
+</g>
+<!-- kg_auth.groups -->
+<g id="kg_auth.groups" class="node">
+<title>kg_auth.groups</title>
+<g id="a_kg_auth.groups"><a xlink:title="kg_auth.groups&#10;Group definitions for collaborative access control (ADR&#45;082)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2548.15" cy="-5652.9" rx="433" ry="342.48"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="2244.15,-5832.9 2244.15,-5892.9 2852.15,-5892.9 2852.15,-5832.9 2244.15,-5832.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5832.9 2244.15,-5892.9 2852.15,-5892.9 2852.15,-5832.9 2244.15,-5832.9"/>
+<text text-anchor="start" x="2375.63" y="-5854.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.groups &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2244.15,-5772.9 2244.15,-5832.9 2852.15,-5832.9 2852.15,-5772.9 2244.15,-5772.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5772.9 2244.15,-5832.9 2852.15,-5832.9 2852.15,-5772.9 2244.15,-5772.9"/>
+<text text-anchor="start" x="2255.15" y="-5794.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2280.04" y="-5794.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2704.25" y="-5794.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2802.05" y="-5794.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2810.95" y="-5794.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2244.15,-5712.9 2244.15,-5772.9 2852.15,-5772.9 2852.15,-5712.9 2244.15,-5712.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5712.9 2244.15,-5772.9 2852.15,-5772.9 2852.15,-5712.9 2244.15,-5712.9"/>
+<text text-anchor="start" x="2255.15" y="-5733.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">group_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2482.02" y="-5734.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2802.05" y="-5734.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2810.95" y="-5734.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2244.15,-5652.9 2244.15,-5712.9 2852.15,-5712.9 2852.15,-5652.9 2244.15,-5652.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5652.9 2244.15,-5712.9 2852.15,-5712.9 2852.15,-5652.9 2244.15,-5652.9"/>
+<text text-anchor="start" x="2255.15" y="-5673.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">display_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2521.11" y="-5674.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2244.15,-5592.9 2244.15,-5652.9 2852.15,-5652.9 2852.15,-5592.9 2244.15,-5592.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5592.9 2244.15,-5652.9 2852.15,-5652.9 2852.15,-5592.9 2244.15,-5592.9"/>
+<text text-anchor="start" x="2255.15" y="-5613.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2789.57" y="-5614.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2244.15,-5532.9 2244.15,-5592.9 2852.15,-5592.9 2852.15,-5532.9 2244.15,-5532.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5532.9 2244.15,-5592.9 2852.15,-5592.9 2852.15,-5532.9 2244.15,-5532.9"/>
+<text text-anchor="start" x="2255.15" y="-5553.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_system &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2727.31" y="-5554.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2244.15,-5472.9 2244.15,-5532.9 2852.15,-5532.9 2852.15,-5472.9 2244.15,-5472.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5472.9 2244.15,-5532.9 2852.15,-5532.9 2852.15,-5472.9 2244.15,-5472.9"/>
+<text text-anchor="start" x="2254.77" y="-5493.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2441.14" y="-5494.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2802.06" y="-5494.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2810.95" y="-5494.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2244.15,-5412.9 2244.15,-5472.9 2852.15,-5472.9 2852.15,-5412.9 2244.15,-5412.9"/>
+<polygon fill="none" stroke="#29235c" points="2244.15,-5412.9 2244.15,-5472.9 2852.15,-5472.9 2852.15,-5412.9 2244.15,-5412.9"/>
+<text text-anchor="start" x="2255.15" y="-5433.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2743.34" y="-5434.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2243.15,-5411.9 2243.15,-5893.9 2853.15,-5893.9 2853.15,-5411.9 2243.15,-5411.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.groups&#45;&gt;kg_auth.users -->
+<!-- kg_auth.groups&#45;&gt;kg_auth.users -->
+<g id="edge22" class="edge">
+<title>kg_auth.groups:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2853.15,-5442.9C3057.42,-5442.9 3049.18,-5214.67 3246.39,-5207.09"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.63,-5210.59 3256.56,-5206.9 3246.5,-5203.59 3246.63,-5210.59"/>
+</g>
+<!-- kg_auth.oauth_access_tokens -->
+<g id="kg_auth.oauth_access_tokens" class="node">
+<title>kg_auth.oauth_access_tokens</title>
+<g id="a_kg_auth.oauth_access_tokens"><a xlink:title="kg_auth.oauth_access_tokens&#10;OAuth access tokens issued to clients">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="1485.5" cy="-3761.9" rx="430.76" ry="342.48"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="1183.5,-3941.9 1183.5,-4001.9 1788.5,-4001.9 1788.5,-3941.9 1183.5,-3941.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3941.9 1183.5,-4001.9 1788.5,-4001.9 1788.5,-3941.9 1183.5,-3941.9"/>
+<text text-anchor="start" x="1207.65" y="-3963.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.oauth_access_tokens &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3881.9 1183.5,-3941.9 1788.5,-3941.9 1788.5,-3881.9 1183.5,-3881.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3881.9 1183.5,-3941.9 1788.5,-3941.9 1788.5,-3881.9 1183.5,-3881.9"/>
+<text text-anchor="start" x="1194.5" y="-3903.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">token_hash</text>
+<text text-anchor="start" x="1359.91" y="-3903.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1418.37" y="-3903.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="1738.41" y="-3903.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1747.3" y="-3903.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3821.9 1183.5,-3881.9 1788.5,-3881.9 1788.5,-3821.9 1183.5,-3821.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3821.9 1183.5,-3881.9 1788.5,-3881.9 1788.5,-3821.9 1183.5,-3821.9"/>
+<text text-anchor="start" x="1194.5" y="-3842.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1418.37" y="-3843.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="1738.41" y="-3843.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1747.3" y="-3843.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3761.9 1183.5,-3821.9 1788.5,-3821.9 1788.5,-3761.9 1183.5,-3761.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3761.9 1183.5,-3821.9 1788.5,-3821.9 1788.5,-3761.9 1183.5,-3761.9"/>
+<text text-anchor="start" x="1194.5" y="-3782.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1679.7" y="-3783.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3701.9 1183.5,-3761.9 1788.5,-3761.9 1788.5,-3701.9 1183.5,-3701.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3701.9 1183.5,-3761.9 1788.5,-3761.9 1788.5,-3701.9 1183.5,-3701.9"/>
+<text text-anchor="start" x="1194.5" y="-3722.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scopes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1708.14" y="-3723.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3641.9 1183.5,-3701.9 1788.5,-3701.9 1788.5,-3641.9 1183.5,-3641.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3641.9 1183.5,-3701.9 1788.5,-3701.9 1788.5,-3641.9 1183.5,-3641.9"/>
+<text text-anchor="start" x="1194.42" y="-3662.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1377.49" y="-3663.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="1738.41" y="-3663.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1747.31" y="-3663.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3581.9 1183.5,-3641.9 1788.5,-3641.9 1788.5,-3581.9 1183.5,-3581.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3581.9 1183.5,-3641.9 1788.5,-3641.9 1788.5,-3581.9 1183.5,-3581.9"/>
+<text text-anchor="start" x="1194.5" y="-3602.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">revoked &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1663.66" y="-3603.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3521.9 1183.5,-3581.9 1788.5,-3581.9 1788.5,-3521.9 1183.5,-3521.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3521.9 1183.5,-3581.9 1788.5,-3581.9 1788.5,-3521.9 1183.5,-3521.9"/>
+<text text-anchor="start" x="1194.5" y="-3542.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1416.58" y="-3543.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="1182,-3520.9 1182,-4002.9 1789,-4002.9 1789,-3520.9 1182,-3520.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.oauth_clients -->
+<g id="kg_auth.oauth_clients" class="node">
+<title>kg_auth.oauth_clients</title>
+<g id="a_kg_auth.oauth_clients"><a xlink:title="kg_auth.oauth_clients&#10;OAuth 2.0 client applications registered to use the API">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2548.15" cy="-3132.9" rx="458.41" ry="511.89"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="2226.15,-3432.9 2226.15,-3492.9 2870.15,-3492.9 2870.15,-3432.9 2226.15,-3432.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3432.9 2226.15,-3492.9 2870.15,-3492.9 2870.15,-3432.9 2226.15,-3432.9"/>
+<text text-anchor="start" x="2330.28" y="-3454.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.oauth_clients &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-3372.9 2226.15,-3432.9 2870.15,-3432.9 2870.15,-3372.9 2226.15,-3372.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3372.9 2226.15,-3432.9 2870.15,-3432.9 2870.15,-3372.9 2226.15,-3372.9"/>
+<text text-anchor="start" x="2237.15" y="-3394.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">client_id</text>
+<text text-anchor="start" x="2354.5" y="-3394.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2500.02" y="-3394.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="2820.05" y="-3394.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2828.95" y="-3394.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-3312.9 2226.15,-3372.9 2870.15,-3372.9 2870.15,-3312.9 2226.15,-3312.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3312.9 2226.15,-3372.9 2870.15,-3372.9 2870.15,-3312.9 2226.15,-3312.9"/>
+<text text-anchor="start" x="2236.99" y="-3333.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_secret_hash &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2539.13" y="-3334.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-3252.9 2226.15,-3312.9 2870.15,-3312.9 2870.15,-3252.9 2226.15,-3252.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3252.9 2226.15,-3312.9 2870.15,-3312.9 2870.15,-3252.9 2226.15,-3252.9"/>
+<text text-anchor="start" x="2237.15" y="-3273.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2500.02" y="-3274.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="2820.05" y="-3274.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2828.95" y="-3274.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-3192.9 2226.15,-3252.9 2870.15,-3252.9 2870.15,-3192.9 2226.15,-3192.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3192.9 2226.15,-3252.9 2870.15,-3252.9 2870.15,-3192.9 2226.15,-3192.9"/>
+<text text-anchor="start" x="2237.15" y="-3213.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2517.81" y="-3214.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2820.05" y="-3214.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2828.95" y="-3214.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-3132.9 2226.15,-3192.9 2870.15,-3192.9 2870.15,-3132.9 2226.15,-3132.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3132.9 2226.15,-3192.9 2870.15,-3192.9 2870.15,-3132.9 2226.15,-3132.9"/>
+<text text-anchor="start" x="2237.15" y="-3153.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">grant_types &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2750.69" y="-3154.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<text text-anchor="start" x="2820.05" y="-3154.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2828.95" y="-3154.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-3072.9 2226.15,-3132.9 2870.15,-3132.9 2870.15,-3072.9 2226.15,-3072.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3072.9 2226.15,-3132.9 2870.15,-3132.9 2870.15,-3072.9 2226.15,-3072.9"/>
+<text text-anchor="start" x="2237.15" y="-3093.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">redirect_uris &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2789.79" y="-3094.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-3012.9 2226.15,-3072.9 2870.15,-3072.9 2870.15,-3012.9 2226.15,-3012.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-3012.9 2226.15,-3072.9 2870.15,-3072.9 2870.15,-3012.9 2226.15,-3012.9"/>
+<text text-anchor="start" x="2237.15" y="-3033.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scopes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2789.79" y="-3034.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-2952.9 2226.15,-3012.9 2870.15,-3012.9 2870.15,-2952.9 2226.15,-2952.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-2952.9 2226.15,-3012.9 2870.15,-3012.9 2870.15,-2952.9 2226.15,-2952.9"/>
+<text text-anchor="start" x="2237.15" y="-2973.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2745.31" y="-2974.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-2892.9 2226.15,-2952.9 2870.15,-2952.9 2870.15,-2892.9 2226.15,-2892.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-2892.9 2226.15,-2952.9 2870.15,-2952.9 2870.15,-2892.9 2226.15,-2892.9"/>
+<text text-anchor="start" x="2237.15" y="-2913.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2761.34" y="-2914.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-2832.9 2226.15,-2892.9 2870.15,-2892.9 2870.15,-2832.9 2226.15,-2832.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-2832.9 2226.15,-2892.9 2870.15,-2892.9 2870.15,-2832.9 2226.15,-2832.9"/>
+<text text-anchor="start" x="2237.15" y="-2853.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2498.22" y="-2854.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2226.15,-2772.9 2226.15,-2832.9 2870.15,-2832.9 2870.15,-2772.9 2226.15,-2772.9"/>
+<polygon fill="none" stroke="#29235c" points="2226.15,-2772.9 2226.15,-2832.9 2870.15,-2832.9 2870.15,-2772.9 2226.15,-2772.9"/>
+<text text-anchor="start" x="2237.15" y="-2793.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2782.68" y="-2794.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2225.15,-2771.9 2225.15,-3493.9 2871.15,-3493.9 2871.15,-2771.9 2225.15,-2771.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.oauth_access_tokens&#45;&gt;kg_auth.oauth_clients -->
+<!-- kg_auth.oauth_access_tokens&#45;&gt;kg_auth.oauth_clients -->
+<g id="edge24" class="edge">
+<title>kg_auth.oauth_access_tokens:e&#45;&gt;kg_auth.oauth_clients:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1789.5,-3851.9C2064.15,-3851.9 1949.98,-3413.79 2215.14,-3403.1"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2215.22,-3406.6 2225.15,-3402.9 2215.08,-3399.6 2215.22,-3406.6"/>
+</g>
+<!-- kg_auth.oauth_access_tokens&#45;&gt;kg_auth.users -->
+<!-- kg_auth.oauth_access_tokens&#45;&gt;kg_auth.users -->
+<g id="edge26" class="edge">
+<title>kg_auth.oauth_access_tokens:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1789.5,-3791.9C2006.64,-3791.9 1937.48,-3556.85 1988.96,-3345.9 2008.46,-3265.99 1972.13,-2663.34 2031.96,-2606.9 2198.83,-2449.46 2896.24,-2450.77 3064.33,-2606.9 3273.99,-2801.63 2974.37,-5148.56 3246.22,-5205.83"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.25,-5209.36 3256.56,-5206.9 3246.97,-5202.39 3246.25,-5209.36"/>
+</g>
+<!-- kg_auth.oauth_authorization_codes -->
+<g id="kg_auth.oauth_authorization_codes" class="node">
+<title>kg_auth.oauth_authorization_codes</title>
+<g id="a_kg_auth.oauth_authorization_codes"><a xlink:title="kg_auth.oauth_authorization_codes&#10;Temporary authorization codes for OAuth Authorization Code flow (web apps)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="1485.5" cy="-4661.9" rx="503.42" ry="469.54"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="1131.5,-4931.9 1131.5,-4991.9 1839.5,-4991.9 1839.5,-4931.9 1131.5,-4931.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4931.9 1131.5,-4991.9 1839.5,-4991.9 1839.5,-4931.9 1131.5,-4931.9"/>
+<text text-anchor="start" x="1169.81" y="-4953.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.oauth_authorization_codes &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4871.9 1131.5,-4931.9 1839.5,-4931.9 1839.5,-4871.9 1131.5,-4871.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4871.9 1131.5,-4931.9 1839.5,-4931.9 1839.5,-4871.9 1131.5,-4871.9"/>
+<text text-anchor="start" x="1142.5" y="-4893.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">code</text>
+<text text-anchor="start" x="1211.86" y="-4893.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1469.37" y="-4893.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="1789.41" y="-4893.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1798.3" y="-4893.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4811.9 1131.5,-4871.9 1839.5,-4871.9 1839.5,-4811.9 1131.5,-4811.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4811.9 1131.5,-4871.9 1839.5,-4871.9 1839.5,-4811.9 1131.5,-4811.9"/>
+<text text-anchor="start" x="1142.5" y="-4832.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1469.37" y="-4833.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="1789.41" y="-4833.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1798.3" y="-4833.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4751.9 1131.5,-4811.9 1839.5,-4811.9 1839.5,-4751.9 1131.5,-4751.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4751.9 1131.5,-4811.9 1839.5,-4811.9 1839.5,-4751.9 1131.5,-4751.9"/>
+<text text-anchor="start" x="1142.5" y="-4772.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1691.61" y="-4773.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="1789.41" y="-4773.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1798.3" y="-4773.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4691.9 1131.5,-4751.9 1839.5,-4751.9 1839.5,-4691.9 1131.5,-4691.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4691.9 1131.5,-4751.9 1839.5,-4751.9 1839.5,-4691.9 1131.5,-4691.9"/>
+<text text-anchor="start" x="1142.5" y="-4712.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">redirect_uri &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1737.83" y="-4713.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<text text-anchor="start" x="1789.41" y="-4713.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1798.3" y="-4713.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4631.9 1131.5,-4691.9 1839.5,-4691.9 1839.5,-4631.9 1131.5,-4631.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4631.9 1131.5,-4691.9 1839.5,-4691.9 1839.5,-4631.9 1131.5,-4631.9"/>
+<text text-anchor="start" x="1142.5" y="-4652.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scopes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1759.14" y="-4653.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4571.9 1131.5,-4631.9 1839.5,-4631.9 1839.5,-4571.9 1131.5,-4571.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4571.9 1131.5,-4631.9 1839.5,-4631.9 1839.5,-4571.9 1131.5,-4571.9"/>
+<text text-anchor="start" x="1142.5" y="-4592.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">code_challenge &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1508.46" y="-4593.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4511.9 1131.5,-4571.9 1839.5,-4571.9 1839.5,-4511.9 1131.5,-4511.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4511.9 1131.5,-4571.9 1839.5,-4571.9 1839.5,-4511.9 1131.5,-4511.9"/>
+<text text-anchor="start" x="1142.42" y="-4532.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">code_challenge_method &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1526.37" y="-4533.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(10)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4451.9 1131.5,-4511.9 1839.5,-4511.9 1839.5,-4451.9 1131.5,-4451.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4451.9 1131.5,-4511.9 1839.5,-4511.9 1839.5,-4451.9 1131.5,-4451.9"/>
+<text text-anchor="start" x="1142.5" y="-4472.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1428.49" y="-4473.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="1789.41" y="-4473.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1798.3" y="-4473.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4391.9 1131.5,-4451.9 1839.5,-4451.9 1839.5,-4391.9 1131.5,-4391.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4391.9 1131.5,-4451.9 1839.5,-4451.9 1839.5,-4391.9 1131.5,-4391.9"/>
+<text text-anchor="start" x="1142.5" y="-4412.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">used &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1714.66" y="-4413.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1131.5,-4331.9 1131.5,-4391.9 1839.5,-4391.9 1839.5,-4331.9 1131.5,-4331.9"/>
+<polygon fill="none" stroke="#29235c" points="1131.5,-4331.9 1131.5,-4391.9 1839.5,-4391.9 1839.5,-4331.9 1131.5,-4331.9"/>
+<text text-anchor="start" x="1142.5" y="-4352.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1467.58" y="-4353.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="1130.5,-4330.9 1130.5,-4992.9 1840.5,-4992.9 1840.5,-4330.9 1130.5,-4330.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.oauth_authorization_codes&#45;&gt;kg_auth.oauth_clients -->
+<!-- kg_auth.oauth_authorization_codes&#45;&gt;kg_auth.oauth_clients -->
+<g id="edge28" class="edge">
+<title>kg_auth.oauth_authorization_codes:e&#45;&gt;kg_auth.oauth_clients:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1840.5,-4841.9C2105.05,-4841.9 1939.13,-3914.63 2031.96,-3666.9 2081.73,-3534.07 2079.88,-3409.15 2214.76,-3403.13"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2215.22,-3406.62 2225.15,-3402.9 2215.07,-3399.62 2215.22,-3406.62"/>
+</g>
+<!-- kg_auth.oauth_authorization_codes&#45;&gt;kg_auth.users -->
+<!-- kg_auth.oauth_authorization_codes&#45;&gt;kg_auth.users -->
+<g id="edge30" class="edge">
+<title>kg_auth.oauth_authorization_codes:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1840.5,-4781.9C2120.39,-4781.9 1942.36,-4445.88 1988.96,-4169.9 2005.46,-4072.16 1958.56,-3792.53 2031.96,-3725.9 2116.89,-3648.8 2978.16,-3650.19 3064.33,-3725.9 3310.97,-3942.59 2932.97,-5179.91 3246.11,-5206.47"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.42,-5209.98 3256.56,-5206.9 3246.71,-5202.99 3246.42,-5209.98"/>
+</g>
+<!-- kg_auth.oauth_clients&#45;&gt;kg_auth.users -->
+<!-- kg_auth.oauth_clients&#45;&gt;kg_auth.users -->
+<g id="edge32" class="edge">
+<title>kg_auth.oauth_clients:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2871.15,-2922.9C3212.78,-2922.9 3000.11,-3331.36 3064.33,-3666.9 3096.12,-3832.96 3084.6,-5153.82 3246.67,-5205.35"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.14,-5208.81 3256.56,-5206.9 3247.22,-5201.89 3246.14,-5208.81"/>
+</g>
+<!-- kg_auth.oauth_device_codes -->
+<g id="kg_auth.oauth_device_codes" class="node">
+<title>kg_auth.oauth_device_codes</title>
+<g id="a_kg_auth.oauth_device_codes"><a xlink:title="kg_auth.oauth_device_codes&#10;Device authorization codes for OAuth Device Authorization Grant flow (CLI tools)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="1485.5" cy="-2946.9" rx="430.76" ry="384.83"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="1183.5,-3156.9 1183.5,-3216.9 1788.5,-3216.9 1788.5,-3156.9 1183.5,-3156.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3156.9 1183.5,-3216.9 1788.5,-3216.9 1788.5,-3156.9 1183.5,-3156.9"/>
+<text text-anchor="start" x="1215.65" y="-3178.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.oauth_device_codes &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3096.9 1183.5,-3156.9 1788.5,-3156.9 1788.5,-3096.9 1183.5,-3096.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3096.9 1183.5,-3156.9 1788.5,-3156.9 1788.5,-3096.9 1183.5,-3096.9"/>
+<text text-anchor="start" x="1194.5" y="-3118.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">device_code</text>
+<text text-anchor="start" x="1374.12" y="-3118.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1418.37" y="-3118.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="1738.41" y="-3118.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1747.3" y="-3118.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-3036.9 1183.5,-3096.9 1788.5,-3096.9 1788.5,-3036.9 1183.5,-3036.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-3036.9 1183.5,-3096.9 1788.5,-3096.9 1788.5,-3036.9 1183.5,-3036.9"/>
+<text text-anchor="start" x="1194.5" y="-3057.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_code &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1436.16" y="-3058.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="1738.41" y="-3058.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1747.3" y="-3058.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-2976.9 1183.5,-3036.9 1788.5,-3036.9 1788.5,-2976.9 1183.5,-2976.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-2976.9 1183.5,-3036.9 1788.5,-3036.9 1788.5,-2976.9 1183.5,-2976.9"/>
+<text text-anchor="start" x="1194.5" y="-2997.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1418.37" y="-2998.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="1738.41" y="-2998.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1747.3" y="-2998.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-2916.9 1183.5,-2976.9 1788.5,-2976.9 1788.5,-2916.9 1183.5,-2916.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-2916.9 1183.5,-2976.9 1788.5,-2976.9 1788.5,-2916.9 1183.5,-2916.9"/>
+<text text-anchor="start" x="1194.5" y="-2937.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1679.7" y="-2938.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-2856.9 1183.5,-2916.9 1788.5,-2916.9 1788.5,-2856.9 1183.5,-2856.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-2856.9 1183.5,-2916.9 1788.5,-2916.9 1788.5,-2856.9 1183.5,-2856.9"/>
+<text text-anchor="start" x="1194.5" y="-2877.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scopes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1708.14" y="-2878.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-2796.9 1183.5,-2856.9 1788.5,-2856.9 1788.5,-2796.9 1183.5,-2796.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-2796.9 1183.5,-2856.9 1788.5,-2856.9 1788.5,-2796.9 1183.5,-2796.9"/>
+<text text-anchor="start" x="1194.5" y="-2817.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1475.25" y="-2818.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-2736.9 1183.5,-2796.9 1788.5,-2796.9 1788.5,-2736.9 1183.5,-2736.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-2736.9 1183.5,-2796.9 1788.5,-2796.9 1788.5,-2736.9 1183.5,-2736.9"/>
+<text text-anchor="start" x="1194.42" y="-2757.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1377.49" y="-2758.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="1738.41" y="-2758.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1747.31" y="-2758.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1183.5,-2676.9 1183.5,-2736.9 1788.5,-2736.9 1788.5,-2676.9 1183.5,-2676.9"/>
+<polygon fill="none" stroke="#29235c" points="1183.5,-2676.9 1183.5,-2736.9 1788.5,-2736.9 1788.5,-2676.9 1183.5,-2676.9"/>
+<text text-anchor="start" x="1194.5" y="-2697.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1416.58" y="-2698.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="1182,-2675.9 1182,-3217.9 1789,-3217.9 1789,-2675.9 1182,-2675.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.oauth_device_codes&#45;&gt;kg_auth.oauth_clients -->
+<!-- kg_auth.oauth_device_codes&#45;&gt;kg_auth.oauth_clients -->
+<g id="edge34" class="edge">
+<title>kg_auth.oauth_device_codes:e&#45;&gt;kg_auth.oauth_clients:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1789.5,-3006.9C2047.71,-3006.9 1965.74,-3392.53 2214.98,-3402.7"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2215.08,-3406.2 2225.15,-3402.9 2215.22,-3399.2 2215.08,-3406.2"/>
+</g>
+<!-- kg_auth.oauth_device_codes&#45;&gt;kg_auth.users -->
+<!-- kg_auth.oauth_device_codes&#45;&gt;kg_auth.users -->
+<g id="edge36" class="edge">
+<title>kg_auth.oauth_device_codes:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1789.5,-2946.9C1847.67,-2946.9 1982.2,-2513.04 2031.96,-2482.9 2228.18,-2364.04 2896.5,-2326.49 3064.33,-2482.9 3283.81,-2687.44 2960.55,-5150.65 3246.58,-5205.95"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.27,-5209.44 3256.56,-5206.9 3246.93,-5202.47 3246.27,-5209.44"/>
+</g>
+<!-- kg_auth.oauth_external_provider_tokens -->
+<g id="kg_auth.oauth_external_provider_tokens" class="node">
+<title>kg_auth.oauth_external_provider_tokens</title>
+<g id="a_kg_auth.oauth_external_provider_tokens"><a xlink:title="kg_auth.oauth_external_provider_tokens&#10;OAuth tokens FROM external providers (Google, GitHub, etc.) &#45; not tokens issued by our system">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2548.15" cy="-4107.9" rx="516.38" ry="257.27"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="2185.15,-4227.9 2185.15,-4287.9 2911.15,-4287.9 2911.15,-4227.9 2185.15,-4227.9"/>
+<polygon fill="none" stroke="#29235c" points="2185.15,-4227.9 2185.15,-4287.9 2911.15,-4287.9 2911.15,-4227.9 2185.15,-4227.9"/>
+<text text-anchor="start" x="2196.01" y="-4249.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.oauth_external_provider_tokens &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2185.15,-4167.9 2185.15,-4227.9 2911.15,-4227.9 2911.15,-4167.9 2185.15,-4167.9"/>
+<polygon fill="none" stroke="#29235c" points="2185.15,-4167.9 2185.15,-4227.9 2911.15,-4227.9 2911.15,-4167.9 2185.15,-4167.9"/>
+<text text-anchor="start" x="2196.15" y="-4189.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">token_hash</text>
+<text text-anchor="start" x="2361.56" y="-4189.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2541.02" y="-4189.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="2861.05" y="-4189.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2869.95" y="-4189.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2185.15,-4107.9 2185.15,-4167.9 2911.15,-4167.9 2911.15,-4107.9 2185.15,-4107.9"/>
+<polygon fill="none" stroke="#29235c" points="2185.15,-4107.9 2185.15,-4167.9 2911.15,-4167.9 2911.15,-4107.9 2185.15,-4107.9"/>
+<text text-anchor="start" x="2196.15" y="-4128.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2802.34" y="-4129.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2185.15,-4047.9 2185.15,-4107.9 2911.15,-4107.9 2911.15,-4047.9 2185.15,-4047.9"/>
+<polygon fill="none" stroke="#29235c" points="2185.15,-4047.9 2185.15,-4107.9 2911.15,-4107.9 2911.15,-4047.9 2185.15,-4047.9"/>
+<text text-anchor="start" x="2196.15" y="-4068.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">provider &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2597.9" y="-4069.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2185.15,-3987.9 2185.15,-4047.9 2911.15,-4047.9 2911.15,-3987.9 2185.15,-3987.9"/>
+<polygon fill="none" stroke="#29235c" points="2185.15,-3987.9 2185.15,-4047.9 2911.15,-4047.9 2911.15,-3987.9 2185.15,-3987.9"/>
+<text text-anchor="start" x="2196.15" y="-4008.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scopes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2830.79" y="-4009.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2185.15,-3927.9 2185.15,-3987.9 2911.15,-3987.9 2911.15,-3927.9 2185.15,-3927.9"/>
+<polygon fill="none" stroke="#29235c" points="2185.15,-3927.9 2185.15,-3987.9 2911.15,-3987.9 2911.15,-3927.9 2185.15,-3927.9"/>
+<text text-anchor="start" x="2196.15" y="-3948.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2500.13" y="-3949.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2861.05" y="-3949.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2869.95" y="-3949.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2184.15,-3926.9 2184.15,-4288.9 2912.15,-4288.9 2912.15,-3926.9 2184.15,-3926.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.oauth_external_provider_tokens&#45;&gt;kg_auth.users -->
+<!-- kg_auth.oauth_external_provider_tokens&#45;&gt;kg_auth.users -->
+<g id="edge38" class="edge">
+<title>kg_auth.oauth_external_provider_tokens:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2912.15,-4137.9C3039.2,-4137.9 3015.46,-4262.62 3064.33,-4379.9 3208.19,-4725.07 2885.13,-5198.26 3246.51,-5206.78"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.52,-5210.28 3256.56,-5206.9 3246.6,-5203.28 3246.52,-5210.28"/>
+</g>
+<!-- kg_auth.oauth_refresh_tokens -->
+<g id="kg_auth.oauth_refresh_tokens" class="node">
+<title>kg_auth.oauth_refresh_tokens</title>
+<g id="a_kg_auth.oauth_refresh_tokens"><a xlink:title="kg_auth.oauth_refresh_tokens&#10;OAuth refresh tokens for long&#45;lived sessions">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="469.52" cy="-3877.9" rx="469.54" ry="427.19"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="139.52,-4117.9 139.52,-4177.9 799.52,-4177.9 799.52,-4117.9 139.52,-4117.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-4117.9 139.52,-4177.9 799.52,-4177.9 799.52,-4117.9 139.52,-4117.9"/>
+<text text-anchor="start" x="191.18" y="-4139.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.oauth_refresh_tokens &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-4057.9 139.52,-4117.9 799.52,-4117.9 799.52,-4057.9 139.52,-4057.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-4057.9 139.52,-4117.9 799.52,-4117.9 799.52,-4057.9 139.52,-4057.9"/>
+<text text-anchor="start" x="150.52" y="-4079.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">token_hash</text>
+<text text-anchor="start" x="315.93" y="-4079.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="429.39" y="-4079.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="749.43" y="-4079.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="758.32" y="-4079.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3997.9 139.52,-4057.9 799.52,-4057.9 799.52,-3997.9 139.52,-3997.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3997.9 139.52,-4057.9 799.52,-4057.9 799.52,-3997.9 139.52,-3997.9"/>
+<text text-anchor="start" x="150.52" y="-4018.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="429.39" y="-4019.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<text text-anchor="start" x="749.43" y="-4019.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="758.32" y="-4019.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3937.9 139.52,-3997.9 799.52,-3997.9 799.52,-3937.9 139.52,-3937.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3937.9 139.52,-3997.9 799.52,-3997.9 799.52,-3937.9 139.52,-3937.9"/>
+<text text-anchor="start" x="150.52" y="-3958.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="651.63" y="-3959.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="749.43" y="-3959.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="758.32" y="-3959.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3877.9 139.52,-3937.9 799.52,-3937.9 799.52,-3877.9 139.52,-3877.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3877.9 139.52,-3937.9 799.52,-3937.9 799.52,-3877.9 139.52,-3877.9"/>
+<text text-anchor="start" x="150.52" y="-3898.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scopes &#160;&#160;&#160;</text>
+<text text-anchor="start" x="719.16" y="-3899.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text[]</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3817.9 139.52,-3877.9 799.52,-3877.9 799.52,-3817.9 139.52,-3817.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3817.9 139.52,-3877.9 799.52,-3877.9 799.52,-3817.9 139.52,-3817.9"/>
+<text text-anchor="start" x="150.34" y="-3838.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">access_token_hash &#160;&#160;&#160;</text>
+<text text-anchor="start" x="468.5" y="-3839.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(255)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3757.9 139.52,-3817.9 799.52,-3817.9 799.52,-3757.9 139.52,-3757.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3757.9 139.52,-3817.9 799.52,-3817.9 799.52,-3757.9 139.52,-3757.9"/>
+<text text-anchor="start" x="150.52" y="-3778.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="388.51" y="-3779.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="749.43" y="-3779.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="758.32" y="-3779.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3697.9 139.52,-3757.9 799.52,-3757.9 799.52,-3697.9 139.52,-3697.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3697.9 139.52,-3757.9 799.52,-3757.9 799.52,-3697.9 139.52,-3697.9"/>
+<text text-anchor="start" x="150.52" y="-3718.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">revoked &#160;&#160;&#160;</text>
+<text text-anchor="start" x="674.69" y="-3719.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3637.9 139.52,-3697.9 799.52,-3697.9 799.52,-3637.9 139.52,-3637.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3637.9 139.52,-3697.9 799.52,-3697.9 799.52,-3637.9 139.52,-3637.9"/>
+<text text-anchor="start" x="150.52" y="-3658.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="427.6" y="-3659.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="139.52,-3577.9 139.52,-3637.9 799.52,-3637.9 799.52,-3577.9 139.52,-3577.9"/>
+<polygon fill="none" stroke="#29235c" points="139.52,-3577.9 139.52,-3637.9 799.52,-3637.9 799.52,-3577.9 139.52,-3577.9"/>
+<text text-anchor="start" x="150.52" y="-3598.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">last_used &#160;&#160;&#160;</text>
+<text text-anchor="start" x="427.6" y="-3599.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="138.52,-3576.9 138.52,-4178.9 800.52,-4178.9 800.52,-3576.9 138.52,-3576.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.oauth_refresh_tokens&#45;&gt;kg_auth.oauth_access_tokens -->
+<!-- kg_auth.oauth_refresh_tokens&#45;&gt;kg_auth.oauth_access_tokens -->
+<g id="edge40" class="edge">
+<title>kg_auth.oauth_refresh_tokens:e&#45;&gt;kg_auth.oauth_access_tokens:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M800.52,-3847.9C969.12,-3847.9 1008.76,-3909.3 1172.07,-3911.82"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="1172.47,-3915.32 1182.5,-3911.9 1172.52,-3908.32 1172.47,-3915.32"/>
+</g>
+<!-- kg_auth.oauth_refresh_tokens&#45;&gt;kg_auth.oauth_clients -->
+<!-- kg_auth.oauth_refresh_tokens&#45;&gt;kg_auth.oauth_clients -->
+<g id="edge42" class="edge">
+<title>kg_auth.oauth_refresh_tokens:e&#45;&gt;kg_auth.oauth_clients:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M800.52,-4027.9C1088.92,-4027.9 751.48,-3578.16 982.04,-3404.9 1090.09,-3323.7 2044.7,-3399.5 2215.07,-3402.79"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2215.11,-3406.29 2225.15,-3402.9 2215.18,-3399.29 2215.11,-3406.29"/>
+</g>
+<!-- kg_auth.oauth_refresh_tokens&#45;&gt;kg_auth.users -->
+<!-- kg_auth.oauth_refresh_tokens&#45;&gt;kg_auth.users -->
+<g id="edge44" class="edge">
+<title>kg_auth.oauth_refresh_tokens:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M800.52,-3967.9C840.28,-3967.9 953.79,-2575.88 982.04,-2547.9 1142.12,-2389.34 1793.07,-2540.23 1988.96,-2428.9 2016.24,-2413.4 2003.81,-2386.77 2031.96,-2372.9 2237.73,-2271.47 2896.71,-2216.26 3064.33,-2372.9 3292.34,-2585.97 2948.82,-5148.39 3246.18,-5205.92"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.27,-5209.44 3256.56,-5206.9 3246.93,-5202.47 3246.27,-5209.44"/>
+</g>
+<!-- kg_auth.resource_grants -->
+<g id="kg_auth.resource_grants" class="node">
+<title>kg_auth.resource_grants</title>
+<g id="a_kg_auth.resource_grants"><a xlink:title="kg_auth.resource_grants&#10;Instance&#45;level access grants for owned resources (ADR&#45;082)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2548.15" cy="-4778.9" rx="434.33" ry="384.83"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="2243.15,-4988.9 2243.15,-5048.9 2853.15,-5048.9 2853.15,-4988.9 2243.15,-4988.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4988.9 2243.15,-5048.9 2853.15,-5048.9 2853.15,-4988.9 2243.15,-4988.9"/>
+<text text-anchor="start" x="2308.95" y="-5010.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.resource_grants &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4928.9 2243.15,-4988.9 2853.15,-4988.9 2853.15,-4928.9 2243.15,-4928.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4928.9 2243.15,-4988.9 2853.15,-4988.9 2853.15,-4928.9 2243.15,-4928.9"/>
+<text text-anchor="start" x="2254.15" y="-4950.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2279.04" y="-4950.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2705.25" y="-4950.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2803.05" y="-4950.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2811.95" y="-4950.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4868.9 2243.15,-4928.9 2853.15,-4928.9 2853.15,-4868.9 2243.15,-4868.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4868.9 2243.15,-4928.9 2853.15,-4928.9 2853.15,-4868.9 2243.15,-4868.9"/>
+<text text-anchor="start" x="2254.15" y="-4889.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">resource_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2500.81" y="-4890.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2803.05" y="-4890.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2811.95" y="-4890.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4808.9 2243.15,-4868.9 2853.15,-4868.9 2853.15,-4808.9 2243.15,-4808.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4808.9 2243.15,-4868.9 2853.15,-4868.9 2853.15,-4808.9 2243.15,-4808.9"/>
+<text text-anchor="start" x="2254.15" y="-4829.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">resource_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2483.02" y="-4830.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="2803.05" y="-4830.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2811.95" y="-4830.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4748.9 2243.15,-4808.9 2853.15,-4808.9 2853.15,-4748.9 2243.15,-4748.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4748.9 2243.15,-4808.9 2853.15,-4808.9 2853.15,-4748.9 2243.15,-4748.9"/>
+<text text-anchor="start" x="2254.15" y="-4769.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">principal_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2500.81" y="-4770.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="2803.05" y="-4770.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2811.95" y="-4770.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4688.9 2243.15,-4748.9 2853.15,-4748.9 2853.15,-4688.9 2243.15,-4688.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4688.9 2243.15,-4748.9 2853.15,-4748.9 2853.15,-4688.9 2243.15,-4688.9"/>
+<text text-anchor="start" x="2254.15" y="-4709.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">principal_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2705.25" y="-4710.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2803.05" y="-4710.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2811.95" y="-4710.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4628.9 2243.15,-4688.9 2853.15,-4688.9 2853.15,-4628.9 2243.15,-4628.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4628.9 2243.15,-4688.9 2853.15,-4688.9 2853.15,-4628.9 2243.15,-4628.9"/>
+<text text-anchor="start" x="2254.15" y="-4649.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">permission &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2500.81" y="-4650.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(20)</text>
+<text text-anchor="start" x="2803.05" y="-4650.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2811.95" y="-4650.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4568.9 2243.15,-4628.9 2853.15,-4628.9 2853.15,-4568.9 2243.15,-4568.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4568.9 2243.15,-4628.9 2853.15,-4628.9 2853.15,-4568.9 2243.15,-4568.9"/>
+<text text-anchor="start" x="2253.88" y="-4589.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">granted_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2442.14" y="-4590.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2803.06" y="-4590.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2811.95" y="-4590.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2243.15,-4508.9 2243.15,-4568.9 2853.15,-4568.9 2853.15,-4508.9 2243.15,-4508.9"/>
+<polygon fill="none" stroke="#29235c" points="2243.15,-4508.9 2243.15,-4568.9 2853.15,-4568.9 2853.15,-4508.9 2243.15,-4508.9"/>
+<text text-anchor="start" x="2254.15" y="-4529.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">granted_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2744.34" y="-4530.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2242.15,-4507.9 2242.15,-5049.9 2854.15,-5049.9 2854.15,-4507.9 2242.15,-4507.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.resource_grants&#45;&gt;kg_auth.users -->
+<!-- kg_auth.resource_grants&#45;&gt;kg_auth.users -->
+<g id="edge46" class="edge">
+<title>kg_auth.resource_grants:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2854.15,-4538.9C3197.19,-4538.9 2915.86,-5193.27 3246.1,-5206.69"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.49,-5210.2 3256.56,-5206.9 3246.63,-5203.2 3246.49,-5210.2"/>
+</g>
+<!-- kg_auth.resources -->
+<g id="kg_auth.resources" class="node">
+<title>kg_auth.resources</title>
+<g id="a_kg_auth.resources"><a xlink:title="kg_auth.resources&#10;Dynamic resource type registry (ADR&#45;028)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="3577.56" cy="-7335.9" rx="470.45" ry="384.83"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="3247.56,-7545.9 3247.56,-7605.9 3908.56,-7605.9 3908.56,-7545.9 3247.56,-7545.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7545.9 3247.56,-7605.9 3908.56,-7605.9 3908.56,-7545.9 3247.56,-7545.9"/>
+<text text-anchor="start" x="3384.21" y="-7567.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.resources &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7485.9 3247.56,-7545.9 3908.56,-7545.9 3908.56,-7485.9 3247.56,-7485.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7485.9 3247.56,-7545.9 3908.56,-7545.9 3908.56,-7485.9 3247.56,-7485.9"/>
+<text text-anchor="start" x="3258.56" y="-7507.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">resource_type</text>
+<text text-anchor="start" x="3461.28" y="-7507.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3538.43" y="-7507.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="3858.47" y="-7507.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3867.36" y="-7507.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7425.9 3247.56,-7485.9 3908.56,-7485.9 3908.56,-7425.9 3247.56,-7425.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7425.9 3247.56,-7485.9 3908.56,-7485.9 3908.56,-7425.9 3247.56,-7425.9"/>
+<text text-anchor="start" x="3258.56" y="-7446.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3845.99" y="-7447.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7365.9 3247.56,-7425.9 3908.56,-7425.9 3908.56,-7365.9 3247.56,-7365.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7365.9 3247.56,-7425.9 3908.56,-7425.9 3908.56,-7365.9 3247.56,-7365.9"/>
+<text text-anchor="start" x="3258.56" y="-7386.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">parent_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3577.52" y="-7387.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7305.9 3247.56,-7365.9 3908.56,-7365.9 3908.56,-7305.9 3247.56,-7305.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7305.9 3247.56,-7365.9 3908.56,-7365.9 3908.56,-7305.9 3247.56,-7305.9"/>
+<text text-anchor="start" x="3258.08" y="-7326.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">available_actions &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3538.5" y="-7327.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)[]</text>
+<text text-anchor="start" x="3858.53" y="-7327.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3867.42" y="-7327.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7245.9 3247.56,-7305.9 3908.56,-7305.9 3908.56,-7245.9 3247.56,-7245.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7245.9 3247.56,-7305.9 3908.56,-7305.9 3908.56,-7245.9 3247.56,-7245.9"/>
+<text text-anchor="start" x="3258.56" y="-7266.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">supports_scoping &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3783.73" y="-7267.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7185.9 3247.56,-7245.9 3908.56,-7245.9 3908.56,-7185.9 3247.56,-7185.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7185.9 3247.56,-7245.9 3908.56,-7245.9 3908.56,-7185.9 3247.56,-7185.9"/>
+<text text-anchor="start" x="3258.56" y="-7206.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3821.09" y="-7207.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7125.9 3247.56,-7185.9 3908.56,-7185.9 3908.56,-7125.9 3247.56,-7125.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7125.9 3247.56,-7185.9 3908.56,-7185.9 3908.56,-7125.9 3247.56,-7125.9"/>
+<text text-anchor="start" x="3258.56" y="-7146.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">registered_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3497.55" y="-7147.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="3858.47" y="-7147.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="3867.36" y="-7147.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="3247.56,-7065.9 3247.56,-7125.9 3908.56,-7125.9 3908.56,-7065.9 3247.56,-7065.9"/>
+<polygon fill="none" stroke="#29235c" points="3247.56,-7065.9 3247.56,-7125.9 3908.56,-7125.9 3908.56,-7065.9 3247.56,-7065.9"/>
+<text text-anchor="start" x="3258.56" y="-7086.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">registered_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="3577.52" y="-7087.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="3246.06,-7064.9 3246.06,-7606.9 3909.06,-7606.9 3909.06,-7064.9 3246.06,-7064.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.resources&#45;&gt;kg_auth.resources -->
+<!-- kg_auth.resources&#45;&gt;kg_auth.resources -->
+<g id="edge48" class="edge">
+<title>kg_auth.resources:e&#45;&gt;kg_auth.resources:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M3908.56,-7395.9C4145.56,-7533.79 4145.56,-7749.57 3578.06,-7749.57 3017.76,-7749.57 3010.65,-7656.2 3238.65,-7521.13"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3240.71,-7523.98 3247.56,-7515.9 3237.16,-7517.94 3240.71,-7523.98"/>
+</g>
+<!-- kg_auth.role_permissions -->
+<g id="kg_auth.role_permissions" class="node">
+<title>kg_auth.role_permissions</title>
+<g id="a_kg_auth.role_permissions"><a xlink:title="kg_auth.role_permissions&#10;Dynamic role permissions with scoping (ADR&#45;028)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2548.15" cy="-7511.9" rx="440.56" ry="511.89"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="2239.15,-7811.9 2239.15,-7871.9 2858.15,-7871.9 2858.15,-7811.9 2239.15,-7811.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7811.9 2239.15,-7871.9 2858.15,-7871.9 2858.15,-7811.9 2239.15,-7811.9"/>
+<text text-anchor="start" x="2304.14" y="-7833.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.role_permissions &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7751.9 2239.15,-7811.9 2858.15,-7811.9 2858.15,-7751.9 2239.15,-7751.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7751.9 2239.15,-7811.9 2858.15,-7811.9 2858.15,-7751.9 2239.15,-7751.9"/>
+<text text-anchor="start" x="2250.15" y="-7773.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2275.04" y="-7773.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2710.25" y="-7773.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2808.05" y="-7773.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2816.95" y="-7773.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7691.9 2239.15,-7751.9 2858.15,-7751.9 2858.15,-7691.9 2239.15,-7691.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7691.9 2239.15,-7751.9 2858.15,-7751.9 2858.15,-7691.9 2239.15,-7691.9"/>
+<text text-anchor="start" x="2250.15" y="-7712.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">role_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2505.81" y="-7713.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2808.05" y="-7713.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2816.95" y="-7713.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7631.9 2239.15,-7691.9 2858.15,-7691.9 2858.15,-7631.9 2239.15,-7631.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7631.9 2239.15,-7691.9 2858.15,-7691.9 2858.15,-7631.9 2239.15,-7631.9"/>
+<text text-anchor="start" x="2250" y="-7652.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">resource_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2488.08" y="-7653.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="2808.12" y="-7653.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2817.01" y="-7653.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7571.9 2239.15,-7631.9 2858.15,-7631.9 2858.15,-7571.9 2239.15,-7571.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7571.9 2239.15,-7631.9 2858.15,-7631.9 2858.15,-7571.9 2239.15,-7571.9"/>
+<text text-anchor="start" x="2250.15" y="-7592.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">action &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2505.81" y="-7593.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2808.05" y="-7593.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2816.95" y="-7593.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7511.9 2239.15,-7571.9 2858.15,-7571.9 2858.15,-7511.9 2239.15,-7511.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7511.9 2239.15,-7571.9 2858.15,-7571.9 2858.15,-7511.9 2239.15,-7511.9"/>
+<text text-anchor="start" x="2250.15" y="-7532.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scope_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2544.9" y="-7533.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7451.9 2239.15,-7511.9 2858.15,-7511.9 2858.15,-7451.9 2239.15,-7451.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7451.9 2239.15,-7511.9 2858.15,-7511.9 2858.15,-7451.9 2239.15,-7451.9"/>
+<text text-anchor="start" x="2250.15" y="-7472.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scope_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2527.11" y="-7473.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7391.9 2239.15,-7451.9 2858.15,-7451.9 2858.15,-7391.9 2239.15,-7391.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7391.9 2239.15,-7451.9 2858.15,-7451.9 2858.15,-7391.9 2239.15,-7391.9"/>
+<text text-anchor="start" x="2250.15" y="-7412.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scope_filter &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2770.68" y="-7413.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7331.9 2239.15,-7391.9 2858.15,-7391.9 2858.15,-7331.9 2239.15,-7331.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7331.9 2239.15,-7391.9 2858.15,-7391.9 2858.15,-7331.9 2239.15,-7331.9"/>
+<text text-anchor="start" x="2250.15" y="-7352.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">granted &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2694.22" y="-7353.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<text text-anchor="start" x="2808.05" y="-7353.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2816.95" y="-7353.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7271.9 2239.15,-7331.9 2858.15,-7331.9 2858.15,-7271.9 2239.15,-7271.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7271.9 2239.15,-7331.9 2858.15,-7331.9 2858.15,-7271.9 2239.15,-7271.9"/>
+<text text-anchor="start" x="2250.15" y="-7292.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">inherited_from &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2544.9" y="-7293.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7211.9 2239.15,-7271.9 2858.15,-7271.9 2858.15,-7211.9 2239.15,-7211.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7211.9 2239.15,-7271.9 2858.15,-7271.9 2858.15,-7211.9 2239.15,-7211.9"/>
+<text text-anchor="start" x="2250.15" y="-7232.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2447.13" y="-7233.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2808.05" y="-7233.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2816.95" y="-7233.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2239.15,-7151.9 2239.15,-7211.9 2858.15,-7211.9 2858.15,-7151.9 2239.15,-7151.9"/>
+<polygon fill="none" stroke="#29235c" points="2239.15,-7151.9 2239.15,-7211.9 2858.15,-7211.9 2858.15,-7151.9 2239.15,-7151.9"/>
+<text text-anchor="start" x="2250.15" y="-7172.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2749.34" y="-7173.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2237.65,-7150.9 2237.65,-7872.9 2858.65,-7872.9 2858.65,-7150.9 2237.65,-7150.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.resources -->
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.resources -->
+<g id="edge50" class="edge">
+<title>kg_auth.role_permissions:e&#45;&gt;kg_auth.resources:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2859.15,-7661.9C3039.74,-7661.9 3061.78,-7521.27 3236.49,-7516.05"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3236.61,-7519.55 3246.56,-7515.9 3236.51,-7512.55 3236.61,-7519.55"/>
+</g>
+<!-- kg_auth.roles -->
+<g id="kg_auth.roles" class="node">
+<title>kg_auth.roles</title>
+<g id="a_kg_auth.roles"><a xlink:title="kg_auth.roles&#10;Dynamic role definitions with inheritance (ADR&#45;028)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="4527.07" cy="-6555.9" rx="436.07" ry="427.19"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="4221.07,-6795.9 4221.07,-6855.9 4834.07,-6855.9 4834.07,-6795.9 4221.07,-6795.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6795.9 4221.07,-6855.9 4834.07,-6855.9 4834.07,-6795.9 4221.07,-6795.9"/>
+<text text-anchor="start" x="4369.29" y="-6817.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.roles &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6735.9 4221.07,-6795.9 4834.07,-6795.9 4834.07,-6735.9 4221.07,-6735.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6735.9 4221.07,-6795.9 4834.07,-6795.9 4834.07,-6735.9 4221.07,-6735.9"/>
+<text text-anchor="start" x="4232.07" y="-6757.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">role_name</text>
+<text text-anchor="start" x="4383.21" y="-6757.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4481.73" y="-6757.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="4783.98" y="-6757.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="4792.87" y="-6757.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6675.9 4221.07,-6735.9 4834.07,-6735.9 4834.07,-6675.9 4221.07,-6675.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6675.9 4221.07,-6735.9 4834.07,-6735.9 4834.07,-6675.9 4221.07,-6675.9"/>
+<text text-anchor="start" x="4231.6" y="-6696.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">display_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4464.01" y="-6697.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="4784.04" y="-6697.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="4792.94" y="-6697.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6615.9 4221.07,-6675.9 4834.07,-6675.9 4834.07,-6615.9 4221.07,-6615.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6615.9 4221.07,-6675.9 4834.07,-6675.9 4834.07,-6615.9 4221.07,-6615.9"/>
+<text text-anchor="start" x="4232.07" y="-6636.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">description &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4771.5" y="-6637.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6555.9 4221.07,-6615.9 4834.07,-6615.9 4834.07,-6555.9 4221.07,-6555.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6555.9 4221.07,-6615.9 4834.07,-6615.9 4834.07,-6555.9 4221.07,-6555.9"/>
+<text text-anchor="start" x="4232.07" y="-6576.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_builtin &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4709.24" y="-6577.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6495.9 4221.07,-6555.9 4834.07,-6555.9 4834.07,-6495.9 4221.07,-6495.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6495.9 4221.07,-6555.9 4834.07,-6555.9 4834.07,-6495.9 4221.07,-6495.9"/>
+<text text-anchor="start" x="4232.07" y="-6516.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">is_active &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4709.24" y="-6517.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">boolean</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6435.9 4221.07,-6495.9 4834.07,-6495.9 4834.07,-6435.9 4221.07,-6435.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6435.9 4221.07,-6495.9 4834.07,-6495.9 4834.07,-6435.9 4221.07,-6435.9"/>
+<text text-anchor="start" x="4232.07" y="-6456.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">parent_role &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4520.82" y="-6457.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6375.9 4221.07,-6435.9 4834.07,-6435.9 4834.07,-6375.9 4221.07,-6375.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6375.9 4221.07,-6435.9 4834.07,-6435.9 4834.07,-6375.9 4221.07,-6375.9"/>
+<text text-anchor="start" x="4232.07" y="-6396.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4423.06" y="-6397.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="4783.98" y="-6397.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="4792.87" y="-6397.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6315.9 4221.07,-6375.9 4834.07,-6375.9 4834.07,-6315.9 4221.07,-6315.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6315.9 4221.07,-6375.9 4834.07,-6375.9 4834.07,-6315.9 4221.07,-6315.9"/>
+<text text-anchor="start" x="4232.07" y="-6336.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">created_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4725.27" y="-6337.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="4221.07,-6255.9 4221.07,-6315.9 4834.07,-6315.9 4834.07,-6255.9 4221.07,-6255.9"/>
+<polygon fill="none" stroke="#29235c" points="4221.07,-6255.9 4221.07,-6315.9 4834.07,-6315.9 4834.07,-6255.9 4221.07,-6255.9"/>
+<text text-anchor="start" x="4232.07" y="-6276.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metadata &#160;&#160;&#160;</text>
+<text text-anchor="start" x="4746.6" y="-6277.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="4219.57,-6254.9 4219.57,-6856.9 4834.57,-6856.9 4834.57,-6254.9 4219.57,-6254.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.roles -->
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.roles -->
+<g id="edge52" class="edge">
+<title>kg_auth.role_permissions:e&#45;&gt;kg_auth.roles:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2859.15,-7301.9C3026.97,-7301.9 3002.73,-7141.01 3064.33,-6984.9 3104.11,-6884.1 3024.23,-6814.44 3107.33,-6744.9 3267.61,-6610.78 3839.18,-6732.23 4047.79,-6744.9 4121.32,-6749.37 4141.18,-6764.46 4210.02,-6765.8"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="4210.04,-6769.3 4220.07,-6765.9 4210.1,-6762.3 4210.04,-6769.3"/>
+</g>
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.roles -->
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.roles -->
+<g id="edge54" class="edge">
+<title>kg_auth.role_permissions:e&#45;&gt;kg_auth.roles:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2859.15,-7721.9C3042.1,-7721.9 2968.41,-7055.95 3107.33,-6936.9 3294.79,-6776.25 3952.24,-6766.14 4209.96,-6765.9"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="4210.07,-6769.4 4220.07,-6765.9 4210.07,-6762.4 4210.07,-6769.4"/>
+</g>
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.users -->
+<!-- kg_auth.role_permissions&#45;&gt;kg_auth.users -->
+<g id="edge56" class="edge">
+<title>kg_auth.role_permissions:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2859.15,-7181.9C2985.57,-7181.9 3008.58,-7098.36 3064.33,-6984.9 3150.47,-6809.61 3061.02,-5261.16 3246.63,-5208.29"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3247.14,-5211.75 3256.56,-5206.9 3246.17,-5204.82 3247.14,-5211.75"/>
+</g>
+<!-- kg_auth.roles&#45;&gt;kg_auth.roles -->
+<!-- kg_auth.roles&#45;&gt;kg_auth.roles -->
+<g id="edge58" class="edge">
+<title>kg_auth.roles:e&#45;&gt;kg_auth.roles:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M4834.07,-6465.9C5071.07,-6617.93 5071.07,-7011.99 4527.57,-7011.99 3990.71,-7011.99 3984.15,-6920.21 4212.5,-6771.44"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="4214.57,-6774.27 4221.07,-6765.9 4210.77,-6768.39 4214.57,-6774.27"/>
+</g>
+<!-- kg_auth.roles&#45;&gt;kg_auth.users -->
+<!-- kg_auth.roles&#45;&gt;kg_auth.users -->
+<g id="edge60" class="edge">
+<title>kg_auth.roles:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M4835.07,-6345.9C4931.56,-6345.9 4886.22,-6209.99 4834.07,-6128.81 4416.81,-5479.19 3675.02,-6048.63 3257.56,-5399.14 3213.35,-5330.35 3174.59,-5217.15 3246.23,-5207.55"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.8,-5211.02 3256.56,-5206.9 3246.36,-5204.04 3246.8,-5211.02"/>
+</g>
+<!-- kg_auth.user_groups -->
+<g id="kg_auth.user_groups" class="node">
+<title>kg_auth.user_groups</title>
+<g id="a_kg_auth.user_groups"><a xlink:title="kg_auth.user_groups&#10;Group membership assignments (ADR&#45;082)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="1485.5" cy="-5897.9" rx="420.04" ry="214.92"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="1190.5,-5987.9 1190.5,-6047.9 1780.5,-6047.9 1780.5,-5987.9 1190.5,-5987.9"/>
+<polygon fill="none" stroke="#29235c" points="1190.5,-5987.9 1190.5,-6047.9 1780.5,-6047.9 1780.5,-5987.9 1190.5,-5987.9"/>
+<text text-anchor="start" x="1272.97" y="-6009.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.user_groups &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1190.5,-5927.9 1190.5,-5987.9 1780.5,-5987.9 1780.5,-5927.9 1190.5,-5927.9"/>
+<polygon fill="none" stroke="#29235c" points="1190.5,-5927.9 1190.5,-5987.9 1780.5,-5987.9 1780.5,-5927.9 1190.5,-5927.9"/>
+<text text-anchor="start" x="1201.5" y="-5949.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">user_id</text>
+<text text-anchor="start" x="1306.41" y="-5949.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1632.61" y="-5949.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="1730.41" y="-5949.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1739.3" y="-5949.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1190.5,-5867.9 1190.5,-5927.9 1780.5,-5927.9 1780.5,-5867.9 1190.5,-5867.9"/>
+<polygon fill="none" stroke="#29235c" points="1190.5,-5867.9 1190.5,-5927.9 1780.5,-5927.9 1780.5,-5867.9 1190.5,-5867.9"/>
+<text text-anchor="start" x="1201.5" y="-5889.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">group_id</text>
+<text text-anchor="start" x="1325.98" y="-5889.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1632.61" y="-5889.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="1730.41" y="-5889.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1739.3" y="-5889.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1190.5,-5807.9 1190.5,-5867.9 1780.5,-5867.9 1780.5,-5807.9 1190.5,-5807.9"/>
+<polygon fill="none" stroke="#29235c" points="1190.5,-5807.9 1190.5,-5867.9 1780.5,-5867.9 1780.5,-5807.9 1190.5,-5807.9"/>
+<text text-anchor="start" x="1201.01" y="-5828.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">added_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1369.49" y="-5829.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="1730.41" y="-5829.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="1739.31" y="-5829.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="1190.5,-5747.9 1190.5,-5807.9 1780.5,-5807.9 1780.5,-5747.9 1190.5,-5747.9"/>
+<polygon fill="none" stroke="#29235c" points="1190.5,-5747.9 1190.5,-5807.9 1780.5,-5807.9 1780.5,-5747.9 1190.5,-5747.9"/>
+<text text-anchor="start" x="1201.5" y="-5768.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">added_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="1671.7" y="-5769.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="1189.5,-5746.9 1189.5,-6048.9 1781.5,-6048.9 1781.5,-5746.9 1189.5,-5746.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.user_groups&#45;&gt;kg_auth.groups -->
+<!-- kg_auth.user_groups&#45;&gt;kg_auth.groups -->
+<g id="edge62" class="edge">
+<title>kg_auth.user_groups:e&#45;&gt;kg_auth.groups:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1781.5,-5897.9C1987.5,-5897.9 2032.21,-5806.03 2232.85,-5802.98"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="2233.17,-5806.48 2243.15,-5802.9 2233.12,-5799.48 2233.17,-5806.48"/>
+</g>
+<!-- kg_auth.user_groups&#45;&gt;kg_auth.users -->
+<!-- kg_auth.user_groups&#45;&gt;kg_auth.users -->
+<g id="edge64" class="edge">
+<title>kg_auth.user_groups:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1781.5,-5777.9C2077.13,-5777.9 1937.67,-5437.05 1988.96,-5145.9 2002.08,-5071.4 1977.63,-3837.54 2031.96,-3784.9 2114.34,-3705.08 2977.96,-3709.42 3064.33,-3784.9 3301.86,-3992.48 2945.5,-5180.97 3246.52,-5206.48"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.42,-5209.98 3256.56,-5206.9 3246.71,-5202.99 3246.42,-5209.98"/>
+</g>
+<!-- kg_auth.user_groups&#45;&gt;kg_auth.users -->
+<!-- kg_auth.user_groups&#45;&gt;kg_auth.users -->
+<g id="edge66" class="edge">
+<title>kg_auth.user_groups:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M1781.5,-5957.9C2153.98,-5957.9 1936.44,-5514.66 1988.96,-5145.9 1999.23,-5073.81 1979.63,-3886.54 2031.96,-3835.9 2073.17,-3796.02 3021.05,-3798.27 3064.33,-3835.9 3293.88,-4035.5 2956.65,-5180.76 3246.44,-5206.46"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.42,-5209.96 3256.56,-5206.9 3246.72,-5202.97 3246.42,-5209.96"/>
+</g>
+<!-- kg_auth.user_roles -->
+<g id="kg_auth.user_roles" class="node">
+<title>kg_auth.user_roles</title>
+<g id="a_kg_auth.user_roles"><a xlink:title="kg_auth.user_roles&#10;User role assignments with optional scoping (ADR&#45;028)">
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2548.15" cy="-6585.9" rx="448.11" ry="384.83"/>
+<polygon fill="#2d7d9a" stroke="transparent" points="2233.15,-6795.9 2233.15,-6855.9 2863.15,-6855.9 2863.15,-6795.9 2233.15,-6795.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6795.9 2233.15,-6855.9 2863.15,-6855.9 2863.15,-6795.9 2233.15,-6795.9"/>
+<text text-anchor="start" x="2349.86" y="-6817.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_auth.user_roles &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6735.9 2233.15,-6795.9 2863.15,-6795.9 2863.15,-6735.9 2233.15,-6735.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6735.9 2233.15,-6795.9 2863.15,-6795.9 2863.15,-6735.9 2233.15,-6735.9"/>
+<text text-anchor="start" x="2244.15" y="-6757.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2269.04" y="-6757.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2715.25" y="-6757.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2813.05" y="-6757.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2821.95" y="-6757.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6675.9 2233.15,-6735.9 2863.15,-6735.9 2863.15,-6675.9 2233.15,-6675.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6675.9 2233.15,-6735.9 2863.15,-6735.9 2863.15,-6675.9 2233.15,-6675.9"/>
+<text text-anchor="start" x="2244.15" y="-6696.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2715.25" y="-6697.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2813.05" y="-6697.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2821.95" y="-6697.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6615.9 2233.15,-6675.9 2863.15,-6675.9 2863.15,-6615.9 2233.15,-6615.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6615.9 2233.15,-6675.9 2863.15,-6675.9 2863.15,-6615.9 2233.15,-6615.9"/>
+<text text-anchor="start" x="2244.15" y="-6636.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">role_name &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2510.81" y="-6637.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2813.05" y="-6637.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2821.95" y="-6637.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6555.9 2233.15,-6615.9 2863.15,-6615.9 2863.15,-6555.9 2233.15,-6555.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6555.9 2233.15,-6615.9 2863.15,-6615.9 2863.15,-6555.9 2233.15,-6555.9"/>
+<text text-anchor="start" x="2244.15" y="-6576.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scope_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2549.9" y="-6577.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6495.9 2233.15,-6555.9 2863.15,-6555.9 2863.15,-6495.9 2233.15,-6495.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6495.9 2233.15,-6555.9 2863.15,-6555.9 2863.15,-6495.9 2233.15,-6495.9"/>
+<text text-anchor="start" x="2244.15" y="-6516.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">scope_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2532.11" y="-6517.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6435.9 2233.15,-6495.9 2863.15,-6495.9 2863.15,-6435.9 2233.15,-6435.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6435.9 2233.15,-6495.9 2863.15,-6495.9 2863.15,-6435.9 2233.15,-6435.9"/>
+<text text-anchor="start" x="2244.1" y="-6456.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">assigned_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2452.14" y="-6457.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2813.06" y="-6457.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2821.95" y="-6457.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6375.9 2233.15,-6435.9 2863.15,-6435.9 2863.15,-6375.9 2233.15,-6375.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6375.9 2233.15,-6435.9 2863.15,-6435.9 2863.15,-6375.9 2233.15,-6375.9"/>
+<text text-anchor="start" x="2244.15" y="-6396.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">assigned_by &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2754.34" y="-6397.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.15,-6315.9 2233.15,-6375.9 2863.15,-6375.9 2863.15,-6315.9 2233.15,-6315.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.15,-6315.9 2233.15,-6375.9 2863.15,-6375.9 2863.15,-6315.9 2233.15,-6315.9"/>
+<text text-anchor="start" x="2244.15" y="-6336.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">expires_at &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2491.22" y="-6337.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2232.15,-6314.9 2232.15,-6856.9 2864.15,-6856.9 2864.15,-6314.9 2232.15,-6314.9"/>
+</a>
+</g>
+</g>
+<!-- kg_auth.user_roles&#45;&gt;kg_auth.roles -->
+<!-- kg_auth.user_roles&#45;&gt;kg_auth.roles -->
+<g id="edge68" class="edge">
+<title>kg_auth.user_roles:e&#45;&gt;kg_auth.roles:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2864.15,-6645.9C3390.51,-6645.9 3535.8,-6563.72 4047.79,-6685.9 4126.54,-6704.69 4135.05,-6761.01 4210.07,-6765.6"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="4209.97,-6769.1 4220.07,-6765.9 4210.18,-6762.1 4209.97,-6769.1"/>
+</g>
+<!-- kg_auth.user_roles&#45;&gt;kg_auth.users -->
+<!-- kg_auth.user_roles&#45;&gt;kg_auth.users -->
+<g id="edge70" class="edge">
+<title>kg_auth.user_roles:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2864.15,-6405.9C2998.66,-6405.9 3004.74,-6299.49 3064.33,-6178.9 3160.36,-5984.59 3040.24,-5230.97 3246.49,-5207.46"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.77,-5210.95 3256.56,-5206.9 3246.38,-5203.96 3246.77,-5210.95"/>
+</g>
+<!-- kg_auth.user_roles&#45;&gt;kg_auth.users -->
+<!-- kg_auth.user_roles&#45;&gt;kg_auth.users -->
+<g id="edge72" class="edge">
+<title>kg_auth.user_roles:e&#45;&gt;kg_auth.users:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M2864.15,-6705.9C3114.7,-6705.9 2995.3,-6419.75 3064.33,-6178.9 3124.05,-5970.55 3039.11,-5230.53 3246.46,-5207.45"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="3246.77,-5210.94 3256.56,-5206.9 3246.38,-5203.95 3246.77,-5210.94"/>
+</g>
+<!-- kg_auth.users&#45;&gt;kg_auth.roles -->
+<!-- kg_auth.users&#45;&gt;kg_auth.roles -->
+<g id="edge74" class="edge">
+<title>kg_auth.users:e&#45;&gt;kg_auth.roles:w</title>
+<path fill="none" stroke="#29235c" stroke-width="3" d="M3898.56,-5026.9C4288.1,-5026.9 3835.18,-6735.47 4209.91,-6765.5"/>
+<polygon fill="#29235c" stroke="#29235c" stroke-width="3" points="4209.94,-6769 4220.07,-6765.9 4210.22,-6762.01 4209.94,-6769"/>
+</g>
+<!-- kg_logs.api_metrics -->
+<g id="kg_logs.api_metrics" class="node">
+<title>kg_logs.api_metrics</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6172.73" cy="-14410.9" rx="430.76" ry="384.83"/>
+<polygon fill="#2d8e5e" stroke="transparent" points="5870.73,-14620.9 5870.73,-14680.9 6475.73,-14680.9 6475.73,-14620.9 5870.73,-14620.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14620.9 5870.73,-14680.9 6475.73,-14680.9 6475.73,-14620.9 5870.73,-14620.9"/>
+<text text-anchor="start" x="5969.63" y="-14642.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_logs.api_metrics &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14560.9 5870.73,-14620.9 6475.73,-14620.9 6475.73,-14560.9 5870.73,-14560.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14560.9 5870.73,-14620.9 6475.73,-14620.9 6475.73,-14560.9 5870.73,-14560.9"/>
+<text text-anchor="start" x="5881.73" y="-14582.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="5906.62" y="-14582.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6327.83" y="-14582.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6425.64" y="-14582.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-14582.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14500.9 5870.73,-14560.9 6475.73,-14560.9 6475.73,-14500.9 5870.73,-14500.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14500.9 5870.73,-14560.9 6475.73,-14560.9 6475.73,-14500.9 5870.73,-14500.9"/>
+<text text-anchor="start" x="5881.66" y="-14521.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">timestamp &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6064.72" y="-14522.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="6425.64" y="-14522.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.54" y="-14522.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14440.9 5870.73,-14500.9 6475.73,-14500.9 6475.73,-14440.9 5870.73,-14440.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14440.9 5870.73,-14500.9 6475.73,-14500.9 6475.73,-14440.9 5870.73,-14440.9"/>
+<text text-anchor="start" x="5881.73" y="-14461.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">endpoint &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6105.6" y="-14462.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<text text-anchor="start" x="6425.64" y="-14462.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-14462.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14380.9 5870.73,-14440.9 6475.73,-14440.9 6475.73,-14380.9 5870.73,-14380.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14380.9 5870.73,-14440.9 6475.73,-14440.9 6475.73,-14380.9 5870.73,-14380.9"/>
+<text text-anchor="start" x="5881.73" y="-14401.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">method &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6123.39" y="-14402.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(10)</text>
+<text text-anchor="start" x="6425.64" y="-14402.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-14402.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14320.9 5870.73,-14380.9 6475.73,-14380.9 6475.73,-14320.9 5870.73,-14320.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14320.9 5870.73,-14380.9 6475.73,-14380.9 6475.73,-14320.9 5870.73,-14320.9"/>
+<text text-anchor="start" x="5881.73" y="-14341.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status_code &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6327.83" y="-14342.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6425.64" y="-14342.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-14342.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14260.9 5870.73,-14320.9 6475.73,-14320.9 6475.73,-14260.9 5870.73,-14260.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14260.9 5870.73,-14320.9 6475.73,-14320.9 6475.73,-14260.9 5870.73,-14260.9"/>
+<text text-anchor="start" x="5881.73" y="-14281.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">duration_ms &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6228.3" y="-14282.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">numeric(10,2)</text>
+<text text-anchor="start" x="6425.64" y="-14282.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-14282.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14200.9 5870.73,-14260.9 6475.73,-14260.9 6475.73,-14200.9 5870.73,-14200.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14200.9 5870.73,-14260.9 6475.73,-14260.9 6475.73,-14200.9 5870.73,-14200.9"/>
+<text text-anchor="start" x="5881.73" y="-14221.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">client_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6144.69" y="-14222.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-14140.9 5870.73,-14200.9 6475.73,-14200.9 6475.73,-14140.9 5870.73,-14140.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-14140.9 5870.73,-14200.9 6475.73,-14200.9 6475.73,-14140.9 5870.73,-14140.9"/>
+<text text-anchor="start" x="5881.73" y="-14161.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">error_message &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6413.15" y="-14162.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5869.23,-14139.9 5869.23,-14681.9 6476.23,-14681.9 6476.23,-14139.9 5869.23,-14139.9"/>
+</g>
+<!-- kg_logs.audit_trail -->
+<g id="kg_logs.audit_trail" class="node">
+<title>kg_logs.audit_trail</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="6172.73" cy="-13506.9" rx="430.76" ry="469.54"/>
+<polygon fill="#2d8e5e" stroke="transparent" points="5870.73,-13776.9 5870.73,-13836.9 6475.73,-13836.9 6475.73,-13776.9 5870.73,-13776.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13776.9 5870.73,-13836.9 6475.73,-13836.9 6475.73,-13776.9 5870.73,-13776.9"/>
+<text text-anchor="start" x="5982.06" y="-13798.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_logs.audit_trail &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13716.9 5870.73,-13776.9 6475.73,-13776.9 6475.73,-13716.9 5870.73,-13716.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13716.9 5870.73,-13776.9 6475.73,-13776.9 6475.73,-13716.9 5870.73,-13716.9"/>
+<text text-anchor="start" x="5881.73" y="-13738.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="5906.62" y="-13738.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6327.83" y="-13738.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="6425.64" y="-13738.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-13738.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13656.9 5870.73,-13716.9 6475.73,-13716.9 6475.73,-13656.9 5870.73,-13656.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13656.9 5870.73,-13716.9 6475.73,-13716.9 6475.73,-13656.9 5870.73,-13656.9"/>
+<text text-anchor="start" x="5881.66" y="-13677.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">timestamp &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6064.72" y="-13678.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="6425.64" y="-13678.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.54" y="-13678.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13596.9 5870.73,-13656.9 6475.73,-13656.9 6475.73,-13596.9 5870.73,-13596.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13596.9 5870.73,-13656.9 6475.73,-13656.9 6475.73,-13596.9 5870.73,-13596.9"/>
+<text text-anchor="start" x="5881.73" y="-13617.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6366.93" y="-13618.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13536.9 5870.73,-13596.9 6475.73,-13596.9 6475.73,-13536.9 5870.73,-13536.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13536.9 5870.73,-13596.9 6475.73,-13596.9 6475.73,-13536.9 5870.73,-13536.9"/>
+<text text-anchor="start" x="5881.73" y="-13557.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">action &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6105.6" y="-13558.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(100)</text>
+<text text-anchor="start" x="6425.64" y="-13558.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-13558.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13476.9 5870.73,-13536.9 6475.73,-13536.9 6475.73,-13476.9 5870.73,-13476.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13476.9 5870.73,-13536.9 6475.73,-13536.9 6475.73,-13476.9 5870.73,-13476.9"/>
+<text text-anchor="start" x="5881.73" y="-13497.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">resource_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6123.39" y="-13498.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="6425.64" y="-13498.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-13498.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13416.9 5870.73,-13476.9 6475.73,-13476.9 6475.73,-13416.9 5870.73,-13416.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13416.9 5870.73,-13476.9 6475.73,-13476.9 6475.73,-13416.9 5870.73,-13416.9"/>
+<text text-anchor="start" x="5881.73" y="-13437.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">resource_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6144.69" y="-13438.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(200)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13356.9 5870.73,-13416.9 6475.73,-13416.9 6475.73,-13356.9 5870.73,-13356.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13356.9 5870.73,-13416.9 6475.73,-13416.9 6475.73,-13356.9 5870.73,-13356.9"/>
+<text text-anchor="start" x="5881.73" y="-13377.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">details &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6388.26" y="-13378.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13296.9 5870.73,-13356.9 6475.73,-13356.9 6475.73,-13296.9 5870.73,-13296.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13296.9 5870.73,-13356.9 6475.73,-13356.9 6475.73,-13296.9 5870.73,-13296.9"/>
+<text text-anchor="start" x="5881.73" y="-13317.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">ip_address &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6413.16" y="-13318.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">inet</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13236.9 5870.73,-13296.9 6475.73,-13296.9 6475.73,-13236.9 5870.73,-13236.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13236.9 5870.73,-13296.9 6475.73,-13296.9 6475.73,-13236.9 5870.73,-13236.9"/>
+<text text-anchor="start" x="5881.73" y="-13257.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">user_agent &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6413.15" y="-13258.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">text</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="5870.73,-13176.9 5870.73,-13236.9 6475.73,-13236.9 6475.73,-13176.9 5870.73,-13176.9"/>
+<polygon fill="none" stroke="#29235c" points="5870.73,-13176.9 5870.73,-13236.9 6475.73,-13236.9 6475.73,-13176.9 5870.73,-13176.9"/>
+<text text-anchor="start" x="5881.73" y="-13197.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">outcome &#160;&#160;&#160;</text>
+<text text-anchor="start" x="6123.39" y="-13198.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="6425.64" y="-13198.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="6434.53" y="-13198.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="5869.23,-13175.9 5869.23,-13837.9 6476.23,-13837.9 6476.23,-13175.9 5869.23,-13175.9"/>
+</g>
+<!-- kg_logs.health_checks -->
+<g id="kg_logs.health_checks" class="node">
+<title>kg_logs.health_checks</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="2535.73" cy="-16318.9" rx="430.76" ry="257.27"/>
+<polygon fill="#2d8e5e" stroke="transparent" points="2233.73,-16438.9 2233.73,-16498.9 2838.73,-16498.9 2838.73,-16438.9 2233.73,-16438.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.73,-16438.9 2233.73,-16498.9 2838.73,-16498.9 2838.73,-16438.9 2233.73,-16438.9"/>
+<text text-anchor="start" x="2312.15" y="-16460.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_logs.health_checks &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.73,-16378.9 2233.73,-16438.9 2838.73,-16438.9 2838.73,-16378.9 2233.73,-16378.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.73,-16378.9 2233.73,-16438.9 2838.73,-16438.9 2838.73,-16378.9 2233.73,-16378.9"/>
+<text text-anchor="start" x="2244.73" y="-16400.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="2269.62" y="-16400.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2690.83" y="-16400.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="2788.64" y="-16400.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2797.53" y="-16400.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.73,-16318.9 2233.73,-16378.9 2838.73,-16378.9 2838.73,-16318.9 2233.73,-16318.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.73,-16318.9 2233.73,-16378.9 2838.73,-16378.9 2838.73,-16318.9 2233.73,-16318.9"/>
+<text text-anchor="start" x="2244.66" y="-16339.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">timestamp &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2427.72" y="-16340.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="2788.64" y="-16340.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2797.54" y="-16340.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.73,-16258.9 2233.73,-16318.9 2838.73,-16318.9 2838.73,-16258.9 2233.73,-16258.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.73,-16258.9 2233.73,-16318.9 2838.73,-16318.9 2838.73,-16258.9 2233.73,-16258.9"/>
+<text text-anchor="start" x="2244.73" y="-16279.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">service &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2486.39" y="-16280.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2788.64" y="-16280.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2797.53" y="-16280.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.73,-16198.9 2233.73,-16258.9 2838.73,-16258.9 2838.73,-16198.9 2233.73,-16198.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.73,-16198.9 2233.73,-16258.9 2838.73,-16258.9 2838.73,-16198.9 2233.73,-16198.9"/>
+<text text-anchor="start" x="2244.73" y="-16219.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">status &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2486.39" y="-16220.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="2788.64" y="-16220.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="2797.53" y="-16220.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="2233.73,-16138.9 2233.73,-16198.9 2838.73,-16198.9 2838.73,-16138.9 2233.73,-16138.9"/>
+<polygon fill="none" stroke="#29235c" points="2233.73,-16138.9 2233.73,-16198.9 2838.73,-16198.9 2838.73,-16138.9 2233.73,-16138.9"/>
+<text text-anchor="start" x="2244.73" y="-16159.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">metrics &#160;&#160;&#160;</text>
+<text text-anchor="start" x="2751.26" y="-16160.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="2232.23,-16137.9 2232.23,-16499.9 2839.23,-16499.9 2839.23,-16137.9 2232.23,-16137.9"/>
+</g>
+<!-- kg_logs.job_events -->
+<g id="kg_logs.job_events" class="node">
+<title>kg_logs.job_events</title>
+<ellipse fill="none" stroke="black" stroke-width="0" cx="9977.73" cy="-15753.9" rx="430.76" ry="257.27"/>
+<polygon fill="#2d8e5e" stroke="transparent" points="9675.73,-15873.9 9675.73,-15933.9 10280.73,-15933.9 10280.73,-15873.9 9675.73,-15873.9"/>
+<polygon fill="none" stroke="#29235c" points="9675.73,-15873.9 9675.73,-15933.9 10280.73,-15933.9 10280.73,-15873.9 9675.73,-15873.9"/>
+<text text-anchor="start" x="9779.04" y="-15895.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#ffffff"> &#160;&#160;&#160;&#160;&#160;&#160;kg_logs.job_events &#160;&#160;&#160;&#160;&#160;&#160;</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9675.73,-15813.9 9675.73,-15873.9 10280.73,-15873.9 10280.73,-15813.9 9675.73,-15813.9"/>
+<polygon fill="none" stroke="#29235c" points="9675.73,-15813.9 9675.73,-15873.9 10280.73,-15873.9 10280.73,-15813.9 9675.73,-15813.9"/>
+<text text-anchor="start" x="9686.73" y="-15835.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">id</text>
+<text text-anchor="start" x="9711.62" y="-15835.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10132.83" y="-15835.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">integer</text>
+<text text-anchor="start" x="10230.64" y="-15835.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10239.53" y="-15835.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9675.73,-15753.9 9675.73,-15813.9 10280.73,-15813.9 10280.73,-15753.9 9675.73,-15753.9"/>
+<polygon fill="none" stroke="#29235c" points="9675.73,-15753.9 9675.73,-15813.9 10280.73,-15813.9 10280.73,-15753.9 9675.73,-15753.9"/>
+<text text-anchor="start" x="9686.73" y="-15774.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">job_id &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9928.39" y="-15775.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="10230.64" y="-15775.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10239.53" y="-15775.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9675.73,-15693.9 9675.73,-15753.9 10280.73,-15753.9 10280.73,-15693.9 9675.73,-15693.9"/>
+<polygon fill="none" stroke="#29235c" points="9675.73,-15693.9 9675.73,-15753.9 10280.73,-15753.9 10280.73,-15693.9 9675.73,-15693.9"/>
+<text text-anchor="start" x="9686.66" y="-15714.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">timestamp &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9869.72" y="-15715.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">timestamp with time zone</text>
+<text text-anchor="start" x="10230.64" y="-15715.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10239.54" y="-15715.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9675.73,-15633.9 9675.73,-15693.9 10280.73,-15693.9 10280.73,-15633.9 9675.73,-15633.9"/>
+<polygon fill="none" stroke="#29235c" points="9675.73,-15633.9 9675.73,-15693.9 10280.73,-15693.9 10280.73,-15633.9 9675.73,-15633.9"/>
+<text text-anchor="start" x="9686.73" y="-15654.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">event_type &#160;&#160;&#160;</text>
+<text text-anchor="start" x="9928.39" y="-15655.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">character varying(50)</text>
+<text text-anchor="start" x="10230.64" y="-15655.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c"> </text>
+<text text-anchor="start" x="10239.53" y="-15655.1" font-family="Helvetica,sans-Serif" font-weight="bold" font-size="32.00" fill="#29235c">(!)</text>
+<polygon fill="#e7e2dd" stroke="transparent" points="9675.73,-15573.9 9675.73,-15633.9 10280.73,-15633.9 10280.73,-15573.9 9675.73,-15573.9"/>
+<polygon fill="none" stroke="#29235c" points="9675.73,-15573.9 9675.73,-15633.9 10280.73,-15633.9 10280.73,-15573.9 9675.73,-15573.9"/>
+<text text-anchor="start" x="9686.73" y="-15594.1" font-family="Helvetica,sans-Serif" font-size="32.00" fill="#29235c">details &#160;&#160;&#160;</text>
+<text text-anchor="start" x="10193.26" y="-15595.1" font-family="Helvetica,sans-Serif" font-style="italic" font-size="32.00" fill="#29235c">jsonb</text>
+<polygon fill="none" stroke="#29235c" stroke-width="2" points="9674.23,-15572.9 9674.23,-15934.9 10281.23,-15934.9 10281.23,-15572.9 9674.23,-15572.9"/>
+</g>
+</g>
+</svg>
+
+</div>
+
+<div class="toolbar">
+  <div class="group searchwrap">
+    <input id="search" type="search" placeholder="Find a table…" autocomplete="off" spellcheck="false">
+    <div id="matches"></div>
+  </div>
+  <div class="group">
+    <button id="fit" title="Fit to screen">Fit</button>
+    <button id="zin" title="Zoom in">+</button>
+    <button id="zout" title="Zoom out">−</button>
+    <button id="reset" title="Clear highlight">Clear</button>
+    <span id="count"></span>
+  </div>
+  <div class="group legend"><span class="chip"><i style="background:#475569"></i>public</span><span class="chip"><i style="background:#7c3aed"></i>kg_api</span><span class="chip"><i style="background:#2d7d9a"></i>kg_auth</span><span class="chip"><i style="background:#2d8e5e"></i>kg_logs</span></div>
+  <div class="group">
+    <button id="theme" title="Toggle light/dark">◐</button>
+  </div>
+</div>
+<div class="hint">Drag to pan · scroll to zoom · click a table to trace its relationships</div>
+
+<script>
+(function () {
+  "use strict";
+  var svg = document.getElementById("erd");
+  var stage = document.getElementById("stage");
+  var vb = "0.00 0.00 10996.36 17107.29".split(/\s+/).map(Number); // x y w h
+  var full = { x: vb[0], y: vb[1], w: vb[2], h: vb[3] };
+  var view = { x: full.x, y: full.y, w: full.w, h: full.h };
+
+  function apply() {
+    svg.setAttribute("viewBox", view.x + " " + view.y + " " + view.w + " " + view.h);
+  }
+  function fit() { view = { x: full.x, y: full.y, w: full.w, h: full.h }; apply(); }
+  apply();
+
+  // ---- pan ----
+  var panning = false, sx = 0, sy = 0;
+  stage.addEventListener("pointerdown", function (e) {
+    if (e.target.closest("g.node")) return; // let clicks select tables
+    panning = true; sx = e.clientX; sy = e.clientY;
+    stage.classList.add("grabbing"); stage.setPointerCapture(e.pointerId);
+  });
+  stage.addEventListener("pointermove", function (e) {
+    if (!panning) return;
+    var r = stage.getBoundingClientRect();
+    view.x -= (e.clientX - sx) * (view.w / r.width);
+    view.y -= (e.clientY - sy) * (view.h / r.height);
+    sx = e.clientX; sy = e.clientY; apply();
+  });
+  function endPan() { panning = false; stage.classList.remove("grabbing"); }
+  stage.addEventListener("pointerup", endPan);
+  stage.addEventListener("pointercancel", endPan);
+
+  // ---- zoom (toward cursor) ----
+  function zoomAt(cx, cy, factor) {
+    var r = stage.getBoundingClientRect();
+    var px = view.x + ((cx - r.left) / r.width) * view.w;
+    var py = view.y + ((cy - r.top) / r.height) * view.h;
+    var nw = Math.min(full.w * 4, Math.max(full.w / 400, view.w * factor));
+    var nh = nw * (view.h / view.w);
+    view.x = px - ((cx - r.left) / r.width) * nw;
+    view.y = py - ((cy - r.top) / r.height) * nh;
+    view.w = nw; view.h = nh; apply();
+  }
+  stage.addEventListener("wheel", function (e) {
+    e.preventDefault();
+    zoomAt(e.clientX, e.clientY, e.deltaY > 0 ? 1.15 : 1 / 1.15);
+  }, { passive: false });
+  document.getElementById("zin").onclick = function () {
+    var r = stage.getBoundingClientRect();
+    zoomAt(r.left + r.width / 2, r.top + r.height / 2, 1 / 1.3);
+  };
+  document.getElementById("zout").onclick = function () {
+    var r = stage.getBoundingClientRect();
+    zoomAt(r.left + r.width / 2, r.top + r.height / 2, 1.3);
+  };
+  document.getElementById("fit").onclick = fit;
+
+  // ---- build adjacency from the SVG ----
+  var nodes = {};   // id -> <g>
+  Array.prototype.forEach.call(svg.querySelectorAll("g.node"), function (g) {
+    if (g.id) nodes[g.id] = g;
+  });
+  var edges = [];   // { g, a, b }
+  Array.prototype.forEach.call(svg.querySelectorAll("g.edge"), function (g) {
+    var t = g.querySelector("title");
+    if (!t) return;
+    var m = t.textContent.split("->");
+    if (m.length !== 2) return;
+    var a = m[0].split(":")[0].trim();
+    var b = m[1].split(":")[0].trim();
+    edges.push({ g: g, a: a, b: b });
+  });
+  var neighbors = {};
+  edges.forEach(function (e) {
+    (neighbors[e.a] = neighbors[e.a] || {})[e.b] = true;
+    (neighbors[e.b] = neighbors[e.b] || {})[e.a] = true;
+  });
+
+  var countEl = document.getElementById("count");
+  function clearFocus() {
+    svg.classList.remove("focusing");
+    Object.keys(nodes).forEach(function (id) { nodes[id].classList.remove("dim", "hit"); });
+    edges.forEach(function (e) { e.g.classList.remove("dim"); });
+    countEl.textContent = "";
+  }
+  function focus(id) {
+    if (!nodes[id]) return;
+    var keep = {}; keep[id] = true;
+    Object.keys(neighbors[id] || {}).forEach(function (n) { keep[n] = true; });
+    svg.classList.add("focusing");
+    Object.keys(nodes).forEach(function (nid) {
+      nodes[nid].classList.toggle("dim", !keep[nid]);
+      nodes[nid].classList.toggle("hit", nid === id);
+    });
+    var deg = 0;
+    edges.forEach(function (e) {
+      var on = e.a === id || e.b === id;
+      e.g.classList.toggle("dim", !on);
+      if (on) deg++;
+    });
+    countEl.textContent = id.replace(/^[^.]+\./, "") + " · " + deg + " relationship" + (deg === 1 ? "" : "s");
+  }
+  svg.addEventListener("click", function (e) {
+    var g = e.target.closest("g.node");
+    if (g && g.id) focus(g.id);
+  });
+  document.getElementById("reset").onclick = clearFocus;
+
+  // center the viewBox on a node's bounding box (in SVG user units)
+  function centerOn(id) {
+    var g = nodes[id]; if (!g) return;
+    var bb = g.getBBox();
+    var pad = Math.max(bb.width, bb.height) * 1.6 + 40;
+    view.w = Math.max(bb.width + pad, full.w / 40);
+    var r = stage.getBoundingClientRect();
+    view.h = view.w * (r.height / r.width); // match the stage aspect ratio
+
+    view.x = bb.x + bb.width / 2 - view.w / 2;
+    view.y = bb.y + bb.height / 2 - view.h / 2;
+    apply();
+  }
+
+  // ---- search ----
+  var ids = Object.keys(nodes).sort();
+  var search = document.getElementById("search");
+  var matchBox = document.getElementById("matches");
+  var active = -1, shown = [];
+  function renderMatches(q) {
+    q = q.trim().toLowerCase();
+    shown = q ? ids.filter(function (id) { return id.toLowerCase().indexOf(q) >= 0; }).slice(0, 12) : [];
+    active = -1;
+    if (!shown.length) { matchBox.style.display = "none"; matchBox.innerHTML = ""; return; }
+    matchBox.innerHTML = shown.map(function (id) {
+      return '<div data-id="' + id + '">' + id + "</div>";
+    }).join("");
+    matchBox.style.display = "block";
+  }
+  function choose(id) {
+    search.value = id; matchBox.style.display = "none";
+    focus(id); centerOn(id);
+  }
+  search.addEventListener("input", function () { renderMatches(search.value); });
+  search.addEventListener("keydown", function (e) {
+    if (!shown.length) return;
+    if (e.key === "ArrowDown") { active = (active + 1) % shown.length; }
+    else if (e.key === "ArrowUp") { active = (active - 1 + shown.length) % shown.length; }
+    else if (e.key === "Enter") { choose(shown[active >= 0 ? active : 0]); return; }
+    else return;
+    e.preventDefault();
+    Array.prototype.forEach.call(matchBox.children, function (c, i) {
+      c.classList.toggle("active", i === active);
+    });
+  });
+  matchBox.addEventListener("click", function (e) {
+    var d = e.target.closest("[data-id]"); if (d) choose(d.getAttribute("data-id"));
+  });
+  document.addEventListener("click", function (e) {
+    if (!e.target.closest(".searchwrap")) matchBox.style.display = "none";
+  });
+
+  // ---- theme toggle (embeds respect ?theme=) ----
+  var root = document.documentElement;
+  var q = new URLSearchParams(location.search).get("theme");
+  if (q === "dark" || q === "light") root.classList.add(q);
+  document.getElementById("theme").onclick = function () {
+    var dark = root.classList.contains("dark") ||
+      (!root.classList.contains("light") &&
+       window.matchMedia("(prefers-color-scheme: dark)").matches);
+    root.classList.remove("dark", "light");
+    root.classList.add(dark ? "light" : "dark");
+  };
+})();
+</script>
+</body>
+</html>

--- a/docs/reference/schema.dbml
+++ b/docs/reference/schema.dbml
@@ -1,0 +1,857 @@
+// Database schema for the Knowledge Graph System control plane.
+// GENERATED FILE — edit the SQL DDL, then run `make docs-schema`.
+// Generated: 2026-07-02
+//
+// Render: schema/scripts/render-schema-diagram.mjs (interactive ERD)
+// Or paste into https://dbdiagram.io to explore/edit.
+
+Table "public"."graph_metrics" [headercolor: #475569] {
+  "metric_name" "character varying(255)" [pk, not null, note: 'Unique metric identifier (e.g., vocabulary_change_counter, concept_count)']
+  "counter" "bigint" [not null, note: 'Increments on every change (create/delete/consolidate) - never decrements']
+  "last_measured_counter" "bigint" [not null, note: 'Counter value when epistemic status was last measured']
+  "last_measured_at" "timestamp without time zone" [note: 'Timestamp when epistemic status was last measured']
+  "updated_at" "timestamp without time zone" [note: 'Timestamp of last counter increment']
+  "notes" "text"
+  Note: 'Change counters for triggering periodic epistemic status measurement'
+}
+
+Table "public"."schema_migrations" [headercolor: #475569] {
+  "version" "integer" [pk, not null, note: 'Sequential migration number (001, 002, 003, ...)']
+  "name" "text" [not null, note: 'Descriptive migration name (e.g., baseline, add_embedding_config)']
+  "applied_at" "timestamp without time zone" [not null, note: 'Timestamp when migration was applied']
+  Note: 'Tracks applied schema migrations for safe schema evolution - ADR-040'
+}
+
+Table "kg_api"."aggressiveness_profiles" [headercolor: #7c3aed] {
+  "profile_name" "character varying(50)" [pk, not null]
+  "control_x1" "double precision" [not null]
+  "control_y1" "double precision" [not null]
+  "control_x2" "double precision" [not null]
+  "control_y2" "double precision" [not null]
+  "description" "text"
+  "is_builtin" "boolean"
+  "created_at" "timestamp without time zone"
+  "updated_at" "timestamp without time zone"
+}
+
+Table "kg_api"."ai_extraction_config" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "provider" "character varying(50)" [not null, unique, note: 'AI provider: openai, anthropic, ollama, or vllm']
+  "model_name" "character varying(200)" [not null, note: 'Model identifier (e.g., gpt-4o, claude-sonnet-4-20250514)']
+  "supports_vision" "boolean" [note: 'Whether the model supports vision/image inputs']
+  "supports_json_mode" "boolean" [note: 'Whether the model supports JSON mode for structured outputs']
+  "max_tokens" "integer" [note: 'Maximum token limit for the model']
+  "created_at" "timestamp with time zone"
+  "updated_at" "timestamp with time zone"
+  "updated_by" "character varying(100)"
+  "active" "boolean" [note: 'Only one config can be active at a time (enforced by unique index)']
+  "base_url" "character varying(255)" [note: 'Base URL for local providers (e.g., http://localhost:11434 for Ollama)']
+  "temperature" "double precision" [note: 'Sampling temperature (0.0-1.0, lower = more consistent). Used by local providers.']
+  "top_p" "double precision" [note: 'Nucleus sampling threshold (0.0-1.0). Used by local providers.']
+  "gpu_layers" "integer" [note: 'GPU layers for inference: -1 = auto, 0 = CPU only, >0 = specific layer count (llama.cpp)']
+  "num_threads" "integer" [note: 'CPU threads for inference (used by local CPU-based providers)']
+  "thinking_mode" "character varying(20)" [note: 'Thinking mode for reasoning models (Ollama 0.12.x+): off, low, medium, high. GPT-OSS: off=low, others pass through. Standard models: off=disabled, low/medium/high=enabled.']
+  "max_concurrent_requests" "integer" [note: 'Maximum number of concurrent API requests allowed for this provider. Limits parallelism to prevent rate limit errors and resource thrashing. Recommended: OpenAI=8, Anthropic=4, Ollama=1']
+  "max_retries" "integer" [note: 'Maximum number of retry attempts for rate-limited requests (429 errors). Uses exponential backoff with jitter: 1s, 2s, 4s, 8s, 16s, 32s, 64s, ... Higher values provide more resilience with multiple workers. Recommended: 8 for cloud providers, 3 for local']
+  Note: 'AI extraction provider configuration for runtime-switchable models - ADR-041'
+}
+
+Table "kg_api"."ai_vision_config" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "provider" "character varying(50)" [not null, unique, note: 'Provider performing image->prose description']
+  "model_name" "character varying(200)" [not null, note: 'Vision model id; ’’ resolves from the catalog supports_vision rows']
+  "max_tokens" "integer"
+  "temperature" "double precision"
+  "created_at" "timestamp with time zone"
+  "updated_at" "timestamp with time zone"
+  "updated_by" "character varying(100)"
+  "active" "boolean" [note: 'Only one vision config active at a time (enforced by partial unique index)']
+  Note: 'Active vision (image->prose) provider selection — ADR-802 / #378. Selection-only; connectivity reused from per-provider config.'
+}
+
+Table "kg_api"."annealing_options" [headercolor: #7c3aed] {
+  "key" "character varying(100)" [pk, not null]
+  "value" "text" [not null]
+  "description" "text"
+  "updated_at" "timestamp with time zone"
+  Note: 'Tunable parameters for ontology annealing cycles (ADR-200 Phase 3b). Code defaults apply when a key is absent; database values override.'
+}
+
+Table "kg_api"."annealing_pressure_history" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "epoch" "integer" [not null]
+  "total_ontologies" "integer" [not null]
+  "total_concepts" "integer" [not null]
+  "avg_concepts_per_ontology" "double precision" [not null]
+  "pressure_score" "double precision" [not null]
+  "pressure_zone" "character varying(20)" [not null]
+  "pressure_recommendation" "jsonb" [not null]
+  "recorded_at" "timestamp with time zone" [not null]
+  Note: 'One row per annealing cycle: ecological snapshot + Bezier pressure read-out (#249, ADR-206 §Phase 3). Drives the web admin ”pressure” panel and the future trend chart.'
+}
+
+Table "kg_api"."annealing_proposals" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "proposal_type" "character varying(20)" [not null]
+  "ontology_name" "character varying(200)" [not null]
+  "anchor_concept_id" "character varying(100)"
+  "target_ontology" "character varying(200)"
+  "reasoning" "text" [not null]
+  "mass_score" "numeric(10,4)"
+  "coherence_score" "numeric(10,4)"
+  "protection_score" "numeric(10,4)"
+  "status" "character varying(20)" [not null]
+  "created_at" "timestamp with time zone" [not null]
+  "created_at_epoch" "integer" [not null]
+  "reviewed_at" "timestamp with time zone"
+  "reviewed_by" "character varying(100)"
+  "reviewer_notes" "text"
+  "expires_at" "timestamp with time zone"
+  "executed_at" "timestamp with time zone"
+  "execution_result" "jsonb"
+  "suggested_name" "character varying(200)"
+  "suggested_description" "text"
+  "proposal_kind" "character varying(20)" [not null]
+  "params" "jsonb"
+}
+
+Table "kg_api"."artifacts" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "artifact_type" "character varying(50)" [not null, note: 'Type of computation: polarity_analysis, projection, etc.']
+  "representation" "character varying(50)" [not null, note: 'Source UI/tool: polarity_explorer, cli, mcp_server, etc.']
+  "name" "character varying(200)"
+  "owner_id" "integer"
+  "graph_epoch" "bigint" [not null, note: 'graph_change_counter at creation for freshness validation']
+  "created_at" "timestamp with time zone" [not null]
+  "expires_at" "timestamp with time zone"
+  "parameters" "jsonb" [not null]
+  "metadata" "jsonb"
+  "inline_result" "jsonb" [note: 'Small results (<10KB) stored inline']
+  "garage_key" "character varying(200)" [note: 'Pointer to Garage blob for large results']
+  "query_definition_id" "integer"
+  "ontology" "character varying(200)"
+  "concept_ids" "text[]" [note: 'Concept IDs involved in this artifact']
+  Note: 'Computed artifact metadata with Garage blob pointers (ADR-083)'
+}
+
+Table "kg_api"."catalog_edge" [headercolor: #7c3aed] {
+  "parent_kind" "character varying(16)" [pk, not null]
+  "parent_id" "text" [pk, not null]
+  "child_kind" "character varying(16)" [pk, not null]
+  "child_id" "text" [pk, not null]
+  "graph_epoch" "bigint" [not null]
+  Note: 'ADR-501: parent->child membership edges projecting canonical :SCOPED_BY (ontology<-document) and :HAS_SOURCE/:APPEARS (document<-concept). A concept may have many parent documents (DAG).'
+}
+
+Table "kg_api"."catalog_node" [headercolor: #7c3aed] {
+  "kind" "character varying(16)" [pk, not null]
+  "node_id" "text" [pk, not null]
+  "name" "text" [not null]
+  "name_lower" "text" [not null]
+  "child_count" "integer" [not null, note: 'Number of direct children (documents-in-ontology, concepts-in-document); 0 for leaf concepts.']
+  "content_type" "character varying(32)"
+  "properties" "jsonb" [not null]
+  "graph_epoch" "bigint" [not null, note: 'graph_change_counter at build time; compared to kg_api.get_graph_epoch() for staleness.']
+  "indexed_at" "timestamp with time zone" [not null]
+  Note: 'ADR-501: materialized identity/metadata for catalog nodes (ontology/document/concept). Source of truth is the AGE graph; rebuilt on graph epoch advance.'
+}
+
+Table "kg_api"."concept_access_stats" [headercolor: #7c3aed] {
+  "concept_id" "character varying(100)" [pk, not null]
+  "access_count" "integer"
+  "last_accessed" "timestamp with time zone"
+  "avg_query_time_ms" "numeric(10,2)"
+  "queries_as_start" "integer"
+  "queries_as_result" "integer"
+  Note: 'Node-level access patterns for caching - ADR-025'
+}
+
+Table "kg_api"."concept_version_metadata" [headercolor: #7c3aed] {
+  "concept_id" "character varying(100)" [pk, not null]
+  "created_in_version" "integer"
+  "last_modified_version" "integer"
+}
+
+Table "kg_api"."edge_usage_stats" [headercolor: #7c3aed] {
+  "from_concept_id" "character varying(100)" [pk, not null]
+  "to_concept_id" "character varying(100)" [pk, not null]
+  "relationship_type" "character varying(100)" [pk, not null]
+  "traversal_count" "integer"
+  "last_traversed" "timestamp with time zone"
+  "avg_query_time_ms" "numeric(10,2)"
+  Note: 'Performance tracking for graph traversals - ADR-025'
+}
+
+Table "kg_api"."embedding_config_legacy" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "provider" "character varying(50)" [not null, note: 'Embedding provider: local (sentence-transformers) or openai']
+  "model_name" "character varying(200)" [not null, note: 'Model identifier (HuggingFace ID for local, OpenAI model name for remote)']
+  "embedding_dimensions" "integer" [not null]
+  "precision" "character varying(20)" [not null]
+  "max_memory_mb" "integer" [note: 'Maximum RAM allocation for local model (local provider only)']
+  "num_threads" "integer" [note: 'CPU threads for inference (local provider only)']
+  "device" "character varying(20)" [note: 'Compute device: cpu, cuda, or mps (local provider only)']
+  "batch_size" "integer" [note: 'Batch size for embedding generation']
+  "max_seq_length" "integer"
+  "normalize_embeddings" "boolean"
+  "created_at" "timestamp with time zone"
+  "updated_at" "timestamp with time zone"
+  "updated_by" "character varying(100)"
+  "active" "boolean" [note: 'Only one config can be active at a time (enforced by unique constraint)']
+  "delete_protected" "boolean" [note: 'Prevents deletion without first removing protection (default configs)']
+  "change_protected" "boolean" [note: 'Prevents changing provider/dimensions without explicit unlock (safety)']
+  Note: 'Resource-aware embedding configuration for local and remote models - ADR-039. Includes preset for nomic-embed-text-v1.5.'
+}
+
+Table "kg_api"."embedding_generation_jobs" [headercolor: #7c3aed] {
+  "job_id" "uuid" [pk, not null]
+  "job_type" "character varying(50)" [not null]
+  "target_types" "character varying(100)[]"
+  "target_count" "integer"
+  "status" "character varying(20)" [not null]
+  "processed_count" "integer"
+  "failed_count" "integer"
+  "embedding_model" "character varying(100)"
+  "embedding_provider" "character varying(50)"
+  "created_at" "timestamp with time zone"
+  "started_at" "timestamp with time zone"
+  "completed_at" "timestamp with time zone"
+  "duration_ms" "integer"
+  "result_summary" "jsonb"
+  "error_message" "text"
+  Note: 'ADR-045: Tracks embedding generation jobs for audit trail and progress monitoring'
+}
+
+Table "kg_api"."embedding_profile" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "name" "character varying(200)" [not null]
+  "vector_space" "character varying(100)" [not null, note: 'Compatibility key for the universal TEXT/prose space (concepts, edges, docs, image-prose). Profiles with the same text vector_space produce comparable text embeddings. Image embeddings are independent — see image_vector_space (ADR-803).']
+  "multimodal" "boolean" [note: 'When true, the text model also handles image embeddings (e.g. SigLIP 2)']
+  "text_provider" "character varying(50)" [not null]
+  "text_model_name" "character varying(200)" [not null]
+  "text_loader" "character varying(50)" [not null, note: 'How to load text model: sentence-transformers, transformers (AutoModel), or api']
+  "text_revision" "character varying(200)"
+  "text_dimensions" "integer" [not null]
+  "text_precision" "character varying(20)"
+  "text_trust_remote_code" "boolean"
+  "image_provider" "character varying(50)"
+  "image_model_name" "character varying(200)"
+  "image_loader" "character varying(50)" [note: 'How to load image model: sentence-transformers, transformers (AutoModel), or api']
+  "image_revision" "character varying(200)"
+  "image_dimensions" "integer"
+  "image_precision" "character varying(20)"
+  "image_trust_remote_code" "boolean"
+  "device" "character varying(20)"
+  "max_memory_mb" "integer"
+  "num_threads" "integer"
+  "batch_size" "integer"
+  "max_seq_length" "integer"
+  "normalize_embeddings" "boolean"
+  "active" "boolean"
+  "delete_protected" "boolean"
+  "change_protected" "boolean"
+  "created_at" "timestamp with time zone"
+  "updated_at" "timestamp with time zone"
+  "updated_by" "character varying(100)"
+  "text_query_prefix" "character varying(200)" [note: 'Prefix prepended for search queries (e.g. search_query: )']
+  "text_document_prefix" "character varying(200)" [note: 'Prefix prepended for stored documents (e.g. search_document: )']
+  "image_vector_space" "character varying(100)" [note: 'Independent vector_space of the image (modality) embedding index (ADR-803). NULL for text-only / multimodal profiles. Never compared to text vector_space.']
+  Note: 'Unified embedding profile with text + image model slots. Replaces embedding_config.'
+}
+
+Table "kg_api"."graph_epoch_kinds" [headercolor: #7c3aed] {
+  "kind" "text" [pk, not null]
+  "semantic_wallclock" "boolean" [not null, note: 'When TRUE, occurred_at is the meaningful timestamp for downstream consumers. When FALSE, occurred_at is recorded for audit/forensics but should not drive time-based queries on the resulting graph state.']
+  "description" "text"
+  Note: 'ADR-203: Discriminator for graph_epochs.kind. semantic_wallclock distinguishes events whose occurred_at is semantically primary (ingestion, edit) from those where it is forensic-only (reasoning, annealing).'
+}
+
+Table "kg_api"."graph_epochs" [headercolor: #7c3aed] {
+  "event_id" "bigint" [pk, not null, note: 'Monotonic logical-time id. Foreign-keyed by Instance.created_at_event_id.']
+  "occurred_at" "timestamp with time zone" [not null]
+  "kind" "text" [not null, note: 'ingestion | reasoning | annealing | edit. Determines whether occurred_at is semantically meaningful for the rows attributable to this event.']
+  "actor" "text"
+  "counter_after" "bigint"
+  "metadata" "jsonb" [not null]
+  "status" "text" [not null, note: 'ADR-207/#384: in_progress (set at record_graph_epoch) | completed | failed. Only in_progress blocks the committed watermark — both completed and failed count toward it (per-chunk commits mean a failed job may have mutated the graph). The completed/failed split is for analytics (drop zero-instance jobs from hot/stale signals), not for freshness.']
+  Note: 'ADR-203: Monotonic event log of graph mutations. Distinct from graph_change_counter (ADR-079) which is a composite cache-invalidation checksum.'
+}
+
+Table "kg_api"."jobs" [headercolor: #7c3aed] {
+  "job_id" "text" [pk, not null, note: 'Unique job identifier (UUID)']
+  "job_type" "text" [not null, note: 'Type of job: ingestion, restore, backup, vocab_refresh, vocab_consolidate']
+  "content_hash" "text" [note: 'SHA256 hash for deduplication (used with ontology to detect duplicates)']
+  "ontology" "text" [note: 'Target ontology for the job']
+  "status" "text" [not null, note: 'Job status: pending_approval, approved, running, completed, failed, cancelled']
+  "progress" "text" [note: 'Progress message for UI display']
+  "result" "text" [note: 'Final result data (JSON)']
+  "error" "text" [note: 'Error message if failed']
+  "created_at" "timestamp without time zone" [not null]
+  "started_at" "timestamp without time zone"
+  "completed_at" "timestamp without time zone"
+  "job_data" "jsonb" [not null, note: 'Job-specific parameters (JSON)']
+  "analysis" "text" [note: 'Pre-approval analysis (cost/time estimates)']
+  "approved_at" "timestamp without time zone" [note: 'When job was approved by user']
+  "approved_by" "text" [note: 'Who approved the job']
+  "expires_at" "timestamp without time zone" [note: 'When pending approval expires']
+  "processing_mode" "text" [note: 'Execution mode: serial or parallel']
+  "job_source" "character varying(50)" [note: 'Source of job creation: user_cli, user_api, scheduled_task, system']
+  "created_by" "character varying(100)" [note: 'User or system identifier that created the job']
+  "is_system_job" "boolean" [note: 'True for system-scheduled jobs (cannot be deleted by users)']
+  "user_id" "integer" [not null, note: 'User who submitted the job (FK to kg_auth.users.id)']
+  "source_filename" "text" [note: 'Display name for source: filename, ”stdin”, or MCP session ID (best-effort metadata)']
+  "source_type" "text" [note: 'Ingestion method: file (CLI file), stdin (pipe), mcp (Claude), api (direct) - enables source-aware queries']
+  "source_path" "text" [note: 'Full filesystem path for file ingestion (null for stdin/mcp/api) - helps identify exact source file']
+  "source_hostname" "text" [note: 'Hostname where ingestion initiated (CLI only, null for MCP/API) - useful for distributed deployments']
+  "artifact_id" "integer" [note: 'Artifact created by this job (ADR-083). NULL for jobs that do not produce artifacts.']
+  "priority" "integer" [not null]
+  "claimed_by" "text"
+  "claimed_at" "timestamp with time zone"
+  "cancelled" "boolean" [not null]
+  "retries" "integer" [not null]
+  "max_retries" "integer" [not null]
+  Note: 'Unified job queue for all background tasks (ingestion, backup, vocab, scheduled)'
+}
+
+Table "kg_api"."ontology_tombstones" [headercolor: #7c3aed] {
+  "name" "character varying(200)" [pk, not null]
+  "removed_at" "timestamp with time zone" [not null]
+  "removed_by" "character varying(100)"
+  "reason" "text"
+  Note: 'Positive operator-intent signal that an ontology was deliberately removed and must not be silently recreated by a subsequent ingest (#402 Defect B2). Operator-initiated delete writes a row; annealing dissolution does not.'
+}
+
+Table "kg_api"."ontology_versions" [headercolor: #7c3aed] {
+  "version_id" "integer" [pk, not null]
+  "version_number" "character varying(20)" [not null, unique]
+  "created_at" "timestamp with time zone" [not null]
+  "created_by" "character varying(100)"
+  "change_summary" "text"
+  "is_active" "boolean"
+  "vocabulary_snapshot" "jsonb" [not null]
+  "types_added" "text[]"
+  "types_aliased" "jsonb"
+  "types_deprecated" "text[]"
+  "backward_compatible" "boolean"
+  "migration_required" "boolean"
+  Note: 'Formal ontology versioning with immutable snapshots - ADR-026'
+}
+
+Table "kg_api"."platform_config" [headercolor: #7c3aed] {
+  "key" "character varying(100)" [pk, not null]
+  "value" "text" [not null]
+  "description" "text"
+  "updated_at" "timestamp with time zone"
+  "updated_by" "character varying(100)"
+  Note: 'Platform lifecycle configuration for operator control plane (ADR-061)'
+}
+
+Table "kg_api"."provider_model_catalog" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "provider" "character varying(50)" [not null]
+  "model_id" "character varying(300)" [not null]
+  "display_name" "character varying(300)"
+  "category" "character varying(50)" [not null]
+  "context_length" "integer"
+  "max_completion_tokens" "integer"
+  "supports_vision" "boolean"
+  "supports_json_mode" "boolean"
+  "supports_tool_use" "boolean"
+  "supports_streaming" "boolean"
+  "price_prompt_per_m" "numeric"
+  "price_completion_per_m" "numeric"
+  "price_cache_read_per_m" "numeric"
+  "enabled" "boolean"
+  "is_default" "boolean"
+  "sort_order" "integer"
+  "upstream_provider" "character varying(100)"
+  "raw_metadata" "jsonb"
+  "fetched_at" "timestamp with time zone"
+  "created_at" "timestamp with time zone"
+  "updated_at" "timestamp with time zone"
+  Note: 'Cached model catalog per AI provider with curation and pricing (ADR-800)'
+}
+
+Table "kg_api"."pruning_recommendations" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "relationship_type" "character varying(100)" [not null]
+  "target_type" "character varying(100)"
+  "action_type" "character varying(50)" [not null]
+  "review_level" "character varying(20)" [not null]
+  "reasoning" "text" [not null]
+  "similarity" "numeric(4,3)"
+  "value_score" "numeric(10,2)"
+  "metadata" "jsonb"
+  "status" "character varying(50)" [not null]
+  "created_at" "timestamp with time zone" [not null]
+  "reviewed_at" "timestamp with time zone"
+  "reviewed_by" "character varying(100)"
+  "reviewer_notes" "text"
+  "executed_at" "timestamp with time zone"
+  "expires_at" "timestamp with time zone"
+  Note: 'Pending vocabulary management actions - ADR-032'
+}
+
+Table "kg_api"."query_definitions" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "name" "character varying(200)" [not null]
+  "definition_type" "character varying(50)" [not null, note: 'Type of query: block_diagram, cypher, search, polarity, connection, exploration, program']
+  "definition" "jsonb" [not null, note: 'Query parameters/structure as JSON']
+  "owner_id" "integer"
+  "created_at" "timestamp with time zone" [not null]
+  "updated_at" "timestamp with time zone" [not null]
+  "metadata" "jsonb" [note: 'Optional metadata (nodeCount, edgeCount, description, etc.)']
+  Note: 'Saved query recipes that can be re-executed (ADR-083)'
+}
+
+Table "kg_api"."rate_limits" [headercolor: #7c3aed] {
+  "client_id" "character varying(100)" [pk, not null]
+  "endpoint" "character varying(200)" [pk, not null]
+  "window_start" "timestamp with time zone" [pk, not null]
+  "request_count" "integer" [not null]
+}
+
+Table "kg_api"."relationship_vocabulary" [headercolor: #7c3aed] {
+  "relationship_type" "character varying(100)" [pk, not null]
+  "description" "text"
+  "category" "character varying(50)"
+  "added_by" "character varying(100)"
+  "added_at" "timestamp with time zone" [not null]
+  "usage_count" "integer"
+  "is_active" "boolean"
+  "is_builtin" "boolean"
+  "synonyms" "character varying(100)[]"
+  "deprecation_reason" "text"
+  "embedding" "jsonb" [note: 'Cached embedding vector (JSONB array) for synonym detection (ADR-032)']
+  "embedding_model" "character varying(100)"
+  "embedding_generated_at" "timestamp with time zone"
+  "grounding_contribution" "double precision" [note: 'ADR-046: Measures impact on concept grounding strength (0.0-1.0). Higher values indicate this edge type significantly affects truth convergence.']
+  "last_grounding_calculated" "timestamp with time zone" [note: 'ADR-046: Timestamp when grounding metrics were last recalculated. Enables staleness detection.']
+  "avg_confidence" "double precision" [note: 'ADR-046: Average confidence score across all edges of this type. Helps identify low-quality edge types.']
+  "semantic_diversity" "double precision" [note: 'ADR-046: Semantic diversity score (0.0-1.0). High diversity may indicate overly broad type; low diversity may indicate well-defined type.']
+  "embedding_quality_score" "double precision" [note: 'ADR-045: Quality score for embedding (based on validation checks like magnitude, dimensionality)']
+  "embedding_validation_status" "character varying(20)" [note: 'ADR-045: Validation status - stale indicates model changed since generation']
+  "category_source" "character varying(20)" [note: 'Source of category assignment: builtin (hand-assigned) or computed (ADR-047)']
+  "category_confidence" "double precision" [note: 'Confidence score (0.0-1.0) for computed categories based on max similarity to seed types']
+  "category_scores" "jsonb" [note: 'Full category similarity breakdown as JSON: {”causation”: 0.85, ”composition”: 0.45, ...}']
+  "category_ambiguous" "boolean" [note: 'True if runner-up category score > 0.70 (potential multi-category type)']
+  "direction_semantics" "character varying(20)" [note: 'LLM-determined direction: outward (from→to), inward (from←to), bidirectional (symmetric). NULL = not yet determined by LLM.']
+  Note: 'Canonical relationship types with embeddings - ADR-025, ADR-032'
+}
+
+Table "kg_api"."scheduled_jobs" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "name" "character varying(100)" [not null, unique, note: 'Unique identifier for the scheduled job']
+  "launcher_class" "character varying(255)" [not null, note: 'Python class name in launcher registry (e.g., CategoryRefreshLauncher)']
+  "schedule_cron" "character varying(100)" [not null, note: 'Cron expression for schedule (e.g., ”0 */6 * * *” = every 6 hours)']
+  "enabled" "boolean" [note: 'Whether this schedule is active (can be disabled on failure)']
+  "max_retries" "integer" [note: 'Max consecutive failures before auto-disabling schedule']
+  "retry_count" "integer" [note: 'Current consecutive failure count (reset on success or skip)']
+  "last_run" "timestamp without time zone" [note: 'Last time the schedule was checked (success, skip, or failure)']
+  "last_success" "timestamp without time zone" [note: 'Last time a job was successfully enqueued']
+  "last_failure" "timestamp without time zone" [note: 'Last time the launcher failed with an exception']
+  "next_run" "timestamp without time zone" [note: 'Calculated next run time (from cron expression or backoff)']
+  "created_at" "timestamp without time zone"
+  "updated_at" "timestamp without time zone"
+  Note: 'Scheduled background jobs: - category_refresh: Re-integrate LLM-generated vocabulary categories (every 6 hours) - vocab_consolidation: Auto-consolidate vocabulary based on hysteresis thresholds (every 12 hours)'
+}
+
+Table "kg_api"."schema_migrations" [headercolor: #7c3aed] {
+  "version" "integer" [pk, not null, note: 'Migration number matching schema/migrations/NNN_*.sql files']
+  "description" "text" [not null, note: 'Human-readable description of what this migration does']
+  "applied_at" "timestamp without time zone" [not null, note: 'When this migration was applied to the database']
+  Note: 'Tracks applied database migrations for backup/restore compatibility. Schema version is included in backups to ensure restore compatibility when database schema evolves. See ADR-015 for details.'
+}
+
+Table "kg_api"."sessions" [headercolor: #7c3aed] {
+  "session_id" "character varying(100)" [pk, not null]
+  "user_id" "integer"
+  "created_at" "timestamp with time zone" [not null]
+  "expires_at" "timestamp with time zone" [not null]
+  "last_activity" "timestamp with time zone" [not null]
+  "metadata" "jsonb"
+}
+
+Table "kg_api"."skipped_relationships" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "relationship_type" "character varying(100)" [not null]
+  "from_concept_label" "character varying(500)"
+  "to_concept_label" "character varying(500)"
+  "job_id" "character varying(50)"
+  "ontology" "character varying(200)"
+  "first_seen" "timestamp with time zone" [not null]
+  "last_seen" "timestamp with time zone" [not null]
+  "occurrence_count" "integer"
+  "sample_context" "jsonb"
+  Note: 'Capture layer for unmatched relationship types - ADR-025'
+}
+
+Table "kg_api"."source_embeddings" [headercolor: #7c3aed] {
+  "embedding_id" "integer" [pk, not null]
+  "source_id" "text" [not null, note: 'Reference to Source node in Apache AGE graph']
+  "chunk_index" "integer" [not null, note: '0-based chunk number within source (e.g., 0, 1, 2...)']
+  "chunk_strategy" "text" [not null, note: 'Chunking strategy used: sentence, paragraph, semantic, or count']
+  "start_offset" "integer" [not null, note: 'Character offset in Source.full_text where chunk starts (0-based)']
+  "end_offset" "integer" [not null, note: 'Character offset in Source.full_text where chunk ends (exclusive)']
+  "chunk_text" "text" [not null, note: 'Actual chunk content stored for verification (should match Source.full_text[start_offset:end_offset])']
+  "chunk_hash" "text" [not null, note: 'SHA256 hash of chunk_text - verifies chunk integrity']
+  "source_hash" "text" [not null, note: 'SHA256 hash of Source.full_text - detects when source text changes (stale embedding indicator)']
+  "embedding" "bytea" [not null, note: 'Vector embedding bytes (float16 or float32 array, packed as bytea)']
+  "embedding_model" "text" [not null, note: 'Embedding model name (e.g., ”nomic-ai/nomic-embed-text-v1.5”, ”text-embedding-3-small”)']
+  "embedding_dimension" "integer" [not null, note: 'Embedding vector dimension (must match system embedding_config for cosine similarity)']
+  "embedding_provider" "text"
+  "created_at" "timestamp with time zone"
+  "updated_at" "timestamp with time zone"
+  Note: 'ADR-068: Embeddings for source text chunks with offset tracking and hash verification'
+}
+
+Table "kg_api"."synonym_clusters" [headercolor: #7c3aed] {
+  "cluster_id" "uuid" [pk, not null]
+  "representative_type" "character varying(100)" [note: 'The canonical type to use when merging cluster members. Usually has highest usage_count or is builtin.']
+  "member_types" "character varying(100)[]"
+  "avg_similarity" "double precision" [note: 'Average cosine similarity between all pairs of member embeddings. Higher values indicate stronger synonym relationship.']
+  "cluster_size" "integer"
+  "total_usage_count" "integer"
+  "detected_at" "timestamp with time zone"
+  "detection_method" "character varying(50)"
+  "is_active" "boolean"
+  "merge_recommended" "boolean"
+  "merge_completed_at" "timestamp with time zone"
+  Note: 'ADR-046: Tracks groups of synonymous edge types discovered through embedding-based semantic similarity (threshold > 0.85)'
+}
+
+Table "kg_api"."system_api_keys" [headercolor: #7c3aed] {
+  "provider" "character varying(50)" [pk, not null, note: 'Provider name: openai, anthropic']
+  "encrypted_key" "bytea" [not null, note: 'Fernet-encrypted API key (AES-128-CBC + HMAC-SHA256)']
+  "updated_at" "timestamp with time zone" [note: 'Last time key was updated']
+  "validation_status" "character varying(20)" [note: 'API key validation state: valid, invalid, or untested']
+  "last_validated_at" "timestamp with time zone" [note: 'Timestamp of last validation check (typically at API startup)']
+  "validation_error" "text" [note: 'Error message from last failed validation attempt']
+  Note: 'Encrypted system API keys for LLM providers (ADR-031, ADR-041)'
+}
+
+Table "kg_api"."system_initialization_status" [headercolor: #7c3aed] {
+  "component" "character varying(50)" [pk, not null]
+  "initialized" "boolean"
+  "initialized_at" "timestamp with time zone"
+  "initialization_job_id" "uuid"
+  "version" "character varying(20)"
+  "metadata" "jsonb"
+  "last_processed_vocab_change_counter" "bigint" [not null, note: 'Snapshot of vocabulary_change_counter at the time this initialization component last completed embedding work. The cold-start and VocabEmbeddingLauncher paths compare current counter vs. this value to detect new work since the last successful run. Replaces the binary `initialized` flag for embedding components (the flag stays for non-counter-driven components). Default 0 means ”no work has completed yet” — correct initial state.']
+  Note: 'ADR-045: Tracks completion of system initialization tasks like cold start embedding generation'
+}
+
+Table "kg_api"."vocabulary_audit" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "relationship_type" "character varying(100)"
+  "action" "character varying(50)" [not null]
+  "performed_by" "character varying(100)"
+  "performed_at" "timestamp with time zone" [not null]
+  "details" "jsonb"
+}
+
+Table "kg_api"."vocabulary_config" [headercolor: #7c3aed] {
+  "key" "character varying(100)" [pk, not null]
+  "value" "text" [not null]
+  "description" "text"
+  "updated_at" "timestamp with time zone" [not null]
+  "updated_by" "character varying(100)"
+  Note: 'System configuration for automatic vocabulary management (ADR-032)'
+}
+
+Table "kg_api"."vocabulary_history" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "relationship_type" "character varying(100)" [not null]
+  "action" "character varying(50)" [not null]
+  "performed_by" "character varying(100)" [not null]
+  "performed_at" "timestamp with time zone" [not null]
+  "target_type" "character varying(100)"
+  "reason" "text"
+  "metadata" "jsonb"
+  "aggressiveness" "numeric(4,3)"
+  "zone" "character varying(20)"
+  "vocab_size_before" "integer"
+  "vocab_size_after" "integer"
+  Note: 'Detailed vocabulary change tracking with context (ADR-032)'
+}
+
+Table "kg_api"."vocabulary_suggestions" [headercolor: #7c3aed] {
+  "id" "integer" [pk, not null]
+  "relationship_type" "character varying(100)" [not null]
+  "suggestion_type" "character varying(50)" [not null]
+  "confidence" "numeric(3,2)" [not null]
+  "suggested_canonical_type" "character varying(100)"
+  "suggested_category" "character varying(50)"
+  "suggested_description" "text"
+  "similar_types" "jsonb"
+  "reasoning" "text"
+  "created_at" "timestamp with time zone" [not null]
+  "reviewed" "boolean"
+  "curator_decision" "character varying(50)"
+  "curator_notes" "text"
+  Note: 'LLM-assisted vocabulary curation suggestions - ADR-026'
+}
+
+Table "kg_api"."worker_lanes" [headercolor: #7c3aed] {
+  "name" "text" [pk, not null]
+  "job_types" "text[]" [not null]
+  "max_slots" "integer" [not null]
+  "poll_interval_ms" "integer" [not null]
+  "stale_timeout_minutes" "integer" [not null]
+  "enabled" "boolean" [not null]
+  "updated_at" "timestamp with time zone" [not null]
+  Note: 'Worker lane configuration for database-driven job dispatch (ADR-100)'
+}
+
+Table "kg_api"."worker_status" [headercolor: #7c3aed] {
+  "worker_id" "character varying(100)" [pk, not null]
+  "last_heartbeat" "timestamp with time zone" [not null]
+  "current_job_id" "character varying(50)"
+  "status" "character varying(50)" [not null]
+  "metadata" "jsonb"
+}
+
+Table "kg_auth"."groups" [headercolor: #2d7d9a] {
+  "id" "integer" [pk, not null]
+  "group_name" "character varying(100)" [not null, unique]
+  "display_name" "character varying(200)"
+  "description" "text"
+  "is_system" "boolean" [note: 'System groups (public, admins) cannot be deleted']
+  "created_at" "timestamp with time zone" [not null]
+  "created_by" "integer"
+  Note: 'Group definitions for collaborative access control (ADR-082)'
+}
+
+Table "kg_auth"."oauth_access_tokens" [headercolor: #2d7d9a] {
+  "token_hash" "character varying(255)" [pk, not null, note: 'SHA256 hash of the actual token (tokens are not stored in plaintext)']
+  "client_id" "character varying(255)" [not null]
+  "user_id" "integer" [note: 'NULL for client_credentials grant (machine-to-machine), set for user-delegated grants']
+  "scopes" "text[]"
+  "expires_at" "timestamp with time zone" [not null, note: 'Access tokens expire in 1 hour']
+  "revoked" "boolean"
+  "created_at" "timestamp with time zone"
+  Note: 'OAuth access tokens issued to clients'
+}
+
+Table "kg_auth"."oauth_authorization_codes" [headercolor: #2d7d9a] {
+  "code" "character varying(255)" [pk, not null]
+  "client_id" "character varying(255)" [not null]
+  "user_id" "integer" [not null]
+  "redirect_uri" "text" [not null]
+  "scopes" "text[]"
+  "code_challenge" "character varying(255)" [note: 'PKCE code challenge (hash of code verifier)']
+  "code_challenge_method" "character varying(10)"
+  "expires_at" "timestamp with time zone" [not null, note: 'Authorization codes expire in 10 minutes']
+  "used" "boolean"
+  "created_at" "timestamp with time zone"
+  Note: 'Temporary authorization codes for OAuth Authorization Code flow (web apps)'
+}
+
+Table "kg_auth"."oauth_clients" [headercolor: #2d7d9a] {
+  "client_id" "character varying(255)" [pk, not null]
+  "client_secret_hash" "character varying(255)"
+  "client_name" "character varying(255)" [not null]
+  "client_type" "character varying(50)" [not null, note: 'public = no client secret (CLI, web apps), confidential = has client secret (MCP server)']
+  "grant_types" "text[]" [not null, note: 'Allowed OAuth grant types: authorization_code, urn:ietf:params:oauth:grant-type:device_code, client_credentials, refresh_token']
+  "redirect_uris" "text[]"
+  "scopes" "text[]"
+  "is_active" "boolean"
+  "created_by" "integer"
+  "created_at" "timestamp with time zone"
+  "metadata" "jsonb"
+  Note: 'OAuth 2.0 client applications registered to use the API'
+}
+
+Table "kg_auth"."oauth_device_codes" [headercolor: #2d7d9a] {
+  "device_code" "character varying(255)" [pk, not null, note: 'Long code used by device for polling']
+  "user_code" "character varying(50)" [not null, unique, note: 'Human-friendly code displayed to user (e.g., ABCD-1234)']
+  "client_id" "character varying(255)" [not null]
+  "user_id" "integer"
+  "scopes" "text[]"
+  "status" "character varying(50)"
+  "expires_at" "timestamp with time zone" [not null, note: 'Device codes expire in 10 minutes']
+  "created_at" "timestamp with time zone"
+  Note: 'Device authorization codes for OAuth Device Authorization Grant flow (CLI tools)'
+}
+
+Table "kg_auth"."oauth_external_provider_tokens" [headercolor: #2d7d9a] {
+  "token_hash" "character varying(255)" [pk, not null]
+  "user_id" "integer"
+  "provider" "character varying(50)"
+  "scopes" "text[]"
+  "expires_at" "timestamp with time zone" [not null]
+  Note: 'OAuth tokens FROM external providers (Google, GitHub, etc.) - not tokens issued by our system'
+}
+
+Table "kg_auth"."oauth_refresh_tokens" [headercolor: #2d7d9a] {
+  "token_hash" "character varying(255)" [pk, not null]
+  "client_id" "character varying(255)" [not null]
+  "user_id" "integer" [not null]
+  "scopes" "text[]"
+  "access_token_hash" "character varying(255)"
+  "expires_at" "timestamp with time zone" [not null, note: 'Refresh tokens expire in 7 days (CLI) or 30 days (web)']
+  "revoked" "boolean"
+  "created_at" "timestamp with time zone"
+  "last_used" "timestamp with time zone" [note: 'Updated when refresh token is used to obtain new access token']
+  Note: 'OAuth refresh tokens for long-lived sessions'
+}
+
+Table "kg_auth"."resource_grants" [headercolor: #2d7d9a] {
+  "id" "integer" [pk, not null]
+  "resource_type" "character varying(50)" [not null, note: 'Type: ontology, artifact, report, etc.']
+  "resource_id" "character varying(200)" [not null, note: 'Specific resource identifier']
+  "principal_type" "character varying(20)" [not null, note: 'Grant to user or group']
+  "principal_id" "integer" [not null]
+  "permission" "character varying(20)" [not null, note: 'read, write, or admin access']
+  "granted_at" "timestamp with time zone" [not null]
+  "granted_by" "integer"
+  Note: 'Instance-level access grants for owned resources (ADR-082)'
+}
+
+Table "kg_auth"."resources" [headercolor: #2d7d9a] {
+  "resource_type" "character varying(100)" [pk, not null]
+  "description" "text"
+  "parent_type" "character varying(100)"
+  "available_actions" "character varying(50)[]" [not null]
+  "supports_scoping" "boolean"
+  "metadata" "jsonb"
+  "registered_at" "timestamp with time zone" [not null]
+  "registered_by" "character varying(100)"
+  Note: 'Dynamic resource type registry (ADR-028)'
+}
+
+Table "kg_auth"."role_permissions" [headercolor: #2d7d9a] {
+  "id" "integer" [pk, not null]
+  "role_name" "character varying(50)" [not null]
+  "resource_type" "character varying(100)" [not null]
+  "action" "character varying(50)" [not null]
+  "scope_type" "character varying(50)"
+  "scope_id" "character varying(200)"
+  "scope_filter" "jsonb"
+  "granted" "boolean" [not null]
+  "inherited_from" "character varying(50)"
+  "created_at" "timestamp with time zone" [not null]
+  "created_by" "integer"
+  Note: 'Dynamic role permissions with scoping (ADR-028)'
+}
+
+Table "kg_auth"."roles" [headercolor: #2d7d9a] {
+  "role_name" "character varying(50)" [pk, not null]
+  "display_name" "character varying(100)" [not null]
+  "description" "text"
+  "is_builtin" "boolean"
+  "is_active" "boolean"
+  "parent_role" "character varying(50)"
+  "created_at" "timestamp with time zone" [not null]
+  "created_by" "integer"
+  "metadata" "jsonb"
+  Note: 'Dynamic role definitions with inheritance (ADR-028)'
+}
+
+Table "kg_auth"."user_groups" [headercolor: #2d7d9a] {
+  "user_id" "integer" [pk, not null]
+  "group_id" "integer" [pk, not null]
+  "added_at" "timestamp with time zone" [not null]
+  "added_by" "integer"
+  Note: 'Group membership assignments (ADR-082)'
+}
+
+Table "kg_auth"."user_roles" [headercolor: #2d7d9a] {
+  "id" "integer" [pk, not null]
+  "user_id" "integer" [not null]
+  "role_name" "character varying(50)" [not null]
+  "scope_type" "character varying(50)"
+  "scope_id" "character varying(200)"
+  "assigned_at" "timestamp with time zone" [not null]
+  "assigned_by" "integer"
+  "expires_at" "timestamp with time zone"
+  Note: 'User role assignments with optional scoping (ADR-028)'
+}
+
+Table "kg_auth"."users" [headercolor: #2d7d9a] {
+  "id" "integer" [pk, not null]
+  "username" "character varying(100)" [not null, unique]
+  "password_hash" "character varying(255)" [not null]
+  "primary_role" "character varying(50)" [not null, note: 'Primary role (backwards compatibility) - user can have additional roles in user_roles table']
+  "created_at" "timestamp with time zone" [not null]
+  "last_login" "timestamp with time zone"
+  "disabled" "boolean"
+}
+
+Table "kg_logs"."api_metrics" [headercolor: #2d8e5e] {
+  "id" "integer" [pk, not null]
+  "timestamp" "timestamp with time zone" [not null]
+  "endpoint" "character varying(200)" [not null]
+  "method" "character varying(10)" [not null]
+  "status_code" "integer" [not null]
+  "duration_ms" "numeric(10,2)" [not null]
+  "client_id" "character varying(100)"
+  "error_message" "text"
+}
+
+Table "kg_logs"."audit_trail" [headercolor: #2d8e5e] {
+  "id" "integer" [pk, not null]
+  "timestamp" "timestamp with time zone" [not null]
+  "user_id" "integer"
+  "action" "character varying(100)" [not null]
+  "resource_type" "character varying(50)" [not null]
+  "resource_id" "character varying(200)"
+  "details" "jsonb"
+  "ip_address" "inet"
+  "user_agent" "text"
+  "outcome" "character varying(50)" [not null]
+}
+
+Table "kg_logs"."health_checks" [headercolor: #2d8e5e] {
+  "id" "integer" [pk, not null]
+  "timestamp" "timestamp with time zone" [not null]
+  "service" "character varying(50)" [not null]
+  "status" "character varying(50)" [not null]
+  "metrics" "jsonb"
+}
+
+Table "kg_logs"."job_events" [headercolor: #2d8e5e] {
+  "id" "integer" [pk, not null]
+  "job_id" "character varying(50)" [not null]
+  "timestamp" "timestamp with time zone" [not null]
+  "event_type" "character varying(50)" [not null]
+  "details" "jsonb"
+}
+
+Ref: "kg_api"."artifacts"."query_definition_id" > "kg_api"."query_definitions"."id"
+Ref: "kg_api"."artifacts"."owner_id" > "kg_auth"."users"."id"
+Ref: "kg_api"."concept_version_metadata"."created_in_version" > "kg_api"."ontology_versions"."version_id"
+Ref: "kg_api"."concept_version_metadata"."last_modified_version" > "kg_api"."ontology_versions"."version_id"
+Ref: "kg_api"."graph_epochs"."kind" > "kg_api"."graph_epoch_kinds"."kind"
+Ref: "kg_api"."jobs"."artifact_id" > "kg_api"."artifacts"."id"
+Ref: "kg_api"."jobs"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_api"."query_definitions"."owner_id" > "kg_auth"."users"."id"
+Ref: "kg_api"."synonym_clusters"."representative_type" > "kg_api"."relationship_vocabulary"."relationship_type"
+Ref: "kg_api"."system_initialization_status"."initialization_job_id" > "kg_api"."embedding_generation_jobs"."job_id"
+Ref: "kg_auth"."groups"."created_by" > "kg_auth"."users"."id"
+Ref: "kg_auth"."oauth_access_tokens"."client_id" > "kg_auth"."oauth_clients"."client_id"
+Ref: "kg_auth"."oauth_access_tokens"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_auth"."oauth_authorization_codes"."client_id" > "kg_auth"."oauth_clients"."client_id"
+Ref: "kg_auth"."oauth_authorization_codes"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_auth"."oauth_clients"."created_by" > "kg_auth"."users"."id"
+Ref: "kg_auth"."oauth_device_codes"."client_id" > "kg_auth"."oauth_clients"."client_id"
+Ref: "kg_auth"."oauth_device_codes"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_auth"."oauth_external_provider_tokens"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_auth"."oauth_refresh_tokens"."access_token_hash" > "kg_auth"."oauth_access_tokens"."token_hash"
+Ref: "kg_auth"."oauth_refresh_tokens"."client_id" > "kg_auth"."oauth_clients"."client_id"
+Ref: "kg_auth"."oauth_refresh_tokens"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_auth"."resource_grants"."granted_by" > "kg_auth"."users"."id"
+Ref: "kg_auth"."resources"."parent_type" > "kg_auth"."resources"."resource_type"
+Ref: "kg_auth"."role_permissions"."resource_type" > "kg_auth"."resources"."resource_type"
+Ref: "kg_auth"."role_permissions"."inherited_from" > "kg_auth"."roles"."role_name"
+Ref: "kg_auth"."role_permissions"."role_name" > "kg_auth"."roles"."role_name"
+Ref: "kg_auth"."role_permissions"."created_by" > "kg_auth"."users"."id"
+Ref: "kg_auth"."roles"."parent_role" > "kg_auth"."roles"."role_name"
+Ref: "kg_auth"."roles"."created_by" > "kg_auth"."users"."id"
+Ref: "kg_auth"."user_groups"."group_id" > "kg_auth"."groups"."id"
+Ref: "kg_auth"."user_groups"."added_by" > "kg_auth"."users"."id"
+Ref: "kg_auth"."user_groups"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_auth"."user_roles"."role_name" > "kg_auth"."roles"."role_name"
+Ref: "kg_auth"."user_roles"."assigned_by" > "kg_auth"."users"."id"
+Ref: "kg_auth"."user_roles"."user_id" > "kg_auth"."users"."id"
+Ref: "kg_auth"."users"."primary_role" > "kg_auth"."roles"."role_name"

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -11,7 +11,13 @@ Relational schema for the Kappa Graph control plane. The knowledge graph itself 
 Backed by PostgreSQL 18 with Apache AGE 1.7.0. This page is generated from `schema/00_baseline.sql` and `schema/migrations/*.sql`; do not edit it by hand.
 
 <!-- GENERATED FILE — edit the SQL DDL, then run `make docs-schema`. -->
-<!-- Generated: 2026-07-01 -->
+<!-- Generated: 2026-07-02 -->
+
+## Diagram
+
+<iframe src="../schema-erd.html" title="Interactive schema ER diagram" loading="lazy" style="width:100%;height:720px;border:1px solid var(--md-default-fg-color--lightest,#ccc);border-radius:8px;"></iframe>
+
+[Open the diagram full screen ↗](schema-erd.html){target=_blank} · generated from [`schema.dbml`](schema.dbml), which you can paste into [dbdiagram.io](https://dbdiagram.io) to explore or edit.
 
 ## Schemas
 

--- a/schema/scripts/generate-schema-docs.py
+++ b/schema/scripts/generate-schema-docs.py
@@ -30,6 +30,7 @@ BASELINE = SCHEMA_ROOT / "00_baseline.sql"
 MIGRATIONS_DIR = SCHEMA_ROOT / "migrations"
 OUTPUT_DIR = PROJECT_ROOT / "docs" / "reference"
 OUTPUT_FILE = OUTPUT_DIR / "schema.md"
+DBML_FILE = OUTPUT_DIR / "schema.dbml"
 
 # Platform versions are pinned in the Postgres image, not in the DDL. Stated
 # here so the reference does not repeat the stale "Postgres 16 / AGE 1.5.0"
@@ -46,6 +47,18 @@ SCHEMA_BLURBS = {
     "kg_auth": "Authentication and authorization (dynamic RBAC).",
     "kg_logs": "Observability: audit trails, metrics, health.",
 }
+
+# Header fill per schema for the interactive ER diagram. Deep, opaque hues so
+# the renderer's white header text stays legible in light and dark themes (one
+# hue = one schema; see the Mermaid/charts way). Tables are colored by schema
+# instead of clustered, which keeps the packed layout compact and near-square.
+SCHEMA_COLORS = {
+    "public": "#475569",  # slate — bookkeeping
+    "kg_api": "#7c3aed",  # violet — core operational service
+    "kg_auth": "#2d7d9a",  # teal — auth/security
+    "kg_logs": "#2d8e5e",  # green — observability
+}
+SCHEMA_COLOR_DEFAULT = "#334155"
 
 
 def strip_sql_comments_inline(line: str) -> str:
@@ -500,6 +513,126 @@ def render_er_diagram(schema: str, edges, tables) -> list:
     return out
 
 
+def _dbml_note(text: str) -> str:
+    """Escape a comment for a DBML single-quoted `note:` string.
+
+    DBML single-quoted strings have no backslash escape, so an embedded
+    apostrophe would terminate the string. Swap ASCII quotes for typographic
+    ones and collapse whitespace to keep the note on one line.
+    """
+    return (
+        " ".join(text.split())
+        .replace("'", "’")
+        .replace('"', "”")
+    )
+
+
+def _dbml_ident(name: str) -> str:
+    """Quote a DBML identifier (schema, table, or column) defensively."""
+    return f'"{name}"'
+
+
+def _parent_ref_column(flags) -> str:
+    """Pull the referenced parent column out of an ``FK → target(col)`` flag."""
+    for flag in flags:
+        m = re.match(r"FK → [\w.]+\s*\(([^)]+)\)", flag)
+        if m:
+            return m.group(1).split(",")[0].strip().strip('"')
+    return ""
+
+
+def _table_pk(tbl) -> str:
+    """Return a table's single primary-key column name, or '' if none/composite."""
+    pks = [c["name"] for c in tbl["columns"] if "PK" in c["flags"]]
+    return pks[0] if len(pks) == 1 else ""
+
+
+def render_dbml(tables, table_comments, column_comments, edges) -> str:
+    """Render the schema as DBML (https://dbml.dbdiagram.io).
+
+    Schema-qualified, quoted table names keep cross-schema name collisions
+    (kg_api.jobs vs kg_logs.jobs) distinct. Column types, PK/NOT NULL/UNIQUE
+    flags, and table/column comments carry through as DBML settings and notes.
+    Foreign keys become ``Ref`` lines. Each table is tinted by schema via
+    ``headercolor`` rather than clustered into a TableGroup: color keeps the
+    schema legible while letting the renderer pack the 60-odd tables into a
+    compact, near-square layout instead of one table-per-schema column. The
+    output is both the render source for the interactive ERD and a portable
+    artifact that pastes directly into dbdiagram.io.
+    """
+    today = date.today().isoformat()
+    out = [
+        "// Database schema for the Knowledge Graph System control plane.",
+        "// GENERATED FILE — edit the SQL DDL, then run `make docs-schema`.",
+        f"// Generated: {today}",
+        "//",
+        "// Render: schema/scripts/render-schema-diagram.mjs (interactive ERD)",
+        "// Or paste into https://dbdiagram.io to explore/edit.",
+        "",
+    ]
+
+    by_schema = {}
+    for qualified, tbl in tables.items():
+        by_schema.setdefault(tbl["schema"], []).append((qualified, tbl))
+
+    schema_order = ["public", "kg_api", "kg_auth", "kg_logs"]
+    ordered = [s for s in schema_order if s in by_schema]
+    ordered += [s for s in sorted(by_schema) if s not in schema_order]
+
+    for schema in ordered:
+        color = SCHEMA_COLORS.get(schema, SCHEMA_COLOR_DEFAULT)
+        for qualified, tbl in sorted(by_schema[schema], key=lambda x: x[1]["name"]):
+            ref = f'{_dbml_ident(schema)}.{_dbml_ident(tbl["name"])}'
+            out.append(f"Table {ref} [headercolor: {color}] {{")
+            for col in tbl["columns"]:
+                settings = []
+                if "PK" in col["flags"]:
+                    settings.append("pk")
+                if "NOT NULL" in col["flags"]:
+                    settings.append("not null")
+                if "UNIQUE" in col["flags"]:
+                    settings.append("unique")
+                comment = column_comments.get(f"{qualified}.{col['name']}", "")
+                if comment:
+                    settings.append(f"note: '{_dbml_note(comment)}'")
+                setting_str = f" [{', '.join(settings)}]" if settings else ""
+                col_type = col["type"] or "text"
+                out.append(
+                    f'  {_dbml_ident(col["name"])} "{col_type}"{setting_str}'
+                )
+            tc = table_comments.get(qualified)
+            if tc:
+                out.append(f"  Note: '{_dbml_note(tc)}'")
+            out.append("}")
+            out.append("")
+
+    # Foreign-key references. Skip any whose endpoints we cannot fully resolve
+    # to a column (DBML refs are column-to-column).
+    seen = set()
+    for child_q, parent_q, child_col in sorted(set(edges)):
+        child = tables.get(child_q)
+        parent = tables.get(parent_q)
+        if not child or not parent:
+            continue
+        child_flags = next(
+            (c["flags"] for c in child["columns"] if c["name"] == child_col), []
+        )
+        parent_col = _parent_ref_column(child_flags) or _table_pk(parent)
+        if not parent_col:
+            continue
+        line = (
+            f'Ref: {_dbml_ident(child["schema"])}.{_dbml_ident(child["name"])}'
+            f'.{_dbml_ident(child_col)} > '
+            f'{_dbml_ident(parent["schema"])}.{_dbml_ident(parent["name"])}'
+            f'.{_dbml_ident(parent_col)}'
+        )
+        if line not in seen:
+            seen.add(line)
+            out.append(line)
+
+    return "\n".join(out) + "\n"
+
+
 def render(tables, table_comments, column_comments, migrations):
     """Render the full markdown page as a string."""
     today = date.today().isoformat()
@@ -532,6 +665,26 @@ def render(tables, table_comments, column_comments, migrations):
     out.append("<!-- GENERATED FILE — edit the SQL DDL, then run "
                "`make docs-schema`. -->")
     out.append(f"<!-- Generated: {today} -->")
+    out.append("")
+
+    # Interactive ER diagram. schema-erd.html is a self-contained page rendered
+    # from schema.dbml by render-schema-diagram.mjs. The iframe src is relative
+    # to the *built* URL (use_directory_urls puts this page at reference/schema/,
+    # so its sibling static file is one level up); the markdown links below are
+    # source-relative and rewritten by mkdocs.
+    out.append("## Diagram")
+    out.append("")
+    out.append(
+        '<iframe src="../schema-erd.html" title="Interactive schema ER diagram" '
+        'loading="lazy" style="width:100%;height:720px;border:1px solid '
+        'var(--md-default-fg-color--lightest,#ccc);border-radius:8px;"></iframe>'
+    )
+    out.append("")
+    out.append(
+        "[Open the diagram full screen ↗](schema-erd.html){target=_blank} · "
+        "generated from [`schema.dbml`](schema.dbml), which you can paste into "
+        "[dbdiagram.io](https://dbdiagram.io) to explore or edit."
+    )
     out.append("")
 
     # Group tables by logical schema.
@@ -657,9 +810,17 @@ def main() -> int:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     OUTPUT_FILE.write_text(page)
 
+    # DBML source for the interactive ER diagram (rendered by
+    # render-schema-diagram.mjs) and for pasting into dbdiagram.io.
+    fk_edges = collect_fk_edges(tables)
+    dbml = render_dbml(tables, table_comments, column_comments, fk_edges)
+    DBML_FILE.write_text(dbml)
+
     print(
-        f"Generated {OUTPUT_FILE.relative_to(PROJECT_ROOT)} "
-        f"({len(tables)} tables, {len(migrations)} migrations)"
+        f"Generated {OUTPUT_FILE.relative_to(PROJECT_ROOT)} and "
+        f"{DBML_FILE.relative_to(PROJECT_ROOT)} "
+        f"({len(tables)} tables, {len(fk_edges)} FK edges, "
+        f"{len(migrations)} migrations)"
     )
     return 0
 

--- a/schema/scripts/package-lock.json
+++ b/schema/scripts/package-lock.json
@@ -1,0 +1,221 @@
+{
+  "name": "kg-schema-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kg-schema-scripts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@softwaretechnik/dbml-renderer": "1.0.31"
+      }
+    },
+    "node_modules/@aduh95/viz.js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@aduh95/viz.js/-/viz.js-3.4.0.tgz",
+      "integrity": "sha512-KI2nVf9JdwWCXqK6RVf+9/096G7VWN4Z84mnynlyZKao2xQENW8WNEjLmvdlxS5X8PNWXFC1zqwm7tveOXw/4A==",
+      "license": "MIT"
+    },
+    "node_modules/@softwaretechnik/dbml-renderer": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@softwaretechnik/dbml-renderer/-/dbml-renderer-1.0.31.tgz",
+      "integrity": "sha512-ThoBDBc2/ODuCtvrHKLaZNHvBhSMdgTXae7z1hOgXn+i5Qdqp1tq5nK1rrkm7THfnAIXuZ3WxAeos1iRZSKeOw==",
+      "license": "ISC",
+      "dependencies": {
+        "@aduh95/viz.js": "3.4.0",
+        "yargs": "^17.7.2",
+        "zod": "^3.25.67"
+      },
+      "bin": {
+        "dbml-renderer": "lib/index.js"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/schema/scripts/package-lock.json
+++ b/schema/scripts/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kg-schema-scripts",
       "version": "1.0.0",
       "dependencies": {
+        "@aduh95/viz.js": "3.4.0",
         "@softwaretechnik/dbml-renderer": "1.0.31"
       }
     },

--- a/schema/scripts/package.json
+++ b/schema/scripts/package.json
@@ -8,6 +8,7 @@
     "render-diagram": "node render-schema-diagram.mjs"
   },
   "dependencies": {
+    "@aduh95/viz.js": "3.4.0",
     "@softwaretechnik/dbml-renderer": "1.0.31"
   }
 }

--- a/schema/scripts/package.json
+++ b/schema/scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "kg-schema-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Schema documentation tooling: render the interactive ER diagram from schema.dbml.",
+  "scripts": {
+    "render-diagram": "node render-schema-diagram.mjs"
+  },
+  "dependencies": {
+    "@softwaretechnik/dbml-renderer": "1.0.31"
+  }
+}

--- a/schema/scripts/render-schema-diagram.mjs
+++ b/schema/scripts/render-schema-diagram.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+/**
+ * Render the interactive Entity-Relationship diagram from schema.dbml.
+ *
+ * Source of truth: docs/reference/schema.dbml (emitted by
+ * generate-schema-docs.py from the SQL DDL). This script turns that DBML into
+ * a self-contained interactive HTML page — no database, no system Graphviz:
+ * @softwaretechnik/dbml-renderer produces the Graphviz `dot`, and the bundled
+ * @aduh95/viz.js (Graphviz compiled to WebAssembly) lays it out to SVG. We
+ * inject `pack` so the ~60 mostly-disconnected tables tile into a compact,
+ * near-square block instead of one tall vertical strip, then wrap the SVG in a
+ * viewer with pan, zoom, table search, and click-to-highlight relationships.
+ *
+ * Runs in CI with nothing but Node (see .github/workflows/docs.yml). The
+ * output page is copied verbatim into the mkdocs site and embedded by
+ * docs/reference/schema-diagram.md.
+ *
+ * Run directly or via `make docs-schema`.
+ *
+ * Output: docs/reference/schema-diagram.html
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+// Both deps are CommonJS; load them through require from this package's
+// node_modules so the script works regardless of the caller's cwd.
+const { run } = require("@softwaretechnik/dbml-renderer");
+const vizRenderStringSync = require("@aduh95/viz.js/sync");
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(SCRIPT_DIR, "..", "..");
+const DBML_FILE = resolve(PROJECT_ROOT, "docs", "reference", "schema.dbml");
+const OUTPUT_FILE = resolve(PROJECT_ROOT, "docs", "reference", "schema-erd.html");
+
+// Schema → header fill. Must match SCHEMA_COLORS in generate-schema-docs.py;
+// used here only to render the legend (the table fills already live in the SVG).
+const SCHEMA_COLORS = {
+  public: "#475569",
+  kg_api: "#7c3aed",
+  kg_auth: "#2d7d9a",
+  kg_logs: "#2d8e5e",
+};
+
+/** Turn schema.dbml into a packed, near-square Graphviz SVG string. */
+function renderSvg(dbml) {
+  let dot = run(dbml, "dot");
+  // Component packing: lay out each connected piece, then tile them into a
+  // grid (array_c4 = row-major, 4 columns) so disconnected tables don't stack
+  // into a strip. Modest separations keep the packed block dense.
+  dot = dot.replace(
+    "rankdir=LR;",
+    'rankdir=LR;\n  pack=true;\n  packmode="array_c4";\n  ranksep=0.6;\n  nodesep=0.4;'
+  );
+  return vizRenderStringSync(dot, { engine: "dot", format: "svg" });
+}
+
+/**
+ * Prepare the Graphviz SVG for embedding: drop the fixed pt width/height so it
+ * scales to its container, and tag it with an id the viewer script targets.
+ * The viewBox (which carries the true coordinate extent) is preserved.
+ */
+function prepareSvg(svg) {
+  const viewBox = (svg.match(/viewBox="([^"]+)"/) || [])[1] || "0 0 1000 1000";
+  const inner = svg.slice(svg.indexOf("<svg"));
+  const openTagEnd = inner.indexOf(">") + 1;
+  const body = inner.slice(openTagEnd);
+  const open =
+    `<svg id="erd" xmlns="http://www.w3.org/2000/svg" ` +
+    `xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="${viewBox}" ` +
+    `preserveAspectRatio="xMidYMid meet">`;
+  return { svg: open + body, viewBox };
+}
+
+/** Build the standalone interactive HTML page. */
+function buildHtml(svg, viewBox) {
+  const legend = Object.entries(SCHEMA_COLORS)
+    .map(
+      ([name, color]) =>
+        `<span class="chip"><i style="background:${color}"></i>${name}</span>`
+    )
+    .join("");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Knowledge Graph — Schema ER Diagram</title>
+<style>
+  /* --erd-cell / --erd-ink recolor the two theme-sensitive fills baked into
+     the Graphviz SVG (light beige cells, navy ink for text/borders/edges).
+     Schema header fills and their white text work in both modes, so they stay
+     fixed. The attribute-selector rules further down apply these vars. */
+  :root {
+    --bg: #ffffff; --fg: #1a2233; --panel: #f4f5f7; --border: #d0d5dd;
+    --muted: #667085; --accent: #7c3aed; --dim: 0.12;
+    --erd-cell: #e7e2dd; --erd-ink: #29235c;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #0f1419; --fg: #e6e9ee; --panel: #1a222c; --border: #2c3745;
+            --muted: #93a0b4; --dim: 0.08;
+            --erd-cell: #212a36; --erd-ink: #cfd8e6; }
+  }
+  html.dark {
+    --bg: #0f1419; --fg: #e6e9ee; --panel: #1a222c; --border: #2c3745;
+    --muted: #93a0b4; --dim: 0.08;
+    --erd-cell: #212a36; --erd-ink: #cfd8e6;
+  }
+  html.light {
+    --bg: #ffffff; --fg: #1a2233; --panel: #f4f5f7; --border: #d0d5dd;
+    --muted: #667085; --dim: 0.12;
+    --erd-cell: #e7e2dd; --erd-ink: #29235c;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
+    font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  #stage { position: fixed; inset: 0; overflow: hidden; cursor: grab; }
+  #stage.grabbing { cursor: grabbing; }
+  #erd { width: 100%; height: 100%; display: block; touch-action: none; }
+  #erd .node, #erd .edge { transition: opacity 0.15s ease; }
+  /* Recolor the two theme-sensitive baked colors to the active theme. A CSS
+     fill/stroke property overrides the SVG presentation attribute, and the
+     attribute selector targets exactly those elements. Schema header fills
+     (#7c3aed etc.) and white header text are intentionally left alone. */
+  #erd [fill="#e7e2dd"] { fill: var(--erd-cell); }
+  #erd [fill="#29235c"] { fill: var(--erd-ink); }
+  #erd [stroke="#29235c"] { stroke: var(--erd-ink); }
+  #erd.focusing .node.dim, #erd.focusing .edge.dim { opacity: var(--dim); }
+  #erd .node.hit > * { outline: none; }
+  .toolbar {
+    position: fixed; top: 12px; left: 12px; right: 12px; display: flex;
+    gap: 8px; align-items: center; flex-wrap: wrap; z-index: 10;
+    pointer-events: none;
+  }
+  .toolbar > * { pointer-events: auto; }
+  .group {
+    display: flex; gap: 4px; align-items: center; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 10px; padding: 4px 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+  }
+  button {
+    font: inherit; color: var(--fg); background: transparent; border: 0;
+    border-radius: 7px; padding: 6px 10px; cursor: pointer; white-space: nowrap;
+  }
+  button:hover { background: var(--border); }
+  input[type=search] {
+    font: inherit; color: var(--fg); background: var(--bg);
+    border: 1px solid var(--border); border-radius: 7px; padding: 6px 10px;
+    width: 190px; outline: none;
+  }
+  input[type=search]:focus { border-color: var(--accent); }
+  .legend { gap: 12px; }
+  .chip { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .chip i { width: 12px; height: 12px; border-radius: 3px; display: inline-block; }
+  .hint {
+    position: fixed; bottom: 10px; left: 12px; color: var(--muted);
+    font-size: 12px; z-index: 10; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 8px; padding: 4px 9px;
+  }
+  #count { color: var(--muted); font-size: 12px; padding: 0 4px; }
+  #matches {
+    position: absolute; top: 40px; left: 0; background: var(--panel);
+    border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
+    min-width: 220px; max-height: 260px; overflow-y: auto; display: none;
+  }
+  #matches div { padding: 6px 10px; cursor: pointer; }
+  #matches div:hover, #matches div.active { background: var(--border); }
+  .searchwrap { position: relative; }
+</style>
+</head>
+<body>
+<div id="stage">
+${svg}
+</div>
+
+<div class="toolbar">
+  <div class="group searchwrap">
+    <input id="search" type="search" placeholder="Find a table…" autocomplete="off" spellcheck="false">
+    <div id="matches"></div>
+  </div>
+  <div class="group">
+    <button id="fit" title="Fit to screen">Fit</button>
+    <button id="zin" title="Zoom in">+</button>
+    <button id="zout" title="Zoom out">−</button>
+    <button id="reset" title="Clear highlight">Clear</button>
+    <span id="count"></span>
+  </div>
+  <div class="group legend">${legend}</div>
+  <div class="group">
+    <button id="theme" title="Toggle light/dark">◐</button>
+  </div>
+</div>
+<div class="hint">Drag to pan · scroll to zoom · click a table to trace its relationships</div>
+
+<script>
+(function () {
+  "use strict";
+  var svg = document.getElementById("erd");
+  var stage = document.getElementById("stage");
+  var vb = "${viewBox}".split(/\\s+/).map(Number); // x y w h
+  var full = { x: vb[0], y: vb[1], w: vb[2], h: vb[3] };
+  var view = { x: full.x, y: full.y, w: full.w, h: full.h };
+
+  function apply() {
+    svg.setAttribute("viewBox", view.x + " " + view.y + " " + view.w + " " + view.h);
+  }
+  function fit() { view = { x: full.x, y: full.y, w: full.w, h: full.h }; apply(); }
+  apply();
+
+  // ---- pan ----
+  var panning = false, sx = 0, sy = 0;
+  stage.addEventListener("pointerdown", function (e) {
+    if (e.target.closest("g.node")) return; // let clicks select tables
+    panning = true; sx = e.clientX; sy = e.clientY;
+    stage.classList.add("grabbing"); stage.setPointerCapture(e.pointerId);
+  });
+  stage.addEventListener("pointermove", function (e) {
+    if (!panning) return;
+    var r = stage.getBoundingClientRect();
+    view.x -= (e.clientX - sx) * (view.w / r.width);
+    view.y -= (e.clientY - sy) * (view.h / r.height);
+    sx = e.clientX; sy = e.clientY; apply();
+  });
+  function endPan() { panning = false; stage.classList.remove("grabbing"); }
+  stage.addEventListener("pointerup", endPan);
+  stage.addEventListener("pointercancel", endPan);
+
+  // ---- zoom (toward cursor) ----
+  function zoomAt(cx, cy, factor) {
+    var r = stage.getBoundingClientRect();
+    var px = view.x + ((cx - r.left) / r.width) * view.w;
+    var py = view.y + ((cy - r.top) / r.height) * view.h;
+    var nw = Math.min(full.w * 4, Math.max(full.w / 400, view.w * factor));
+    var nh = nw * (view.h / view.w);
+    view.x = px - ((cx - r.left) / r.width) * nw;
+    view.y = py - ((cy - r.top) / r.height) * nh;
+    view.w = nw; view.h = nh; apply();
+  }
+  stage.addEventListener("wheel", function (e) {
+    e.preventDefault();
+    zoomAt(e.clientX, e.clientY, e.deltaY > 0 ? 1.15 : 1 / 1.15);
+  }, { passive: false });
+  document.getElementById("zin").onclick = function () {
+    var r = stage.getBoundingClientRect();
+    zoomAt(r.left + r.width / 2, r.top + r.height / 2, 1 / 1.3);
+  };
+  document.getElementById("zout").onclick = function () {
+    var r = stage.getBoundingClientRect();
+    zoomAt(r.left + r.width / 2, r.top + r.height / 2, 1.3);
+  };
+  document.getElementById("fit").onclick = fit;
+
+  // ---- build adjacency from the SVG ----
+  var nodes = {};   // id -> <g>
+  Array.prototype.forEach.call(svg.querySelectorAll("g.node"), function (g) {
+    if (g.id) nodes[g.id] = g;
+  });
+  var edges = [];   // { g, a, b }
+  Array.prototype.forEach.call(svg.querySelectorAll("g.edge"), function (g) {
+    var t = g.querySelector("title");
+    if (!t) return;
+    var m = t.textContent.split("->");
+    if (m.length !== 2) return;
+    var a = m[0].split(":")[0].trim();
+    var b = m[1].split(":")[0].trim();
+    edges.push({ g: g, a: a, b: b });
+  });
+  var neighbors = {};
+  edges.forEach(function (e) {
+    (neighbors[e.a] = neighbors[e.a] || {})[e.b] = true;
+    (neighbors[e.b] = neighbors[e.b] || {})[e.a] = true;
+  });
+
+  var countEl = document.getElementById("count");
+  function clearFocus() {
+    svg.classList.remove("focusing");
+    Object.keys(nodes).forEach(function (id) { nodes[id].classList.remove("dim", "hit"); });
+    edges.forEach(function (e) { e.g.classList.remove("dim"); });
+    countEl.textContent = "";
+  }
+  function focus(id) {
+    if (!nodes[id]) return;
+    var keep = {}; keep[id] = true;
+    Object.keys(neighbors[id] || {}).forEach(function (n) { keep[n] = true; });
+    svg.classList.add("focusing");
+    Object.keys(nodes).forEach(function (nid) {
+      nodes[nid].classList.toggle("dim", !keep[nid]);
+      nodes[nid].classList.toggle("hit", nid === id);
+    });
+    var deg = 0;
+    edges.forEach(function (e) {
+      var on = e.a === id || e.b === id;
+      e.g.classList.toggle("dim", !on);
+      if (on) deg++;
+    });
+    countEl.textContent = id.replace(/^[^.]+\\./, "") + " · " + deg + " relationship" + (deg === 1 ? "" : "s");
+  }
+  svg.addEventListener("click", function (e) {
+    var g = e.target.closest("g.node");
+    if (g && g.id) focus(g.id);
+  });
+  document.getElementById("reset").onclick = clearFocus;
+
+  // center the viewBox on a node's bounding box (in SVG user units)
+  function centerOn(id) {
+    var g = nodes[id]; if (!g) return;
+    var bb = g.getBBox();
+    var pad = Math.max(bb.width, bb.height) * 1.6 + 40;
+    view.w = Math.max(bb.width + pad, full.w / 40);
+    var r = stage.getBoundingClientRect();
+    view.h = view.w * (r.height / r.width); // match the stage aspect ratio
+
+    view.x = bb.x + bb.width / 2 - view.w / 2;
+    view.y = bb.y + bb.height / 2 - view.h / 2;
+    apply();
+  }
+
+  // ---- search ----
+  var ids = Object.keys(nodes).sort();
+  var search = document.getElementById("search");
+  var matchBox = document.getElementById("matches");
+  var active = -1, shown = [];
+  function renderMatches(q) {
+    q = q.trim().toLowerCase();
+    shown = q ? ids.filter(function (id) { return id.toLowerCase().indexOf(q) >= 0; }).slice(0, 12) : [];
+    active = -1;
+    if (!shown.length) { matchBox.style.display = "none"; matchBox.innerHTML = ""; return; }
+    matchBox.innerHTML = shown.map(function (id) {
+      return '<div data-id="' + id + '">' + id + "</div>";
+    }).join("");
+    matchBox.style.display = "block";
+  }
+  function choose(id) {
+    search.value = id; matchBox.style.display = "none";
+    focus(id); centerOn(id);
+  }
+  search.addEventListener("input", function () { renderMatches(search.value); });
+  search.addEventListener("keydown", function (e) {
+    if (!shown.length) return;
+    if (e.key === "ArrowDown") { active = (active + 1) % shown.length; }
+    else if (e.key === "ArrowUp") { active = (active - 1 + shown.length) % shown.length; }
+    else if (e.key === "Enter") { choose(shown[active >= 0 ? active : 0]); return; }
+    else return;
+    e.preventDefault();
+    Array.prototype.forEach.call(matchBox.children, function (c, i) {
+      c.classList.toggle("active", i === active);
+    });
+  });
+  matchBox.addEventListener("click", function (e) {
+    var d = e.target.closest("[data-id]"); if (d) choose(d.getAttribute("data-id"));
+  });
+  document.addEventListener("click", function (e) {
+    if (!e.target.closest(".searchwrap")) matchBox.style.display = "none";
+  });
+
+  // ---- theme toggle (embeds respect ?theme=) ----
+  var root = document.documentElement;
+  var q = new URLSearchParams(location.search).get("theme");
+  if (q === "dark" || q === "light") root.classList.add(q);
+  document.getElementById("theme").onclick = function () {
+    var dark = root.classList.contains("dark") ||
+      (!root.classList.contains("light") &&
+       window.matchMedia("(prefers-color-scheme: dark)").matches);
+    root.classList.remove("dark", "light");
+    root.classList.add(dark ? "light" : "dark");
+  };
+})();
+</script>
+</body>
+</html>
+`;
+}
+
+function main() {
+  const dbml = readFileSync(DBML_FILE, "utf8");
+  const { svg, viewBox } = prepareSvg(renderSvg(dbml));
+  const html = buildHtml(svg, viewBox);
+  writeFileSync(OUTPUT_FILE, html);
+  const nodes = (svg.match(/class="node"/g) || []).length;
+  const edges = (svg.match(/class="edge"/g) || []).length;
+  console.log(
+    `Generated docs/reference/schema-erd.html ` +
+      `(${nodes} tables, ${edges} relationships, viewBox ${viewBox})`
+  );
+}
+
+main();

--- a/schema/scripts/render-schema-diagram.mjs
+++ b/schema/scripts/render-schema-diagram.mjs
@@ -12,12 +12,12 @@
  * viewer with pan, zoom, table search, and click-to-highlight relationships.
  *
  * Runs in CI with nothing but Node (see .github/workflows/docs.yml). The
- * output page is copied verbatim into the mkdocs site and embedded by
- * docs/reference/schema-diagram.md.
+ * output page is copied verbatim into the mkdocs site and embedded (via iframe)
+ * by docs/reference/schema.md.
  *
  * Run directly or via `make docs-schema`.
  *
- * Output: docs/reference/schema-diagram.html
+ * Output: docs/reference/schema-erd.html
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -36,26 +36,45 @@ const PROJECT_ROOT = resolve(SCRIPT_DIR, "..", "..");
 const DBML_FILE = resolve(PROJECT_ROOT, "docs", "reference", "schema.dbml");
 const OUTPUT_FILE = resolve(PROJECT_ROOT, "docs", "reference", "schema-erd.html");
 
-// Schema → header fill. Must match SCHEMA_COLORS in generate-schema-docs.py;
-// used here only to render the legend (the table fills already live in the SVG).
-const SCHEMA_COLORS = {
-  public: "#475569",
-  kg_api: "#7c3aed",
-  kg_auth: "#2d7d9a",
-  kg_logs: "#2d8e5e",
-};
+// The two theme-sensitive colors baked into the dbml-renderer 1.0.31 SVG (cell
+// fill, ink for text/borders/edges). The viewer recolors these per theme; if a
+// renderer bump changes the palette, prepareSvg() asserts they still appear so
+// the mismatch fails loudly instead of rendering unreadably in dark mode.
+const BAKED_CELL = "#e7e2dd";
+const BAKED_INK = "#29235c";
+
+/**
+ * Schema → header fill, read back from the DBML's own `headercolor:` settings
+ * so the legend can never drift from the colors generate-schema-docs.py baked
+ * into the diagram (single source of truth: the .dbml).
+ */
+function schemaColors(dbml) {
+  const re = /Table\s+"([^"]+)"\."[^"]+"\s+\[headercolor:\s*(#[0-9a-fA-F]{6})\]/g;
+  const map = {};
+  let m;
+  while ((m = re.exec(dbml)) !== null) {
+    if (!(m[1] in map)) map[m[1]] = m[2];
+  }
+  return map;
+}
 
 /** Turn schema.dbml into a packed, near-square Graphviz SVG string. */
 function renderSvg(dbml) {
-  let dot = run(dbml, "dot");
+  const dot = run(dbml, "dot");
   // Component packing: lay out each connected piece, then tile them into a
   // grid (array_c4 = row-major, 4 columns) so disconnected tables don't stack
   // into a strip. Modest separations keep the packed block dense.
-  dot = dot.replace(
+  const packed = dot.replace(
     "rankdir=LR;",
     'rankdir=LR;\n  pack=true;\n  packmode="array_c4";\n  ranksep=0.6;\n  nodesep=0.4;'
   );
-  return vizRenderStringSync(dot, { engine: "dot", format: "svg" });
+  if (packed === dot) {
+    throw new Error(
+      "pack injection failed: 'rankdir=LR;' not found in dbml-renderer dot " +
+        "output — the renderer's format likely changed. Update renderSvg()."
+    );
+  }
+  return vizRenderStringSync(packed, { engine: "dot", format: "svg" });
 }
 
 /**
@@ -64,6 +83,17 @@ function renderSvg(dbml) {
  * The viewBox (which carries the true coordinate extent) is preserved.
  */
 function prepareSvg(svg) {
+  // The viewer's dark theme recolors these two baked colors via CSS. If a
+  // renderer upgrade changes the palette they'd silently stop matching and dark
+  // mode would render unreadably, so fail the build instead.
+  for (const color of [BAKED_CELL, BAKED_INK]) {
+    if (!svg.includes(color)) {
+      throw new Error(
+        `expected baked color ${color} not found in the rendered SVG — the ` +
+          "dbml-renderer palette changed; update BAKED_* and the viewer CSS."
+      );
+    }
+  }
   const viewBox = (svg.match(/viewBox="([^"]+)"/) || [])[1] || "0 0 1000 1000";
   const inner = svg.slice(svg.indexOf("<svg"));
   const openTagEnd = inner.indexOf(">") + 1;
@@ -76,8 +106,8 @@ function prepareSvg(svg) {
 }
 
 /** Build the standalone interactive HTML page. */
-function buildHtml(svg, viewBox) {
-  const legend = Object.entries(SCHEMA_COLORS)
+function buildHtml(svg, viewBox, colors) {
+  const legend = Object.entries(colors)
     .map(
       ([name, color]) =>
         `<span class="chip"><i style="background:${color}"></i>${name}</span>`
@@ -126,9 +156,9 @@ function buildHtml(svg, viewBox) {
      fill/stroke property overrides the SVG presentation attribute, and the
      attribute selector targets exactly those elements. Schema header fills
      (#7c3aed etc.) and white header text are intentionally left alone. */
-  #erd [fill="#e7e2dd"] { fill: var(--erd-cell); }
-  #erd [fill="#29235c"] { fill: var(--erd-ink); }
-  #erd [stroke="#29235c"] { stroke: var(--erd-ink); }
+  #erd [fill="${BAKED_CELL}"] { fill: var(--erd-cell); }
+  #erd [fill="${BAKED_INK}"] { fill: var(--erd-ink); }
+  #erd [stroke="${BAKED_INK}"] { stroke: var(--erd-ink); }
   #erd.focusing .node.dim, #erd.focusing .edge.dim { opacity: var(--dim); }
   #erd .node.hit > * { outline: none; }
   .toolbar {
@@ -378,7 +408,7 @@ ${svg}
 function main() {
   const dbml = readFileSync(DBML_FILE, "utf8");
   const { svg, viewBox } = prepareSvg(renderSvg(dbml));
-  const html = buildHtml(svg, viewBox);
+  const html = buildHtml(svg, viewBox, schemaColors(dbml));
   writeFileSync(OUTPUT_FILE, html);
   const nodes = (svg.match(/class="node"/g) || []).length;
   const edges = (svg.match(/class="edge"/g) || []).length;


### PR DESCRIPTION
## What
Adds a full, navigable ER diagram of all 60 control-plane tables to the Database Schema reference — generated from the same DDL parse the reference already uses. **No database, no system Graphviz**; runs in CI with Node + Python only.

## How
- **`generate-schema-docs.py`** also emits **`docs/reference/schema.dbml`**: schema-qualified tables tinted by schema via `headercolor` (color instead of clusters, so the renderer packs the mostly-disconnected tables into a compact block), types + PK/NOT NULL/UNIQUE flags, comments as notes, FK edges as `Ref`s. Doubles as a portable artifact — paste into [dbdiagram.io](https://dbdiagram.io).
- **`render-schema-diagram.mjs`** renders it to SVG via `@softwaretechnik/dbml-renderer` + `@aduh95/viz.js` (Graphviz-wasm), injecting Graphviz `pack` to tile ~square, then wraps it in a self-contained viewer: **pan, zoom-to-cursor, table search, click-to-trace-relationships, light/dark toggle** (recolors only the two theme-sensitive baked colors via CSS vars + attribute selectors).
- `schema.md` embeds the viewer (iframe) + links the full-screen page and DBML source; per-schema Mermaid diagrams remain as the GitHub-native fallback.
- Wired into `make docs-schema` and the docs deploy workflow.

## Verification (local)
- `make docs-schema` → 60 tables, 37 FK edges, all three artifacts
- `doclint --enforce-adrs` ✓ · `link_check --fail-on-broken` ✓
- Full `mkdocs build` ✓ — standalone page + DBML publish as siblings; the `../schema-erd.html` embed resolves under directory URLs (no warnings)
- Layout + dark/light rendering eyeballed via rasterized previews

Follows the two CI hotfixes (#543, #544) that got `main` green first.

https://claude.ai/code/session_017Her5fGimBvtzYD4q9tNnf