### PR TITLE
fix(docs): build ERD search results via DOM, not innerHTML

### DIFF
--- a/docs/reference/schema-erd.html
+++ b/docs/reference/schema-erd.html
@@ -4111,10 +4111,17 @@
     q = q.trim().toLowerCase();
     shown = q ? ids.filter(function (id) { return id.toLowerCase().indexOf(q) >= 0; }).slice(0, 12) : [];
     active = -1;
-    if (!shown.length) { matchBox.style.display = "none"; matchBox.innerHTML = ""; return; }
-    matchBox.innerHTML = shown.map(function (id) {
-      return '<div data-id="' + id + '">' + id + "</div>";
-    }).join("");
+    matchBox.textContent = "";
+    if (!shown.length) { matchBox.style.display = "none"; return; }
+    // Build rows via the DOM (setAttribute + textContent) rather than an HTML
+    // string, so a table name is never parsed as markup — future identifiers
+    // with unusual characters stay inert.
+    shown.forEach(function (id) {
+      var row = document.createElement("div");
+      row.setAttribute("data-id", id);
+      row.textContent = id;
+      matchBox.appendChild(row);
+    });
     matchBox.style.display = "block";
   }
   function choose(id) {

--- a/schema/scripts/render-schema-diagram.mjs
+++ b/schema/scripts/render-schema-diagram.mjs
@@ -358,10 +358,17 @@ ${svg}
     q = q.trim().toLowerCase();
     shown = q ? ids.filter(function (id) { return id.toLowerCase().indexOf(q) >= 0; }).slice(0, 12) : [];
     active = -1;
-    if (!shown.length) { matchBox.style.display = "none"; matchBox.innerHTML = ""; return; }
-    matchBox.innerHTML = shown.map(function (id) {
-      return '<div data-id="' + id + '">' + id + "</div>";
-    }).join("");
+    matchBox.textContent = "";
+    if (!shown.length) { matchBox.style.display = "none"; return; }
+    // Build rows via the DOM (setAttribute + textContent) rather than an HTML
+    // string, so a table name is never parsed as markup — future identifiers
+    // with unusual characters stay inert.
+    shown.forEach(function (id) {
+      var row = document.createElement("div");
+      row.setAttribute("data-id", id);
+      row.textContent = id;
+      matchBox.appendChild(row);
+    });
     matchBox.style.display = "block";
   }
   function choose(id) {


### PR DESCRIPTION
## Why
Final code-review follow-up (#545). The ER-diagram viewer's search dropdown was the one runtime `innerHTML` sink: it concatenated each table `id` into `<div data-id="…">…</div>`. Safe for current `snake_case` names, but an identifier with unusual characters would break the row or inject markup.

## Fix
Build each row with `createElement` + `setAttribute("data-id", id)` + `textContent = id`, so the id is treated as data, never parsed as markup. The keydown/click handlers already operate on `matchBox.children` and `data-id`, so behavior is unchanged. Output now has **zero `innerHTML`**.

## Verification
- Regenerated `schema-erd.html`; embedded viewer JS `node --check` clean
- `render-schema-diagram.mjs` `node --check` clean

## On the other deferred item (generated-date churn)
Not fixed because it's **moot**: `schema-erd.html` carries no date stamp (verified), so it doesn't churn. Only `schema.md`/`schema.dbml` embed a date, matching the existing convention for every generated reference doc — a separate cross-cutting decision, out of scope here.

https://claude.ai/code/session_017Her5fGimBvtzYD4q9tNnf